### PR TITLE
Pane Manager (list/focus/close panes)

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,7 +5,7 @@ const globalElements = {
   disconnectBtn: document.getElementById('disconnectBtn'),
   resetLayoutBtn: document.getElementById('resetLayoutBtn'),
   status: document.getElementById('connectionStatus'),
-  statusMeta: document.getElementById('statusMeta'),
+  paneManagerBtn: document.getElementById('paneManagerBtn'),
   pulseCanvas: document.getElementById('pulseCanvas'),
   workqueueBtn: document.getElementById('workqueueBtn'),
   refreshAgentsBtn: document.getElementById('refreshAgentsBtn'),
@@ -25,6 +25,10 @@ const globalElements = {
   commandPaletteEmpty: document.getElementById('commandPaletteEmpty'),
   shortcutsModal: document.getElementById('shortcutsModal'),
   shortcutsCloseBtn: document.getElementById('shortcutsCloseBtn'),
+  paneManagerModal: document.getElementById('paneManagerModal'),
+  paneManagerCloseBtn: document.getElementById('paneManagerCloseBtn'),
+  paneManagerList: document.getElementById('paneManagerList'),
+  paneManagerEmpty: document.getElementById('paneManagerEmpty'),
   workqueueModal: document.getElementById('workqueueModal'),
   workqueueCloseBtn: document.getElementById('workqueueCloseBtn'),
   wqQueueSelect: document.getElementById('wqQueueSelect'),
@@ -649,12 +653,12 @@ function updateGlobalStatus() {
   const panes = paneManager.panes;
   if (!uiState.authed) {
     setStatusPill(globalElements.status, 'disconnected', 'sign in required');
-    if (globalElements.statusMeta) globalElements.statusMeta.textContent = 'sign in required';
+    if (globalElements.paneManagerBtn) globalElements.paneManagerBtn.textContent = 'sign in required';
     return;
   }
   if (panes.length === 0) {
     setStatusPill(globalElements.status, 'disconnected', '');
-    if (globalElements.statusMeta) globalElements.statusMeta.textContent = '';
+    if (globalElements.paneManagerBtn) globalElements.paneManagerBtn.textContent = '';
     return;
   }
 
@@ -678,7 +682,7 @@ function updateGlobalStatus() {
       ? firstError.statusMeta
       : `panes: ${connectedCount}/${total} connected`;
   setStatusPill(globalElements.status, state, meta);
-  if (globalElements.statusMeta) globalElements.statusMeta.textContent = meta;
+  if (globalElements.paneManagerBtn) globalElements.paneManagerBtn.textContent = meta;
 }
 
 function updateConnectionControls() {
@@ -833,6 +837,167 @@ function openShortcuts() {
 function closeShortcuts() {
   globalElements.shortcutsModal?.classList.remove('open');
   globalElements.shortcutsModal?.setAttribute('aria-hidden', 'true');
+}
+
+// Pane Manager (admin-only)
+
+const paneManagerUiState = {
+  open: false,
+  selectedIndex: 0
+};
+
+function isPaneManagerOpen() {
+  return !!globalElements.paneManagerModal?.classList.contains('open');
+}
+
+function paneLabel(pane) {
+  const kind = pane?.kind || 'chat';
+  if (kind === 'workqueue') return 'Workqueue';
+  if (kind === 'cron') return 'Cron';
+  if (kind === 'timeline') return 'Timeline';
+  return 'Chat';
+}
+
+function paneIcon(pane) {
+  const kind = pane?.kind || 'chat';
+  if (kind === 'workqueue') return 'WQ';
+  if (kind === 'cron') return '⏰';
+  if (kind === 'timeline') return '🕒';
+  return '💬';
+}
+
+function paneTargetLabel(pane) {
+  if (!pane) return '';
+  if (pane.kind === 'workqueue') return String(pane.workqueue?.queue || 'dev-team');
+  if (pane.kind === 'cron' || pane.kind === 'timeline') return 'gateway';
+  return String(pane.agentId || 'main');
+}
+
+function renderPaneManager() {
+  const panes = paneManager?.panes || [];
+  const list = globalElements.paneManagerList;
+  const empty = globalElements.paneManagerEmpty;
+  if (!list || !empty) return;
+
+  list.innerHTML = '';
+  empty.hidden = panes.length > 0;
+
+  const selected = Math.max(0, Math.min(paneManagerUiState.selectedIndex, panes.length - 1));
+  paneManagerUiState.selectedIndex = selected;
+
+  panes.forEach((pane, idx) => {
+    const row = document.createElement('div');
+    row.className = 'pane-manager-row';
+    row.setAttribute('role', 'option');
+    row.dataset.index = String(idx);
+    row.dataset.paneKey = String(pane.key || '');
+    row.setAttribute('aria-selected', idx === selected ? 'true' : 'false');
+
+    const state = String(pane.statusState || (pane.connected ? 'connected' : 'disconnected'));
+
+    row.innerHTML = `
+      <div class="pane-manager-main">
+        <div class="pane-manager-kind" title="${escapeHtml(paneLabel(pane))}">
+          <span class="pane-manager-icon" aria-hidden="true">${escapeHtml(paneIcon(pane))}</span>
+          <span class="pane-manager-kind-label">${escapeHtml(paneLabel(pane))}</span>
+        </div>
+        <div class="pane-manager-target" title="${escapeHtml(paneTargetLabel(pane))}">${escapeHtml(paneTargetLabel(pane))}</div>
+        <div class="pane-manager-state" data-state="${escapeHtml(state)}">${escapeHtml(state)}</div>
+      </div>
+      <div class="pane-manager-actions">
+        <button class="secondary pane-manager-focus" type="button" data-action="focus">Focus</button>
+        <button class="secondary pane-manager-close" type="button" data-action="close">Close</button>
+      </div>
+    `;
+
+    row.addEventListener('mousemove', () => {
+      paneManagerUiState.selectedIndex = idx;
+      renderPaneManager();
+    });
+
+    row.addEventListener('click', (event) => {
+      const action = event?.target?.dataset?.action;
+      paneManagerUiState.selectedIndex = idx;
+      if (action === 'close') {
+        try {
+          paneManager.removePane(pane.key);
+        } catch {}
+        renderPaneManager();
+        return;
+      }
+      // Default: focus
+      closePaneManager();
+      focusPaneIndex(idx);
+    });
+
+    list.appendChild(row);
+  });
+}
+
+function openPaneManager() {
+  if (roleState.role !== 'admin') return;
+  if (!uiState.authed) {
+    showLogin('Please sign in to continue.');
+    return;
+  }
+  if (!globalElements.paneManagerModal) return;
+
+  paneManagerUiState.open = true;
+  paneManagerUiState.selectedIndex = 0;
+
+  globalElements.paneManagerModal.classList.add('open');
+  globalElements.paneManagerModal.setAttribute('aria-hidden', 'false');
+  renderPaneManager();
+
+  // Ensure keydown events go somewhere stable.
+  try {
+    globalElements.paneManagerModal.focus?.();
+  } catch {}
+}
+
+function closePaneManager({ restoreFocus = true } = {}) {
+  if (!globalElements.paneManagerModal) return;
+  paneManagerUiState.open = false;
+  globalElements.paneManagerModal.classList.remove('open');
+  globalElements.paneManagerModal.setAttribute('aria-hidden', 'true');
+  if (restoreFocus) {
+    try {
+      const pane = paneManager?.panes?.[0];
+      pane?.elements?.input?.focus?.();
+    } catch {}
+  }
+}
+
+function paneManagerHandleKeydown(event) {
+  if (!isPaneManagerOpen()) return false;
+  const panes = paneManager?.panes || [];
+  if (event.key === 'Escape') {
+    event.preventDefault();
+    closePaneManager();
+    return true;
+  }
+  if (panes.length === 0) return false;
+
+  if (event.key === 'ArrowDown') {
+    event.preventDefault();
+    paneManagerUiState.selectedIndex = Math.min(panes.length - 1, paneManagerUiState.selectedIndex + 1);
+    renderPaneManager();
+    return true;
+  }
+  if (event.key === 'ArrowUp') {
+    event.preventDefault();
+    paneManagerUiState.selectedIndex = Math.max(0, paneManagerUiState.selectedIndex - 1);
+    renderPaneManager();
+    return true;
+  }
+  if (event.key === 'Enter') {
+    event.preventDefault();
+    const idx = Math.max(0, Math.min(panes.length - 1, paneManagerUiState.selectedIndex));
+    closePaneManager();
+    focusPaneIndex(idx);
+    return true;
+  }
+  return false;
 }
 
 // Command palette (admin-only)
@@ -5288,11 +5453,23 @@ function focusPaneIndex(idx) {
     pane.elements?.root?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
   } catch {}
 
-  // Prefer focusing the chat input when available.
+  // Prefer focusing the chat input when available (and visible).
   const input = pane.elements?.input;
   if (input && typeof input.focus === 'function') {
-    input.focus();
-    return;
+    const isVisible = (() => {
+      try {
+        if (input.disabled) return false;
+        if (input.hidden) return false;
+        if (input.getClientRects && input.getClientRects().length === 0) return false;
+        return true;
+      } catch {
+        return true;
+      }
+    })();
+    if (isVisible) {
+      input.focus();
+      return;
+    }
   }
 
   // Fallback: focus first focusable control inside the pane.
@@ -5325,6 +5502,9 @@ window.addEventListener('keydown', (event) => {
     return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
   })();
 
+  // If Pane Manager is open, it gets first dibs on keys.
+  if (paneManagerHandleKeydown(event)) return;
+
   // Add-pane shortcuts (admin-only)
   // Ctrl/Cmd+Shift+C → new chat
   // Ctrl/Cmd+Shift+W → new workqueue
@@ -5345,6 +5525,13 @@ window.addEventListener('keydown', (event) => {
     }
   }
 
+  // Cmd/Ctrl+P opens Pane Manager (even while typing).
+  if ((event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey && String(event.key || '').toLowerCase() === 'p') {
+    event.preventDefault();
+    openPaneManager();
+    return;
+  }
+
   // Cmd/Ctrl+K opens command palette (even while typing).
   if ((event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey && String(event.key || '').toLowerCase() === 'k') {
     event.preventDefault();
@@ -5354,6 +5541,7 @@ window.addEventListener('keydown', (event) => {
 
   if (event.key === 'Escape') {
     closeCommandPalette();
+    closePaneManager();
     closeShortcuts();
     closeSettings();
     closeWorkqueue();
@@ -5440,6 +5628,17 @@ globalElements.disconnectBtn?.addEventListener('click', () => {
 
 globalElements.resetLayoutBtn?.addEventListener('click', () => {
   paneManager.resetAdminLayoutToDefault({ confirm: true });
+});
+
+globalElements.paneManagerBtn?.addEventListener('click', (event) => {
+  event?.preventDefault?.();
+  openPaneManager();
+});
+
+globalElements.paneManagerCloseBtn?.addEventListener('click', () => closePaneManager());
+
+globalElements.paneManagerModal?.addEventListener('click', (event) => {
+  if (event.target === globalElements.paneManagerModal) closePaneManager();
 });
 
 globalElements.status?.addEventListener('click', () => {

--- a/index.html
+++ b/index.html
@@ -32,7 +32,13 @@
         <div class="topbar-actions">
           <div class="status compact">
             <div class="status-pill" id="connectionStatus" data-testid="connection-status">disconnected</div>
-            <div class="status-meta" id="statusMeta"></div>
+            <button
+              class="status-meta status-meta-btn"
+              id="paneManagerBtn"
+              type="button"
+              aria-label="Open pane manager"
+              data-testid="panes-indicator"
+            ></button>
           </div>
           <div id="paneControls" class="pane-controls" hidden>
             <div class="pane-add-wrap">
@@ -225,6 +231,7 @@
           <div class="shortcut-group">
             <h3 class="shortcut-group-title">Panes</h3>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>1</kbd>..<kbd>4</kbd></div><div class="shortcut-desc">Focus pane 14</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>P</kbd></div><div class="shortcut-desc">Open Pane Manager</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Open command palette</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Pane switcher (cycle focus)</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd></div><div class="shortcut-desc">Add pane</div></div>
@@ -239,6 +246,22 @@
             <h3 class="shortcut-group-title">Agents</h3>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>R</kbd></div><div class="shortcut-desc">Refresh agent list</div></div>
           </div>
+        </div>
+      </div>
+    </div>
+
+    <div id="paneManagerModal" class="modal" aria-hidden="true" data-testid="pane-manager-modal" tabindex="-1">
+      <div class="modal-card" role="dialog" aria-modal="true" aria-labelledby="paneManagerTitle">
+        <div class="modal-header">
+          <h2 id="paneManagerTitle">Panes</h2>
+          <button id="paneManagerCloseBtn" class="icon-btn" type="button" aria-label="Close pane manager">✕</button>
+        </div>
+        <div class="modal-body">
+          <div class="hint" style="margin-bottom: 10px;">
+            Arrow keys to navigate • Enter to focus • Esc to close
+          </div>
+          <div id="paneManagerList" class="pane-manager-list" role="listbox" aria-label="Open panes" data-testid="pane-manager-list"></div>
+          <div id="paneManagerEmpty" class="hint" hidden>No panes.</div>
         </div>
       </div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -1126,6 +1126,79 @@ button.send-btn .btn-icon {
   color: var(--muted);
 }
 
+/* Pane Manager */
+
+.status-meta-btn {
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.status-meta-btn:hover {
+  color: var(--text);
+}
+
+.pane-manager-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: min(56vh, 520px);
+  overflow: auto;
+  padding-right: 2px;
+}
+
+.pane-manager-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 10px;
+  align-items: center;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.pane-manager-row[aria-selected="true"] {
+  border-color: rgba(110, 231, 183, 0.5);
+  background: rgba(110, 231, 183, 0.08);
+}
+
+.pane-manager-main {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 10px;
+  align-items: center;
+  min-width: 0;
+}
+
+.pane-manager-kind {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.pane-manager-target {
+  color: var(--muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pane-manager-state {
+  font-size: 12px;
+  color: var(--muted);
+  text-transform: lowercase;
+  white-space: nowrap;
+}
+
+.pane-manager-actions {
+  display: inline-flex;
+  gap: 8px;
+}
+
 /* Agents modal */
 
 .agents-toolbar {

--- a/tests/pane.manager.e2e.spec.js
+++ b/tests/pane.manager.e2e.spec.js
@@ -1,0 +1,51 @@
+const { test, expect } = require('@playwright/test');
+const { installPageFailureAssertions } = require('./helpers/pw-assertions');
+const { startClawnsoleTestApp } = require('./helpers/pw-app');
+
+let app;
+
+test.beforeAll(async () => {
+  app = await startClawnsoleTestApp();
+});
+
+test.afterAll(() => {
+  app?.stop?.();
+});
+
+test('pane manager: lists panes + focuses via keyboard', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const modal = page.locator('#paneManagerModal');
+  await expect(modal).toHaveAttribute('aria-hidden', 'true');
+
+  // Ctrl+P should open pane manager (even while a pane input is focused).
+  await page.keyboard.press('Control+P');
+  await expect(modal).toHaveAttribute('aria-hidden', 'false');
+
+  const rows = page.locator('.pane-manager-row');
+  await expect(rows).toHaveCount(2);
+
+  // Focus the 2nd pane (default Workqueue) using arrow keys + Enter.
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.press('Enter');
+  await expect(modal).toHaveAttribute('aria-hidden', 'true');
+
+  const panes = page.locator('[data-pane]');
+  await expect(panes).toHaveCount(2);
+
+  // Active element should be inside the 2nd pane.
+  const focusedPaneIndex = await page.evaluate(() => {
+    const panes = Array.from(document.querySelectorAll('[data-pane]'));
+    const active = document.activeElement;
+    return panes.findIndex((p) => p === active || (active && p.contains(active)));
+  });
+  expect(focusedPaneIndex).toBe(1);
+});


### PR DESCRIPTION
Implements #155:\n\n- Click panes indicator in banner to open Pane Manager\n- Cmd/Ctrl+P shortcut\n- Lists panes (type/target/connection state) with Focus/Close\n- Arrow keys + Enter focuses\n- Adds Playwright E2E coverage\n\nNotes:\n- Focus helper now avoids focusing hidden chat input for non-chat panes.