### PR TITLE
workqueue: assignments list/set CLI

### DIFF
--- a/bin/clawnsole.js
+++ b/bin/clawnsole.js
@@ -2,7 +2,15 @@
 
 const fs = require('fs');
 const path = require('path');
-const { enqueueItem, claimNext, transitionItem, loadState, statePaths } = require('../lib/workqueue');
+const {
+  enqueueItem,
+  claimNext,
+  transitionItem,
+  loadState,
+  statePaths,
+  listAssignments,
+  setAssignments
+} = require('../lib/workqueue');
 
 function parseArgs(argv) {
   const args = argv.slice(2);
@@ -51,6 +59,8 @@ Workqueue commands:
   progress           <itemId> --agent <id> --note <text> [--leaseMs <ms>]
   inspect            <itemId>
   list               [--queue <name>] [--status <s1,s2>]
+  assignments list
+  assignments set    --agent <id> --queues <q1,q2>
 
 Notes:
   - Data is stored at: ${statePaths().stateFile}
@@ -182,6 +192,33 @@ async function main() {
       .sort((a, b) => String(a.createdAt).localeCompare(String(b.createdAt)));
     printJson({ ok: true, items });
     return;
+  }
+
+  if (cmd === 'assignments') {
+    const subcmd = rest[0];
+
+    if (!subcmd || subcmd === 'help' || subcmd === '--help' || subcmd === '-h') {
+      process.stdout.write(usage());
+      return;
+    }
+
+    if (subcmd === 'list') {
+      const assignments = listAssignments(null);
+      printJson({ ok: true, assignments });
+      return;
+    }
+
+    if (subcmd === 'set') {
+      const agent = args.agent;
+      const queues = parseCsv(args.queues);
+      if (!agent) die('assignments set requires --agent');
+      if (!queues.length) die('assignments set requires --queues q1,q2');
+      const result = setAssignments(null, { agentId: agent, queues });
+      printJson({ ok: true, agentId: result.agentId, queues: result.queues });
+      return;
+    }
+
+    die(`unknown workqueue assignments command: ${subcmd}\n\n${usage()}`);
   }
 
   die(`unknown workqueue command: ${cmd}\n\n${usage()}`);

--- a/lib/workqueue.js
+++ b/lib/workqueue.js
@@ -51,10 +51,12 @@ function normalizeState(state) {
   const s = state && typeof state === 'object' ? state : {};
   const queues = s.queues && typeof s.queues === 'object' ? s.queues : {};
   const items = Array.isArray(s.items) ? s.items : [];
+  const assignments = s.assignments && typeof s.assignments === 'object' ? s.assignments : {};
   return {
     version: 1,
     queues,
-    items
+    items,
+    assignments
   };
 }
 
@@ -262,6 +264,33 @@ function claimNext(rootDir, { agentId, queues, leaseMs }) {
   });
 }
 
+function listAssignments(rootDir) {
+  const { lockFile } = statePaths(rootDir);
+  return withFileLock(lockFile, () => {
+    const state = loadState(rootDir);
+    const assignments = state.assignments && typeof state.assignments === 'object' ? state.assignments : {};
+    return assignments;
+  });
+}
+
+function setAssignments(rootDir, { agentId, queues }) {
+  const { lockFile } = statePaths(rootDir);
+  const agent = String(agentId || '').trim();
+  if (!agent) throw new Error('agentId required');
+
+  const q = Array.isArray(queues) ? queues : [];
+  const normalized = q.map((s) => String(s).trim()).filter(Boolean);
+  if (!normalized.length) throw new Error('queues required');
+
+  return withFileLock(lockFile, () => {
+    const state = loadState(rootDir);
+    if (!state.assignments || typeof state.assignments !== 'object') state.assignments = {};
+    state.assignments[agent] = normalized;
+    saveState(rootDir, state);
+    return { agentId: agent, queues: normalized };
+  });
+}
+
 function transitionItem(rootDir, { itemId, agentId, status, error, result, note, leaseMs }) {
   const { lockFile } = statePaths(rootDir);
   const id = String(itemId || '').trim();
@@ -338,6 +367,8 @@ module.exports = {
   enqueueItem,
   claimNext,
   transitionItem,
+  listAssignments,
+  setAssignments,
   // exported for tests
   findItemByDedupeKey
 };

--- a/tests/unit/clawnsole-cli-assignments.test.js
+++ b/tests/unit/clawnsole-cli-assignments.test.js
@@ -1,0 +1,46 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+function tempHome() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'clawnsole-cli-'));
+  return dir;
+}
+
+function run(args, env = {}) {
+  const bin = path.join(__dirname, '..', '..', 'bin', 'clawnsole.js');
+  const out = execFileSync('node', [bin, ...args], {
+    env: { ...process.env, ...env },
+    encoding: 'utf8'
+  });
+  return out;
+}
+
+test('clawnsole workqueue assignments set/list prints expected json and normalizes queues', () => {
+  const home = tempHome();
+  const env = { OPENCLAW_HOME: path.join(home, '.openclaw') };
+
+  const setOut = run(['workqueue', 'assignments', 'set', '--agent', 'agent-1', '--queues', ' dev-team, ,qa  ,dev-team  '], env);
+  const setJson = JSON.parse(setOut);
+  assert.equal(setJson.ok, true);
+  assert.equal(setJson.agentId, 'agent-1');
+  assert.deepEqual(setJson.queues, ['dev-team', 'qa', 'dev-team']);
+
+  const listOut = run(['workqueue', 'assignments', 'list'], env);
+  const listJson = JSON.parse(listOut);
+  assert.equal(listJson.ok, true);
+  assert.deepEqual(listJson.assignments['agent-1'], ['dev-team', 'qa', 'dev-team']);
+});
+
+test('clawnsole workqueue assignments set requires non-empty queues', () => {
+  const home = tempHome();
+  const env = { OPENCLAW_HOME: path.join(home, '.openclaw') };
+
+  assert.throws(
+    () => run(['workqueue', 'assignments', 'set', '--agent', 'agent-1', '--queues', ' ,  '], env),
+    /assignments set requires --queues/
+  );
+});


### PR DESCRIPTION
Implements `clawnsole workqueue assignments list` and `... assignments set --agent --queues`.

- Persists assignments in workqueue state file (`assignments` map)
- Validates/normalizes queue CSV (trim + drop empties)
- Adds unit tests covering set/list + arg validation