### PR TITLE
Testing infra: reusable Playwright harness (mock-gateway + server fixtures)

### DIFF
--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -1,173 +1,17 @@
-const { test, expect } = require('@playwright/test');
-const { spawn } = require('child_process');
-const http = require('http');
+const { test, expect } = require('./ui/fixtures');
+const { installPageFailureAssertions } = require('./helpers/pw-assertions');
 const fs = require('fs');
-const os = require('os');
 const path = require('path');
 
-const { installPageFailureAssertions } = require('./helpers/pw-assertions');
-
-function getFreePort(host = '127.0.0.1') {
-  return new Promise((resolve, reject) => {
-    const server = http.createServer();
-    server.listen(0, host, () => {
-      const addr = server.address();
-      const port = addr && typeof addr === 'object' ? addr.port : null;
-      server.close(() => resolve(port));
-    });
-    server.on('error', reject);
-  });
-}
-
-function waitForHttp(url, timeoutMs = 10000, proc, label) {
-  return new Promise((resolve, reject) => {
-    const start = Date.now();
-    const attempt = () => {
-      http
-        .get(url, (res) => {
-          res.resume();
-          resolve();
-        })
-        .on('error', () => {
-          if (Date.now() - start > timeoutMs) {
-            let details = '';
-            if (proc) {
-              const stdout = proc.__stdout || '';
-              const stderr = proc.__stderr || '';
-              if (stdout || stderr) {
-                details = `\n${label || 'process'} output:\n${stdout}${stderr}`;
-              }
-              if (proc.exitCode !== null && proc.exitCode !== undefined) {
-                details += `\n${label || 'process'} exit code: ${proc.exitCode}`;
-              }
-            }
-            reject(new Error(`timeout waiting for ${url}${details}`));
-            return;
-          }
-          setTimeout(attempt, 250);
-        });
-    };
-    attempt();
-  });
-}
-
-function captureOutput(proc) {
-  proc.__stdout = '';
-  proc.__stderr = '';
-  proc.stdout?.on('data', (chunk) => {
-    proc.__stdout += chunk.toString();
-  });
-  proc.stderr?.on('data', (chunk) => {
-    proc.__stderr += chunk.toString();
-  });
-  return proc;
-}
-
-let serverProc;
-let gatewayProc;
-let tempHome;
-let skipReason = '';
-let serverPort;
-let gatewayPort;
-
-test.beforeAll(async () => {
-  tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'clawnsole-test-'));
-  gatewayPort = await getFreePort();
-  serverPort = await getFreePort();
-
-  const openclawDir = path.join(tempHome, '.openclaw');
-  fs.mkdirSync(openclawDir, { recursive: true });
-  fs.writeFileSync(
-    path.join(openclawDir, 'openclaw.json'),
-    JSON.stringify(
-      {
-        gateway: {
-          port: gatewayPort,
-          auth: { token: 'test-token', mode: 'token' }
-        }
-      },
-      null,
-      2
-    )
-  );
-  fs.writeFileSync(
-    path.join(openclawDir, 'clawnsole.json'),
-    JSON.stringify(
-      {
-        adminPassword: 'admin',
-        authVersion: 'test'
-      },
-      null,
-      2
-    )
-  );
-
-  try {
-    gatewayProc = captureOutput(
-      spawn('node', ['scripts/mock-gateway.js'], {
-        env: { ...process.env, HOME: tempHome, MOCK_GATEWAY_PORT: String(gatewayPort) },
-        stdio: ['ignore', 'pipe', 'pipe']
-      })
-    );
-    gatewayProc.on('exit', (code, signal) => {
-      // eslint-disable-next-line no-console
-      console.log(`mock-gateway exited code=${code} signal=${signal}`);
-      if (gatewayProc?.__stdout || gatewayProc?.__stderr) {
-        // eslint-disable-next-line no-console
-        console.log(`mock-gateway output:\n${gatewayProc.__stdout || ''}${gatewayProc.__stderr || ''}`);
-      }
-    });
-    await waitForHttp(`http://127.0.0.1:${gatewayPort}`, 10000, gatewayProc, 'mock-gateway');
-  } catch (err) {
-    const message = String(err);
-    if (message.includes('EPERM') || message.includes('operation not permitted')) {
-      skipReason = 'Local environment disallows binding to ports (EPERM).';
-      return;
-    }
-    throw err;
-  }
-
-  try {
-    serverProc = captureOutput(
-      spawn('node', ['server.js'], {
-        // Force IPv4 bind; some CI environments bind IPv6-only by default and 127.0.0.1 then refuses.
-        env: { ...process.env, HOME: tempHome, PORT: String(serverPort), HOST: '127.0.0.1' },
-        stdio: ['ignore', 'pipe', 'pipe']
-      })
-    );
-    serverProc.on('exit', (code, signal) => {
-      // eslint-disable-next-line no-console
-      console.log(`clawnsole server exited code=${code} signal=${signal}`);
-      if (serverProc?.__stdout || serverProc?.__stderr) {
-        // eslint-disable-next-line no-console
-        console.log(`clawnsole server output:\n${serverProc.__stdout || ''}${serverProc.__stderr || ''}`);
-      }
-    });
-    await waitForHttp(`http://127.0.0.1:${serverPort}/meta`, 10000, serverProc, 'clawnsole');
-  } catch (err) {
-    const message = String(err);
-    if (message.includes('EPERM') || message.includes('operation not permitted')) {
-      skipReason = 'Local environment disallows binding to ports (EPERM).';
-      return;
-    }
-    throw err;
-  }
-});
-
-test.afterAll(() => {
-  if (serverProc) serverProc.kill('SIGTERM');
-  if (gatewayProc) gatewayProc.kill('SIGTERM');
-});
-
-test('admin login persists, send/receive, upload attachment', async ({ page }, testInfo) => {
+test('admin login persists, send/receive, upload attachment', async ({ page, clawnsole }, testInfo) => {
   test.setTimeout(180000);
-  test.skip(!!skipReason, skipReason);
+  test.skip(!!clawnsole.skipReason, clawnsole.skipReason);
 
   const guards = installPageFailureAssertions(page, {
-    appOrigin: `http://127.0.0.1:${serverPort}`
+    appOrigin: clawnsole.serverUrl
   });
 
-  await page.goto(`http://127.0.0.1:${serverPort}/`);
+  await page.goto(`${clawnsole.serverUrl}/`);
 
   // iOS Safari will auto-zoom focused inputs when font-size < 16px.
   const fontSizes = await page.evaluate(() => {
@@ -193,7 +37,7 @@ test('admin login persists, send/receive, upload attachment', async ({ page }, t
 
   // Agent list refresh should not require a full page reload.
   // Update the underlying openclaw.json and click refresh; the agent select should populate.
-  const openclawConfigPath = path.join(tempHome, '.openclaw', 'openclaw.json');
+  const openclawConfigPath = path.join(clawnsole.tempHome, '.openclaw', 'openclaw.json');
   const openclawCfg = JSON.parse(fs.readFileSync(openclawConfigPath, 'utf8'));
   openclawCfg.agents = {
     defaults: { workspace: '' },
@@ -253,20 +97,15 @@ test('admin login persists, send/receive, upload attachment', async ({ page }, t
   guards.dispose();
 });
 
-test('add pane menu offers chat vs workqueue; workqueue pane has queue dropdown', async ({ page }) => {
+test('add pane menu offers chat vs workqueue; workqueue pane has queue dropdown', async ({ page, clawnsole }) => {
   test.setTimeout(180000);
-  test.skip(!!skipReason, skipReason);
+  test.skip(!!clawnsole.skipReason, clawnsole.skipReason);
 
   const guards = installPageFailureAssertions(page, {
-    appOrigin: `http://127.0.0.1:${serverPort}`
+    appOrigin: clawnsole.serverUrl
   });
 
-  await page.goto(`http://127.0.0.1:${serverPort}/`);
-  await page.fill('#loginPassword', 'admin');
-  await page.click('#loginBtn');
-  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
-
-  await page.waitForSelector('[data-pane] [data-pane-input]', { timeout: 90000 });
+  await clawnsole.gotoAndLoginAdmin(page);
 
   const beforeCount = await page.locator('[data-pane]').count();
 
@@ -289,18 +128,15 @@ test('add pane menu offers chat vs workqueue; workqueue pane has queue dropdown'
   guards.dispose();
 });
 
-test('workqueue modal has sortable list headers', async ({ page }) => {
+test('workqueue modal has sortable list headers', async ({ page, clawnsole }) => {
   test.setTimeout(180000);
-  test.skip(!!skipReason, skipReason);
+  test.skip(!!clawnsole.skipReason, clawnsole.skipReason);
 
   const guards = installPageFailureAssertions(page, {
-    appOrigin: `http://127.0.0.1:${serverPort}`
+    appOrigin: clawnsole.serverUrl
   });
 
-  await page.goto(`http://127.0.0.1:${serverPort}/`);
-  await page.fill('#loginPassword', 'admin');
-  await page.click('#loginBtn');
-  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+  await clawnsole.gotoAndLoginAdmin(page);
 
   await page.click('#workqueueBtn');
   await expect(page.locator('#workqueueModal')).toHaveClass(/open/);
@@ -320,19 +156,14 @@ test('workqueue modal has sortable list headers', async ({ page }) => {
   guards.dispose();
 });
 
-test('admin can add cron + timeline panes', async ({ page }) => {
-  test.skip(!!skipReason, skipReason);
+test('admin can add cron + timeline panes', async ({ page, clawnsole }) => {
+  test.skip(!!clawnsole.skipReason, clawnsole.skipReason);
 
   const guards = installPageFailureAssertions(page, {
-    appOrigin: `http://127.0.0.1:${serverPort}`
+    appOrigin: clawnsole.serverUrl
   });
 
-  await page.goto(`http://127.0.0.1:${serverPort}/`);
-
-  await page.fill('#loginPassword', 'admin');
-  await page.click('#loginBtn');
-  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
-  await page.waitForSelector('[data-pane] [data-pane-input]', { timeout: 90000 });
+  await clawnsole.gotoAndLoginAdmin(page);
 
   page.on('dialog', (dialog) => {
     throw new Error(`unexpected dialog: ${dialog.type()} ${dialog.message()}`);
@@ -363,19 +194,14 @@ test('admin can add cron + timeline panes', async ({ page }) => {
   guards.dispose();
 });
 
-
-test('workqueue modal renders as kanban board and supports enqueue', async ({ page }) => {
-  test.skip(!!skipReason, skipReason);
+test('workqueue modal renders as kanban board and supports enqueue', async ({ page, clawnsole }) => {
+  test.skip(!!clawnsole.skipReason, clawnsole.skipReason);
 
   const guards = installPageFailureAssertions(page, {
-    appOrigin: `http://127.0.0.1:${serverPort}`
+    appOrigin: clawnsole.serverUrl
   });
 
-  await page.goto(`http://127.0.0.1:${serverPort}/`);
-
-  await page.fill('#loginPassword', 'admin');
-  await page.click('#loginBtn');
-  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+  await clawnsole.gotoAndLoginAdmin(page);
 
   await expect(page.locator('#workqueueBtn')).toBeVisible();
   await page.click('#workqueueBtn');

--- a/tests/ui/fixtures.js
+++ b/tests/ui/fixtures.js
@@ -1,0 +1,204 @@
+const base = require('@playwright/test');
+const { spawn } = require('child_process');
+const http = require('http');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function getFreePort(host = '127.0.0.1') {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer();
+    server.listen(0, host, () => {
+      const addr = server.address();
+      const port = addr && typeof addr === 'object' ? addr.port : null;
+      server.close(() => resolve(port));
+    });
+    server.on('error', reject);
+  });
+}
+
+function captureOutput(proc) {
+  proc.__stdout = '';
+  proc.__stderr = '';
+  proc.stdout?.on('data', (chunk) => {
+    proc.__stdout += chunk.toString();
+  });
+  proc.stderr?.on('data', (chunk) => {
+    proc.__stderr += chunk.toString();
+  });
+  return proc;
+}
+
+function waitForHttp(url, timeoutMs = 10000) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const attempt = () => {
+      http
+        .get(url, (res) => {
+          res.resume();
+          resolve();
+        })
+        .on('error', () => {
+          if (Date.now() - start > timeoutMs) {
+            reject(new Error(`timeout waiting for ${url}`));
+            return;
+          }
+          setTimeout(attempt, 250);
+        });
+    };
+    attempt();
+  });
+}
+
+function formatProcOutput(proc, label) {
+  if (!proc) return '';
+  const stdout = proc.__stdout || '';
+  const stderr = proc.__stderr || '';
+  const code = proc.exitCode;
+
+  let details = '';
+  if (stdout || stderr) details += `${label} output:\n${stdout}${stderr}`;
+  if (code !== null && code !== undefined) details += `\n${label} exit code: ${code}`;
+  return details.trim();
+}
+
+const test = base.test.extend({
+  clawnsole: [
+    async ({}, use) => {
+      const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'clawnsole-test-'));
+      const gatewayPort = await getFreePort();
+      const serverPort = await getFreePort();
+
+      const openclawDir = path.join(tempHome, '.openclaw');
+      fs.mkdirSync(openclawDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(openclawDir, 'openclaw.json'),
+        JSON.stringify(
+          {
+            gateway: {
+              port: gatewayPort,
+              auth: { token: 'test-token', mode: 'token' }
+            }
+          },
+          null,
+          2
+        )
+      );
+      fs.writeFileSync(
+        path.join(openclawDir, 'clawnsole.json'),
+        JSON.stringify(
+          {
+            adminPassword: 'admin',
+            authVersion: 'test'
+          },
+          null,
+          2
+        )
+      );
+
+      const envBase = { ...process.env, HOME: tempHome };
+
+      let gatewayProc;
+      let serverProc;
+      let skipReason = '';
+
+      const startGateway = async () => {
+        gatewayProc = captureOutput(
+          spawn('node', ['scripts/mock-gateway.js'], {
+            env: { ...envBase, MOCK_GATEWAY_PORT: String(gatewayPort) },
+            stdio: ['ignore', 'pipe', 'pipe']
+          })
+        );
+
+        await waitForHttp(`http://127.0.0.1:${gatewayPort}`, 10000);
+      };
+
+      const startServer = async () => {
+        serverProc = captureOutput(
+          spawn('node', ['server.js'], {
+            // Force IPv4 bind; some CI environments bind IPv6-only by default and 127.0.0.1 then refuses.
+            env: { ...envBase, PORT: String(serverPort), HOST: '127.0.0.1' },
+            stdio: ['ignore', 'pipe', 'pipe']
+          })
+        );
+
+        await waitForHttp(`http://127.0.0.1:${serverPort}/meta`, 10000);
+      };
+
+      try {
+        await startGateway();
+        await startServer();
+      } catch (err) {
+        const message = String(err);
+        if (message.includes('EPERM') || message.includes('operation not permitted')) {
+          skipReason = 'Local environment disallows binding to ports (EPERM).';
+        } else {
+          const details = [
+            formatProcOutput(gatewayProc, 'mock-gateway'),
+            formatProcOutput(serverProc, 'clawnsole')
+          ]
+            .filter(Boolean)
+            .join('\n\n');
+          const e = new Error(details ? `${message}\n\n${details}` : message);
+          e.cause = err;
+          throw e;
+        }
+      }
+
+      const serverUrl = `http://127.0.0.1:${serverPort}`;
+      const adminUrl = `${serverUrl}/admin`;
+      const guestUrl = `${serverUrl}/guest`;
+
+      const api = {
+        tempHome,
+        serverPort,
+        gatewayPort,
+        serverUrl,
+        adminUrl,
+        guestUrl,
+        skipReason,
+        procs: {
+          serverProc,
+          gatewayProc
+        },
+        async gotoAndLoginAdmin(page, password = 'admin') {
+          await page.goto(`${serverUrl}/`);
+          await page.fill('#loginPassword', password);
+          await page.click('#loginBtn');
+          await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+          await page.waitForSelector('[data-pane] [data-pane-input]', { timeout: 90000 });
+        }
+      };
+
+      await use(api);
+
+      try {
+        serverProc?.kill('SIGTERM');
+      } catch {}
+      try {
+        gatewayProc?.kill('SIGTERM');
+      } catch {}
+    },
+    { scope: 'worker' }
+  ]
+});
+
+test.afterEach(async ({ clawnsole }, testInfo) => {
+  if (!clawnsole) return;
+  if (testInfo.status === testInfo.expectedStatus) return;
+
+  const gw = formatProcOutput(clawnsole.procs?.gatewayProc, 'mock-gateway');
+  const srv = formatProcOutput(clawnsole.procs?.serverProc, 'clawnsole');
+  const text = [gw, srv].filter(Boolean).join('\n\n');
+  if (!text) return;
+
+  await testInfo.attach('process-output', {
+    body: text,
+    contentType: 'text/plain'
+  });
+});
+
+module.exports = {
+  test,
+  expect: base.expect
+};


### PR DESCRIPTION
Implements a reusable Playwright worker-scoped fixture to start a temp HOME, mock gateway, and clawnsole server, and attaches captured process logs on test failure.

- Adds tests/ui/fixtures.js exporting {test, expect} and clawnsole helper (serverUrl/adminUrl/guestUrl + gotoAndLoginAdmin)
- Refactors tests/ui.spec.js to use the harness (removes duplicated boot/teardown logic)

Closes #105.