### PR TITLE
Work queues MVP: file-backed CLI + atomic claim

### DIFF
--- a/bin/clawnsole.js
+++ b/bin/clawnsole.js
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const { enqueueItem, claimNext, transitionItem, loadState, statePaths } = require('../lib/workqueue');
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const out = { _: [] };
+  while (args.length) {
+    const a = args.shift();
+    if (a === '--') {
+      out._.push(...args);
+      break;
+    }
+    if (a.startsWith('--')) {
+      const key = a.slice(2);
+      const next = args[0];
+      if (!next || next.startsWith('--')) {
+        out[key] = true;
+      } else {
+        out[key] = args.shift();
+      }
+    } else {
+      out._.push(a);
+    }
+  }
+  return out;
+}
+
+function die(msg, code = 1) {
+  process.stderr.write(String(msg || 'error') + '\n');
+  process.exit(code);
+}
+
+function printJson(obj) {
+  process.stdout.write(JSON.stringify(obj, null, 2) + '\n');
+}
+
+function usage() {
+  return `clawnsole (MVP)
+
+Usage:
+  clawnsole workqueue <command> [options]
+
+Workqueue commands:
+  enqueue            --queue <name> --title <t> --instructions <text> [--priority <n>]
+  claim-next         --agent <id> --queues <q1,q2> [--leaseMs <ms>]
+  done               <itemId> --agent <id> [--result <json|@file>]
+  fail               <itemId> --agent <id> --error <text>
+  progress           <itemId> --agent <id> --note <text> [--leaseMs <ms>]
+  inspect            <itemId>
+  list               [--queue <name>] [--status <s1,s2>]
+
+Notes:
+  - Data is stored at: ${statePaths().stateFile}
+`;
+}
+
+function parseCsv(value) {
+  const raw = String(value || '').trim();
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function parseMaybeJsonOrFile(value) {
+  if (value === undefined) return undefined;
+  const raw = String(value);
+  if (raw.startsWith('@')) {
+    const filePath = raw.slice(1);
+    const text = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(text);
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const [top, sub, ...rest] = args._;
+
+  if (!top || top === 'help' || top === '--help' || top === '-h') {
+    process.stdout.write(usage());
+    return;
+  }
+
+  if (top !== 'workqueue') {
+    die(`unknown command: ${top}\n\n${usage()}`);
+  }
+
+  const cmd = sub;
+  if (!cmd || cmd === 'help' || cmd === '--help' || cmd === '-h') {
+    process.stdout.write(usage());
+    return;
+  }
+
+  if (cmd === 'enqueue') {
+    const queue = args.queue;
+    const title = args.title;
+    const instructions = args.instructions;
+    const priority = args.priority !== undefined ? Number(args.priority) : 0;
+    if (!queue) die('enqueue requires --queue');
+    if (!instructions) die('enqueue requires --instructions');
+    const item = enqueueItem(null, { queue, title, instructions, priority });
+    printJson({ ok: true, item });
+    return;
+  }
+
+  if (cmd === 'claim-next') {
+    const agent = args.agent;
+    const queues = parseCsv(args.queues);
+    const leaseMs = args.leaseMs !== undefined ? Number(args.leaseMs) : undefined;
+    if (!agent) die('claim-next requires --agent');
+    if (!queues.length) die('claim-next requires --queues q1,q2');
+    const item = claimNext(null, { agentId: agent, queues, leaseMs });
+    printJson({ ok: true, item });
+    return;
+  }
+
+  if (cmd === 'done') {
+    const itemId = rest[0];
+    const agent = args.agent;
+    if (!itemId) die('done requires <itemId>');
+    if (!agent) die('done requires --agent');
+    const result = parseMaybeJsonOrFile(args.result);
+    const item = transitionItem(null, { itemId, agentId: agent, status: 'done', result });
+    printJson({ ok: true, item });
+    return;
+  }
+
+  if (cmd === 'fail') {
+    const itemId = rest[0];
+    const agent = args.agent;
+    const error = args.error;
+    if (!itemId) die('fail requires <itemId>');
+    if (!agent) die('fail requires --agent');
+    if (!error) die('fail requires --error');
+    const item = transitionItem(null, { itemId, agentId: agent, status: 'failed', error });
+    printJson({ ok: true, item });
+    return;
+  }
+
+  if (cmd === 'progress') {
+    const itemId = rest[0];
+    const agent = args.agent;
+    const note = args.note;
+    const leaseMs = args.leaseMs !== undefined ? Number(args.leaseMs) : undefined;
+    if (!itemId) die('progress requires <itemId>');
+    if (!agent) die('progress requires --agent');
+    if (!note) die('progress requires --note');
+    const item = transitionItem(null, { itemId, agentId: agent, status: 'in_progress', note, leaseMs });
+    printJson({ ok: true, item });
+    return;
+  }
+
+  if (cmd === 'inspect') {
+    const itemId = rest[0];
+    if (!itemId) die('inspect requires <itemId>');
+    const state = loadState(null);
+    const item = state.items.find((it) => it.id === itemId) || null;
+    printJson({ ok: true, item });
+    return;
+  }
+
+  if (cmd === 'list') {
+    const queue = args.queue;
+    const status = parseCsv(args.status);
+    const state = loadState(null);
+    const items = state.items
+      .filter((it) => {
+        if (queue && it.queue !== queue) return false;
+        if (status.length && !status.includes(it.status)) return false;
+        return true;
+      })
+      .sort((a, b) => String(a.createdAt).localeCompare(String(b.createdAt)));
+    printJson({ ok: true, items });
+    return;
+  }
+
+  die(`unknown workqueue command: ${cmd}\n\n${usage()}`);
+}
+
+main().catch((err) => {
+  die(err && err.stack ? err.stack : String(err));
+});

--- a/lib/workqueue.js
+++ b/lib/workqueue.js
@@ -1,0 +1,301 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const crypto = require('crypto');
+
+function nowMs() {
+  return Date.now();
+}
+
+function toInt(value, fallback) {
+  const n = Number.parseInt(String(value ?? ''), 10);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function defaultDataRoot() {
+  const openclawHome = process.env.OPENCLAW_HOME || path.join(os.homedir(), '.openclaw');
+  return path.join(openclawHome, 'clawnsole');
+}
+
+function statePaths(rootDir) {
+  const dir = rootDir || defaultDataRoot();
+  return {
+    dir,
+    stateFile: path.join(dir, 'work-queues.json'),
+    lockFile: path.join(dir, 'work-queues.lock')
+  };
+}
+
+function readJson(filePath, fallback) {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return fallback;
+  }
+}
+
+function writeJsonAtomic(filePath, data) {
+  const dir = path.dirname(filePath);
+  ensureDir(dir);
+  const tmp = `${filePath}.tmp.${process.pid}.${nowMs()}`;
+  fs.writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n', 'utf8');
+  fs.renameSync(tmp, filePath);
+}
+
+function normalizeState(state) {
+  const s = state && typeof state === 'object' ? state : {};
+  const queues = s.queues && typeof s.queues === 'object' ? s.queues : {};
+  const items = Array.isArray(s.items) ? s.items : [];
+  return {
+    version: 1,
+    queues,
+    items
+  };
+}
+
+function withFileLock(lockPath, fn, opts = {}) {
+  const staleMs = opts.staleMs ?? 60_000;
+  const timeoutMs = opts.timeoutMs ?? 30_000;
+  const start = nowMs();
+
+  ensureDir(path.dirname(lockPath));
+
+  while (true) {
+    try {
+      const fd = fs.openSync(lockPath, 'wx');
+      try {
+        fs.writeFileSync(fd, JSON.stringify({ pid: process.pid, at: new Date().toISOString() }) + '\n');
+      } catch {}
+      try {
+        return fn();
+      } finally {
+        try {
+          fs.closeSync(fd);
+        } catch {}
+        try {
+          fs.unlinkSync(lockPath);
+        } catch {}
+      }
+    } catch (err) {
+      // lock exists
+      try {
+        const st = fs.statSync(lockPath);
+        const age = nowMs() - st.mtimeMs;
+        if (age > staleMs) {
+          try {
+            fs.unlinkSync(lockPath);
+            continue;
+          } catch {}
+        }
+      } catch {}
+
+      if (nowMs() - start > timeoutMs) {
+        const e = new Error(`Timed out waiting for lock: ${lockPath}`);
+        e.code = 'LOCK_TIMEOUT';
+        throw e;
+      }
+
+      // simple backoff
+      const sleepMs = 25 + Math.floor(Math.random() * 50);
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, sleepMs);
+    }
+  }
+}
+
+function loadState(rootDir) {
+  const { stateFile } = statePaths(rootDir);
+  return normalizeState(readJson(stateFile, null));
+}
+
+function saveState(rootDir, state) {
+  const { stateFile } = statePaths(rootDir);
+  writeJsonAtomic(stateFile, normalizeState(state));
+}
+
+function ensureQueue(state, queueName) {
+  const name = String(queueName || '').trim();
+  if (!name) throw new Error('queue name required');
+  if (!state.queues[name]) {
+    state.queues[name] = { name, createdAt: new Date().toISOString() };
+  }
+  return state.queues[name];
+}
+
+function createItem({ queue, title, instructions, priority }) {
+  const id = crypto.randomUUID();
+  const createdAt = new Date().toISOString();
+  return {
+    id,
+    queue,
+    title: String(title || '').trim() || '(untitled)',
+    instructions: String(instructions || '').trim(),
+    priority: Number.isFinite(priority) ? priority : 0,
+    status: 'ready',
+    claimedBy: '',
+    claimedAt: '',
+    leaseUntil: 0,
+    attempts: 0,
+    lastError: '',
+    createdAt,
+    updatedAt: createdAt
+  };
+}
+
+function enqueueItem(rootDir, { queue, title, instructions, priority }) {
+  const { lockFile } = statePaths(rootDir);
+  return withFileLock(lockFile, () => {
+    const state = loadState(rootDir);
+    ensureQueue(state, queue);
+    const item = createItem({ queue, title, instructions, priority });
+    state.items.push(item);
+    saveState(rootDir, state);
+    return item;
+  });
+}
+
+function listItems(state, { queues, status } = {}) {
+  const queueSet = queues && queues.length ? new Set(queues) : null;
+  const statusSet = status && status.length ? new Set(status) : null;
+  return state.items
+    .filter((it) => {
+      if (queueSet && !queueSet.has(it.queue)) return false;
+      if (statusSet && !statusSet.has(it.status)) return false;
+      return true;
+    })
+    .slice();
+}
+
+function pickNextReady(items) {
+  const ready = items.filter((it) => it.status === 'ready');
+  ready.sort((a, b) => {
+    const pr = (b.priority || 0) - (a.priority || 0);
+    if (pr !== 0) return pr;
+    return String(a.createdAt || '').localeCompare(String(b.createdAt || ''));
+  });
+  return ready[0] || null;
+}
+
+function reapExpiredLeases(state) {
+  const now = nowMs();
+  let changed = false;
+  for (const it of state.items) {
+    if ((it.status === 'claimed' || it.status === 'in_progress') && it.leaseUntil && it.leaseUntil < now) {
+      it.status = 'ready';
+      it.claimedBy = '';
+      it.claimedAt = '';
+      it.leaseUntil = 0;
+      it.updatedAt = new Date().toISOString();
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+function claimNext(rootDir, { agentId, queues, leaseMs }) {
+  const { lockFile } = statePaths(rootDir);
+  const lease = toInt(leaseMs, 15 * 60_000);
+  const agent = String(agentId || '').trim();
+  if (!agent) throw new Error('agentId required');
+
+  return withFileLock(lockFile, () => {
+    const state = loadState(rootDir);
+    const changedByReap = reapExpiredLeases(state);
+
+    const items = listItems(state, {
+      queues: queues && queues.length ? queues : null
+    });
+
+    const next = pickNextReady(items);
+    if (!next) {
+      if (changedByReap) saveState(rootDir, state);
+      return null;
+    }
+
+    const now = nowMs();
+    next.status = 'claimed';
+    next.claimedBy = agent;
+    next.claimedAt = new Date(now).toISOString();
+    next.leaseUntil = now + lease;
+    next.attempts = (next.attempts || 0) + 1;
+    next.updatedAt = new Date().toISOString();
+
+    saveState(rootDir, state);
+    return next;
+  });
+}
+
+function transitionItem(rootDir, { itemId, agentId, status, error, result, note, leaseMs }) {
+  const { lockFile } = statePaths(rootDir);
+  const id = String(itemId || '').trim();
+  const agent = String(agentId || '').trim();
+  if (!id) throw new Error('itemId required');
+  if (!agent) throw new Error('agentId required');
+
+  return withFileLock(lockFile, () => {
+    const state = loadState(rootDir);
+    reapExpiredLeases(state);
+
+    const item = state.items.find((it) => it.id === id);
+    if (!item) {
+      const e = new Error(`item not found: ${id}`);
+      e.code = 'NOT_FOUND';
+      throw e;
+    }
+
+    // For MVP: require that the acting agent is the claimer for non-terminal actions.
+    const terminal = new Set(['done', 'failed', 'canceled']);
+    if (!terminal.has(status)) {
+      if (item.claimedBy && item.claimedBy !== agent) {
+        const e = new Error(`item claimed by another agent: ${item.claimedBy}`);
+        e.code = 'CLAIMED_BY_OTHER';
+        throw e;
+      }
+    }
+
+    item.status = status;
+    item.updatedAt = new Date().toISOString();
+
+    if (status === 'in_progress') {
+      item.claimedBy = item.claimedBy || agent;
+      item.claimedAt = item.claimedAt || new Date().toISOString();
+    }
+
+    if (status === 'failed') {
+      item.lastError = String(error || '').trim();
+    }
+
+    if (status === 'done') {
+      // store a small result snapshot (optional)
+      if (result !== undefined) item.result = result;
+    }
+
+    if (note) {
+      item.lastNote = String(note);
+    }
+
+    if (leaseMs) {
+      const lease = toInt(leaseMs, null);
+      if (lease && (status === 'claimed' || status === 'in_progress')) {
+        item.leaseUntil = nowMs() + lease;
+      }
+    }
+
+    saveState(rootDir, state);
+    return item;
+  });
+}
+
+module.exports = {
+  statePaths,
+  loadState,
+  saveState,
+  ensureQueue,
+  enqueueItem,
+  claimNext,
+  transitionItem
+};

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "test:ui": "playwright test",
     "test:deploy": "playwright test tests/deploy.e2e.spec.js"
   },
+  "bin": {
+    "clawnsole": "bin/clawnsole.js"
+  },
   "dependencies": {
     "ws": "^8.18.0"
   },

--- a/tests/unit/workqueue.test.js
+++ b/tests/unit/workqueue.test.js
@@ -1,0 +1,30 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { enqueueItem, claimNext, loadState } = require('../../lib/workqueue');
+
+function tempRoot() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'clawnsole-wq-'));
+  process.env.OPENCLAW_HOME = dir; // isolate
+  return dir;
+}
+
+test('workqueue: enqueue + claim-next claims exactly one item', () => {
+  tempRoot();
+
+  enqueueItem(null, { queue: 'dev', title: 'a', instructions: 'do a', priority: 0 });
+  enqueueItem(null, { queue: 'dev', title: 'b', instructions: 'do b', priority: 0 });
+
+  const first = claimNext(null, { agentId: 'agent-1', queues: ['dev'], leaseMs: 60_000 });
+  const second = claimNext(null, { agentId: 'agent-2', queues: ['dev'], leaseMs: 60_000 });
+
+  assert.ok(first);
+  assert.ok(second);
+  assert.notEqual(first.id, second.id);
+
+  const state = loadState(null);
+  const claimed = state.items.filter((it) => it.status === 'claimed');
+  assert.equal(claimed.length, 2);
+});


### PR DESCRIPTION
Opened by: Dev 🖥️ (OpenClaw)

## What
Adds an MVP work-queue implementation with a stable CLI contract, suitable for agents to claim/distribute dev-team tasks.

## Why
We want to start tracking & distributing tasks via a work queue, before any UI work.

## How to test
- `npm test`

Try the CLI locally:
```bash
node bin/clawnsole.js workqueue enqueue --queue dev --title "Test" --instructions "Say hi" --priority 1
node bin/clawnsole.js workqueue claim-next --agent agent-a --queues dev --leaseMs 600000
node bin/clawnsole.js workqueue done <id> --agent agent-a
```

## Notes
- Persistence: `~/.openclaw/clawnsole/work-queues.json`
- Atomicity: `~/.openclaw/clawnsole/work-queues.lock` (with stale lock cleanup)

## Risk
Low-medium. New codepaths only used when invoking the CLI.

## Rollback
Revert this PR.
