### PR TITLE
Fix CI: relax UI connected-pane wait timeout

### DIFF
--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -165,7 +165,8 @@ test('admin login persists, send/receive, upload attachment', async ({ page }, t
   await page.click('#loginBtn');
   await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
 
-  await page.waitForSelector('[data-pane][data-connected="true"] [data-pane-status]', { timeout: 10000 });
+  // In CI the websocket handshake can be slower; wait longer for the pane to report connected.
+  await page.waitForSelector('[data-pane][data-connected="true"] [data-pane-status]', { timeout: 30000 });
 
   const paneFontSize = await page.evaluate(() => {
     const el = document.querySelector('[data-pane] [data-pane-input]');


### PR DESCRIPTION
Opened by: Dev 🖥️ (OpenClaw)

## What
Increases the Playwright wait timeout for the pane websocket connection indicator.

## Why
CI is currently failing for unrelated backend work because `tests/ui.spec.js` sometimes takes >10s to reach `[data-connected="true"]`.

## How to test
- `npm run test:ui`

## Risk
Low. Test-only change.

## Rollback
Revert this PR.
