### PR TITLE
Workqueue: ownership enforcement + robust file lock retry

### DIFF
--- a/lib/workqueue.js
+++ b/lib/workqueue.js
@@ -66,29 +66,22 @@ function withFileLock(lockPath, fn, opts = {}) {
   ensureDir(path.dirname(lockPath));
 
   while (true) {
+    let fd;
     try {
-      const fd = fs.openSync(lockPath, 'wx');
-      try {
-        fs.writeFileSync(fd, JSON.stringify({ pid: process.pid, at: new Date().toISOString() }) + '\n');
-      } catch {}
-      try {
-        return fn();
-      } finally {
-        try {
-          fs.closeSync(fd);
-        } catch {}
-        try {
-          fs.unlinkSync(lockPath);
-        } catch {}
-      }
+      fd = fs.openSync(lockPath, 'wx');
     } catch (err) {
+      // Only retry when the lock already exists.
+      if (err && err.code !== 'EEXIST') {
+        throw err;
+      }
+
       // lock exists
       try {
         const st = fs.statSync(lockPath);
         const age = nowMs() - st.mtimeMs;
         if (age > staleMs) {
           try {
-            fs.unlinkSync(lockPath);
+            fs.rmSync(lockPath, { force: true });
             continue;
           } catch {}
         }
@@ -103,6 +96,21 @@ function withFileLock(lockPath, fn, opts = {}) {
       // simple backoff
       const sleepMs = 25 + Math.floor(Math.random() * 50);
       Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, sleepMs);
+      continue;
+    }
+
+    try {
+      try {
+        fs.writeFileSync(fd, JSON.stringify({ pid: process.pid, at: new Date().toISOString() }) + '\n');
+      } catch {}
+      return fn();
+    } finally {
+      try {
+        fs.closeSync(fd);
+      } catch {}
+      try {
+        fs.rmSync(lockPath, { force: true });
+      } catch {}
     }
   }
 }
@@ -247,14 +255,12 @@ function transitionItem(rootDir, { itemId, agentId, status, error, result, note,
       throw e;
     }
 
-    // For MVP: require that the acting agent is the claimer for non-terminal actions.
-    const terminal = new Set(['done', 'failed', 'canceled']);
-    if (!terminal.has(status)) {
-      if (item.claimedBy && item.claimedBy !== agent) {
-        const e = new Error(`item claimed by another agent: ${item.claimedBy}`);
-        e.code = 'CLAIMED_BY_OTHER';
-        throw e;
-      }
+    // Ownership: if an item is claimed, only the claimer can transition it.
+    // This prevents another agent from accidentally (or maliciously) completing/failing someone else's work.
+    if (item.claimedBy && item.claimedBy !== agent) {
+      const e = new Error(`item claimed by another agent: ${item.claimedBy}`);
+      e.code = 'CLAIMED_BY_OTHER';
+      throw e;
     }
 
     item.status = status;

--- a/tests/unit/workqueue.test.js
+++ b/tests/unit/workqueue.test.js
@@ -3,28 +3,86 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { enqueueItem, claimNext, loadState } = require('../../lib/workqueue');
+
+const { enqueueItem, claimNext, loadState, saveState, transitionItem } = require('../../lib/workqueue');
 
 function tempRoot() {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'clawnsole-wq-'));
-  process.env.OPENCLAW_HOME = dir; // isolate
-  return dir;
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'clawnsole-wq-'));
 }
 
-test('workqueue: enqueue + claim-next claims exactly one item', () => {
-  tempRoot();
+test('workqueue: enqueue + claim-next claims distinct items', () => {
+  const root = tempRoot();
 
-  enqueueItem(null, { queue: 'dev', title: 'a', instructions: 'do a', priority: 0 });
-  enqueueItem(null, { queue: 'dev', title: 'b', instructions: 'do b', priority: 0 });
+  enqueueItem(root, { queue: 'dev', title: 'a', instructions: 'do a', priority: 0 });
+  enqueueItem(root, { queue: 'dev', title: 'b', instructions: 'do b', priority: 0 });
 
-  const first = claimNext(null, { agentId: 'agent-1', queues: ['dev'], leaseMs: 60_000 });
-  const second = claimNext(null, { agentId: 'agent-2', queues: ['dev'], leaseMs: 60_000 });
+  const first = claimNext(root, { agentId: 'agent-1', queues: ['dev'], leaseMs: 60_000 });
+  const second = claimNext(root, { agentId: 'agent-2', queues: ['dev'], leaseMs: 60_000 });
 
   assert.ok(first);
   assert.ok(second);
   assert.notEqual(first.id, second.id);
 
-  const state = loadState(null);
+  const state = loadState(root);
   const claimed = state.items.filter((it) => it.status === 'claimed');
   assert.equal(claimed.length, 2);
+});
+
+test('workqueue: priority ordering (higher priority claimed first)', () => {
+  const root = tempRoot();
+
+  const low = enqueueItem(root, { queue: 'dev', title: 'low', instructions: 'l', priority: 0 });
+  const high = enqueueItem(root, { queue: 'dev', title: 'high', instructions: 'h', priority: 5 });
+
+  const claimed = claimNext(root, { agentId: 'agent-1', queues: ['dev'], leaseMs: 60_000 });
+  assert.ok(claimed);
+  assert.equal(claimed.id, high.id);
+
+  const claimed2 = claimNext(root, { agentId: 'agent-2', queues: ['dev'], leaseMs: 60_000 });
+  assert.ok(claimed2);
+  assert.equal(claimed2.id, low.id);
+});
+
+test('workqueue: lease expiry reaps claimed items back to ready', () => {
+  const root = tempRoot();
+
+  const item = enqueueItem(root, { queue: 'dev', title: 'a', instructions: 'x', priority: 0 });
+
+  // Claim with a short lease, then force-expire by editing state.
+  const claimed = claimNext(root, { agentId: 'agent-1', queues: ['dev'], leaseMs: 1 });
+  assert.ok(claimed);
+  assert.equal(claimed.id, item.id);
+
+  const state = loadState(root);
+  const it = state.items.find((x) => x.id === item.id);
+  assert.ok(it);
+  it.leaseUntil = Date.now() - 1; // expired
+  saveState(root, state);
+
+  // Next claim should reap the expired lease and allow a new agent to claim.
+  const reclaimed = claimNext(root, { agentId: 'agent-2', queues: ['dev'], leaseMs: 60_000 });
+  assert.ok(reclaimed);
+  assert.equal(reclaimed.id, item.id);
+  assert.equal(reclaimed.claimedBy, 'agent-2');
+});
+
+test('workqueue: claimed-by-other enforced for terminal transitions (done/failed)', () => {
+  const root = tempRoot();
+
+  enqueueItem(root, { queue: 'dev', title: 'a', instructions: 'x', priority: 0 });
+  const claimed = claimNext(root, { agentId: 'agent-1', queues: ['dev'], leaseMs: 60_000 });
+  assert.ok(claimed);
+
+  assert.throws(
+    () => transitionItem(root, { itemId: claimed.id, agentId: 'agent-2', status: 'done', result: { ok: true } }),
+    (err) => err && err.code === 'CLAIMED_BY_OTHER'
+  );
+
+  assert.throws(
+    () => transitionItem(root, { itemId: claimed.id, agentId: 'agent-2', status: 'failed', error: 'nope' }),
+    (err) => err && err.code === 'CLAIMED_BY_OTHER'
+  );
+
+  const done = transitionItem(root, { itemId: claimed.id, agentId: 'agent-1', status: 'done', result: { ok: true } });
+  assert.equal(done.status, 'done');
 });


### PR DESCRIPTION
Opened by: Dev-2 ⚙️ (OpenClaw)

## Summary
Hardens the workqueue implementation so we can build on it safely:

- Fixes `withFileLock()` to **only retry on `EEXIST`** (lock already present). Other filesystem errors now surface immediately instead of silently spinning until timeout.
- Enforces **claimer ownership** for *all* item transitions when `claimedBy` is set (prevents another agent from completing/failing someone else’s work).
- Expands unit tests to lock down:
  - priority ordering
  - lease expiry reaping
  - claimed-by-other for terminal transitions (`done`/`failed`)

## Why
We hit a reproducible `LOCK_TIMEOUT` on `transitionItem()` even when the lock file wasn’t present, due to treating non-`EEXIST` open errors as “lock exists.” This also blocked phase-0 correctness tests.

## How to test
- `npm test`

## Risk
Low-medium. Changes are limited to the workqueue library + unit tests.

## Rollback
Revert this PR.
