### PR TITLE
Pane header: type pill + subtle per-type tint

### DIFF
--- a/app.js
+++ b/app.js
@@ -2830,6 +2830,9 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
   const elements = {
     root,
     name: root.querySelector('[data-pane-name]'),
+    typePill: root.querySelector('[data-pane-type-pill]'),
+    typeIcon: root.querySelector('[data-pane-type-icon]'),
+    typeText: root.querySelector('[data-pane-type-text]'),
     agentSelect: root.querySelector('[data-pane-agent-select]'),
     agentWrap: root.querySelector('.pane-agent'),
     status: root.querySelector('[data-pane-status]'),
@@ -2885,10 +2888,26 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
     client: null
   };
 
-  // Mark pane kind on root for CSS + debugging.
+  const paneKindMeta = (kind) => {
+    const k = String(kind || 'chat');
+    if (k === 'workqueue') return { label: 'WORKQUEUE', icon: '🧰' };
+    if (k === 'cron') return { label: 'CRON', icon: '⏱' };
+    if (k === 'timeline') return { label: 'TIMELINE', icon: '🕒' };
+    return { label: 'CHAT', icon: '💬' };
+  };
+
+  // Mark pane kind on root for CSS + debugging + type pill.
   try {
     elements.root.dataset.paneKind = pane.kind;
     elements.root.classList.add(`pane-kind-${pane.kind}`);
+
+    const meta = paneKindMeta(pane.kind);
+    if (elements.typeText) elements.typeText.textContent = meta.label;
+    if (elements.typeIcon) elements.typeIcon.textContent = meta.icon;
+    if (elements.typePill) {
+      elements.typePill.classList.remove('pane-type-chat', 'pane-type-workqueue', 'pane-type-cron', 'pane-type-timeline');
+      elements.typePill.classList.add(`pane-type-${pane.kind}`);
+    }
   } catch {}
 
   if (elements.closeBtn) {

--- a/index.html
+++ b/index.html
@@ -71,6 +71,10 @@
             <div class="pane-header">
               <div class="pane-header-left">
                 <div class="pane-name" data-pane-name data-testid="pane-type-label">Pane</div>
+                <div class="pane-type-pill" data-pane-type-pill data-testid="pane-type-pill" aria-label="Pane type">
+                  <span class="pane-type-icon" data-pane-type-icon aria-hidden="true">💬</span>
+                  <span class="pane-type-text" data-pane-type-text>CHAT</span>
+                </div>
                 <div class="pane-agent">
                   <span class="agent-label">Agent</span>
                   <select data-pane-agent-select aria-label="Select agent" data-testid="pane-agent-select"></select>

--- a/styles.css
+++ b/styles.css
@@ -410,8 +410,9 @@ body::before {
   gap: 12px;
   padding: 8px 10px;
   border-radius: 16px;
-  background: rgba(9, 12, 16, 0.18);
+  background: linear-gradient(90deg, var(--pane-header-tint, rgba(9, 12, 16, 0.18)), rgba(9, 12, 16, 0.12));
   border: 1px solid rgba(255, 255, 255, 0.08);
+  border-left: 4px solid var(--pane-accent, rgba(255, 179, 71, 0.55));
   position: relative;
   z-index: 2;
 }
@@ -429,6 +430,72 @@ body::before {
   letter-spacing: 0.14em;
   color: var(--muted);
   white-space: nowrap;
+}
+
+.pane-type-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  line-height: 1;
+  user-select: none;
+}
+
+.pane-type-icon {
+  font-size: 12px;
+  opacity: 0.95;
+}
+
+.pane-type-text {
+  font-weight: 650;
+}
+
+/* Per-pane subtle treatment */
+.pane-kind-chat {
+  --pane-accent: rgba(127, 209, 185, 0.75);
+  --pane-header-tint: rgba(127, 209, 185, 0.08);
+}
+
+.pane-kind-workqueue {
+  --pane-accent: rgba(255, 179, 71, 0.8);
+  --pane-header-tint: rgba(255, 179, 71, 0.09);
+}
+
+.pane-kind-cron {
+  --pane-accent: rgba(162, 155, 254, 0.8);
+  --pane-header-tint: rgba(162, 155, 254, 0.09);
+}
+
+.pane-kind-timeline {
+  --pane-accent: rgba(86, 204, 242, 0.78);
+  --pane-header-tint: rgba(86, 204, 242, 0.08);
+}
+
+.pane-type-chat {
+  border-color: rgba(127, 209, 185, 0.45);
+  background: rgba(127, 209, 185, 0.12);
+}
+
+.pane-type-workqueue {
+  border-color: rgba(255, 179, 71, 0.55);
+  background: rgba(255, 179, 71, 0.12);
+}
+
+.pane-type-cron {
+  border-color: rgba(162, 155, 254, 0.55);
+  background: rgba(162, 155, 254, 0.12);
+}
+
+.pane-type-timeline {
+  border-color: rgba(86, 204, 242, 0.55);
+  background: rgba(86, 204, 242, 0.12);
 }
 
 .pane-agent {

--- a/tests/pane.cron.e2e.spec.js
+++ b/tests/pane.cron.e2e.spec.js
@@ -30,6 +30,7 @@ test('pane: cron renders + lists jobs from gateway', async ({ page }) => {
   const panes = page.locator('[data-pane]');
   const cronPane = panes.last();
 
+  await expect(cronPane.locator('[data-testid="pane-type-pill"]')).toContainText('CRON');
   await expect(cronPane.locator('.cron-pane')).toHaveCount(1);
   await expect(cronPane.locator('.cron-job__title', { hasText: 'Nightly report' })).toBeVisible({ timeout: 20000 });
   await expect(cronPane.locator('.cron-job__title', { hasText: 'PR sweep' })).toBeVisible();

--- a/tests/pane.timeline.e2e.spec.js
+++ b/tests/pane.timeline.e2e.spec.js
@@ -30,6 +30,8 @@ test('pane: timeline renders + shows recent cron run events', async ({ page }) =
   const panes = page.locator('[data-pane]');
   const timelinePane = panes.last();
 
+  await expect(timelinePane.locator('[data-testid="pane-type-pill"]')).toContainText('TIMELINE');
+
   const cronPane = timelinePane.locator('.cron-pane');
   await expect(cronPane).toHaveCount(1);
 
@@ -87,6 +89,8 @@ test('pane: timeline filters + range + actions', async ({ page }) => {
 
   const panes = page.locator('[data-pane]');
   const timelinePane = panes.last();
+
+  await expect(timelinePane.locator('[data-testid="pane-type-pill"]')).toContainText('TIMELINE');
 
   // Baseline: fixture should render timeline items.
   await expect(timelinePane.getByTestId('timeline-item').first()).toBeVisible({ timeout: 60000 });

--- a/tests/pane.workqueue.e2e.spec.js
+++ b/tests/pane.workqueue.e2e.spec.js
@@ -30,6 +30,7 @@ test('pane: workqueue renders + core controls visible', async ({ page }) => {
   const panes = page.locator('[data-pane]');
   const wqPane = panes.last();
 
+  await expect(wqPane.locator('[data-testid="pane-type-pill"]')).toContainText('WORKQUEUE');
   await expect(wqPane.locator('.wq-pane')).toHaveCount(1);
   await expect(wqPane.locator('[data-wq-refresh]')).toBeVisible();
   await expect(wqPane.locator('[data-wq-queue-select]')).toBeVisible();


### PR DESCRIPTION
Fixes #129.

- Adds a pane type pill (CHAT/WORKQUEUE/CRON/TIMELINE) with icon in the pane header.
- Applies a subtle per-type header tint + left border accent via CSS vars on pane kind.
- Updates UI e2e tests to assert the correct type pill is shown for Workqueue/Cron/Timeline panes.

Notes:
- Non-chat panes already hide the composer via existing CSS; this change keeps that behavior.
