### PR TITLE
Add per-pane Playwright E2E specs

### DIFF
--- a/tests/helpers/pw-app.js
+++ b/tests/helpers/pw-app.js
@@ -1,0 +1,147 @@
+const { spawn } = require('child_process');
+const http = require('http');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function getFreePort(host = '127.0.0.1') {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer();
+    server.listen(0, host, () => {
+      const addr = server.address();
+      const port = addr && typeof addr === 'object' ? addr.port : null;
+      server.close(() => resolve(port));
+    });
+    server.on('error', reject);
+  });
+}
+
+function waitForHttp(url, timeoutMs = 10000, proc, label) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const attempt = () => {
+      http
+        .get(url, (res) => {
+          res.resume();
+          resolve();
+        })
+        .on('error', () => {
+          if (Date.now() - start > timeoutMs) {
+            let details = '';
+            if (proc) {
+              const stdout = proc.__stdout || '';
+              const stderr = proc.__stderr || '';
+              if (stdout || stderr) {
+                details = `\n${label || 'process'} output:\n${stdout}${stderr}`;
+              }
+              if (proc.exitCode !== null && proc.exitCode !== undefined) {
+                details += `\n${label || 'process'} exit code: ${proc.exitCode}`;
+              }
+            }
+            reject(new Error(`timeout waiting for ${url}${details}`));
+            return;
+          }
+          setTimeout(attempt, 250);
+        });
+    };
+    attempt();
+  });
+}
+
+function captureOutput(proc) {
+  proc.__stdout = '';
+  proc.__stderr = '';
+  proc.stdout?.on('data', (chunk) => {
+    proc.__stdout += chunk.toString();
+  });
+  proc.stderr?.on('data', (chunk) => {
+    proc.__stderr += chunk.toString();
+  });
+  return proc;
+}
+
+async function startClawnsoleTestApp() {
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'clawnsole-test-'));
+  const gatewayPort = await getFreePort();
+  const serverPort = await getFreePort();
+
+  const openclawDir = path.join(tempHome, '.openclaw');
+  fs.mkdirSync(openclawDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(openclawDir, 'openclaw.json'),
+    JSON.stringify(
+      {
+        gateway: {
+          port: gatewayPort,
+          auth: { token: 'test-token', mode: 'token' }
+        }
+      },
+      null,
+      2
+    )
+  );
+  fs.writeFileSync(
+    path.join(openclawDir, 'clawnsole.json'),
+    JSON.stringify(
+      {
+        adminPassword: 'admin',
+        authVersion: 'test'
+      },
+      null,
+      2
+    )
+  );
+
+  let skipReason = '';
+  let gatewayProc;
+  let serverProc;
+
+  try {
+    gatewayProc = captureOutput(
+      spawn('node', ['scripts/mock-gateway.js'], {
+        env: { ...process.env, HOME: tempHome, MOCK_GATEWAY_PORT: String(gatewayPort) },
+        stdio: ['ignore', 'pipe', 'pipe']
+      })
+    );
+    await waitForHttp(`http://127.0.0.1:${gatewayPort}`, 10000, gatewayProc, 'mock-gateway');
+  } catch (err) {
+    const message = String(err);
+    if (message.includes('EPERM') || message.includes('operation not permitted')) {
+      skipReason = 'Local environment disallows binding to ports (EPERM).';
+    } else {
+      throw err;
+    }
+  }
+
+  try {
+    serverProc = captureOutput(
+      spawn('node', ['server.js'], {
+        env: { ...process.env, HOME: tempHome, PORT: String(serverPort), HOST: '127.0.0.1' },
+        stdio: ['ignore', 'pipe', 'pipe']
+      })
+    );
+    await waitForHttp(`http://127.0.0.1:${serverPort}/meta`, 10000, serverProc, 'clawnsole');
+  } catch (err) {
+    const message = String(err);
+    if (message.includes('EPERM') || message.includes('operation not permitted')) {
+      skipReason = 'Local environment disallows binding to ports (EPERM).';
+    } else {
+      throw err;
+    }
+  }
+
+  const stop = () => {
+    try {
+      serverProc?.kill('SIGTERM');
+    } catch {}
+    try {
+      gatewayProc?.kill('SIGTERM');
+    } catch {}
+  };
+
+  return { tempHome, gatewayPort, serverPort, skipReason, stop };
+}
+
+module.exports = {
+  startClawnsoleTestApp
+};

--- a/tests/pane.chat.e2e.spec.js
+++ b/tests/pane.chat.e2e.spec.js
@@ -1,0 +1,35 @@
+const { test, expect } = require('@playwright/test');
+const { installPageFailureAssertions } = require('./helpers/pw-assertions');
+const { startClawnsoleTestApp } = require('./helpers/pw-app');
+
+let app;
+
+test.beforeAll(async () => {
+  app = await startClawnsoleTestApp();
+});
+
+test.afterAll(() => {
+  app?.stop?.();
+});
+
+test('pane: chat (admin) renders + can send/receive', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const pane = page.locator('[data-pane]').first();
+  await expect(pane.locator('[data-pane-input]')).toBeVisible({ timeout: 90000 });
+
+  await pane.locator('[data-pane-input]').fill('hello from e2e');
+  await pane.locator('[data-pane-send]').click();
+
+  // Mock gateway streams a delta then a final reply.
+  const reply = pane.locator('.chat-bubble.assistant', { hasText: 'mock-reply: hello from e2e' });
+  await expect(reply).toHaveCount(1, { timeout: 20000 });
+});

--- a/tests/pane.cron.e2e.spec.js
+++ b/tests/pane.cron.e2e.spec.js
@@ -1,0 +1,43 @@
+const { test, expect } = require('@playwright/test');
+const { installPageFailureAssertions } = require('./helpers/pw-assertions');
+const { startClawnsoleTestApp } = require('./helpers/pw-app');
+
+let app;
+
+test.beforeAll(async () => {
+  app = await startClawnsoleTestApp();
+});
+
+test.afterAll(() => {
+  app?.stop?.();
+});
+
+test('pane: cron renders + lists jobs from gateway', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  await expect(page.locator('#addPaneBtn')).toBeVisible();
+  await page.click('#addPaneBtn');
+  await page.getByRole('button', { name: 'Cron pane' }).click();
+
+  const panes = page.locator('[data-pane]');
+  const cronPane = panes.last();
+
+  await expect(cronPane.locator('.cron-pane')).toHaveCount(1);
+  await expect(cronPane.locator('.cron-job__title', { hasText: 'Nightly report' })).toBeVisible({ timeout: 20000 });
+  await expect(cronPane.locator('.cron-job__title', { hasText: 'PR sweep' })).toBeVisible();
+
+  // Core interaction: toggle a details view.
+  const viewBtn = cronPane.getByRole('button', { name: 'View' }).first();
+  const details = cronPane.locator('[data-cron-details-for]').first();
+  await expect(details).toBeHidden();
+  await viewBtn.click();
+  await expect(details).toBeVisible();
+});

--- a/tests/pane.timeline.e2e.spec.js
+++ b/tests/pane.timeline.e2e.spec.js
@@ -1,0 +1,38 @@
+const { test, expect } = require('@playwright/test');
+const { installPageFailureAssertions } = require('./helpers/pw-assertions');
+const { startClawnsoleTestApp } = require('./helpers/pw-app');
+
+let app;
+
+test.beforeAll(async () => {
+  app = await startClawnsoleTestApp();
+});
+
+test.afterAll(() => {
+  app?.stop?.();
+});
+
+test('pane: timeline renders + shows recent cron run events', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  await expect(page.locator('#addPaneBtn')).toBeVisible();
+  await page.click('#addPaneBtn');
+  await page.getByRole('button', { name: 'Timeline pane' }).click();
+
+  const panes = page.locator('[data-pane]');
+  const timelinePane = panes.last();
+
+  await expect(timelinePane.locator('.cron-pane')).toHaveCount(1);
+
+  // Timeline fetches cron.list then cron.runs; assert at least one event rendered.
+  await expect(timelinePane.locator('.timeline-item').first()).toBeVisible({ timeout: 60000 });
+  await expect(timelinePane.locator('.hint', { hasText: 'mock run ok' }).first()).toBeVisible();
+});

--- a/tests/pane.workqueue.e2e.spec.js
+++ b/tests/pane.workqueue.e2e.spec.js
@@ -1,0 +1,38 @@
+const { test, expect } = require('@playwright/test');
+const { installPageFailureAssertions } = require('./helpers/pw-assertions');
+const { startClawnsoleTestApp } = require('./helpers/pw-app');
+
+let app;
+
+test.beforeAll(async () => {
+  app = await startClawnsoleTestApp();
+});
+
+test.afterAll(() => {
+  app?.stop?.();
+});
+
+test('pane: workqueue renders + core controls visible', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  await expect(page.locator('#addPaneBtn')).toBeVisible();
+  await page.click('#addPaneBtn');
+  await page.getByRole('button', { name: 'Workqueue pane' }).click();
+
+  const panes = page.locator('[data-pane]');
+  const wqPane = panes.last();
+
+  await expect(wqPane.locator('.wq-pane')).toHaveCount(1);
+  await expect(wqPane.locator('[data-wq-refresh]')).toBeVisible();
+  await expect(wqPane.locator('[data-wq-queue-select]')).toBeVisible();
+  // Workqueue pane should not show chat composer controls.
+  await expect(wqPane.locator('[data-pane-input]')).toBeHidden();
+});


### PR DESCRIPTION
Closes #100.\n\nAdds dedicated Playwright E2E specs for each pane kind (chat/workqueue/cron/timeline) using a shared helper that boots a mock gateway + local server with temp HOME.\n\nRun: npm run test:ui