### PR TITLE
[#22c] Workqueue pane: fetch + minimal renderer (debug hook)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1012,6 +1012,38 @@ button.send-btn .btn-icon {
   overflow-wrap: anywhere;
 }
 
+/* Minimal workqueue pane renderer (Issue #22c) */
+.wq-counts {
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: 6px 10px;
+  margin: 8px 0 0;
+}
+
+.wq-counts dt {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.wq-counts dd {
+  margin: 0;
+  font-size: 12px;
+}
+
+.wq-simple-list {
+  list-style: none;
+  padding: 0;
+  margin: 8px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.wq-simple-list .meta {
+  font-size: 12px;
+  color: var(--muted);
+}
+
 
 .chat-thread {
   display: flex;


### PR DESCRIPTION
Implements minimal standalone renderer per #22c.

- Adds fetchWorkqueueSummary + fetchWorkqueueItems client helpers
- Adds renderWorkqueuePane(rootEl, {queue}) + window.__debug.renderWorkqueuePane hook
- Simple counts + active + ready/pending lists; scrollable + basic headings

Tests: npm test