### PR TITLE
Status filter: multiselect dropdown in workqueue pane

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -967,6 +967,51 @@ button.send-btn .btn-icon {
   flex: 1;
 }
 
+.wq-status-multiselect {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.wq-status-selected {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-height: 28px;
+}
+
+.wq-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  color: var(--text);
+}
+
+.wq-status-details > summary {
+  cursor: pointer;
+  user-select: none;
+  width: fit-content;
+}
+
+.wq-status-menu {
+  margin-top: 8px;
+  padding: 10px;
+  border-radius: 12px;
+  background: rgba(12, 15, 20, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.wq-status-presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
 .wq-label {
   font-size: 11px;
   letter-spacing: 0.04em;

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -271,6 +271,7 @@ test('add pane menu offers chat vs workqueue; workqueue pane has queue dropdown'
 
   const wqPane = page.locator('[data-pane] .wq-pane').first();
   await expect(wqPane.locator('[data-wq-queue-select]')).toBeVisible();
+  await expect(wqPane.locator('[data-wq-status-details]')).toBeVisible();
 });
 
 


### PR DESCRIPTION
Fixes #88.

- Replace CSV text input with a status multiselect dropdown (checkbox chips)
- Show selected statuses as pills
- Add presets (Default/Open/Active/All) + Clear
- Add UI test assertion for the new control

Tests: npm test; playwright (single spec)