### PR TITLE
Workqueue pane: hide chat composer / full-pane

### DIFF
--- a/app.js
+++ b/app.js
@@ -2725,6 +2725,12 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
     client: null
   };
 
+  // Mark pane kind on root for CSS + debugging.
+  try {
+    elements.root.dataset.paneKind = pane.kind;
+    elements.root.classList.add(`pane-kind-${pane.kind}`);
+  } catch {}
+
   if (elements.closeBtn) {
     elements.closeBtn.hidden = !closable;
     elements.closeBtn.addEventListener('click', () => {

--- a/styles.css
+++ b/styles.css
@@ -380,6 +380,16 @@ body::before {
   padding-bottom: 6px;
 }
 
+/* Workqueue pane should be full-height: never show chat composer UI in this pane. */
+.pane-kind-workqueue {
+  --actions-height: 0px;
+}
+
+.pane-kind-workqueue .chat-input-row,
+.pane-kind-workqueue .scroll-down {
+  display: none !important;
+}
+
 .pane-header {
   display: flex;
   align-items: center;

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -215,6 +215,17 @@ test('admin login persists, send/receive, upload attachment', async ({ page }, t
 
   await expect(pane.locator('[data-pane-send]')).toBeEnabled({ timeout: 90000 });
 
+  // Workqueue pane should not render the chat composer UI.
+  await expect(page.locator('#addPaneBtn')).toBeVisible();
+  await page.click('#addPaneBtn');
+  await page.getByRole('button', { name: 'Workqueue pane' }).click();
+
+  const panes = page.locator('[data-pane]');
+  const wqPane = panes.last();
+  await expect(wqPane.locator('.wq-pane')).toHaveCount(1);
+  await expect(wqPane.locator('.chat-input-row')).toBeHidden();
+  await expect(wqPane.locator('[data-pane-input]')).toBeHidden();
+
   const paneFontSize = await page.evaluate(() => {
     const el = document.querySelector('[data-pane] [data-pane-input]');
     return el ? getComputedStyle(el).fontSize : '';


### PR DESCRIPTION
Fixes #91.

- Mark panes with a kind-specific class (pane-kind-*)
- Ensure workqueue panes never show chat composer UI (CSS + JS)
- Add UI coverage verifying workqueue pane hides composer

Tests:
- npm test
- npm run test:ui -- tests/ui.spec.js