### PR TITLE
Topbar: Add Chat Pane / Add Queue Pane

### DIFF
--- a/app.js
+++ b/app.js
@@ -38,7 +38,8 @@ const globalElements = {
   loginError: document.getElementById('loginError'),
   logoutBtn: document.getElementById('logoutBtn'),
   paneControls: document.getElementById('paneControls'),
-  addPaneBtn: document.getElementById('addPaneBtn'),
+  addChatPaneBtn: document.getElementById('addChatPaneBtn'),
+  addQueuePaneBtn: document.getElementById('addQueuePaneBtn'),
   layoutSelect: document.getElementById('layoutSelect'),
   paneGrid: document.getElementById('paneGrid'),
   paneTemplate: document.getElementById('paneTemplate')
@@ -3645,9 +3646,14 @@ globalElements.logoutBtn?.addEventListener('click', async () => {
   window.location.replace('/');
 });
 
-globalElements.addPaneBtn?.addEventListener('click', (event) => {
+globalElements.addChatPaneBtn?.addEventListener('click', (event) => {
   event?.preventDefault?.();
-  paneManager.openAddPaneMenu(globalElements.addPaneBtn);
+  paneManager.addPane('chat');
+});
+
+globalElements.addQueuePaneBtn?.addEventListener('click', (event) => {
+  event?.preventDefault?.();
+  paneManager.addPane('workqueue');
 });
 
 // layoutSelect deprecated; layout is inferred from pane count.

--- a/index.html
+++ b/index.html
@@ -35,8 +35,11 @@
             <div class="status-meta" id="statusMeta"></div>
           </div>
           <div id="paneControls" class="pane-controls" hidden>
-            <button id="addPaneBtn" class="icon-btn" type="button" aria-label="Add pane">
-              +
+            <button id="addChatPaneBtn" class="icon-btn" type="button" aria-label="Add chat pane">
+              +Chat
+            </button>
+            <button id="addQueuePaneBtn" class="icon-btn" type="button" aria-label="Add queue pane">
+              +Queue
             </button>
             <select id="layoutSelect" aria-label="Pane layout">
               <option value="1">1-up</option>


### PR DESCRIPTION
Implements clawnsole#11 (steps 2-3): make topbar add actions explicit (chat vs queue) and removes the add-pane mode-toggle UX.