### PR TITLE
Playwright: timeline pane golden-path (filters/range/actions)

### DIFF
--- a/tests/helpers/pw-app.js
+++ b/tests/helpers/pw-app.js
@@ -74,6 +74,12 @@ async function startClawnsoleTestApp() {
         gateway: {
           port: gatewayPort,
           auth: { token: 'test-token', mode: 'token' }
+        },
+        agents: {
+          list: [
+            { id: 'dev', name: 'dev' },
+            { id: 'main', name: 'main' }
+          ]
         }
       },
       null,

--- a/tests/pane.timeline.e2e.spec.js
+++ b/tests/pane.timeline.e2e.spec.js
@@ -65,3 +65,58 @@ test('pane: timeline renders + shows recent cron run events', async ({ page }) =
   await expect(timelinePane.locator('.timeline-item').first()).toBeVisible({ timeout: 60000 });
   await expect(timelinePane.locator('.hint', { hasText: 'mock run ok' }).first()).toBeVisible();
 });
+
+test('pane: timeline filters + range + actions', async ({ page }) => {
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  const dialogs = [];
+  page.on('dialog', async (dialog) => {
+    dialogs.push({ type: dialog.type(), message: dialog.message() });
+    await dialog.accept();
+  });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  await page.click('#addPaneBtn');
+  await page.getByRole('button', { name: 'Timeline pane' }).click();
+
+  const panes = page.locator('[data-pane]');
+  const timelinePane = panes.last();
+
+  // Baseline: fixture should render timeline items.
+  await expect(timelinePane.getByTestId('timeline-item').first()).toBeVisible({ timeout: 60000 });
+
+  // Per-agent filter (depends on /agents fixture in startClawnsoleTestApp).
+  await expect(timelinePane.getByTestId('cron-agent').locator('option[value="dev"]')).toHaveCount(1);
+  await timelinePane.getByTestId('cron-agent').selectOption('dev');
+  await expect(timelinePane.getByText('PR sweep').first()).toBeVisible();
+
+  // Range: the mock gateway returns one event ~60s ago + one ~2h ago for each job.
+  // With dev selected, 1h should drop the ~2h event.
+  await timelinePane.getByTestId('timeline-range').selectOption('3600000');
+  await expect(timelinePane.getByText('mock run ok')).toBeVisible();
+  await expect(timelinePane.getByText('mock error')).toHaveCount(0);
+
+  // Actions: View should show an alert dialog (timeline entries do not embed <details>).
+  await timelinePane.getByTestId('cron-action-view').first().click();
+  await expect
+    .poll(() => dialogs.length)
+    .toBeGreaterThan(0);
+  expect(dialogs[0].message).toContain('job-2');
+
+  // Toggle should persist via mock-gateway cron.update and reflect in UI.
+  await timelinePane.getByTestId('cron-action-toggle').first().click();
+  await expect(timelinePane.getByText('enabled')).toBeVisible();
+
+  // Run should be wired (no dialog, no crash).
+  await timelinePane.getByTestId('cron-action-run').first().click();
+
+  // Delete should remove the job (confirm dialog) and timeline should become empty for dev.
+  await timelinePane.getByTestId('cron-action-delete').first().click();
+  await expect(timelinePane.getByText('No events in range.')).toBeVisible();
+});


### PR DESCRIPTION
Closes #125.

Adds stable data-testid selectors for timeline controls/items/actions, extends mock-gateway to support cron.update/remove with in-memory job store, and adds a Playwright E2E spec covering:
- timeline renders for fixture dataset
- per-agent filter updates timeline
- range filter updates timeline
- action menu: view/toggle/run/delete works (using dialogs + persisted mock store)
- asserts no page/console errors via existing helper.
