### PR TITLE
Fix #69: remove redundant admin role label in navbar

### DIFF
--- a/app.js
+++ b/app.js
@@ -422,7 +422,9 @@ function setAuthState(authed) {
 function setRole(role) {
   roleState.role = role;
   if (globalElements.rolePill) {
-    globalElements.rolePill.textContent = role;
+    // Clawnsole now effectively has a single signed-in role (admin), so showing the raw role name is redundant.
+    globalElements.rolePill.textContent = role === 'admin' ? 'signed in' : role;
+    // Keep the visual “signed in” styling for admin without exposing the role label.
     globalElements.rolePill.classList.toggle('admin', role === 'admin');
   }
   if (role === 'guest') {

--- a/tests/deploy.e2e.spec.js
+++ b/tests/deploy.e2e.spec.js
@@ -33,7 +33,7 @@ test.describe('@deploy Clawnsole deploy e2e', () => {
     await page.waitForURL(/\/admin\/?$/, { timeout: 20000 });
 
     // Ensure we are not "bounced" back to signed out.
-    await expect(page.locator('#rolePill')).toContainText(/admin/i, { timeout: 20000 });
+    await expect(page.locator('#rolePill')).toContainText(/signed in/i, { timeout: 20000 });
     await expect(page.locator('#loginOverlay')).not.toHaveClass(/open/, { timeout: 20000 });
 
     // Wait for pane to connect.
@@ -53,6 +53,6 @@ test.describe('@deploy Clawnsole deploy e2e', () => {
     // Regression guard: do a reload and ensure we are still authed (no silent logout/bounce).
     await page.reload({ waitUntil: 'domcontentloaded' });
     await expect(page.locator('#loginOverlay')).not.toHaveClass(/open/, { timeout: 20000 });
-    await expect(page.locator('#rolePill')).toContainText(/admin/i, { timeout: 20000 });
+    await expect(page.locator('#rolePill')).toContainText(/signed in/i, { timeout: 20000 });
   });
 });

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -229,5 +229,5 @@ test('admin login persists, send/receive, upload attachment', async ({ page }, t
 
   await page.reload();
   await expect(page.locator('#loginOverlay')).not.toHaveClass(/open/);
-  await expect(page.locator('#rolePill')).toContainText('admin');
+  await expect(page.locator('#rolePill')).toContainText('signed in');
 });


### PR DESCRIPTION
Clawnsole now effectively has a single signed-in role (admin), so the navbar role pill no longer shows the raw role name. It now reads ‘signed in’ when authed and keeps ‘signed out’ when not.

- Updates UI role pill text
- Updates e2e/ui tests accordingly

Fixes #69.