### PR TITLE
Fix Workqueue + Timeline panes to use full height

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -961,8 +961,9 @@ button.send-btn .btn-icon {
   }
 }
 
-/* Workqueue pane (Issue #70): keep controls visible and make list scroll within viewport. */
-.wq-pane {
+/* Workqueue/Cron/Timeline panes: keep controls visible and make list scroll within viewport. */
+.wq-pane,
+.cron-pane {
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -970,7 +971,8 @@ button.send-btn .btn-icon {
   padding: 0;
 }
 
-.wq-pane .wq-toolbar {
+.wq-pane .wq-toolbar,
+.cron-pane .wq-toolbar {
   position: sticky;
   top: 0;
   z-index: 3;
@@ -1111,33 +1113,39 @@ button.send-btn .btn-icon {
   flex-wrap: wrap;
 }
 
-.wq-pane .wq-layout {
+.wq-pane .wq-layout,
+.cron-pane .wq-layout {
   flex: 1;
   min-height: 0;
   padding: 10px;
 }
 
-.wq-pane .wq-list {
+.wq-pane .wq-list,
+.cron-pane .wq-list {
   display: flex;
   flex-direction: column;
   min-height: 0;
 }
 
-.wq-pane .wq-list-body {
+.wq-pane .wq-list-body,
+.cron-pane .wq-list-body {
   flex: 1;
   max-height: none;
 }
 
-.wq-pane .wq-inspect {
+.wq-pane .wq-inspect,
+.cron-pane .wq-inspect {
   min-height: 0;
 }
 
-.wq-pane .wq-inspect-body {
+.wq-pane .wq-inspect-body,
+.cron-pane .wq-inspect-body {
   flex: 1;
   max-height: none;
 }
 
-.wq-pane .wq-list-header button {
+.wq-pane .wq-list-header button,
+.cron-pane .wq-list-header button {
   text-align: left;
 }
 

--- a/tests/pane.workqueue.e2e.spec.js
+++ b/tests/pane.workqueue.e2e.spec.js
@@ -33,6 +33,36 @@ test('pane: workqueue renders + core controls visible', async ({ page }) => {
   await expect(wqPane.locator('.wq-pane')).toHaveCount(1);
   await expect(wqPane.locator('[data-wq-refresh]')).toBeVisible();
   await expect(wqPane.locator('[data-wq-queue-select]')).toBeVisible();
+
+  // Layout regression: toolbar + list should consume full thread height (no dead space below).
+  const thread = wqPane.locator('[data-pane-thread]');
+  const toolbar = wqPane.locator('.wq-pane .wq-toolbar');
+  const layout = wqPane.locator('.wq-pane .wq-layout');
+  await expect(toolbar).toBeVisible();
+  await expect(layout).toBeVisible();
+
+  const [threadBox, toolbarBox, layoutBox] = await Promise.all([
+    thread.boundingBox(),
+    toolbar.boundingBox(),
+    layout.boundingBox()
+  ]);
+  expect(threadBox).toBeTruthy();
+  expect(toolbarBox).toBeTruthy();
+  expect(layoutBox).toBeTruthy();
+
+  // Allow for padding/gap inside the thread; main invariant is that layout reaches the bottom.
+  const threadTop = threadBox.y;
+  const threadBottom = threadBox.y + threadBox.height;
+  const toolbarTop = toolbarBox.y;
+  const layoutBottom = layoutBox.y + layoutBox.height;
+  expect(Math.abs(toolbarTop - threadTop)).toBeLessThan(20);
+  expect(Math.abs(layoutBottom - threadBottom)).toBeLessThan(20);
+
+  const listBody = wqPane.locator('.wq-pane .wq-list-body').first();
+  await expect(listBody).toBeVisible();
+  const listOverflowY = await listBody.evaluate((el) => getComputedStyle(el).overflowY);
+  expect(listOverflowY).toBe('auto');
+
   // Workqueue pane should not show chat composer controls.
   await expect(wqPane.locator('[data-pane-input]')).toBeHidden();
 });


### PR DESCRIPTION
Fixes #132.

- Make cron/timeline panes share the same full-height flex + internal scroll behavior as the workqueue pane.
- Add Playwright assertions to prevent dead-space regressions + ensure the list body is the scroll container.

Tests:
- npm test
- playwright (pane.workqueue + pane.timeline)