### PR TITLE
Support refreshing agent list without full page reload

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,8 @@ const globalElements = {
   statusMeta: document.getElementById('statusMeta'),
   pulseCanvas: document.getElementById('pulseCanvas'),
   workqueueBtn: document.getElementById('workqueueBtn'),
+  refreshAgentsBtn: document.getElementById('refreshAgentsBtn'),
+  toastHost: document.getElementById('toastHost'),
   workqueueModal: document.getElementById('workqueueModal'),
   workqueueCloseBtn: document.getElementById('workqueueCloseBtn'),
   wqQueueSelect: document.getElementById('wqQueueSelect'),
@@ -93,6 +95,125 @@ const uiState = {
   meta: {},
   agents: []
 };
+
+let toastSeq = 0;
+function showToast(message, { kind = 'info', timeoutMs = 2600 } = {}) {
+  if (!globalElements.toastHost) return;
+  const text = typeof message === 'string' ? message.trim() : String(message || '').trim();
+  if (!text) return;
+
+  const el = document.createElement('div');
+  el.className = `toast ${kind === 'error' ? 'toast-error' : 'toast-info'}`;
+  el.textContent = text;
+  const id = ++toastSeq;
+  el.dataset.toastId = String(id);
+
+  globalElements.toastHost.appendChild(el);
+
+  // Force reflow so transitions apply.
+  void el.offsetWidth;
+  el.classList.add('open');
+
+  const remove = () => {
+    try {
+      el.classList.remove('open');
+      setTimeout(() => {
+        try {
+          el.remove();
+        } catch {}
+      }, 220);
+    } catch {}
+  };
+
+  const timer = setTimeout(remove, Math.max(800, Number(timeoutMs) || 2600));
+  el.addEventListener('click', () => {
+    clearTimeout(timer);
+    remove();
+  });
+}
+
+let agentRefreshTimer = null;
+let agentRefreshInFlight = null;
+async function refreshAgents({ reason = 'manual', showSuccessToast = false } = {}) {
+  if (roleState.role !== 'admin') return uiState.agents;
+  if (!uiState.authed) return uiState.agents;
+
+  if (agentRefreshInFlight) return agentRefreshInFlight;
+
+  const prev = Array.isArray(uiState.agents) ? uiState.agents : [];
+  agentRefreshInFlight = (async () => {
+    const next = await fetchAgents();
+    agentRefreshInFlight = null;
+
+    if (!Array.isArray(next) || next.length === 0) {
+      if (prev.length > 0) {
+        showToast('Agent refresh failed; showing last-known list.', { kind: 'error', timeoutMs: 3500 });
+        return prev;
+      }
+      showToast('No agents found.', { kind: 'error', timeoutMs: 3000 });
+      return prev;
+    }
+
+    uiState.agents = next;
+
+    // Preserve UI state (selected agent per pane).
+    paneManager.panes.forEach((pane) => {
+      if (!pane?.elements?.agentSelect) return;
+      const prior = pane.agentId;
+      pane.agentId = normalizeAgentId(prior);
+      renderAgentOptions(pane.elements.agentSelect, pane.agentId);
+      try {
+        pane.elements.agentSelect.value = pane.agentId;
+      } catch {}
+    });
+
+    // Refresh workqueue agent claim selectors (modal + item cards) if present.
+    refreshWorkqueueAgentSelects();
+
+    if (showSuccessToast) {
+      showToast(`Agents refreshed (${reason}).`, { kind: 'info', timeoutMs: 1800 });
+    }
+    return next;
+  })();
+
+  return agentRefreshInFlight;
+}
+
+function scheduleAgentRefresh(reason = 'ws_connected') {
+  if (roleState.role !== 'admin') return;
+  if (!uiState.authed) return;
+  if (agentRefreshTimer) return;
+  agentRefreshTimer = setTimeout(() => {
+    agentRefreshTimer = null;
+    refreshAgents({ reason }).catch(() => {});
+  }, 450);
+}
+
+function refreshWorkqueueAgentSelects() {
+  const selects = document.querySelectorAll('[data-wq-claim-agent]');
+  if (!selects || selects.length === 0) return;
+
+  const agents = Array.isArray(uiState.agents) ? uiState.agents : [];
+  selects.forEach((selectEl) => {
+    if (!selectEl) return;
+    const prior = selectEl.value;
+    selectEl.innerHTML = '';
+    const optNone = document.createElement('option');
+    optNone.value = '';
+    optNone.textContent = 'Unassigned';
+    selectEl.appendChild(optNone);
+    for (const a of agents) {
+      const opt = document.createElement('option');
+      opt.value = a.id;
+      opt.textContent = formatAgentLabel(a, { includeId: true });
+      selectEl.appendChild(opt);
+    }
+    try {
+      selectEl.value = prior;
+    } catch {}
+  });
+}
+
 
 const commandList = [
   { command: '/clear', description: 'Clear local chat history' },
@@ -416,6 +537,12 @@ function setRole(role) {
     globalElements.rolePill.textContent = role === 'admin' ? 'signed in' : role;
     // Keep the visual “signed in” styling for admin without exposing the role label.
     globalElements.rolePill.classList.toggle('admin', role === 'admin');
+  }
+
+  if (globalElements.refreshAgentsBtn) {
+    globalElements.refreshAgentsBtn.hidden = role !== 'admin';
+    globalElements.refreshAgentsBtn.disabled = role !== 'admin';
+    globalElements.refreshAgentsBtn.style.opacity = role === 'admin' ? '1' : '0.5';
   }
   if (role === 'guest') {
     roleState.guestPolicyInjected = false;
@@ -2376,6 +2503,10 @@ function buildClientForPane(pane) {
       paneEnsureHiddenWelcome(pane);
       pane.client.request('sessions.resolve', { key: pane.sessionKey() });
 
+      // Refresh the agent list when we regain connectivity (debounced) so new agents appear
+      // without forcing a full page reload.
+      scheduleAgentRefresh('reconnected');
+
       // If we disconnected mid-stream, pull remote history to catch up.
       paneScheduleCatchUp(pane);
 
@@ -3159,6 +3290,11 @@ globalElements.saveGuestPromptBtn?.addEventListener('click', () => saveGuestProm
 globalElements.recurringPromptCreateBtn?.addEventListener('click', () => createRecurringPromptFromUi());
 globalElements.recurringPromptRefreshBtn?.addEventListener('click', () => loadRecurringPrompts());
 
+globalElements.refreshAgentsBtn?.addEventListener('click', () => {
+  refreshAgents({ reason: 'manual', showSuccessToast: true }).catch(() => {
+    showToast('Agent refresh failed.', { kind: 'error', timeoutMs: 3500 });
+  });
+});
 
 globalElements.workqueueBtn?.addEventListener('click', () => openWorkqueue());
 globalElements.workqueueCloseBtn?.addEventListener('click', () => closeWorkqueue());

--- a/index.html
+++ b/index.html
@@ -45,6 +45,9 @@
             </select>
           </div>
           <div class="role-pill" id="rolePill">signed out</div>
+          <button id="refreshAgentsBtn" class="icon-btn" type="button" aria-label="Refresh agent list" hidden>
+            ⟳
+          </button>
           <button id="workqueueBtn" class="icon-btn" type="button" aria-label="Open workqueue" hidden>
             WQ
           </button>
@@ -148,6 +151,8 @@
         <button id="loginBtn" class="primary">Unlock</button>
       </div>
     </div>
+
+    <div id="toastHost" class="toast-host" aria-live="polite" aria-atomic="true"></div>
 
     <div id="workqueueModal" class="modal" aria-hidden="true">
       <div class="modal-card wide" role="dialog" aria-modal="true" aria-labelledby="workqueueTitle">

--- a/styles.css
+++ b/styles.css
@@ -1853,3 +1853,45 @@ button.send-btn .btn-icon {
   opacity: 0.45;
   cursor: not-allowed;
 }
+
+.toast-host {
+  position: fixed;
+  z-index: 9999;
+  right: 14px;
+  bottom: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: min(420px, calc(100vw - 28px));
+  pointer-events: none;
+}
+
+.toast {
+  pointer-events: auto;
+  padding: 10px 12px;
+  border-radius: 12px;
+  font-size: 14px;
+  line-height: 1.3;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  box-shadow: 0 18px 55px rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(10px);
+  transform: translateY(10px);
+  opacity: 0;
+  transition: opacity 160ms ease, transform 160ms ease;
+}
+
+.toast.open {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.toast-info {
+  background: rgba(18, 24, 36, 0.88);
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.toast-error {
+  background: rgba(48, 20, 22, 0.9);
+  border-color: rgba(255, 92, 92, 0.35);
+  color: rgba(255, 230, 230, 0.95);
+}


### PR DESCRIPTION
Implements #40.

- Adds a topbar refresh button to re-fetch /agents without reloading.
- Preserves per-pane selected agent when possible.
- Adds lightweight toast notifications for refresh success/failure.
- Debounced auto-refresh on websocket reconnect.
- Playwright UI test updates openclaw.json and verifies refresh populates agent option.