### PR TITLE
Remove guest proxy/auth server support

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,7 +39,6 @@ function getRouteRole() {
   try {
     const path = window.location.pathname || '/';
     if (path === '/admin' || path.startsWith('/admin/')) return 'admin';
-    if (path === '/guest' || path.startsWith('/guest/')) return 'guest';
   } catch {}
   return null;
 }
@@ -315,9 +314,8 @@ function resolveWsUrl(raw) {
   return raw;
 }
 
-function computeGatewayTarget(kind) {
-  const key = kind === 'guest' ? 'guestWsUrl' : 'adminWsUrl';
-  const proxyUrl = uiState.meta && uiState.meta[key] ? uiState.meta[key] : '';
+function computeGatewayTarget(_kind) {
+  const proxyUrl = uiState.meta && uiState.meta.adminWsUrl ? uiState.meta.adminWsUrl : '';
   const usingProxy = Boolean(proxyUrl);
   const rawUrl = proxyUrl || globalElements.wsUrl.value.trim();
   return { url: resolveWsUrl(rawUrl), usingProxy };
@@ -468,7 +466,7 @@ function hideLogin() {
 }
 
 async function attemptLogin() {
-  const role = globalElements.loginRole.value === 'admin' ? 'admin' : 'guest';
+  const role = 'admin';
   const password = globalElements.loginPassword.value.trim();
   if (!password) {
     showLogin('Password required.');
@@ -486,9 +484,9 @@ async function attemptLogin() {
       return;
     }
     const data = await res.json();
-    const nextRole = data.role === 'admin' ? 'admin' : 'guest';
+    const nextRole = data.role === 'admin' ? 'admin' : 'admin';
     storage.set('clawnsole.auth.role', nextRole);
-    window.location.replace(nextRole === 'admin' ? '/admin' : '/guest');
+    window.location.replace('/admin');
   } catch {
     showLogin('Login failed. Please retry.');
   }
@@ -497,9 +495,8 @@ async function attemptLogin() {
 function openSettings() {
   globalElements.settingsModal.classList.add('open');
   globalElements.settingsModal.setAttribute('aria-hidden', 'false');
-  if (roleState.role === 'admin') {
-    loadGuestPrompt();
-  }
+  // guest prompt removed
+
 }
 
 function closeSettings() {
@@ -2328,7 +2325,8 @@ globalElements.settingsCloseBtn?.addEventListener('click', () => closeSettings()
 globalElements.settingsModal?.addEventListener('click', (event) => {
   if (event.target === globalElements.settingsModal) closeSettings();
 });
-globalElements.saveGuestPromptBtn?.addEventListener('click', () => saveGuestPrompt());
+// guest prompt removed
+
 
 globalElements.workqueueBtn?.addEventListener('click', () => openWorkqueue());
 globalElements.workqueueCloseBtn?.addEventListener('click', () => closeWorkqueue());

--- a/clawnsole-server.js
+++ b/clawnsole-server.js
@@ -100,20 +100,11 @@ function createClawnsoleServer(options = {}) {
       const raw = fs.readFileSync(clawnsoleConfigPath, 'utf8');
       const cfg = JSON.parse(raw);
       const adminPassword = cfg?.adminPassword || 'admin';
-      const guestPassword = cfg?.guestPassword || 'guest';
-      const guestAgentId = cfg?.guestAgentId || 'clawnsole-guest';
-      const guestPrompt =
-        cfg?.guestPrompt ||
-        'Guest mode: You are assisting a guest. Do not access or summarize private data (email, calendar, files). Do not assume identity; ask how you can help. You may assist with general questions and basic home automation.';
       const authVersion = cfg?.authVersion || '';
-      return { adminPassword, guestPassword, guestAgentId, guestPrompt, authVersion };
+      return { adminPassword, authVersion };
     } catch (err) {
       return {
         adminPassword: 'admin',
-        guestPassword: 'guest',
-        guestAgentId: 'clawnsole-guest',
-        guestPrompt:
-          'Guest mode: You are assisting a guest. Do not access or summarize private data (email, calendar, files). Do not assume identity; ask how you can help. You may assist with general questions and basic home automation.',
         authVersion: ''
       };
     }
@@ -166,16 +157,11 @@ function createClawnsoleServer(options = {}) {
   }
 
   function getRoleFromCookies(req) {
-    const { adminPassword, guestPassword, authVersion } = readUiPasswords();
-    if (!adminPassword && !guestPassword) return 'admin';
+    const { adminPassword, authVersion } = readUiPasswords();
+    if (!adminPassword) return 'admin';
     const cookie = getAuthCookie(req);
-    if (cookie) {
-      if (adminPassword && cookie === encodeAuthCookie(adminPassword, authVersion)) {
-        return 'admin';
-      }
-      if (guestPassword && cookie === encodeAuthCookie(guestPassword, authVersion)) {
-        return 'guest';
-      }
+    if (cookie && cookie === encodeAuthCookie(adminPassword, authVersion)) {
+      return 'admin';
     }
     return null;
   }
@@ -196,19 +182,12 @@ function createClawnsoleServer(options = {}) {
     res.end(JSON.stringify(body));
   }
 
-  let lastGuestSessionKey = null;
-
-  const { handleAdminProxy, handleGuestProxy } = createProxyHandlers({
+  const { handleAdminProxy } = createProxyHandlers({
     WebSocket: WebSocketImpl,
     getRoleFromCookies,
     readToken,
     gatewayWsUrl,
-    heartbeatMs: 2000,
-    getGuestPrompt: () => readUiPasswords().guestPrompt,
-    getGuestAgentId: () => readUiPasswords().guestAgentId,
-    onGuestSessionKey: (key) => {
-      lastGuestSessionKey = key;
-    }
+    heartbeatMs: 2000
   });
 
   const wss = new WebSocketImpl.Server({ noServer: true });
@@ -232,7 +211,6 @@ function createClawnsoleServer(options = {}) {
 
     if (req.url.startsWith('/meta')) {
       const wsUrl = gatewayWsUrl();
-      const { guestAgentId } = readUiPasswords();
       let gatewayPort = readGatewayPort();
       try {
         const parsed = new URL(wsUrl);
@@ -246,8 +224,6 @@ function createClawnsoleServer(options = {}) {
       sendJson(res, 200, {
         wsUrl,
         adminWsUrl: '/admin-ws',
-        guestWsUrl: '/guest-ws',
-        guestAgentId,
         port: gatewayPort
       });
       return;
@@ -309,55 +285,7 @@ function createClawnsoleServer(options = {}) {
       return;
     }
 
-    if (req.url.startsWith('/config/guest-prompt')) {
-      const role = getRoleFromCookies(req);
-      if (role !== 'admin') {
-        sendJson(res, 403, { error: 'forbidden' });
-        return;
-      }
-      if (req.method === 'GET') {
-        const { guestPrompt } = readUiPasswords();
-        sendJson(res, 200, { prompt: guestPrompt });
-        return;
-      }
-      if (req.method === 'POST') {
-        let body = '';
-        req.on('data', (chunk) => {
-          body += chunk.toString();
-        });
-        req.on('end', () => {
-          try {
-            const payload = JSON.parse(body || '{}');
-            const prompt = String(payload.prompt || '').trim();
-            if (prompt.length > 4000) {
-              sendJson(res, 400, { error: 'prompt_too_long' });
-              return;
-            }
-            writeClawnsoleConfig({ guestPrompt: prompt });
-            sendJson(res, 200, { ok: true });
-          } catch (err) {
-            sendJson(res, 400, { error: 'invalid_request' });
-          }
-        });
-        return;
-      }
-      sendJson(res, 405, { error: 'method_not_allowed' });
-      return;
-    }
-
-    if (req.url.startsWith('/diag/guest')) {
-      const role = getRoleFromCookies(req);
-      if (role !== 'admin') {
-        sendJson(res, 403, { error: 'forbidden' });
-        return;
-      }
-      const { guestAgentId } = readUiPasswords();
-      sendJson(res, 200, {
-        guestAgentId,
-        lastGuestSessionKey
-      });
-      return;
-    }
+    // Guest endpoints removed (admin-only server).
 
     // Admin-only workqueue API (for viewing from other devices).
     // NOTE: This is intentionally read-focused for MVP; mutation endpoints can be added later.
@@ -554,17 +482,15 @@ function createClawnsoleServer(options = {}) {
       req.on('end', () => {
         try {
           const payload = JSON.parse(body || '{}');
-          const role = payload.role === 'admin' ? 'admin' : 'guest';
+          const role = 'admin';
           const password = String(payload.password || '');
-          const { adminPassword, guestPassword, authVersion } = readUiPasswords();
-          const ok =
-            (role === 'admin' && password === adminPassword) ||
-            (role === 'guest' && password === guestPassword);
+          const { adminPassword, authVersion } = readUiPasswords();
+          const ok = password === adminPassword;
           if (!ok) {
             sendJson(res, 401, { error: 'invalid_credentials' });
             return;
           }
-          const token = encodeAuthCookie(role === 'admin' ? adminPassword : guestPassword, authVersion);
+          const token = encodeAuthCookie(adminPassword, authVersion);
           res.setHeader('Set-Cookie', [
             `${authCookieName}=${token}; Path=/; HttpOnly; SameSite=Lax`,
             `${roleCookieName}=${role}; Path=/; SameSite=Lax`
@@ -599,10 +525,13 @@ function createClawnsoleServer(options = {}) {
       return;
     }
 
-    const urlPath =
-      req.url === '/' || req.url === '/admin' || req.url === '/admin/' || req.url === '/guest' || req.url === '/guest/'
-        ? '/index.html'
-        : req.url;
+    if (req.url === '/guest' || req.url === '/guest/') {
+      res.writeHead(302, { Location: '/admin' });
+      res.end('Redirecting');
+      return;
+    }
+
+    const urlPath = req.url === '/' || req.url === '/admin' || req.url === '/admin/' ? '/index.html' : req.url;
     const filePath = path.join(root, decodeURIComponent(urlPath));
     if (!filePath.startsWith(root)) {
       res.writeHead(403);
@@ -635,10 +564,8 @@ function createClawnsoleServer(options = {}) {
           sendJson(res, 404, { error: 'token_not_found', mode });
           return;
         }
-        if (req.clawnsoleRole === 'guest') {
-          sendJson(res, 403, { error: 'forbidden' });
-          return;
-        }
+        // guest role removed
+
         sendJson(res, 200, { token, mode });
       } catch (err) {
         sendJson(res, 500, { error: 'token_read_failed', message: String(err) });
@@ -656,10 +583,8 @@ function createClawnsoleServer(options = {}) {
       wss.handleUpgrade(req, socket, head, (ws) => handleAdminProxy(ws, req));
       return;
     }
-    if (req.url === '/guest-ws') {
-      wss.handleUpgrade(req, socket, head, (ws) => handleGuestProxy(ws, req));
-      return;
-    }
+    // /guest-ws removed
+
     socket.destroy();
   });
 

--- a/proxy.js
+++ b/proxy.js
@@ -1,12 +1,3 @@
-const DEFAULT_GUEST_METHODS = new Set([
-  'connect',
-  'chat.send',
-  'chat.history',
-  'chat.abort',
-  'sessions.resolve',
-  'sessions.reset'
-]);
-
 function isLocalhostHost(hostname) {
   const host = String(hostname || '').trim().toLowerCase();
   return host === 'localhost' || host === '127.0.0.1' || host === '::1';
@@ -57,17 +48,7 @@ function resolveWsOrigin(wsUrl) {
   }
 }
 
-function createProxyHandlers({
-  WebSocket,
-  getRoleFromCookies,
-  readToken,
-  gatewayWsUrl,
-  guestAllowedMethods = DEFAULT_GUEST_METHODS,
-  heartbeatMs = 2000,
-  getGuestPrompt,
-  getGuestAgentId,
-  onGuestSessionKey
-}) {
+function createProxyHandlers({ WebSocket, getRoleFromCookies, readToken, gatewayWsUrl, heartbeatMs = 2000 }) {
   function handleAdminProxy(clientSocket, req) {
     const role = getRoleFromCookies(req);
     if (role !== 'admin') {
@@ -105,7 +86,12 @@ function createProxyHandlers({
 
     function normalizeAndSend(frame) {
       if (!frame || frame.type !== 'req') return;
-      if (frame.method === 'chat.send' || frame.method === 'chat.history' || frame.method === 'chat.abort' || frame.method === 'chat.inject') {
+      if (
+        frame.method === 'chat.send' ||
+        frame.method === 'chat.history' ||
+        frame.method === 'chat.abort' ||
+        frame.method === 'chat.inject'
+      ) {
         const key = frame.params?.sessionKey;
         if (typeof key === 'string' && key) adminState.sessionKey = key;
       }
@@ -189,186 +175,11 @@ function createProxyHandlers({
     });
   }
 
-  function handleGuestProxy(clientSocket, req) {
-    const role = getRoleFromCookies(req);
-    if (role !== 'guest') {
-      safeClose(clientSocket, 4401, 'unauthorized');
-      return;
-    }
-
-    const { token } = readToken();
-    const guestAgentId = typeof getGuestAgentId === 'function' ? getGuestAgentId() : 'main';
-    const upstreamUrl = gatewayWsUrl();
-    assertSecureWsUrl(upstreamUrl, { allowInsecure: process.env.CLAWNSOLE_ALLOW_INSECURE_TRANSPORT === '1' });
-    const upstream = new WebSocket(upstreamUrl, { headers: { Origin: resolveWsOrigin(upstreamUrl) } });
-    const pendingFrames = [];
-    const guestState = {
-      sessionKey: null,
-      connectId: null,
-      injected: false
-    };
-    let lastUpstreamAt = Date.now();
-    let recentCount = 0;
-    let closed = false;
-    const heartbeat = setInterval(() => {
-      const idleForMs = Date.now() - lastUpstreamAt;
-      const payload = {
-        type: 'event',
-        event: 'activity',
-        payload: {
-          ts: Date.now(),
-          idleForMs,
-          recentCount
-        }
-      };
-      recentCount = 0;
-      try {
-        clientSocket.send(JSON.stringify(payload));
-      } catch {}
-    }, heartbeatMs);
-
-    function normalizeAndSend(frame) {
-      if (!frame || frame.type !== 'req') return;
-      if (frame.method === 'connect') {
-        const instanceId = frame.params?.client?.instanceId;
-        const clientId = frame.params?.client?.id;
-        const suffix = instanceId || clientId || 'guest';
-        guestState.sessionKey = `agent:${guestAgentId || 'main'}:guest:${suffix}`;
-        guestState.connectId = frame.id;
-        if (typeof onGuestSessionKey === 'function') {
-          onGuestSessionKey(guestState.sessionKey);
-        }
-        frame.params = frame.params || {};
-        frame.params.auth = { token };
-        frame.params.scopes = ['operator.read', 'operator.write'];
-        frame.params.role = 'operator';
-      }
-      if (frame.method === 'chat.send' || frame.method === 'chat.history' || frame.method === 'chat.abort') {
-        frame.params = frame.params || {};
-        frame.params.sessionKey = guestState.sessionKey || frame.params.sessionKey;
-      }
-      if (frame.method === 'sessions.resolve' || frame.method === 'sessions.reset') {
-        frame.params = frame.params || {};
-        frame.params.key = guestState.sessionKey || frame.params.key;
-      }
-      try {
-        upstream.send(JSON.stringify(frame));
-      } catch {}
-    }
-
-    clientSocket.on('message', (data) => {
-      let frame;
-      try {
-        frame = JSON.parse(String(data));
-      } catch {
-        return;
-      }
-      if (frame?.type !== 'req') return;
-      if (!guestAllowedMethods.has(frame.method)) {
-        clientSocket.send(
-          JSON.stringify({
-            type: 'res',
-            id: frame.id || 'unknown',
-            ok: false,
-            error: { code: 'FORBIDDEN', message: 'guest role not allowed for this method' }
-          })
-        );
-        return;
-      }
-
-      if (upstream.readyState !== 1) {
-        pendingFrames.push(frame);
-        return;
-      }
-      normalizeAndSend(frame);
-    });
-
-    upstream.on('open', () => {
-      while (pendingFrames.length > 0) {
-        normalizeAndSend(pendingFrames.shift());
-      }
-    });
-
-    upstream.on('message', (data) => {
-      let frame;
-      try {
-        frame = JSON.parse(String(data));
-      } catch {
-        return;
-      }
-      lastUpstreamAt = Date.now();
-      recentCount += 1;
-      if (frame?.type === 'res' && frame.id === guestState.connectId && frame.ok && !guestState.injected) {
-        guestState.injected = true;
-        const guestPrompt =
-          typeof getGuestPrompt === 'function'
-            ? getGuestPrompt()
-            : 'Guest mode: read-only. Do not access or summarize emails or private data. Do not assume identity; ask how you can help.';
-        if (guestPrompt) {
-          upstream.send(
-            JSON.stringify({
-              type: 'req',
-              id: `guest-reset-${Date.now()}`,
-              method: 'sessions.reset',
-              params: {
-                key: guestState.sessionKey || 'agent:main:guest:default'
-              }
-            })
-          );
-          upstream.send(
-            JSON.stringify({
-              type: 'req',
-              id: `guest-prompt-${Date.now()}`,
-              method: 'chat.inject',
-              params: {
-                sessionKey: guestState.sessionKey || 'agent:main:guest:default',
-                message: guestPrompt,
-                label: 'Guest profile'
-              }
-            })
-          );
-        }
-      }
-      if (frame?.type === 'event') {
-        const eventName = String(frame.event || '');
-        const allowed = eventName === 'chat' || eventName.startsWith('connect.');
-        if (!allowed) {
-          return;
-        }
-
-        if (eventName === 'chat') {
-          const sessionKey = frame.payload?.sessionKey;
-          if (!sessionKey) {
-            return;
-          }
-          if (guestState.sessionKey && sessionKey !== guestState.sessionKey) {
-            return;
-          }
-        }
-      }
-      clientSocket.send(JSON.stringify(frame));
-    });
-
-    const closeBoth = (code, reason) => {
-      if (closed) return;
-      closed = true;
-      safeClose(upstream, code, reason);
-      safeClose(clientSocket, code, reason);
-      clearInterval(heartbeat);
-    };
-
-    clientSocket.on('close', closeBoth);
-    upstream.on('close', (code, reasonBuf) => closeBoth(code, reasonBuf ? reasonBuf.toString() : ''));
-    upstream.on('error', (err) => {
-      const message = err && err.code ? `${err.code} ${err.message || 'upstream error'}` : String(err || 'upstream error');
-      closeBoth(1013, message.slice(0, 180));
-    });
-  }
-
-  return { handleAdminProxy, handleGuestProxy };
+  return {
+    handleAdminProxy
+  };
 }
 
 module.exports = {
-  DEFAULT_GUEST_METHODS,
   createProxyHandlers
 };

--- a/scripts/proxy-self-test.js
+++ b/scripts/proxy-self-test.js
@@ -56,37 +56,6 @@ class FakeWebSocket extends EventEmitter {
   }
 }
 
-function parseLastJson(arr) {
-  const raw = arr[arr.length - 1];
-  return raw ? JSON.parse(raw) : null;
-}
-
-function findEvent(arr, eventName) {
-  return arr
-    .map((item) => {
-      try {
-        return JSON.parse(item);
-      } catch {
-        return null;
-      }
-    })
-    .filter(Boolean)
-    .find((msg) => msg.type === 'event' && msg.event === eventName);
-}
-
-function findChatRun(arr, runId) {
-  return arr
-    .map((item) => {
-      try {
-        return JSON.parse(item);
-      } catch {
-        return null;
-      }
-    })
-    .filter(Boolean)
-    .find((msg) => msg.type === 'event' && msg.event === 'chat' && msg.payload?.runId === runId);
-}
-
 function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -102,296 +71,50 @@ async function run() {
   const readToken = () => ({ token: tokenValue });
   const gatewayWsUrl = () => 'ws://gateway';
 
-  const { handleGuestProxy, handleAdminProxy } = createProxyHandlers({
+  const { handleAdminProxy } = createProxyHandlers({
     WebSocket: FakeWebSocket,
     getRoleFromCookies,
     readToken,
     gatewayWsUrl,
-    heartbeatMs: 25,
-    getGuestPrompt: () => 'guest prompt',
-    getGuestAgentId: () => 'clawnsole-guest'
+    heartbeatMs: 25
   });
 
-  const guestClient = new FakeSocket();
-  handleGuestProxy(guestClient, { role: 'guest' });
-  const guestUpstream = FakeWebSocket.instances[0];
-  if (!guestUpstream) {
-    throw new Error('guest upstream not created');
-  }
-  assert.equal(guestUpstream.options?.headers?.Origin, 'http://gateway');
+  // Unauthorized client should be closed immediately.
+  const badClient = new FakeSocket();
+  handleAdminProxy(badClient, { role: null });
+  assert.equal(badClient.closed, true);
 
-  // Forbidden methods should be rejected even before the upstream connects.
-  guestClient.emit(
-    'message',
-    JSON.stringify({
-      type: 'req',
-      id: 'forbidden-1',
-      method: 'tools.run',
-      params: {}
-    })
-  );
-  const forbidden = parseLastJson(guestClient.sent);
-  assert.equal(forbidden.ok, false);
-  assert.equal(forbidden.error.code, 'FORBIDDEN');
-
-  // Buffer messages until upstream is open (startup reliability).
-  guestClient.emit(
-    'message',
-    JSON.stringify({
-      type: 'req',
-      id: 'connect-1',
-      method: 'connect',
-      params: { client: { id: 'test', instanceId: 'device-1' } }
-    })
-  );
-  guestClient.emit(
-    'message',
-    JSON.stringify({
-      type: 'req',
-      id: 'chat-1',
-      method: 'chat.send',
-      params: { sessionKey: 'override-me', message: 'hi' }
-    })
-  );
-
-  assert.equal(guestUpstream.sent.length, 0, 'should buffer frames until upstream open');
-  guestUpstream.open();
-
-  const guestConnect = JSON.parse(guestUpstream.sent[0]);
-  assert.equal(guestConnect.params.auth.token, tokenValue);
-  assert.ok(guestConnect.params.scopes.includes('operator.write'));
-  assert.equal(guestConnect.params.role, 'operator');
-
-  const guestChat = JSON.parse(guestUpstream.sent[1]);
-  assert.equal(guestChat.params.sessionKey, 'agent:clawnsole-guest:guest:device-1');
-
-  guestUpstream.emit(
-    'message',
-    JSON.stringify({ type: 'event', event: 'connect.challenge', payload: { foo: 'bar' } })
-  );
-  const forwarded = parseLastJson(guestClient.sent);
-  assert.equal(forwarded.event, 'connect.challenge');
-
-  // Guest should not see chat events for other sessions.
-  guestUpstream.emit(
-    'message',
-    JSON.stringify({
-      type: 'event',
-      event: 'chat',
-      payload: {
-        runId: 'run-wrong-session',
-        sessionKey: 'agent:main:admin:device-1',
-        seq: 0,
-        state: 'final',
-        message: { content: [{ text: 'nope' }] }
-      }
-    })
-  );
-  assert.equal(findChatRun(guestClient.sent, 'run-wrong-session'), undefined);
-
-  guestUpstream.emit(
-    'message',
-    JSON.stringify({
-      type: 'event',
-      event: 'chat',
-      payload: {
-        runId: 'run-right-session',
-        sessionKey: 'agent:clawnsole-guest:guest:device-1',
-        seq: 0,
-        state: 'final',
-        message: { content: [{ text: 'ok' }] }
-      }
-    })
-  );
-  assert.ok(findChatRun(guestClient.sent, 'run-right-session'));
-
-  // Non-chat, non-connect.* events should be filtered from guest.
-  guestUpstream.emit('message', JSON.stringify({ type: 'event', event: 'presence', payload: { any: 'data' } }));
-  assert.equal(findEvent(guestClient.sent, 'presence'), undefined);
-
-  guestUpstream.emit('message', JSON.stringify({ type: 'res', id: 'connect-1', ok: true, payload: {} }));
-  const reset = JSON.parse(guestUpstream.sent[2]);
-  const injected = JSON.parse(guestUpstream.sent[3]);
-  assert.equal(reset.method, 'sessions.reset');
-  assert.equal(reset.params.key, 'agent:clawnsole-guest:guest:device-1');
-  assert.equal(injected.method, 'chat.inject');
-  assert.equal(injected.params.sessionKey, 'agent:clawnsole-guest:guest:device-1');
-  assert.equal(injected.params.message, 'guest prompt');
-
-  // Injection should only happen once per connect.
-  guestUpstream.emit('message', JSON.stringify({ type: 'res', id: 'connect-1', ok: true, payload: {} }));
-  assert.equal(guestUpstream.sent.length, 4);
-
-  // Guest clients cannot call chat.inject themselves.
-  guestClient.emit(
-    'message',
-    JSON.stringify({
-      type: 'req',
-      id: 'forbidden-inject-1',
-      method: 'chat.inject',
-      params: { sessionKey: 'override-me', message: 'nope' }
-    })
-  );
-  const forbiddenInject = parseLastJson(guestClient.sent);
-  assert.equal(forbiddenInject.ok, false);
-  assert.equal(forbiddenInject.error.code, 'FORBIDDEN');
-
-  await delay(40);
-  const activity = guestClient.sent.map((item) => JSON.parse(item)).find((msg) => msg.event === 'activity');
-  assert.ok(activity, 'activity event not emitted');
-
+  // Admin proxy should connect upstream and buffer until open.
   const adminClient = new FakeSocket();
   handleAdminProxy(adminClient, { role: 'admin' });
-  const adminUpstream = FakeWebSocket.instances[1];
-  if (!adminUpstream) {
-    throw new Error('admin upstream not created');
-  }
-  assert.equal(adminUpstream.options?.headers?.Origin, 'http://gateway');
+  const upstream = FakeWebSocket.instances[0];
+  assert.ok(upstream, 'admin upstream not created');
+  assert.equal(upstream.options?.headers?.Origin, 'http://gateway');
+
+  // Buffer connect request until upstream is open.
   adminClient.emit(
     'message',
-    JSON.stringify({
-      type: 'req',
-      id: 'connect-2',
-      method: 'connect',
-      params: { client: { id: 'test-admin' } }
-    })
+    JSON.stringify({ type: 'req', id: 'connect-1', method: 'connect', params: { client: { id: 'device-1' } } })
   );
-  assert.equal(adminUpstream.sent.length, 0, 'should buffer admin frames until upstream open');
-  adminUpstream.open();
-  const adminConnect = JSON.parse(adminUpstream.sent[0]);
-  assert.equal(adminConnect.params.auth.token, tokenValue);
+  assert.equal(upstream.sent.length, 0);
 
-  // Admin should only see chat events for its active session (derived from connect).
-  adminUpstream.emit(
-    'message',
-    JSON.stringify({
-      type: 'event',
-      event: 'chat',
-      payload: {
-        runId: 'run-admin-wrong-session',
-        sessionKey: 'agent:clawnsole-guest:guest:device-1',
-        seq: 0,
-        state: 'final',
-        message: { content: [{ text: 'nope' }] }
-      }
-    })
-  );
-  assert.equal(findChatRun(adminClient.sent, 'run-admin-wrong-session'), undefined);
+  upstream.open();
+  assert.equal(upstream.sent.length, 1);
+  const connect = JSON.parse(upstream.sent[0]);
+  assert.equal(connect.method, 'connect');
+  assert.equal(connect.params.auth.token, tokenValue);
+  assert.ok(connect.params.scopes.includes('operator.write'));
 
-  adminUpstream.emit(
-    'message',
-    JSON.stringify({
-      type: 'event',
-      event: 'chat',
-      payload: {
-        runId: 'run-admin-right-session',
-        sessionKey: 'agent:main:admin:test-admin',
-        seq: 0,
-        state: 'final',
-        message: { content: [{ text: 'ok' }] }
-      }
-    })
-  );
-  assert.ok(findChatRun(adminClient.sent, 'run-admin-right-session'));
+  // Heartbeat should emit activity events.
+  await delay(30);
+  const activity = adminClient.sent.map((raw) => JSON.parse(raw)).find((msg) => msg.type === 'event' && msg.event === 'activity');
+  assert.ok(activity);
 
-  // Multiple admin clients must not see each other's chat events, even if the gateway broadcasts.
-  const adminMultiA = new FakeSocket();
-  handleAdminProxy(adminMultiA, { role: 'admin' });
-  const upstreamMultiA = FakeWebSocket.instances[2];
-  assert.ok(upstreamMultiA, 'admin multi upstream A not created');
-  upstreamMultiA.open();
-
-  const adminMultiB = new FakeSocket();
-  handleAdminProxy(adminMultiB, { role: 'admin' });
-  const upstreamMultiB = FakeWebSocket.instances[3];
-  assert.ok(upstreamMultiB, 'admin multi upstream B not created');
-  upstreamMultiB.open();
-
-  adminMultiA.emit(
-    'message',
-    JSON.stringify({
-      type: 'req',
-      id: 'multi-connect-a',
-      method: 'connect',
-      params: { client: { id: 'multi-a', instanceId: 'shared-device' } }
-    })
-  );
-  adminMultiB.emit(
-    'message',
-    JSON.stringify({
-      type: 'req',
-      id: 'multi-connect-b',
-      method: 'connect',
-      params: { client: { id: 'multi-b', instanceId: 'shared-device' } }
-    })
-  );
-
-  adminMultiA.emit(
-    'message',
-    JSON.stringify({
-      type: 'req',
-      id: 'multi-resolve-a',
-      method: 'sessions.resolve',
-      params: { key: 'agent:main:admin:shared-device-pane-a' }
-    })
-  );
-  adminMultiB.emit(
-    'message',
-    JSON.stringify({
-      type: 'req',
-      id: 'multi-resolve-b',
-      method: 'sessions.resolve',
-      params: { key: 'agent:main:admin:shared-device-pane-b' }
-    })
-  );
-
-  const broadcastA = {
-    type: 'event',
-    event: 'chat',
-    payload: {
-      runId: 'run-multi-a',
-      sessionKey: 'agent:main:admin:shared-device-pane-a',
-      seq: 0,
-      state: 'final',
-      message: { content: [{ text: 'a' }] }
-    }
-  };
-  upstreamMultiA.emit('message', JSON.stringify(broadcastA));
-  upstreamMultiB.emit('message', JSON.stringify(broadcastA));
-  assert.ok(findChatRun(adminMultiA.sent, 'run-multi-a'));
-  assert.equal(findChatRun(adminMultiB.sent, 'run-multi-a'), undefined);
-
-  const broadcastB = {
-    type: 'event',
-    event: 'chat',
-    payload: {
-      runId: 'run-multi-b',
-      sessionKey: 'agent:main:admin:shared-device-pane-b',
-      seq: 0,
-      state: 'final',
-      message: { content: [{ text: 'b' }] }
-    }
-  };
-  upstreamMultiA.emit('message', JSON.stringify(broadcastB));
-  upstreamMultiB.emit('message', JSON.stringify(broadcastB));
-  assert.ok(findChatRun(adminMultiB.sent, 'run-multi-b'));
-  assert.equal(findChatRun(adminMultiA.sent, 'run-multi-b'), undefined);
-
-  guestClient.close();
-  guestUpstream.close();
-  adminClient.close();
-  adminUpstream.close();
-  adminMultiA.close();
-  upstreamMultiA.close();
-  adminMultiB.close();
-  upstreamMultiB.close();
-  console.log('proxy-self-test: ok');
   clearTimeout(hardTimeout);
-  process.exit(0);
+  console.log('proxy-self-test: ok');
 }
 
 run().catch((err) => {
-  console.error('proxy-self-test: failed');
-  console.error(err);
+  console.error('proxy-self-test: failed', err);
   process.exit(1);
 });


### PR DESCRIPTION
Closes #8.

- Removed guest role cookies/logic and guest WS proxy endpoint.
- /meta now only returns adminWsUrl.
- /guest now redirects to /admin.
- Updated proxy self-test + unit tests + verify-login script.