### PR TITLE
Docs: HTTPS/TLS setup guidance for ERR_SSL_PROTOCOL_ERROR

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ LaunchAgent to auto-start Clawnsole on login.
 You can also enable automatic updates (LaunchAgent).
 It will expose a nice local URL at http://clawnsole.local (macOS + sudo required).
 
+### HTTPS
+If you’re trying to access a QA/hosted Clawnsole instance over **https** and see `ERR_SSL_PROTOCOL_ERROR`, you likely need TLS termination in front of the app (Caddy/nginx). See: [`docs/HTTPS.md`](./docs/HTTPS.md)
+
 You can override defaults:
 
 - `CLAWNSOLE_REPO` (repo URL)

--- a/docs/HTTPS.md
+++ b/docs/HTTPS.md
@@ -1,0 +1,60 @@
+# HTTPS / TLS for Clawnsole
+
+If you see **ERR_SSL_PROTOCOL_ERROR** when visiting Clawnsole over `https://…`, it almost always means the endpoint on **port 443 is not actually speaking TLS** (e.g. plain HTTP on 443), or a reverse proxy/CDN is misconfigured.
+
+Clawnsole itself is typically run as plain HTTP on a local port (e.g. `127.0.0.1:5173`). The correct fix is to **terminate TLS in front of Clawnsole** using a reverse proxy such as **Caddy** or **nginx**, then proxy to the app over HTTP.
+
+## Recommended: Caddy (TLS termination)
+
+### Caddyfile (public hostname)
+
+Replace:
+- `<clawnsole-hostname>` with your real DNS name (e.g. `clawnsole-qa.example.com`)
+- `<clawnsole-port>` with the current active Clawnsole port (e.g. `5173`)
+
+```caddyfile
+<clawnsole-hostname> {
+  encode zstd gzip
+  reverse_proxy 127.0.0.1:<clawnsole-port>
+}
+
+http://<clawnsole-hostname> {
+  redir https://{host}{uri} permanent
+}
+```
+
+Notes:
+- Caddy will automatically obtain and renew a Let’s Encrypt certificate for publicly-valid hostnames.
+- WebSockets are supported automatically.
+
+### Hardening (recommended)
+- Bind Clawnsole only to localhost.
+- Only expose ports **80/443** publicly.
+
+## Common causes of ERR_SSL_PROTOCOL_ERROR
+
+- **Nothing is terminating TLS** on :443.
+- A proxy is bound to :443 but configured for **HTTP** instead of TLS.
+- Cloudflare (or another CDN) SSL mode mismatch (e.g. “Flexible” vs “Full”).
+
+## Quick debug commands
+
+From a machine that can reach the host:
+
+```bash
+curl -v http://<host>
+curl -vk https://<host>
+
+# Shows the TLS handshake + certificate chain if TLS is configured correctly.
+openssl s_client -connect <host>:443 -servername <host>
+```
+
+Expected:
+- `openssl s_client` prints a certificate chain and negotiates TLS 1.2+.
+- `curl -vk https://…` connects and returns an HTTP response.
+
+## Local development (clawnsole.local)
+
+The default installer sets up `http://clawnsole.local` for convenience.
+
+If you want `https://` locally, you’ll need to configure trusted local certs (e.g. Caddy internal CA or mkcert) and trust that CA in your OS/browser.


### PR DESCRIPTION
## Summary
- Adds `docs/HTTPS.md` describing how to terminate TLS (Caddy/nginx) in front of Clawnsole and troubleshoot `ERR_SSL_PROTOCOL_ERROR`.
- Links the doc from README.

## Why
We’re currently seeing `ERR_SSL_PROTOCOL_ERROR` when trying to access Clawnsole over https. This is usually a sign that :443 isn’t speaking TLS (or a proxy/CDN is misconfigured).

## How to test
- `npm test`
- Read the new docs file and confirm it matches our deployment patterns (Caddy reverse proxy to localhost).

## Risk
Low (docs-only).

## Rollback
Revert this PR.
