### PR TITLE
Workqueue: ship macOS LaunchAgent template for scheduled enqueue

### DIFF
--- a/docs/WORKQUEUE_SCHEDULING.md
+++ b/docs/WORKQUEUE_SCHEDULING.md
@@ -44,7 +44,38 @@ Add a crontab entry (hourly):
 
 Create a LaunchAgent that runs every hour and calls the same command.
 
-This repo doesn't ship a LaunchAgent template yet; if we standardize one, we should add it to `scripts/`.
+This repo ships a template LaunchAgent plist:
+- `scripts/workqueue-enqueue.launchagent.plist`
+
+### Install (per-user)
+
+```bash
+cp scripts/workqueue-enqueue.launchagent.plist \
+  ~/Library/LaunchAgents/ai.openclaw.clawnsole-workqueue-enqueue.plist
+
+# (re)load
+launchctl bootout gui/$(id -u) \
+  ~/Library/LaunchAgents/ai.openclaw.clawnsole-workqueue-enqueue.plist 2>/dev/null || true
+launchctl bootstrap gui/$(id -u) \
+  ~/Library/LaunchAgents/ai.openclaw.clawnsole-workqueue-enqueue.plist
+
+# run once immediately
+launchctl kickstart -k gui/$(id -u)/ai.openclaw.clawnsole-workqueue-enqueue
+```
+
+### Uninstall
+
+```bash
+launchctl bootout gui/$(id -u) \
+  ~/Library/LaunchAgents/ai.openclaw.clawnsole-workqueue-enqueue.plist 2>/dev/null || true
+rm -f ~/Library/LaunchAgents/ai.openclaw.clawnsole-workqueue-enqueue.plist
+```
+
+### Notes
+
+- Launchd provides a minimal environment; the template uses `/bin/bash -lc` so your shell init can set `PATH`.
+- Logs go to `/tmp/clawnsole-workqueue-enqueue.{out,err}.log` by default.
+- Edit the template to change schedule, queue/title/instructions, and the `--dedupeKey` windowing scheme.
 
 ---
 

--- a/scripts/workqueue-enqueue.launchagent.plist
+++ b/scripts/workqueue-enqueue.launchagent.plist
@@ -1,0 +1,44 @@
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <!--
+      Template: macOS LaunchAgent for recurring workqueue enqueue jobs.
+
+      Install:
+        cp scripts/workqueue-enqueue.launchagent.plist ~/Library/LaunchAgents/ai.openclaw.clawnsole-workqueue-enqueue.plist
+        launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/ai.openclaw.clawnsole-workqueue-enqueue.plist || true
+        launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/ai.openclaw.clawnsole-workqueue-enqueue.plist
+        launchctl kickstart -k gui/$(id -u)/ai.openclaw.clawnsole-workqueue-enqueue
+
+      Logs:
+        tail -f /tmp/clawnsole-workqueue-enqueue.{out,err}.log
+
+      Notes:
+      - Launchd provides a minimal environment; use bash -lc so your PATH and node/npm setup are available.
+      - Prefer --dedupeKey so retries don’t spam duplicates.
+    -->
+
+    <key>Label</key>
+    <string>ai.openclaw.clawnsole-workqueue-enqueue</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Every hour (in seconds). Consider StartCalendarInterval if you need a specific time. -->
+    <key>StartInterval</key>
+    <integer>3600</integer>
+
+    <key>ProgramArguments</key>
+    <array>
+      <string>/bin/bash</string>
+      <string>-lc</string>
+      <string>clawnsole workqueue enqueue --queue dev-team --title "Review open PRs" --instructions "Review and ship any safe PRs. Leave comments if blocked." --priority 50 --dedupeKey "hourly-pr-review:$(date -u +%Y-%m-%dT%H)"</string>
+    </array>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/clawnsole-workqueue-enqueue.out.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/clawnsole-workqueue-enqueue.err.log</string>
+  </dict>
+</plist>


### PR DESCRIPTION
Fixes #80\n\nAdds a ready-to-copy LaunchAgent plist template for recurring workqueue enqueue jobs (hourly example) and updates docs with install/uninstall + logging notes.\n\nNotes:\n- Uses /bin/bash -lc to avoid launchd PATH/env gotchas.\n- Example uses --dedupeKey so retries don’t spam duplicates.