### PR TITLE
[OPS] QA Clawnsole as managed LaunchAgent service

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,12 @@ Connect:
 
 - Prod: `http://localhost:5173/admin` (or `/guest`)
 - QA: `http://localhost:5174/admin` (or `/guest`)
+
+If QA keeps dying due to terminal logout / SIGTERM, run it as a managed service (macOS LaunchAgent):
+
+```bash
+cd ~/src/dev/clawnsole
+./scripts/install-qa-launchagent.sh
+```
+
+Runbook + health check: [`docs/DEPLOY.md`](./docs/DEPLOY.md)

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -11,6 +11,54 @@ Clawnsole runs two instances on one host:
 - The app code is in a git checkout under `~/src/dev/clawnsole` (or another workspace folder).
 - Deployed instances can be started directly from a checkout during development.
 
+## Run QA as a managed service (recommended)
+
+The QA instance is a validation environment and should be resilient to terminal logout / accidental SIGTERM.
+On macOS, run it under a LaunchAgent supervisor.
+
+### Install / start (QA)
+From a git checkout (ex: `~/src/dev/clawnsole`):
+
+```bash
+cd ~/src/dev/clawnsole
+./scripts/install-qa-launchagent.sh
+```
+
+This creates a LaunchAgent:
+- Label: `ai.openclaw.clawnsole-qa`
+- Port: `5174`
+- Env: `CLAWNSOLE_INSTANCE=qa`
+
+### Stop (QA)
+```bash
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/ai.openclaw.clawnsole-qa.plist \
+  || launchctl bootout user/$(id -u) ~/Library/LaunchAgents/ai.openclaw.clawnsole-qa.plist
+```
+
+### Status (QA)
+```bash
+launchctl print gui/$(id -u)/ai.openclaw.clawnsole-qa \
+  || launchctl print user/$(id -u)/ai.openclaw.clawnsole-qa
+```
+
+### Restart (QA) — safe for deploys
+This restarts **only QA (5174)** and will not touch Prod (5173):
+
+```bash
+launchctl kickstart -k gui/$(id -u)/ai.openclaw.clawnsole-qa \
+  || launchctl kickstart -k user/$(id -u)/ai.openclaw.clawnsole-qa
+```
+
+### Logs (QA)
+```bash
+tail -n 200 -f ~/.openclaw/logs/clawnsole.qa.out.log ~/.openclaw/logs/clawnsole.qa.err.log
+```
+
+### Health check (QA)
+```bash
+curl -fsS http://127.0.0.1:5174/meta
+```
+
 ## Deploy procedure (manual, deterministic)
 
 ### 1) Update code

--- a/scripts/install-qa-launchagent.sh
+++ b/scripts/install-qa-launchagent.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Installs a macOS LaunchAgent that runs the Clawnsole QA instance:
+# - http://127.0.0.1:5174
+# - CLAWNSOLE_INSTANCE=qa (cookie namespace isolation)
+#
+# This is intentionally separate from Prod (5173). The LaunchAgent label is:
+#   ai.openclaw.clawnsole-qa
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLIST_DST="$HOME/Library/LaunchAgents/ai.openclaw.clawnsole-qa.plist"
+LABEL="ai.openclaw.clawnsole-qa"
+
+PORT="${CLAWNSOLE_QA_PORT:-5174}"
+PATH_VALUE="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+
+mkdir -p "$HOME/Library/LaunchAgents"
+mkdir -p "$HOME/.openclaw/logs"
+
+cat >"$PLIST_DST" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${LABEL}</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/env</string>
+    <string>bash</string>
+    <string>-lc</string>
+    <string>cd "${REPO_DIR}"; exec /usr/bin/env node server.js</string>
+  </array>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PORT</key>
+    <string>${PORT}</string>
+    <key>CLAWNSOLE_INSTANCE</key>
+    <string>qa</string>
+    <key>PATH</key>
+    <string>${PATH_VALUE}</string>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>$HOME/.openclaw/logs/clawnsole.qa.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>$HOME/.openclaw/logs/clawnsole.qa.err.log</string>
+</dict>
+</plist>
+PLIST
+
+if ! plutil -p "$PLIST_DST" >/dev/null 2>&1; then
+  echo "LaunchAgent plist is invalid: $PLIST_DST"
+  exit 1
+fi
+
+USER_ID="$(id -u)"
+DOMAIN_GUI="gui/$USER_ID"
+DOMAIN_USER="user/$USER_ID"
+
+# Remove any prior registration (best-effort)
+launchctl bootout "$DOMAIN_GUI" "$PLIST_DST" >/dev/null 2>&1 || true
+launchctl bootout "$DOMAIN_USER" "$PLIST_DST" >/dev/null 2>&1 || true
+
+TARGET_DOMAIN="$DOMAIN_GUI"
+if ! launchctl print "$DOMAIN_GUI" >/dev/null 2>&1; then
+  TARGET_DOMAIN="$DOMAIN_USER"
+fi
+
+if ! launchctl bootstrap "$TARGET_DOMAIN" "$PLIST_DST" >/dev/null 2>&1; then
+  echo "LaunchAgent bootstrap failed for $TARGET_DOMAIN. Trying legacy load..."
+  launchctl load "$PLIST_DST" >/dev/null 2>&1 || true
+fi
+
+if launchctl print "$DOMAIN_GUI/$LABEL" >/dev/null 2>&1; then
+  launchctl enable "$DOMAIN_GUI/$LABEL" >/dev/null 2>&1 || true
+  launchctl kickstart -k "$DOMAIN_GUI/$LABEL" >/dev/null 2>&1 || true
+elif launchctl print "$DOMAIN_USER/$LABEL" >/dev/null 2>&1; then
+  launchctl enable "$DOMAIN_USER/$LABEL" >/dev/null 2>&1 || true
+  launchctl kickstart -k "$DOMAIN_USER/$LABEL" >/dev/null 2>&1 || true
+else
+  echo "LaunchAgent not registered (yet). It should appear after login or a manual load."
+fi
+
+echo "QA LaunchAgent installed: $PLIST_DST (port $PORT)"


### PR DESCRIPTION
Dev-3 workqueue item: harden QA Clawnsole (5174) as a managed service.

What changed:
- Add scripts/install-qa-launchagent.sh to install a LaunchAgent (ai.openclaw.clawnsole-qa) running CLAWNSOLE_INSTANCE=qa on port 5174.
- Update docs/DEPLOY.md with runbook commands: install/start/stop/status/restart/logs/health check.
- Update README with pointer to the runbook.

Acceptance:
- QA supervised via LaunchAgent + KeepAlive.
- Restart command kickstarts ONLY the QA label; does not touch Prod (5173).
- Health check: curl http://127.0.0.1:5174/meta.

Requesting 🚢