### PR TITLE
UX: Agent picker quick filter + last-active sort

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2305,3 +2305,136 @@ button.send-btn .btn-icon {
   line-height: 1.4;
   color: rgba(230, 238, 246, 0.92);
 }
+
+/* Agent picker (admin) */
+.agent-picker-btn {
+  height: 28px;
+  padding: 0 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(18, 22, 30, 0.7);
+  color: rgba(240, 246, 255, 0.92);
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.agent-picker-btn:hover {
+  border-color: rgba(255, 255, 255, 0.18);
+  background: rgba(20, 26, 36, 0.85);
+}
+
+.agent-picker {
+  position: fixed;
+  z-index: 60;
+  width: 340px;
+  max-width: calc(100vw - 16px);
+  max-height: 320px;
+  overflow: hidden;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(10, 12, 16, 0.96);
+  backdrop-filter: blur(10px);
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.55);
+}
+
+.agent-picker__header {
+  display: flex;
+  gap: 8px;
+  padding: 10px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.agent-picker__filter {
+  flex: 1;
+  height: 28px;
+  padding: 0 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(18, 22, 30, 0.8);
+  color: rgba(240, 246, 255, 0.92);
+  outline: none;
+}
+
+.agent-picker__sort {
+  height: 28px;
+  padding: 0 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(18, 22, 30, 0.8);
+  color: rgba(240, 246, 255, 0.92);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.agent-picker__list {
+  padding: 6px;
+  overflow: auto;
+  max-height: 270px;
+}
+
+.agent-picker-item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 8px 10px;
+  margin: 2px 0;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: rgba(240, 246, 255, 0.92);
+  text-align: left;
+  cursor: pointer;
+}
+
+.agent-picker-item:hover {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.agent-picker-item.active {
+  background: rgba(108, 154, 255, 0.12);
+  border-color: rgba(108, 154, 255, 0.22);
+}
+
+.agent-picker-item__label {
+  font-weight: 500;
+}
+
+.agent-picker-item__meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  justify-content: flex-end;
+  min-width: 90px;
+}
+
+.agent-picker-item__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 18px;
+  padding: 0 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(18, 22, 30, 0.8);
+  font-size: 11px;
+  color: rgba(240, 246, 255, 0.88);
+}
+
+.agent-picker-item__status {
+  font-size: 11px;
+  color: rgba(230, 238, 246, 0.68);
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-picker-empty {
+  padding: 10px;
+  color: rgba(230, 238, 246, 0.7);
+  font-size: 12px;
+}

--- a/tests/agent-picker.e2e.spec.js
+++ b/tests/agent-picker.e2e.spec.js
@@ -1,0 +1,41 @@
+const { test, expect } = require('@playwright/test');
+const { installPageFailureAssertions } = require('./helpers/pw-assertions');
+const { startClawnsoleTestApp } = require('./helpers/pw-app');
+
+let app;
+
+test.beforeAll(async () => {
+  app = await startClawnsoleTestApp();
+});
+
+test.afterAll(() => {
+  app?.stop?.();
+});
+
+test('agent picker: filter reduces list; Esc clears', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const pane = page.locator('[data-pane]').first();
+  const btn = pane.locator('[data-testid="agent-picker-button"]');
+  await expect(btn).toBeVisible({ timeout: 20000 });
+
+  await btn.click();
+
+  const listItems = page.locator('[data-testid="agent-picker-item"]');
+  await expect(listItems).toHaveCount(2);
+
+  const filter = page.locator('[data-testid="agent-filter-input"]');
+  await filter.fill('dev');
+  await expect(listItems).toHaveCount(1);
+
+  await filter.press('Escape');
+  await expect(listItems).toHaveCount(2);
+});


### PR DESCRIPTION
Implements #135.

- Replaces the admin pane agent <select> with a lightweight popover picker.
- Live text filter across agent id, display name, and best-effort status snippet.
- Sort toggle: Agent id vs Last active (best-effort activity cache).
- Shows an activity age pill per agent row.
- Adds Playwright spec covering filter + Esc clear.

Notes:
- Last-active + status snippets are best-effort, derived from UI events (connect/disconnect/chat frames) until a richer agent-status payload exists.