### PR TITLE
test: add cron pane golden-path Playwright coverage

### DIFF
--- a/scripts/mock-gateway.js
+++ b/scripts/mock-gateway.js
@@ -269,6 +269,11 @@ wss.on('connection', (socket) => {
     }
 
     if (frame.method === 'cron.run') {
+      const jobId = String(frame.params?.jobId || frame.params?.id || '').trim();
+      if (jobId === 'job-2') {
+        socket.send(JSON.stringify({ type: 'res', id, ok: false, error: { message: 'cron.run failed (mock: job-2)' } }));
+        return;
+      }
       socket.send(JSON.stringify({ type: 'res', id, ok: true, payload: { ok: true } }));
       return;
     }


### PR DESCRIPTION
## Summary\n- expand  into a full admin golden-path workflow test\n- cover list render, toggle enable/disable, run success + deterministic failure, edit via prompt patch, and delete\n- assert no console/page/request failures via \n- extend mock gateway  to deterministically fail for  so success/failure paths are both testable\n\n## Testing\n- 
Running 1 test using 1 worker

  ✓  1 tests/pane.cron.e2e.spec.js:15:1 › pane: cron admin golden path (toggle/run/edit/delete) (2.5s)

  1 passed (3.6s)\n- 
Running 3 tests using 2 workers

  ✓  2 tests/pane.timeline.e2e.spec.js:15:1 › pane: timeline renders + shows recent cron run events (1.9s)
  ✓  1 tests/pane.cron.e2e.spec.js:15:1 › pane: cron admin golden path (toggle/run/edit/delete) (2.6s)
  ✓  3 tests/pane.timeline.e2e.spec.js:69:1 › pane: timeline filters + range + actions (2.2s)

  3 passed (5.2s)\n\nCloses #124