### PR TITLE
Unit tests for workqueue mutation endpoints

### DIFF
--- a/clawnsole-server.js
+++ b/clawnsole-server.js
@@ -159,9 +159,13 @@ function createClawnsoleServer(options = {}) {
   function getRoleFromCookies(req) {
     const { adminPassword, authVersion } = readUiPasswords();
     if (!adminPassword) return 'admin';
+
     const cookie = getAuthCookie(req);
     if (cookie && cookie === encodeAuthCookie(adminPassword, authVersion)) {
-      return 'admin';
+      // Role is stored separately so we can support different permission levels.
+      // Default to admin for backward compatibility.
+      const role = String(getRoleCookie(req) || 'admin').trim() || 'admin';
+      return role;
     }
     return null;
   }
@@ -417,6 +421,133 @@ function createClawnsoleServer(options = {}) {
       } catch (err) {
         sendJson(res, 500, { error: 'workqueue_error' });
       }
+      return;
+    }
+
+    // Admin-only workqueue mutation API.
+    if (req.url === '/api/workqueue/enqueue') {
+      if (!requireAuth(req, res)) return;
+      if (req.clawnsoleRole !== 'admin') {
+        sendJson(res, 403, { error: 'forbidden' });
+        return;
+      }
+      if (req.method !== 'POST') {
+        sendJson(res, 405, { error: 'method_not_allowed' });
+        return;
+      }
+      let body = '';
+      req.on('data', (chunk) => (body += chunk.toString()));
+      req.on('end', () => {
+        try {
+          const payload = JSON.parse(body || '{}');
+          const queue = String(payload.queue || '').trim();
+          if (!queue) {
+            sendJson(res, 400, { error: 'invalid_request' });
+            return;
+          }
+          const title = String(payload.title || '').trim();
+          const instructions = String(payload.instructions || '').trim();
+          const priority = Number(payload.priority);
+          const dedupeKey = String(payload.dedupeKey || '').trim();
+
+          const { enqueueItem } = require('./lib/workqueue');
+          const item = enqueueItem(null, {
+            queue,
+            title,
+            instructions,
+            priority: Number.isFinite(priority) ? priority : 0,
+            dedupeKey: dedupeKey || undefined
+          });
+          sendJson(res, 200, { ok: true, item });
+        } catch {
+          sendJson(res, 400, { error: 'invalid_request' });
+        }
+      });
+      return;
+    }
+
+    if (req.url === '/api/workqueue/claim-next') {
+      if (!requireAuth(req, res)) return;
+      if (req.clawnsoleRole !== 'admin') {
+        sendJson(res, 403, { error: 'forbidden' });
+        return;
+      }
+      if (req.method !== 'POST') {
+        sendJson(res, 405, { error: 'method_not_allowed' });
+        return;
+      }
+      let body = '';
+      req.on('data', (chunk) => (body += chunk.toString()));
+      req.on('end', () => {
+        try {
+          const payload = JSON.parse(body || '{}');
+          const agentId = String(payload.agentId || '').trim();
+          const queues = Array.isArray(payload.queues)
+            ? payload.queues.map((q) => String(q).trim()).filter(Boolean)
+            : [];
+          const leaseMs = payload.leaseMs;
+          if (!agentId || !queues.length) {
+            sendJson(res, 400, { error: 'invalid_request' });
+            return;
+          }
+          const { claimNext } = require('./lib/workqueue');
+          const item = claimNext(null, { agentId, queues, leaseMs });
+          sendJson(res, 200, { ok: true, item });
+        } catch {
+          sendJson(res, 400, { error: 'invalid_request' });
+        }
+      });
+      return;
+    }
+
+    if (req.url === '/api/workqueue/transition') {
+      if (!requireAuth(req, res)) return;
+      if (req.clawnsoleRole !== 'admin') {
+        sendJson(res, 403, { error: 'forbidden' });
+        return;
+      }
+      if (req.method !== 'POST') {
+        sendJson(res, 405, { error: 'method_not_allowed' });
+        return;
+      }
+      let body = '';
+      req.on('data', (chunk) => (body += chunk.toString()));
+      req.on('end', () => {
+        try {
+          const payload = JSON.parse(body || '{}');
+          const itemId = String(payload.itemId || '').trim();
+          const agentId = String(payload.agentId || '').trim();
+          const status = String(payload.status || '').trim();
+          const note = payload.note;
+          const error = payload.error;
+          const result = payload.result;
+          const leaseMs = payload.leaseMs;
+
+          const allowed = new Set(['ready', 'pending', 'claimed', 'in_progress', 'done', 'failed']);
+          if (!itemId || !agentId || !allowed.has(status)) {
+            sendJson(res, 400, { error: 'invalid_request' });
+            return;
+          }
+
+          const { transitionItem } = require('./lib/workqueue');
+          try {
+            const item = transitionItem(null, { itemId, agentId, status, note, error, result, leaseMs });
+            sendJson(res, 200, { ok: true, item });
+          } catch (err) {
+            if (err && err.code === 'NOT_FOUND') {
+              sendJson(res, 404, { error: 'not_found' });
+              return;
+            }
+            if (err && (err.code === 'NOT_CLAIMED' || err.code === 'CLAIMED_BY_OTHER')) {
+              sendJson(res, 409, { error: 'conflict', code: err.code });
+              return;
+            }
+            sendJson(res, 500, { error: 'workqueue_error' });
+          }
+        } catch {
+          sendJson(res, 400, { error: 'invalid_request' });
+        }
+      });
       return;
     }
 

--- a/tests/unit/workqueue-api.test.js
+++ b/tests/unit/workqueue-api.test.js
@@ -17,6 +17,11 @@ function mkTempEnv() {
   return { dir, openclawHome };
 }
 
+function adminCookie({ password = 'admin', authVersion = 'test', role = 'admin' } = {}) {
+  const auth = Buffer.from(`${password}::${authVersion}`, 'utf8').toString('base64');
+  return `clawnsole_auth=${auth}; clawnsole_role=${role}`;
+}
+
 function httpGetJson(url, headers = {}) {
   return new Promise((resolve, reject) => {
     const req = http.request(url, { method: 'GET', headers }, (res) => {
@@ -31,6 +36,37 @@ function httpGetJson(url, headers = {}) {
       });
     });
     req.on('error', reject);
+    req.end();
+  });
+}
+
+function httpPostJson(url, payload, headers = {}) {
+  return new Promise((resolve, reject) => {
+    const body = JSON.stringify(payload ?? {});
+    const req = http.request(
+      url,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8',
+          'Content-Length': Buffer.byteLength(body),
+          ...headers
+        }
+      },
+      (res) => {
+        let data = '';
+        res.on('data', (chunk) => (data += chunk.toString()));
+        res.on('end', () => {
+          let parsed = null;
+          try {
+            parsed = JSON.parse(data);
+          } catch {}
+          resolve({ status: res.statusCode, json: parsed, raw: data });
+        });
+      }
+    );
+    req.on('error', reject);
+    req.write(body);
     req.end();
   });
 }
@@ -71,9 +107,8 @@ test('workqueue API: lists items for admin cookie', async () => {
 
   const { server, port } = await startServer({ openclawHome });
   try {
-    const cookie = Buffer.from('admin::test', 'utf8').toString('base64');
     const res = await httpGetJson(`http://127.0.0.1:${port}/api/workqueue/items?queue=dev-team`, {
-      Cookie: `clawnsole_auth=${cookie}; clawnsole_role=admin`
+      Cookie: adminCookie()
     });
     assert.equal(res.status, 200);
     assert.equal(res.json?.ok, true);
@@ -89,8 +124,8 @@ test('workqueue API: summary returns counts + active list', async () => {
   fs.mkdirSync(openclawHome, { recursive: true });
   fs.writeFileSync(path.join(openclawHome, 'clawnsole.json'), JSON.stringify({ adminPassword: 'admin', authVersion: 'test' }));
 
-  const a = enqueueItem(null, { queue: 'dev-team', title: 't1', instructions: 'do1', priority: 1 });
-  const b = enqueueItem(null, { queue: 'dev-team', title: 't2', instructions: 'do2', priority: 2 });
+  enqueueItem(null, { queue: 'dev-team', title: 't1', instructions: 'do1', priority: 1 });
+  enqueueItem(null, { queue: 'dev-team', title: 't2', instructions: 'do2', priority: 2 });
 
   // Claim one item to make it active.
   const { claimNext } = require('../../lib/workqueue');
@@ -98,15 +133,151 @@ test('workqueue API: summary returns counts + active list', async () => {
 
   const { server, port } = await startServer();
   try {
-    const cookie = Buffer.from('admin::test', 'utf8').toString('base64');
     const res = await httpGetJson(`http://127.0.0.1:${port}/api/workqueue/summary?queue=dev-team`, {
-      Cookie: `clawnsole_auth=${cookie}; clawnsole_role=admin`
+      Cookie: adminCookie()
     });
     assert.equal(res.status, 200);
     assert.equal(res.json?.ok, true);
     assert.ok(res.json?.counts);
     assert.ok(Array.isArray(res.json?.active));
     assert.ok(res.json.active.length >= 1);
+  } finally {
+    server.close();
+  }
+});
+
+test('workqueue API mutations: enqueue requires auth', async () => {
+  const { openclawHome } = mkTempEnv();
+  fs.mkdirSync(openclawHome, { recursive: true });
+  fs.writeFileSync(path.join(openclawHome, 'clawnsole.json'), JSON.stringify({ adminPassword: 'admin', authVersion: 'test' }));
+
+  const { server, port } = await startServer({ openclawHome });
+  try {
+    const res = await httpPostJson(`http://127.0.0.1:${port}/api/workqueue/enqueue`, {
+      queue: 'dev-team',
+      title: 't',
+      instructions: 'do',
+      priority: 1
+    });
+    assert.equal(res.status, 401);
+    assert.equal(res.json?.error, 'unauthorized');
+  } finally {
+    server.close();
+  }
+});
+
+test('workqueue API mutations: forbidden when role is not admin', async () => {
+  const { openclawHome } = mkTempEnv();
+  fs.mkdirSync(openclawHome, { recursive: true });
+  fs.writeFileSync(path.join(openclawHome, 'clawnsole.json'), JSON.stringify({ adminPassword: 'admin', authVersion: 'test' }));
+
+  const { server, port } = await startServer({ openclawHome });
+  try {
+    const res = await httpPostJson(
+      `http://127.0.0.1:${port}/api/workqueue/enqueue`,
+      { queue: 'dev-team', title: 't', instructions: 'do', priority: 1 },
+      { Cookie: adminCookie({ role: 'user' }) }
+    );
+    assert.equal(res.status, 403);
+    assert.equal(res.json?.error, 'forbidden');
+  } finally {
+    server.close();
+  }
+});
+
+test('workqueue API mutations: happy path enqueue → claim-next → in_progress → done/failed', async () => {
+  const { openclawHome } = mkTempEnv();
+  fs.mkdirSync(openclawHome, { recursive: true });
+  fs.writeFileSync(path.join(openclawHome, 'clawnsole.json'), JSON.stringify({ adminPassword: 'admin', authVersion: 'test' }));
+
+  const { server, port } = await startServer({ openclawHome });
+  try {
+    const cookie = { Cookie: adminCookie() };
+
+    const enq = await httpPostJson(
+      `http://127.0.0.1:${port}/api/workqueue/enqueue`,
+      { queue: 'dev-team', title: 't1', instructions: 'do1', priority: 5 },
+      cookie
+    );
+    assert.equal(enq.status, 200);
+    assert.equal(enq.json?.ok, true);
+    assert.ok(enq.json?.item?.id);
+
+    const claim = await httpPostJson(
+      `http://127.0.0.1:${port}/api/workqueue/claim-next`,
+      { agentId: 'agent-1', queues: ['dev-team'], leaseMs: 60_000 },
+      cookie
+    );
+    assert.equal(claim.status, 200);
+    assert.equal(claim.json?.ok, true);
+    assert.equal(claim.json?.item?.claimedBy, 'agent-1');
+
+    const prog = await httpPostJson(
+      `http://127.0.0.1:${port}/api/workqueue/transition`,
+      { itemId: claim.json.item.id, agentId: 'agent-1', status: 'in_progress', note: 'started', leaseMs: 60_000 },
+      cookie
+    );
+    assert.equal(prog.status, 200);
+    assert.equal(prog.json?.ok, true);
+    assert.equal(prog.json?.item?.status, 'in_progress');
+
+    const done = await httpPostJson(
+      `http://127.0.0.1:${port}/api/workqueue/transition`,
+      { itemId: claim.json.item.id, agentId: 'agent-1', status: 'done', result: { ok: true } },
+      cookie
+    );
+    assert.equal(done.status, 200);
+    assert.equal(done.json?.ok, true);
+    assert.equal(done.json?.item?.status, 'done');
+
+    const enq2 = await httpPostJson(
+      `http://127.0.0.1:${port}/api/workqueue/enqueue`,
+      { queue: 'dev-team', title: 't2', instructions: 'do2', priority: 1 },
+      cookie
+    );
+    const claim2 = await httpPostJson(
+      `http://127.0.0.1:${port}/api/workqueue/claim-next`,
+      { agentId: 'agent-2', queues: ['dev-team'], leaseMs: 60_000 },
+      cookie
+    );
+    const fail = await httpPostJson(
+      `http://127.0.0.1:${port}/api/workqueue/transition`,
+      { itemId: claim2.json.item.id, agentId: 'agent-2', status: 'failed', error: 'nope' },
+      cookie
+    );
+    assert.equal(fail.status, 200);
+    assert.equal(fail.json?.ok, true);
+    assert.equal(fail.json?.item?.status, 'failed');
+    assert.equal(fail.json?.item?.lastError, 'nope');
+  } finally {
+    server.close();
+  }
+});
+
+test('workqueue API mutations: input validation', async () => {
+  const { openclawHome } = mkTempEnv();
+  fs.mkdirSync(openclawHome, { recursive: true });
+  fs.writeFileSync(path.join(openclawHome, 'clawnsole.json'), JSON.stringify({ adminPassword: 'admin', authVersion: 'test' }));
+
+  const { server, port } = await startServer({ openclawHome });
+  try {
+    const cookie = { Cookie: adminCookie() };
+
+    const badEnq = await httpPostJson(`http://127.0.0.1:${port}/api/workqueue/enqueue`, { title: 'x' }, cookie);
+    assert.equal(badEnq.status, 400);
+    assert.equal(badEnq.json?.error, 'invalid_request');
+
+    const badClaim = await httpPostJson(`http://127.0.0.1:${port}/api/workqueue/claim-next`, { queues: ['dev-team'] }, cookie);
+    assert.equal(badClaim.status, 400);
+    assert.equal(badClaim.json?.error, 'invalid_request');
+
+    const badTransition = await httpPostJson(
+      `http://127.0.0.1:${port}/api/workqueue/transition`,
+      { itemId: 'x', agentId: 'a', status: 'nope' },
+      cookie
+    );
+    assert.equal(badTransition.status, 400);
+    assert.equal(badTransition.json?.error, 'invalid_request');
   } finally {
     server.close();
   }


### PR DESCRIPTION
Adds admin-only workqueue mutation endpoints (enqueue/claim-next/transition) and unit tests covering auth, forbidden role, happy path, and validation.