### PR TITLE
Remove 'Press Enter to send' helper text

### DIFF
--- a/app.js
+++ b/app.js
@@ -2209,7 +2209,7 @@ function paneSetChatEnabled(pane) {
     pane.elements.input.placeholder = 'Reconnecting... (Drafting enabled)';
     return;
   }
-  pane.elements.input.placeholder = `Message ${paneAssistantLabel(pane)}... (Press Enter to send)`;
+  pane.elements.input.placeholder = `Message ${paneAssistantLabel(pane)}...`;
 }
 
 function paneEnsureHiddenWelcome(pane) {

--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
 
             <div class="chat-input-row">
               <div class="chat-input-stack">
-                <textarea data-pane-input placeholder="Message... (Press Enter to send)"></textarea>
+                <textarea data-pane-input placeholder="Message..."></textarea>
                 <div data-pane-command-hints class="command-hints" aria-live="polite"></div>
                 <div class="attachment-row">
                   <input class="file-input" data-pane-file-input type="file" multiple />


### PR DESCRIPTION
Fixes #47.

Removes the "(Press Enter to send)" helper copy from the chat input placeholder (index.html + runtime placeholder in app.js).