### PR TITLE
Playwright: Cron pane golden-path coverage (stable selectors)

### DIFF
--- a/app.js
+++ b/app.js
@@ -3513,7 +3513,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
       : `
           <label class="wq-field" style="min-width: 220px;">
             <span class="wq-label">Search</span>
-            <input data-cron-search type="text" placeholder="job name / id" />
+            <input data-cron-search data-testid="cron-search" type="text" placeholder="job name / id" />
           </label>
           <label class="wq-field" style="min-width: 160px;">
             <span class="wq-label">Filters</span>
@@ -3541,7 +3541,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
       </div>
       <div class="wq-layout" style="grid-template-columns: 1fr;">
         <section class="wq-list" aria-label="${isTimeline ? 'Timeline' : 'Cron'} data">
-          <div class="wq-list-body" data-cron-body></div>
+          <div class="wq-list-body" data-cron-body data-testid="cron-body"></div>
         </section>
       </div>
     `;
@@ -3785,9 +3785,9 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
                 return sch.kind ? String(sch.kind) : '';
               })();
               const id = String(job.id || '');
-              return `<div class="cron-job" data-cron-job-card data-job-id="${escapeHtml(id)}">
+              return `<div class="cron-job" data-cron-job-card data-testid="cron-job-card" data-job-id="${escapeHtml(id)}">
                 <div class="cron-job__top">
-                  <div class="cron-job__title">${escapeHtml(job.name || job.id)}</div>
+                  <div class="cron-job__title" data-testid="cron-job-title">${escapeHtml(job.name || job.id)}</div>
                   <div class="cron-job__badges">
                     <span class="pill pill--muted">${escapeHtml(job.agentId || 'main')}</span>
                     <span class="pill ${enabled ? 'pill--ok' : 'pill--warn'}">${enabled ? 'enabled' : 'disabled'}</span>

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
           </div>
           <div id="paneControls" class="pane-controls" hidden>
             <div class="pane-add-wrap">
-              <button id="addPaneBtn" class="icon-btn" type="button" aria-haspopup="menu" aria-expanded="false" aria-label="Add pane">
+              <button id="addPaneBtn" class="icon-btn" type="button" aria-haspopup="menu" aria-expanded="false" aria-label="Add pane" data-testid="add-pane-btn">
                 +
               </button>
             </div>

--- a/tests/pane.cron.e2e.spec.js
+++ b/tests/pane.cron.e2e.spec.js
@@ -32,16 +32,17 @@ test('pane: cron admin golden path (toggle/run/edit/delete)', async ({ page }) =
   await page.click('#loginBtn');
   await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
 
-  await expect(page.locator('#addPaneBtn')).toBeVisible();
-  await page.click('#addPaneBtn');
+  await expect(page.getByTestId('add-pane-btn')).toBeVisible();
+  await page.getByTestId('add-pane-btn').click();
   await page.getByRole('button', { name: 'Cron pane' }).click();
 
   const panes = page.locator('[data-pane]');
   const cronPane = panes.last();
 
   await expect(cronPane.locator('.cron-pane')).toHaveCount(1);
-  await expect(cronPane.locator('.cron-job__title', { hasText: 'Nightly report' })).toBeVisible({ timeout: 20000 });
-  await expect(cronPane.locator('.cron-job__title', { hasText: 'PR sweep' })).toBeVisible();
+  await expect(cronPane.getByTestId('cron-body')).toBeVisible();
+  await expect(cronPane.getByTestId('cron-job-title').filter({ hasText: 'Nightly report' })).toBeVisible({ timeout: 20000 });
+  await expect(cronPane.getByTestId('cron-job-title').filter({ hasText: 'PR sweep' })).toBeVisible();
 
   // Toggle enabled -> disabled for job-1.
   const job1 = cronPane.locator('[data-cron-job-card][data-job-id="job-1"]');


### PR DESCRIPTION
Fixes #124\n\n- Add data-testid hooks to cron pane + add-pane button\n- Update cron E2E test to prefer data-testid selectors