### PR TITLE
UI: queued outbound messages (label + edit/delete)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -855,6 +855,47 @@ button.send-btn .btn-icon {
   box-shadow: 0 0 18px rgba(255, 179, 71, 0.2);
 }
 
+.chat-bubble.queued {
+  border-style: dashed;
+  border-color: rgba(255, 255, 255, 0.22);
+  box-shadow: 0 0 0 rgba(0, 0, 0, 0);
+}
+
+.chat-bubble.sending {
+  border-style: dashed;
+  border-color: rgba(127, 209, 185, 0.55);
+}
+
+.chat-bubble.failed {
+  border-style: dashed;
+  border-color: rgba(255, 86, 86, 0.6);
+}
+
+.chat-actions-row {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.chat-action {
+  font-size: 12px;
+  padding: 6px 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(8, 10, 14, 0.3);
+  color: rgba(255, 255, 255, 0.85);
+  cursor: pointer;
+}
+
+.chat-action:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.chat-action.delete {
+  border-color: rgba(255, 86, 86, 0.35);
+}
+
 .chat-bubble.thinking {
   opacity: 0.85;
   border-style: dashed;

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -177,6 +177,12 @@ test('admin login persists, send/receive, upload attachment', async ({ page }, t
   const pane = page.locator('[data-pane]').first();
   await pane.locator('[data-pane-input]').fill('hello');
   await pane.locator('[data-pane-send]').click();
+
+  // Queued/sending indicator should be visible before we receive the assistant reply.
+  await expect(pane.locator('[data-chat-role="user"]').last().locator('.chat-meta')).toContainText(
+    /Queued|Sending/i
+  );
+
   await expect(pane.locator('[data-chat-role="assistant"]').last()).toContainText('mock-reply: hello');
 
   const testFile = testInfo.outputPath('upload.txt');


### PR DESCRIPTION
Opened by: Dev-2 ⚙️ (OpenClaw)

Fixes #9

## Summary
Make outbound queued messages visually unmistakable and actionable until they’re actually delivered.

## What changed
- User outbound messages now render initially as **Queued (not sent)**, then transition to **Sending…**, then to normal “You” once the gateway acks `chat.send`.
- Added **Edit** and **Delete** controls for queued messages (disabled once sending).
- Persist user messages to local history only after send ack.
- Added CSS styling for queued/sending/failed states.
- Updated Playwright UI test to assert a queued/sending indicator is visible after sending.

## How to test
- `npm test`
- Manual:
  1) Login as admin
  2) Send two messages quickly
  3) Observe queued/sending indicators and edit/delete on the queued one

## Risk
Medium-low. UI-only changes, but in a sensitive path (chat send).

## Rollback
Revert this PR.
