### PR TITLE
Fix clawnsole.local HTTPS by terminating TLS in Caddy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ curl -fsSL https://raw.githubusercontent.com/rmdmattingly/clawnsole/main/scripts
 The installer will prompt for admin/guest passwords and will install a
 LaunchAgent to auto-start Clawnsole on login.
 You can also enable automatic updates (LaunchAgent).
-It will expose a nice local URL at http://clawnsole.local (macOS + sudo required).
+It will expose a nice local URL at https://clawnsole.local (macOS + sudo required).
+(HTTP redirects to HTTPS; HTTPS uses a local/internal Caddy certificate.)
 
 You can override defaults:
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -2,8 +2,11 @@
 
 Clawnsole runs two instances on one host:
 
-- **QA:** `http://clawnsole.local:5174` (`CLAWNSOLE_INSTANCE=qa`, `PORT=5174`)
-- **Prod:** `http://clawnsole.local:5173` (`CLAWNSOLE_INSTANCE=prod`, `PORT=5173`)
+- **QA (direct app port, HTTP):** `http://clawnsole.local:5174` (`CLAWNSOLE_INSTANCE=qa`, `PORT=5174`)
+- **Prod (direct app port, HTTP):** `http://clawnsole.local:5173` (`CLAWNSOLE_INSTANCE=prod`, `PORT=5173`)
+
+The default end-user install also sets up **Caddy TLS termination**, so the friendly URL is:
+- `https://clawnsole.local` (no port)
 
 > Why `CLAWNSOLE_INSTANCE` matters: browser cookies are not port-scoped, so QA/Prod must namespace cookies to avoid login collisions.
 

--- a/docs/https.md
+++ b/docs/https.md
@@ -1,0 +1,48 @@
+# HTTPS / TLS for Clawnsole
+
+Clawnsole itself is an **HTTP** server (it does not speak TLS). For browser-compatible `https://` access you must **terminate TLS in front of Clawnsole** and reverse-proxy to it over plain HTTP.
+
+## Default install (`clawnsole.local` on macOS)
+
+The installer uses **Caddy** as a local reverse proxy.
+
+- `http://clawnsole.local` redirects to `https://clawnsole.local`
+- `https://clawnsole.local` is served with a **Caddy internal certificate** (`tls internal`)
+
+The first time you visit the HTTPS URL your browser may show a certificate warning until you trust Caddy's local CA.
+
+To trust Caddy's local CA (macOS):
+
+```bash
+sudo /opt/homebrew/bin/caddy trust
+```
+
+Then reload `https://clawnsole.local`.
+
+## Public hostname (recommended)
+
+For a real domain with DNS pointing at the server (ports 80/443 open), you can use Caddy with Let's Encrypt:
+
+```caddyfile
+# Replace with your real hostname
+clawnsole.example.com {
+  encode zstd gzip
+  reverse_proxy 127.0.0.1:5173
+}
+
+http://clawnsole.example.com {
+  redir https://{host}{uri} permanent
+}
+```
+
+Caddy handles WebSockets automatically.
+
+## Debugging
+
+If `https://` fails, confirm port 443 is speaking TLS:
+
+```bash
+openssl s_client -connect clawnsole.example.com:443 -servername clawnsole.example.com
+```
+
+A working setup shows a certificate chain and negotiated TLS version (TLS 1.2/1.3).

--- a/scripts/Caddyfile
+++ b/scripts/Caddyfile
@@ -1,3 +1,14 @@
-clawnsole.local {
+# Clawnsole itself is plain HTTP.
+# This Caddyfile terminates TLS and proxies to the active Clawnsole port.
+
+# HTTPS (local/internal cert). To trust the local CA on macOS:
+#   sudo /opt/homebrew/bin/caddy trust
+https://clawnsole.local {
+  tls internal
   reverse_proxy 127.0.0.1:__PORT__
+}
+
+# Redirect HTTP -> HTTPS
+http://clawnsole.local {
+  redir https://{host}{uri} permanent
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -183,7 +183,7 @@ if prompt_yes_no "Enable automatic updates? [y/N]: " "N"; then
   fi
 fi
 
-echo "Setting up http://clawnsole.local (requires sudo)..."
+echo "Setting up https://clawnsole.local (requires sudo)..."
 CLAWNSOLE_PORT="$PORT_VALUE" bash "$INSTALL_DIR/scripts/install-local-domain.sh"
 
-printf "\nClawnsole installed.\n\nOpen:\n  http://clawnsole.local\n\n(Internal app ports: %s and %s; Caddy proxies clawnsole.local to the active one.)\n" "$PORT_VALUE" "$((PORT_VALUE + 2))"
+printf "\nClawnsole installed.\n\nOpen:\n  https://clawnsole.local\n\nIf your browser warns about the certificate, run:\n  sudo /opt/homebrew/bin/caddy trust\n\n(Internal app ports: %s and %s; Caddy proxies clawnsole.local to the active one.)\n" "$PORT_VALUE" "$((PORT_VALUE + 2))"


### PR DESCRIPTION
Fixes #16.

Problem: visiting https://clawnsole.local (or browsers auto-upgrading to https) could fail because the default install path didn't explicitly provide TLS termination guidance.

Changes:
- Update Caddyfile template to explicitly serve https://clawnsole.local with 'tls internal' and redirect http->https.
- Update installer output + README to point to https://clawnsole.local and document 'caddy trust'.
- Add docs/https.md with public-hostname Caddy example + debugging tips.
- Clarify DEPLOY.md that direct app ports remain HTTP; friendly URL uses Caddy.

Test:
- npm test