### PR TITLE
Workqueue: support editing + deleting tasks

### DIFF
--- a/docs/WORKQUEUE_HTTP_API.md
+++ b/docs/WORKQUEUE_HTTP_API.md
@@ -272,3 +272,23 @@ Errors:
 To keep the exposed API safe for remote admin UIs, the server intentionally does **not** expose mutation endpoints like delete/edit/transition.
 
 Server-side mutations beyond `enqueue` and `claim-next` should continue to happen via trusted local scripts/CLIs.
+
+### POST `/api/workqueue/update`
+
+Admin-only. Update a workqueue item.
+
+Body:
+
+```json
+{ "itemId": "...", "patch": { "title": "...", "instructions": "...", "priority": 50, "status": "pending" } }
+```
+
+### POST `/api/workqueue/delete`
+
+Admin-only. Delete a workqueue item.
+
+Body:
+
+```json
+{ "itemId": "..." }
+```

--- a/lib/workqueue.js
+++ b/lib/workqueue.js
@@ -393,6 +393,73 @@ function transitionItem(rootDir, { itemId, agentId, status, error, result, note,
   });
 }
 
+function updateItem(rootDir, { itemId, patch } = {}) {
+  const { lockFile } = statePaths(rootDir);
+  const id = String(itemId || '').trim();
+  const p = patch && typeof patch === 'object' ? patch : {};
+  if (!id) throw new Error('itemId required');
+
+  const allowedStatuses = new Set(['ready', 'pending', 'claimed', 'in_progress', 'done', 'failed']);
+
+  return withFileLock(lockFile, () => {
+    const state = loadState(rootDir);
+    reapExpiredLeases(state);
+
+    const item = state.items.find((it) => it.id === id);
+    if (!item) {
+      const e = new Error(`item not found: ${id}`);
+      e.code = 'NOT_FOUND';
+      throw e;
+    }
+
+    if (p.title !== undefined) item.title = String(p.title || '').trim() || '(untitled)';
+    if (p.instructions !== undefined) item.instructions = String(p.instructions || '').trim();
+    if (p.priority !== undefined) {
+      const pr = Number(p.priority);
+      item.priority = Number.isFinite(pr) ? pr : item.priority;
+    }
+    if (p.status !== undefined) {
+      const st = String(p.status || '').trim();
+      if (!allowedStatuses.has(st)) {
+        const e = new Error(`invalid status: ${st}`);
+        e.code = 'INVALID_STATUS';
+        throw e;
+      }
+      item.status = st;
+
+      // If an admin resets to a non-active state, clear ownership/lease.
+      if (st === 'ready' || st === 'pending') {
+        item.claimedBy = '';
+        item.claimedAt = '';
+        item.leaseUntil = 0;
+      }
+    }
+
+    item.updatedAt = new Date().toISOString();
+    saveState(rootDir, state);
+    return item;
+  });
+}
+
+function deleteItem(rootDir, { itemId } = {}) {
+  const { lockFile } = statePaths(rootDir);
+  const id = String(itemId || '').trim();
+  if (!id) throw new Error('itemId required');
+
+  return withFileLock(lockFile, () => {
+    const state = loadState(rootDir);
+    const idx = state.items.findIndex((it) => it && it.id === id);
+    if (idx < 0) {
+      const e = new Error(`item not found: ${id}`);
+      e.code = 'NOT_FOUND';
+      throw e;
+    }
+    const [removed] = state.items.splice(idx, 1);
+    saveState(rootDir, state);
+    return removed;
+  });
+}
+
 module.exports = {
   statePaths,
   loadState,
@@ -401,6 +468,8 @@ module.exports = {
   enqueueItem,
   claimNext,
   transitionItem,
+  updateItem,
+  deleteItem,
   listAssignments,
   setAssignments,
   resolveClaimQueues,

--- a/styles.css
+++ b/styles.css
@@ -1184,6 +1184,12 @@ button.send-btn .btn-icon {
   max-height: 520px;
 }
 
+.wq-inspect-actions {
+  display: flex;
+  gap: 8px;
+  margin: 10px 0 2px;
+}
+
 .wq-kv {
   display: grid;
   grid-template-columns: 110px 1fr;


### PR DESCRIPTION
Fixes #90.

Adds admin-only endpoints:
- POST /api/workqueue/update
- POST /api/workqueue/delete

Adds basic Workqueue detail actions (Edit/Delete) wired to those endpoints, plus unit tests and docs.

Notes:
- UI uses simple prompt()/confirm() for now (fast path); can be replaced with a proper modal/context menu later.
- Delete shows confirmation + feed toast.