### PR TITLE
[clawnsole #24c] claim-next: infer queues from assignments

### DIFF
--- a/lib/workqueue.js
+++ b/lib/workqueue.js
@@ -291,6 +291,33 @@ function setAssignments(rootDir, { agentId, queues }) {
   });
 }
 
+function resolveClaimQueues(rootDir, { agentId, requestedQueues, defaultQueues } = {}) {
+  const agent = String(agentId || '').trim();
+  if (!agent) throw new Error('agentId required');
+
+  const req = Array.isArray(requestedQueues) ? requestedQueues : [];
+  const normalizedReq = req.map((s) => String(s).trim()).filter(Boolean);
+  if (normalizedReq.length) {
+    return { queues: normalizedReq, source: 'requested' };
+  }
+
+  const state = loadState(rootDir);
+  const assignments = state.assignments && typeof state.assignments === 'object' ? state.assignments : {};
+  const assigned = Array.isArray(assignments[agent]) ? assignments[agent] : [];
+  const normalizedAssigned = assigned.map((s) => String(s).trim()).filter(Boolean);
+  if (normalizedAssigned.length) {
+    return { queues: normalizedAssigned, source: 'assignment' };
+  }
+
+  const def = Array.isArray(defaultQueues) ? defaultQueues : [];
+  const normalizedDef = def.map((s) => String(s).trim()).filter(Boolean);
+  if (normalizedDef.length) {
+    return { queues: normalizedDef, source: 'default' };
+  }
+
+  return { queues: [], reason: 'NO_QUEUES' };
+}
+
 function transitionItem(rootDir, { itemId, agentId, status, error, result, note, leaseMs }) {
   const { lockFile } = statePaths(rootDir);
   const id = String(itemId || '').trim();
@@ -369,6 +396,7 @@ module.exports = {
   transitionItem,
   listAssignments,
   setAssignments,
+  resolveClaimQueues,
   // exported for tests
   findItemByDedupeKey
 };

--- a/tests/unit/clawnsole-cli-claim-next.test.js
+++ b/tests/unit/clawnsole-cli-claim-next.test.js
@@ -1,0 +1,51 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+function tempHome() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'clawnsole-cli-'));
+}
+
+function run(args, env = {}) {
+  const bin = path.join(__dirname, '..', '..', 'bin', 'clawnsole.js');
+  const out = execFileSync('node', [bin, ...args], {
+    env: { ...process.env, ...env },
+    encoding: 'utf8'
+  });
+  return out;
+}
+
+test('clawnsole workqueue claim-next: when --queues omitted uses assignments for agent', () => {
+  const home = tempHome();
+  const env = { OPENCLAW_HOME: path.join(home, '.openclaw') };
+
+  // Create two items in different queues.
+  run(['workqueue', 'enqueue', '--queue', 'dev-team', '--title', 'a', '--instructions', 'x', '--priority', '0'], env);
+  run(['workqueue', 'enqueue', '--queue', 'qa', '--title', 'b', '--instructions', 'y', '--priority', '5'], env);
+
+  // Assign agent to only qa.
+  run(['workqueue', 'assignments', 'set', '--agent', 'agent-1', '--queues', 'qa'], env);
+
+  const claimOut = run(['workqueue', 'claim-next', '--agent', 'agent-1'], env);
+  const claimJson = JSON.parse(claimOut);
+  assert.equal(claimJson.ok, true);
+  assert.ok(claimJson.item);
+  assert.equal(claimJson.item.queue, 'qa');
+});
+
+test("clawnsole workqueue claim-next: returns {ok:true,item:null,reason:'NO_QUEUES'} when no queues resolve", () => {
+  const home = tempHome();
+  const env = {
+    OPENCLAW_HOME: path.join(home, '.openclaw'),
+    CLAWNSOLE_DEFAULT_QUEUES: ''
+  };
+
+  const claimOut = run(['workqueue', 'claim-next', '--agent', 'agent-1'], env);
+  const claimJson = JSON.parse(claimOut);
+  assert.equal(claimJson.ok, true);
+  assert.equal(claimJson.item, null);
+  assert.equal(claimJson.reason, 'NO_QUEUES');
+});

--- a/tests/unit/workqueue-resolve-claim-queues.test.js
+++ b/tests/unit/workqueue-resolve-claim-queues.test.js
@@ -1,0 +1,59 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { saveState, loadState, resolveClaimQueues } = require('../../lib/workqueue');
+
+function tempRoot() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'clawnsole-wq-resolve-'));
+}
+
+test('resolveClaimQueues: prefers explicitly-requested queues', () => {
+  const root = tempRoot();
+  const resolved = resolveClaimQueues(root, {
+    agentId: 'agent-1',
+    requestedQueues: [' qa ', '', 'dev-team'],
+    defaultQueues: ['dev-team']
+  });
+  assert.deepEqual(resolved.queues, ['qa', 'dev-team']);
+  assert.equal(resolved.source, 'requested');
+});
+
+test('resolveClaimQueues: uses assignments when queues omitted', () => {
+  const root = tempRoot();
+  const state = loadState(root);
+  state.assignments = { 'agent-1': ['dev-team', 'qa'] };
+  saveState(root, state);
+
+  const resolved = resolveClaimQueues(root, {
+    agentId: 'agent-1',
+    requestedQueues: [],
+    defaultQueues: ['dev-team']
+  });
+  assert.deepEqual(resolved.queues, ['dev-team', 'qa']);
+  assert.equal(resolved.source, 'assignment');
+});
+
+test('resolveClaimQueues: falls back to defaults when no assignment', () => {
+  const root = tempRoot();
+  const resolved = resolveClaimQueues(root, {
+    agentId: 'agent-1',
+    requestedQueues: [],
+    defaultQueues: ['dev-team']
+  });
+  assert.deepEqual(resolved.queues, ['dev-team']);
+  assert.equal(resolved.source, 'default');
+});
+
+test('resolveClaimQueues: returns NO_QUEUES when nothing resolves', () => {
+  const root = tempRoot();
+  const resolved = resolveClaimQueues(root, {
+    agentId: 'agent-1',
+    requestedQueues: [],
+    defaultQueues: []
+  });
+  assert.deepEqual(resolved.queues, []);
+  assert.equal(resolved.reason, 'NO_QUEUES');
+});


### PR DESCRIPTION
Fixes #24.

Implements optional --queues for `clawnsole workqueue claim-next`.

Behavior:
- If --queues provided: use it.
- If omitted: use assignments for --agent.
- Fallback: CLAWNSOLE_DEFAULT_QUEUES (defaults to "dev-team").
- If still empty: returns {ok:true,item:null,reason:"NO_QUEUES"}.

Adds unit tests for resolve + CLI claim-next selection.