### PR TITLE
[#22c] Admin UI: Workqueue list + filters + inspect

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,9 @@
           <button id="logoutBtn" class="icon-btn" type="button" aria-label="Log out">
             ⎋
           </button>
+          <button id="workqueueBtn" class="icon-btn" type="button" aria-label="Open workqueue" hidden>
+            WQ
+          </button>
           <button id="settingsBtn" class="icon-btn" type="button" aria-label="Open settings">
             ⚙︎
           </button>
@@ -150,6 +153,52 @@
         </label>
         <div id="loginError" class="login-error" role="alert"></div>
         <button id="loginBtn" class="primary">Unlock</button>
+      </div>
+    </div>
+
+    <div id="workqueueModal" class="modal" aria-hidden="true">
+      <div class="modal-card wide" role="dialog" aria-modal="true" aria-labelledby="workqueueTitle">
+        <div class="modal-header">
+          <h2 id="workqueueTitle">Workqueue</h2>
+          <button id="workqueueCloseBtn" class="icon-btn" type="button" aria-label="Close workqueue">
+            ✕
+          </button>
+        </div>
+        <div class="modal-body">
+          <div class="wq-toolbar">
+            <label class="wq-field">
+              Queue
+              <select id="wqQueueSelect" aria-label="Select workqueue"></select>
+            </label>
+            <div class="wq-field">
+              Status
+              <div id="wqStatusFilters" class="wq-status-filters" aria-label="Status filters"></div>
+            </div>
+            <button id="wqRefreshBtn" class="secondary" type="button">Refresh</button>
+          </div>
+
+          <div class="wq-layout">
+            <div class="wq-list" aria-label="Workqueue items">
+              <div class="wq-list-header">
+                <div class="wq-col title">Title</div>
+                <div class="wq-col status">Status</div>
+                <div class="wq-col prio">Prio</div>
+                <div class="wq-col attempts">Att</div>
+                <div class="wq-col claimedBy">Claimed By</div>
+                <div class="wq-col lease">Lease</div>
+              </div>
+              <div id="wqListBody" class="wq-list-body"></div>
+              <div id="wqListEmpty" class="hint" hidden>No items match.</div>
+            </div>
+
+            <div class="wq-inspect" aria-label="Inspect workqueue item">
+              <div class="wq-inspect-header">Item</div>
+              <div id="wqInspectBody" class="wq-inspect-body">
+                <div class="hint">Select an item to inspect.</div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -772,6 +772,185 @@ button.send-btn .btn-icon {
   color: var(--muted);
 }
 
+.modal-card.wide {
+  width: min(1060px, 96vw);
+}
+
+/* Workqueue modal */
+
+.wq-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-end;
+  margin-bottom: 12px;
+}
+
+.wq-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.wq-status-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.wq-status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  cursor: pointer;
+  user-select: none;
+  color: var(--text);
+}
+
+.wq-status-chip input {
+  accent-color: var(--accent);
+}
+
+.wq-layout {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 12px;
+  min-height: 360px;
+}
+
+@media (max-width: 920px) {
+  .wq-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.wq-list {
+  border: 1px solid var(--panel-border);
+  border-radius: 14px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.wq-list-header,
+.wq-row {
+  display: grid;
+  grid-template-columns: 1.4fr 0.6fr 0.25fr 0.25fr 0.6fr 0.45fr;
+  gap: 10px;
+  align-items: center;
+}
+
+.wq-list-header {
+  padding: 10px 12px;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted);
+  background: rgba(0, 0, 0, 0.2);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.wq-list-body {
+  max-height: 520px;
+  overflow: auto;
+}
+
+.wq-row {
+  width: 100%;
+  border: none;
+  background: transparent;
+  padding: 10px 12px;
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.wq-row:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.wq-row.selected {
+  background: rgba(127, 209, 185, 0.12);
+}
+
+.wq-col {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+}
+
+.wq-col.prio,
+.wq-col.attempts {
+  text-align: right;
+}
+
+.wq-inspect {
+  border: 1px solid var(--panel-border);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.02);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.wq-inspect-header {
+  padding: 10px 12px;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted);
+  background: rgba(0, 0, 0, 0.2);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.wq-inspect-body {
+  padding: 12px;
+  overflow: auto;
+  max-height: 520px;
+}
+
+.wq-kv {
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  gap: 10px;
+  font-size: 12px;
+  margin-bottom: 6px;
+}
+
+.wq-kv .k {
+  color: var(--muted);
+}
+
+.wq-inspect-block {
+  margin-top: 12px;
+}
+
+.wq-inspect-label {
+  font-size: 12px;
+  color: var(--muted);
+  margin-bottom: 6px;
+}
+
+.wq-inspect-pre {
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 12px;
+  color: var(--text);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
 
 .chat-thread {
   display: flex;


### PR DESCRIPTION
Dev-2 implementation.

What:
- Adds an admin-only Workqueue modal (WQ button) that fetches queues and items from the existing read-only workqueue API.
- Renders rows: title, status, priority, attempts, claimedBy, lease remaining (live-updating).
- Multi-select status filters + queue selector.
- Right-side inspect panel showing meta + full instructions.

QA:
- npm test
- Manual: open /admin, click WQ, change queue + filters, click row to inspect.

Request: 🚢 if this matches desired UX (it unblocks basic workqueue visibility).