### PR TITLE
Playwright: guest-mode E2E coverage + guest proxy

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -175,8 +175,165 @@ function createProxyHandlers({ WebSocket, getRoleFromCookies, readToken, gateway
     });
   }
 
+  function handleGuestProxy(clientSocket, req) {
+    const role = getRoleFromCookies(req);
+    if (role !== 'guest') {
+      safeClose(clientSocket, 4401, 'unauthorized');
+      return;
+    }
+
+    const { token } = readToken();
+    const upstreamUrl = gatewayWsUrl();
+    assertSecureWsUrl(upstreamUrl, { allowInsecure: process.env.CLAWNSOLE_ALLOW_INSECURE_TRANSPORT === '1' });
+    const upstream = new WebSocket(upstreamUrl, { headers: { Origin: resolveWsOrigin(upstreamUrl) } });
+    const pendingFrames = [];
+    const guestState = {
+      sessionKey: null,
+      injectedPolicy: false
+    };
+    let lastUpstreamAt = Date.now();
+    let recentCount = 0;
+    let closed = false;
+
+    const heartbeat = setInterval(() => {
+      const idleForMs = Date.now() - lastUpstreamAt;
+      const payload = {
+        type: 'event',
+        event: 'activity',
+        payload: {
+          ts: Date.now(),
+          idleForMs,
+          recentCount
+        }
+      };
+      recentCount = 0;
+      try {
+        clientSocket.send(JSON.stringify(payload));
+      } catch {}
+    }, heartbeatMs);
+
+    function maybeInjectGuestPolicy() {
+      if (guestState.injectedPolicy) return;
+      if (!guestState.sessionKey) return;
+      if (upstream.readyState !== 1) return;
+      guestState.injectedPolicy = true;
+      try {
+        upstream.send(
+          JSON.stringify({
+            type: 'req',
+            id: `guest-policy-${Date.now()}`,
+            method: 'chat.inject',
+            params: {
+              sessionKey: guestState.sessionKey,
+              message:
+                'Guest mode: read-only. Do not access or summarize emails or private data. Do not assume the guest is the admin. Ask for their name if needed. You may assist with general questions and basic home automation (lights, climate, scenes).',
+              label: 'Guest policy'
+            }
+          })
+        );
+      } catch {}
+    }
+
+    function normalizeAndSend(frame) {
+      if (!frame || frame.type !== 'req') return;
+      if (
+        frame.method === 'chat.send' ||
+        frame.method === 'chat.history' ||
+        frame.method === 'chat.abort' ||
+        frame.method === 'chat.inject'
+      ) {
+        const key = frame.params?.sessionKey;
+        if (typeof key === 'string' && key) guestState.sessionKey = key;
+      }
+      if (frame.method === 'sessions.resolve' || frame.method === 'sessions.reset') {
+        const key = frame.params?.key;
+        if (typeof key === 'string' && key) guestState.sessionKey = key;
+      }
+      if (frame.method === 'connect') {
+        const instanceId = frame.params?.client?.instanceId;
+        const clientId = frame.params?.client?.id;
+        const suffix = instanceId || clientId || 'guest';
+        guestState.sessionKey = `agent:main:guest:${suffix}`;
+        frame.params = frame.params || {};
+        frame.params.auth = { token };
+        frame.params.scopes = ['operator.read'];
+        frame.params.role = 'guest';
+      }
+      try {
+        upstream.send(JSON.stringify(frame));
+      } catch {}
+
+      if (frame.method === 'connect') {
+        // Best-effort: once connected, inject the guest policy immediately.
+        maybeInjectGuestPolicy();
+      }
+    }
+
+    clientSocket.on('message', (data) => {
+      let frame;
+      try {
+        frame = JSON.parse(String(data));
+      } catch {
+        return;
+      }
+      if (frame?.type !== 'req') return;
+      if (upstream.readyState !== 1) {
+        pendingFrames.push(frame);
+        return;
+      }
+      normalizeAndSend(frame);
+    });
+
+    upstream.on('open', () => {
+      while (pendingFrames.length > 0) {
+        normalizeAndSend(pendingFrames.shift());
+      }
+      maybeInjectGuestPolicy();
+    });
+
+    upstream.on('message', (data) => {
+      lastUpstreamAt = Date.now();
+      recentCount += 1;
+      let frame;
+      try {
+        frame = JSON.parse(String(data));
+      } catch {
+        clientSocket.send(String(data));
+        return;
+      }
+
+      if (frame?.type === 'event' && frame.event === 'chat') {
+        const sessionKey = frame.payload?.sessionKey;
+        if (!sessionKey) {
+          return;
+        }
+        if (guestState.sessionKey && sessionKey !== guestState.sessionKey) {
+          return;
+        }
+      }
+
+      clientSocket.send(JSON.stringify(frame));
+    });
+
+    const closeBoth = (code, reason) => {
+      if (closed) return;
+      closed = true;
+      safeClose(upstream, code, reason);
+      safeClose(clientSocket, code, reason);
+      clearInterval(heartbeat);
+    };
+
+    clientSocket.on('close', closeBoth);
+    upstream.on('close', (code, reasonBuf) => closeBoth(code, reasonBuf ? reasonBuf.toString() : ''));
+    upstream.on('error', (err) => {
+      const message = err && err.code ? `${err.code} ${err.message || 'upstream error'}` : String(err || 'upstream error');
+      closeBoth(1013, message.slice(0, 180));
+    });
+  }
+
   return {
-    handleAdminProxy
+    handleAdminProxy,
+    handleGuestProxy
   };
 }
 

--- a/tests/guest.e2e.spec.js
+++ b/tests/guest.e2e.spec.js
@@ -1,0 +1,190 @@
+const { test, expect } = require('@playwright/test');
+
+const { spawn } = require('child_process');
+const http = require('http');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { installPageFailureAssertions } = require('./helpers/pw-assertions');
+
+function getFreePort(host = '127.0.0.1') {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer();
+    server.listen(0, host, () => {
+      const addr = server.address();
+      const port = addr && typeof addr === 'object' ? addr.port : null;
+      server.close(() => resolve(port));
+    });
+    server.on('error', reject);
+  });
+}
+
+function waitForHttp(url, timeoutMs = 10000, proc, label) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const attempt = () => {
+      http
+        .get(url, (res) => {
+          res.resume();
+          resolve();
+        })
+        .on('error', () => {
+          if (Date.now() - start > timeoutMs) {
+            let details = '';
+            if (proc) {
+              const stdout = proc.__stdout || '';
+              const stderr = proc.__stderr || '';
+              if (stdout || stderr) {
+                details = `\n${label || 'process'} output:\n${stdout}${stderr}`;
+              }
+              if (proc.exitCode !== null && proc.exitCode !== undefined) {
+                details += `\n${label || 'process'} exit code: ${proc.exitCode}`;
+              }
+            }
+            reject(new Error(`timeout waiting for ${url}${details}`));
+            return;
+          }
+          setTimeout(attempt, 250);
+        });
+    };
+    attempt();
+  });
+}
+
+function captureOutput(proc) {
+  proc.__stdout = '';
+  proc.__stderr = '';
+  proc.stdout?.on('data', (chunk) => {
+    proc.__stdout += chunk.toString();
+  });
+  proc.stderr?.on('data', (chunk) => {
+    proc.__stderr += chunk.toString();
+  });
+  return proc;
+}
+
+let serverProc;
+let gatewayProc;
+let tempHome;
+let skipReason = '';
+let serverPort;
+let gatewayPort;
+
+test.beforeAll(async () => {
+  tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'clawnsole-test-'));
+  gatewayPort = await getFreePort();
+  serverPort = await getFreePort();
+
+  const openclawDir = path.join(tempHome, '.openclaw');
+  fs.mkdirSync(openclawDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(openclawDir, 'openclaw.json'),
+    JSON.stringify(
+      {
+        gateway: {
+          port: gatewayPort,
+          auth: { token: 'test-token', mode: 'token' }
+        }
+      },
+      null,
+      2
+    )
+  );
+  fs.writeFileSync(
+    path.join(openclawDir, 'clawnsole.json'),
+    JSON.stringify(
+      {
+        adminPassword: 'admin',
+        guestPassword: 'guest',
+        authVersion: 'test'
+      },
+      null,
+      2
+    )
+  );
+
+  try {
+    gatewayProc = captureOutput(
+      spawn('node', ['scripts/mock-gateway.js'], {
+        env: { ...process.env, HOME: tempHome, MOCK_GATEWAY_PORT: String(gatewayPort) },
+        stdio: ['ignore', 'pipe', 'pipe']
+      })
+    );
+    await waitForHttp(`http://127.0.0.1:${gatewayPort}`, 10000, gatewayProc, 'mock-gateway');
+  } catch (err) {
+    const message = String(err);
+    if (message.includes('EPERM') || message.includes('operation not permitted')) {
+      skipReason = 'Local environment disallows binding to ports (EPERM).';
+      return;
+    }
+    throw err;
+  }
+
+  try {
+    serverProc = captureOutput(
+      spawn('node', ['server.js'], {
+        env: { ...process.env, HOME: tempHome, PORT: String(serverPort), HOST: '127.0.0.1' },
+        stdio: ['ignore', 'pipe', 'pipe']
+      })
+    );
+    await waitForHttp(`http://127.0.0.1:${serverPort}/meta`, 10000, serverProc, 'clawnsole');
+  } catch (err) {
+    const message = String(err);
+    if (message.includes('EPERM') || message.includes('operation not permitted')) {
+      skipReason = 'Local environment disallows binding to ports (EPERM).';
+      return;
+    }
+    throw err;
+  }
+});
+
+test.afterAll(() => {
+  if (serverProc) serverProc.kill('SIGTERM');
+  if (gatewayProc) gatewayProc.kill('SIGTERM');
+});
+
+test('guest can log in at /guest and use chat pane; admin-only controls hidden', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!skipReason, skipReason);
+
+  const guards = installPageFailureAssertions(page, {
+    appOrigin: `http://127.0.0.1:${serverPort}`
+  });
+
+  await page.goto(`http://127.0.0.1:${serverPort}/guest`);
+
+  await page.fill('#loginPassword', 'guest');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/guest\/?$/, { timeout: 10000 });
+
+  await page.waitForSelector('[data-pane] [data-pane-input]', { timeout: 90000 });
+
+  await expect(page.locator('#paneControls')).toHaveAttribute('hidden', '');
+  await expect(page.locator('#addPaneBtn')).toHaveAttribute('hidden', '');
+  await expect(page.locator('#workqueueBtn')).toHaveAttribute('hidden', '');
+  await expect(page.locator('#refreshAgentsBtn')).toHaveAttribute('hidden', '');
+
+  const pane = page.locator('[data-pane]').first();
+  await pane.locator('[data-pane-input]').fill('hello from guest');
+  await pane.locator('[data-pane-send]').click();
+
+  await expect(pane.locator('[data-chat-role="assistant"]').last()).toContainText('mock-reply: hello from guest');
+
+  await guards.assertNoFailures();
+  guards.dispose();
+});
+
+test('guest cannot access /admin route (prompts to sign in as admin)', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!skipReason, skipReason);
+
+  await page.goto(`http://127.0.0.1:${serverPort}/guest`);
+  await page.fill('#loginPassword', 'guest');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/guest\/?$/, { timeout: 10000 });
+
+  await page.goto(`http://127.0.0.1:${serverPort}/admin`);
+  await expect(page.locator('#loginOverlay')).toHaveClass(/open/);
+  await expect(page.locator('#loginError')).toContainText(/Sign in as admin/i);
+});

--- a/tests/unit/clawnsole-server.test.js
+++ b/tests/unit/clawnsole-server.test.js
@@ -96,7 +96,7 @@ test('GET /meta returns gateway urls and port', async () => {
   assert.equal(data.wsUrl, 'ws://127.0.0.1:19999');
   assert.equal(data.adminWsUrl, '/admin-ws');
   assert.equal(data.port, 19999);
-  assert.equal(data.guestWsUrl, undefined);
+  assert.equal(data.guestWsUrl, '/guest-ws');
 });
 
 test('login sets cookies; /auth/role uses auth cookie', async () => {
@@ -297,7 +297,7 @@ test('/auth/logout clears auth cookies', async () => {
   assert.match(joined, /Max-Age=0/);
 });
 
-test('GET /admin serves the kiosk shell (index.html); /guest returns 404', async () => {
+test('GET /admin and /guest serve the kiosk shell (index.html)', async () => {
   const { homeDir, openclawDir } = makeTempHome();
   writeJson(path.join(openclawDir, 'openclaw.json'), { gateway: { port: 18789, auth: { mode: 'token', token: 't' } } });
   writeJson(path.join(openclawDir, 'clawnsole.json'), { adminPassword: 'admin', authVersion: 'v1' });
@@ -310,7 +310,9 @@ test('GET /admin serves the kiosk shell (index.html); /guest returns 404', async
   assert.match(admin.body.toString('utf8'), /<title>Clawnsole<\/title>/);
 
   const guest = await invoke(handleRequest, { url: '/guest' });
-  assert.equal(guest.statusCode, 404);
+  assert.equal(guest.statusCode, 200);
+  assert.match(String(guest.headers['content-type'] || ''), /text\/html/);
+  assert.match(guest.body.toString('utf8'), /<title>Clawnsole<\/title>/);
 });
 
 test('GET /agents is admin-only and returns agent ids', async () => {


### PR DESCRIPTION
Fixes #108.

Adds guest-mode route + proxy so Playwright can cover:
- guest login at /guest
- guest can chat but cannot access /admin UI
- guest policy injected when using guest proxy

Also updates /meta to advertise guestWsUrl and adjusts UI to hide admin-only controls in guest mode.

Tests:
- npm test
- npm run test:ui