### PR TITLE
UX: Pane header target label matches pane kind

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,9 +85,9 @@
                   <span class="pane-type-text" data-pane-type-text>CHAT</span>
                 </div>
                 <div class="pane-agent" data-pane-agent-wrap>
-                  <span class="agent-label">Agent</span>
+                  <span class="agent-label" data-pane-target-label data-testid="pane-target-label">Agent</span>
                   <button class="agent-pill-btn" type="button" data-pane-agent-button aria-label="Change agent" data-testid="pane-agent-button">
-                    <span class="agent-pill-label" data-pane-agent-label>main</span>
+                    <span class="agent-pill-label" data-pane-agent-label data-testid="pane-target-value">main</span>
                   </button>
                   <select data-pane-agent-select aria-label="Select agent" data-testid="pane-agent-select"></select>
                   <div class="agent-warning" data-pane-agent-warning role="status" aria-live="polite" hidden></div>

--- a/tests/pane.manager.e2e.spec.js
+++ b/tests/pane.manager.e2e.spec.js
@@ -49,3 +49,33 @@ test('pane manager: lists panes + focuses via keyboard', async ({ page }) => {
   });
   expect(focusedPaneIndex).toBe(1);
 });
+
+test('pane header: target label matches pane kind (agent vs queue vs jobs vs timeline)', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const chatPane = page.locator('[data-pane][data-pane-kind="chat"]').first();
+  const wqPane = page.locator('[data-pane][data-pane-kind="workqueue"]').first();
+
+  await expect(chatPane.getByTestId('pane-target-label')).toHaveText('Agent');
+  await expect(wqPane.getByTestId('pane-target-label')).toHaveText('Queue');
+
+  await page.getByTestId('add-pane-btn').click();
+  await page.getByTestId('pane-add-menu-cron').click();
+
+  const cronPane = page.locator('[data-pane][data-pane-kind="cron"]').last();
+  await expect(cronPane.getByTestId('pane-target-label')).toHaveText('Jobs');
+
+  await page.getByTestId('add-pane-btn').click();
+  await page.getByTestId('pane-add-menu-timeline').click();
+
+  const timelinePane = page.locator('[data-pane][data-pane-kind="timeline"]').last();
+  await expect(timelinePane.getByTestId('pane-target-label')).toHaveText('Timeline');
+});


### PR DESCRIPTION
Fixes #160.

- Pane header target label now reflects pane kind:
  - Chat: Agent
  - Workqueue: Queue (pill focuses body queue selector)
  - Cron: Jobs (shows active filter summary)
  - Timeline: Timeline (shows active filter summary)
- Added stable Playwright assertion to prevent regressions.