### PR TITLE
UX: Ctrl/Cmd+K command palette (v1)

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,6 +179,27 @@
 
     <div id="toastHost" class="toast-host" aria-live="polite" aria-atomic="true" data-testid="toast-host"></div>
 
+    <div id="commandPaletteModal" class="modal" aria-hidden="true" data-testid="command-palette-modal">
+      <div class="modal-card" role="dialog" aria-modal="true" aria-labelledby="commandPaletteTitle">
+        <div class="modal-header">
+          <h2 id="commandPaletteTitle">Command palette</h2>
+          <button id="commandPaletteCloseBtn" class="icon-btn" type="button" aria-label="Close command palette">✕</button>
+        </div>
+        <div class="modal-body">
+          <input
+            id="commandPaletteInput"
+            class="command-palette-input"
+            type="text"
+            placeholder="Type to search (agents, panes, actions)…"
+            autocomplete="off"
+            spellcheck="false"
+          />
+          <div id="commandPaletteList" class="command-palette-list" role="listbox" aria-label="Commands"></div>
+          <div id="commandPaletteEmpty" class="hint" hidden>No matches.</div>
+        </div>
+      </div>
+    </div>
+
     <div id="shortcutsModal" class="modal" aria-hidden="true" data-testid="shortcuts-modal">
       <div class="modal-card" role="dialog" aria-modal="true" aria-labelledby="shortcutsTitle">
         <div class="modal-header">
@@ -201,7 +222,8 @@
           <div class="shortcut-group">
             <h3 class="shortcut-group-title">Panes</h3>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>1</kbd>..<kbd>4</kbd></div><div class="shortcut-desc">Focus pane 14</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Pane switcher (cycle focus)</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Open command palette</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Pane switcher (cycle focus)</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd></div><div class="shortcut-desc">Add pane</div></div>
           </div>
 

--- a/styles.css
+++ b/styles.css
@@ -1066,6 +1066,66 @@ button.send-btn .btn-icon {
   width: min(1060px, 96vw);
 }
 
+/* Command palette */
+
+.command-palette-input {
+  width: 100%;
+  border: 1px solid var(--panel-border);
+  background: rgba(255, 255, 255, 0.02);
+  color: var(--text);
+  padding: 10px 12px;
+  border-radius: 12px;
+  outline: none;
+  margin-bottom: 10px;
+}
+
+.command-palette-input:focus {
+  border-color: rgba(110, 231, 183, 0.5);
+  box-shadow: 0 0 0 3px rgba(110, 231, 183, 0.12);
+}
+
+.command-palette-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: min(56vh, 520px);
+  overflow: auto;
+  padding-right: 2px;
+}
+
+.command-palette-item {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 10px;
+  align-items: center;
+  text-align: left;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.02);
+  color: inherit;
+}
+
+.command-palette-item[aria-selected="true"] {
+  border-color: rgba(110, 231, 183, 0.5);
+  background: rgba(110, 231, 183, 0.08);
+}
+
+.command-palette-item-label {
+  font-weight: 600;
+}
+
+.command-palette-item-detail {
+  margin-top: 2px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.command-palette-item-meta {
+  font-size: 12px;
+  color: var(--muted);
+}
+
 /* Shortcuts modal */
 
 .shortcut-group {

--- a/tests/ui/command-palette.spec.js
+++ b/tests/ui/command-palette.spec.js
@@ -1,0 +1,47 @@
+const { test, expect } = require('@playwright/test');
+
+const { startTestEnv, loginAdmin, attachConsoleErrorAsserts } = require('./_helpers');
+
+let env;
+
+test.beforeAll(async () => {
+  env = await startTestEnv();
+});
+
+test.afterAll(() => {
+  env?.stop?.();
+});
+
+test.afterEach(async ({ page }) => {
+  if (page.__consoleAsserts) {
+    page.__consoleAsserts.assertNoErrors();
+  }
+});
+
+test('command palette: Ctrl/Cmd+K opens and can add a pane', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+
+  const countBefore = await page.locator('[data-pane]').count();
+
+  await page.keyboard.press('ControlOrMeta+K');
+
+  const modal = page.locator('[data-testid="command-palette-modal"]');
+  await expect(modal).toBeVisible();
+
+  const input = page.locator('#commandPaletteInput');
+  await expect(input).toBeFocused();
+
+  await input.type('add pane: timeline');
+  await page.keyboard.press('Enter');
+
+  const tlPane = page.locator('[data-pane-kind="timeline"]').last();
+  await expect(tlPane).toBeVisible();
+
+  const countAfter = await page.locator('[data-pane]').count();
+  expect(countAfter).toBeGreaterThan(countBefore);
+});


### PR DESCRIPTION
Closes #145\n\n## What\nAdds a minimal command palette for keyboard-first navigation.\n\n## Acceptance criteria (v1 shipped here)\n- [x] Ctrl+K (Cmd+K on mac) opens a command palette modal.\n- [x] Palette supports fuzzy search across:\n  - [x] Agents (by name/id) → focuses (or creates) a Chat pane and switches it to that agent.\n  - [x] Pane actions: Add Pane (Chat/Workqueue/Cron/Timeline), Reset Layout, Toggle shortcuts overlay.\n  - [x] Focus actions: focus pane 1-4, cycle pane focus (via command).\n- [x] Enter executes highlighted command; Esc closes.\n- [x] Works without breaking existing keybindings (moved pane cycle from Cmd/Ctrl+K → Cmd/Ctrl+Shift+K; updated shortcuts overlay).\n- [x] Documented in the shortcuts overlay.\n\n## Follow-ups (not in v1)\n- Add explicit left/right pane focus commands (based on layout).\n- Add focus agent list (once there is a distinct agent list control).\n\n## Tests\n- Added Playwright UI test: command palette opens and can add a Timeline pane.