### PR TITLE
CI: upload Playwright artifacts on UI test failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,24 @@ jobs:
         timeout-minutes: 6
       - run: npm run test:ui
         timeout-minutes: 10
+
+      # Upload Playwright artifacts to make UI failures debuggable in CI.
+      - name: Upload Playwright report (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/**
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Upload Playwright test results (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results
+          path: |
+            test-results/**
+          if-no-files-found: ignore
+          retention-days: 14

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -12,6 +12,10 @@ module.exports = defineConfig({
   use: {
     // Local tests default to the smoke-test port; deploy tests should pass BASE_URL env.
     baseURL: process.env.BASE_URL || process.env.CLAWNSOLE_BASE_URL || 'http://127.0.0.1:18888',
-    trace: 'retain-on-failure'
+
+    // Make failures debuggable both locally and in CI.
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure'
   }
 });


### PR DESCRIPTION
Fixes #103.

- Upload Playwright HTML report and test-results folder as GitHub Actions artifacts on failure.
- Enable screenshot+video retention on failure in Playwright config (trace already enabled).