### PR TITLE
Fix #85: Cron/timeline panes should be full-pane (hide chat composer)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -390,6 +390,19 @@ body::before {
   display: none !important;
 }
 
+/* Cron/timeline panes are also full-height: they are data views, not chat panes. */
+.pane-kind-cron,
+.pane-kind-timeline {
+  --actions-height: 0px;
+}
+
+.pane-kind-cron .chat-input-row,
+.pane-kind-cron .scroll-down,
+.pane-kind-timeline .chat-input-row,
+.pane-kind-timeline .scroll-down {
+  display: none !important;
+}
+
 .pane-header {
   display: flex;
   align-items: center;

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -305,11 +305,17 @@ test('admin can add cron + timeline panes', async ({ page }) => {
   await expect(page.locator('.pane-add-menu')).toBeVisible();
   await page.click('.pane-add-menu__item:text("Cron pane")');
   await expect(panes).toHaveCount(3);
-  await expect(panes.nth(2)).toContainText('Cron');
+  const cronPane = panes.nth(2);
+  await expect(cronPane).toContainText('Cron');
+  await expect(cronPane.locator('.chat-input-row')).toBeHidden();
+  await expect(cronPane.locator('[data-pane-input]')).toBeHidden();
 
   await page.click('#addPaneBtn');
   await expect(page.locator('.pane-add-menu')).toBeVisible();
   await page.click('.pane-add-menu__item:text("Timeline pane")');
   await expect(panes).toHaveCount(4);
-  await expect(panes.nth(3)).toContainText('Timeline');
+  const timelinePane = panes.nth(3);
+  await expect(timelinePane).toContainText('Timeline');
+  await expect(timelinePane.locator('.chat-input-row')).toBeHidden();
+  await expect(timelinePane.locator('[data-pane-input]')).toBeHidden();
 });


### PR DESCRIPTION
Fixes #85.

Cron + Timeline panes are data views and should not show the chat composer or scroll-to-bottom UI. This adds CSS parity with the workqueue pane (actions height = 0; composer + scroll-down hidden), and adds Playwright assertions to prevent regressions.