### PR TITLE
Testing: add frontend unit tests for app.js helpers (rebuilt)

### DIFF
--- a/app.js
+++ b/app.js
@@ -46,6 +46,29 @@ const globalElements = {
   paneTemplate: document.getElementById('paneTemplate')
 };
 
+// Pure helpers live in lib/app-core.js so we can unit-test them under Node.
+const __appCore = (typeof window !== 'undefined' && window.AppCore) ? window.AppCore : {};
+const escapeHtml = __appCore.escapeHtml || ((value) => {
+  const s = String(value ?? '');
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+});
+const fmtRemaining = __appCore.fmtRemaining || ((msUntil) => {
+  if (!Number.isFinite(msUntil)) return '';
+  if (msUntil <= 0) return 'expired';
+  const sec = Math.floor(msUntil / 1000);
+  const min = Math.floor(sec / 60);
+  const hr = Math.floor(min / 60);
+  if (hr > 0) return `${hr}h ${min % 60}m`;
+  if (min > 0) return `${min}m ${sec % 60}s`;
+  return `${sec}s`;
+});
+const sortWorkqueueItems = __appCore.sortWorkqueueItems || ((items, opts) => (Array.isArray(items) ? items.slice() : []));
+
 function getRouteRole() {
   try {
     const path = window.location.pathname || '/';
@@ -710,17 +733,6 @@ function closeWorkqueue() {
   globalElements.workqueueModal?.setAttribute('aria-hidden', 'true');
 }
 
-function fmtRemaining(msUntil) {
-  if (!Number.isFinite(msUntil)) return '';
-  if (msUntil <= 0) return 'expired';
-  const sec = Math.floor(msUntil / 1000);
-  const min = Math.floor(sec / 60);
-  const hr = Math.floor(min / 60);
-  if (hr > 0) return `${hr}h ${min % 60}m`;
-  if (min > 0) return `${min}m ${sec % 60}s`;
-  return `${sec}s`;
-}
-
 function renderWorkqueueStatusFilters() {
   const root = globalElements.wqStatusFilters;
   if (!root) return;
@@ -1291,96 +1303,6 @@ async function fetchAndRenderWorkqueueItemsForPane(pane) {
   }
 }
 
-function sortWorkqueueItems(items, { sortKey = 'default', sortDir = 'desc' } = {}) {
-  const dir = sortDir === 'asc' ? 1 : -1;
-  const statusRank = (s) => {
-    const v = String(s || '').trim();
-    if (v === 'in_progress') return 0;
-    if (v === 'claimed') return 1;
-    if (v === 'ready') return 2;
-    if (v === 'pending') return 3;
-    if (v === 'failed') return 4;
-    if (v === 'done') return 5;
-    return 6;
-  };
-
-  const numOr0 = (v) => (Number.isFinite(Number(v)) ? Number(v) : 0);
-  const timeOr0 = (v) => {
-    if (!v) return 0;
-    const n = Date.parse(String(v));
-    return Number.isFinite(n) ? n : 0;
-  };
-  const leaseOr0 = (v) => (Number.isFinite(Number(v)) ? Number(v) : 0);
-
-  return (Array.isArray(items) ? items : [])
-    .map((it, idx) => ({ it, idx }))
-    .sort((a, b) => {
-      const A = a.it || {};
-      const B = b.it || {};
-
-      // Default: status grouping (active first), then priority desc, then updatedAt desc, then createdAt desc.
-      if (sortKey === 'default') {
-        const sr = statusRank(A.status) - statusRank(B.status);
-        if (sr) return sr;
-        const pr = numOr0(B.priority) - numOr0(A.priority);
-        if (pr) return pr;
-        const ur = timeOr0(B.updatedAt) - timeOr0(A.updatedAt);
-        if (ur) return ur;
-        const cr = timeOr0(B.createdAt) - timeOr0(A.createdAt);
-        if (cr) return cr;
-        return a.idx - b.idx;
-      }
-
-      if (sortKey === 'status') {
-        const sr = (statusRank(A.status) - statusRank(B.status)) * dir;
-        if (sr) return sr;
-      }
-
-      if (sortKey === 'priority') {
-        const pr = (numOr0(A.priority) - numOr0(B.priority)) * dir;
-        if (pr) return pr;
-      }
-
-      if (sortKey === 'updatedAt') {
-        const ur = (timeOr0(A.updatedAt) - timeOr0(B.updatedAt)) * dir;
-        if (ur) return ur;
-      }
-
-      if (sortKey === 'createdAt') {
-        const cr = (timeOr0(A.createdAt) - timeOr0(B.createdAt)) * dir;
-        if (cr) return cr;
-      }
-
-      if (sortKey === 'leaseUntil') {
-        const lr = (leaseOr0(A.leaseUntil) - leaseOr0(B.leaseUntil)) * dir;
-        if (lr) return lr;
-      }
-
-      if (sortKey === 'attempts') {
-        const ar = (numOr0(A.attempts) - numOr0(B.attempts)) * dir;
-        if (ar) return ar;
-      }
-
-      if (sortKey === 'claimedBy') {
-        const av = String(A.claimedBy || '');
-        const bv = String(B.claimedBy || '');
-        const r = av.localeCompare(bv);
-        if (r) return r * dir;
-      }
-
-      if (sortKey === 'title') {
-        const av = String(A.title || '');
-        const bv = String(B.title || '');
-        const r = av.localeCompare(bv);
-        if (r) return r * dir;
-      }
-
-      // Stable fallback.
-      return a.idx - b.idx;
-    })
-    .map((x) => x.it);
-}
-
 function renderWorkqueuePaneItems(pane) {
   const body = pane.elements?.thread?.querySelector('[data-wq-list-body]');
   const empty = pane.elements?.thread?.querySelector('[data-wq-empty]');
@@ -1577,15 +1499,6 @@ async function workqueueClaimNextFromUi() {
   } catch (err) {
     setWorkqueueActionStatus(`Claim failed: ${String(err)}`, 'err');
   }
-}
-
-function escapeHtml(value) {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
 }
 
 function renderMarkdown(text) {

--- a/index.html
+++ b/index.html
@@ -300,6 +300,7 @@
     </div>
 
     <script src="gateway-client.js"></script>
+    <script src="/lib/app-core.js"></script>
     <script src="app.js"></script>
   </body>
 </html>

--- a/lib/app-core.js
+++ b/lib/app-core.js
@@ -1,0 +1,127 @@
+// lib/app-core.js
+// Shared pure helpers extracted from app.js so they can be unit-tested under Node.
+//
+// - In browser: attaches to window.AppCore
+// - In Node: module.exports = AppCore
+(function attachAppCore(root) {
+  function escapeHtml(value) {
+    const s = String(value ?? '');
+    return s
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/\"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function fmtRemaining(msUntil) {
+    if (!Number.isFinite(msUntil)) return '';
+    if (msUntil <= 0) return 'expired';
+    const sec = Math.floor(msUntil / 1000);
+    const min = Math.floor(sec / 60);
+    const hr = Math.floor(min / 60);
+    if (hr > 0) return `${hr}h ${min % 60}m`;
+    if (min > 0) return `${min}m ${sec % 60}s`;
+    return `${sec}s`;
+  }
+
+  function sortWorkqueueItems(items, { sortKey = 'default', sortDir = 'desc' } = {}) {
+    const dir = sortDir === 'asc' ? 1 : -1;
+    const statusRank = (s) => {
+      const v = String(s || '').trim();
+      if (v === 'in_progress') return 0;
+      if (v === 'claimed') return 1;
+      if (v === 'ready') return 2;
+      if (v === 'pending') return 3;
+      if (v === 'failed') return 4;
+      if (v === 'done') return 5;
+      return 6;
+    };
+
+    const numOr0 = (v) => (Number.isFinite(Number(v)) ? Number(v) : 0);
+    const timeOr0 = (v) => {
+      if (!v) return 0;
+      const n = Date.parse(String(v));
+      return Number.isFinite(n) ? n : 0;
+    };
+    const leaseOr0 = (v) => (Number.isFinite(Number(v)) ? Number(v) : 0);
+
+    return (Array.isArray(items) ? items : [])
+      .map((it, idx) => ({ it, idx }))
+      .sort((a, b) => {
+        const A = a.it || {};
+        const B = b.it || {};
+
+        // Default: status grouping (active first), then priority desc, then updatedAt desc, then createdAt desc.
+        if (sortKey === 'default') {
+          const sr = statusRank(A.status) - statusRank(B.status);
+          if (sr) return sr;
+          const pr = numOr0(B.priority) - numOr0(A.priority);
+          if (pr) return pr;
+          const ur = timeOr0(B.updatedAt) - timeOr0(A.updatedAt);
+          if (ur) return ur;
+          const cr = timeOr0(B.createdAt) - timeOr0(A.createdAt);
+          if (cr) return cr;
+          return a.idx - b.idx;
+        }
+
+        if (sortKey === 'status') {
+          const sr = (statusRank(A.status) - statusRank(B.status)) * dir;
+          if (sr) return sr;
+        }
+
+        if (sortKey === 'priority') {
+          const pr = (numOr0(A.priority) - numOr0(B.priority)) * dir;
+          if (pr) return pr;
+        }
+
+        if (sortKey === 'updatedAt') {
+          const ur = (timeOr0(A.updatedAt) - timeOr0(B.updatedAt)) * dir;
+          if (ur) return ur;
+        }
+
+        if (sortKey === 'createdAt') {
+          const cr = (timeOr0(A.createdAt) - timeOr0(B.createdAt)) * dir;
+          if (cr) return cr;
+        }
+
+        if (sortKey === 'leaseUntil') {
+          const lr = (leaseOr0(A.leaseUntil) - leaseOr0(B.leaseUntil)) * dir;
+          if (lr) return lr;
+        }
+
+        if (sortKey === 'attempts') {
+          const ar = (numOr0(A.attempts) - numOr0(B.attempts)) * dir;
+          if (ar) return ar;
+        }
+
+        if (sortKey === 'claimedBy') {
+          const av = String(A.claimedBy || '');
+          const bv = String(B.claimedBy || '');
+          const r = av.localeCompare(bv);
+          if (r) return r * dir;
+        }
+
+        if (sortKey === 'title') {
+          const av = String(A.title || '');
+          const bv = String(B.title || '');
+          const r = av.localeCompare(bv);
+          if (r) return r * dir;
+        }
+
+        // Stable fallback.
+        return a.idx - b.idx;
+      })
+      .map((x) => x.it);
+  }
+
+  const AppCore = { escapeHtml, fmtRemaining, sortWorkqueueItems };
+
+  try {
+    if (typeof module !== 'undefined' && module.exports) module.exports = AppCore;
+  } catch {}
+
+  try {
+    root.AppCore = Object.assign({}, root.AppCore || {}, AppCore);
+  } catch {}
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/tests/unit/app-core.test.js
+++ b/tests/unit/app-core.test.js
@@ -1,0 +1,49 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { escapeHtml, fmtRemaining, sortWorkqueueItems } = require('../../lib/app-core.js');
+
+test('escapeHtml escapes html special chars', () => {
+  assert.equal(escapeHtml('<div a="b">Tom & Jerry</div>'), '&lt;div a=&quot;b&quot;&gt;Tom &amp; Jerry&lt;/div&gt;');
+  assert.equal(escapeHtml("O'Reilly"), 'O&#39;Reilly');
+  assert.equal(escapeHtml(null), '');
+});
+
+test('fmtRemaining formats remaining time', () => {
+  assert.equal(fmtRemaining(NaN), '');
+  assert.equal(fmtRemaining(-1), 'expired');
+  assert.equal(fmtRemaining(0), 'expired');
+  assert.equal(fmtRemaining(999), '0s');
+  assert.equal(fmtRemaining(1000), '1s');
+  assert.equal(fmtRemaining(61_000), '1m 1s');
+  assert.equal(fmtRemaining(3_600_000), '1h 0m');
+  assert.equal(fmtRemaining(3_660_000), '1h 1m');
+});
+
+test('sortWorkqueueItems default groups by status then priority then timestamps', () => {
+  const items = [
+    { id: 'a', status: 'ready', priority: 1, updatedAt: '2026-01-01T00:00:00Z' },
+    { id: 'b', status: 'in_progress', priority: 0, updatedAt: '2026-01-01T00:00:00Z' },
+    { id: 'c', status: 'claimed', priority: 99, updatedAt: '2026-01-02T00:00:00Z' },
+    { id: 'd', status: 'claimed', priority: 5, updatedAt: '2026-01-03T00:00:00Z' },
+    { id: 'e', status: 'ready', priority: 10, updatedAt: '2026-01-04T00:00:00Z' }
+  ];
+
+  const sorted = sortWorkqueueItems(items);
+  assert.deepEqual(sorted.map((it) => it.id), ['b', 'c', 'd', 'e', 'a']);
+});
+
+test('sortWorkqueueItems supports explicit sort keys and stable ordering fallback', () => {
+  const items = [
+    { id: 'a', title: 'b', priority: 1 },
+    { id: 'b', title: 'a', priority: 1 },
+    { id: 'c', title: 'a', priority: 1 }
+  ];
+
+  const byTitleAsc = sortWorkqueueItems(items, { sortKey: 'title', sortDir: 'asc' });
+  assert.deepEqual(byTitleAsc.map((it) => it.id), ['b', 'c', 'a']);
+
+  // For ties, preserve input order.
+  const byPrio = sortWorkqueueItems(items, { sortKey: 'priority', sortDir: 'desc' });
+  assert.deepEqual(byPrio.map((it) => it.id), ['a', 'b', 'c']);
+});


### PR DESCRIPTION
Rebuild of #120 on top of current main after main history rewrite.

Cherry-picked only the commit that extracts app-core helpers + adds unit tests (no Playwright harness/CI retrigger).