### PR TITLE
Pane Manager: quick-find + grouping by pane type

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,8 +260,12 @@
           <div class="hint" style="margin-bottom: 10px;">
             Arrow keys to navigate • Enter to focus • Esc to close
           </div>
+          <label class="pane-manager-search-wrap" for="paneManagerSearch">
+            <span class="pane-manager-search-label">Quick find</span>
+            <input id="paneManagerSearch" class="pane-manager-search" type="search" placeholder="Filter by title, type, or target" autocomplete="off" data-testid="pane-manager-search" />
+          </label>
           <div id="paneManagerList" class="pane-manager-list" role="listbox" aria-label="Open panes" data-testid="pane-manager-list"></div>
-          <div id="paneManagerEmpty" class="hint" hidden>No panes.</div>
+          <div id="paneManagerEmpty" class="hint" hidden>No panes match this filter.</div>
         </div>
       </div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -1139,13 +1139,59 @@ button.send-btn .btn-icon {
   color: var(--text);
 }
 
+.pane-manager-search-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0 0 10px;
+}
+
+.pane-manager-search-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.pane-manager-search {
+  width: 100%;
+}
+
 .pane-manager-list {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
   max-height: min(56vh, 520px);
   overflow: auto;
   padding-right: 2px;
+}
+
+.pane-manager-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.pane-manager-group-header {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text);
+  border-radius: 10px;
+  padding: 8px 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+}
+
+.pane-manager-group-title {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+}
+
+.pane-manager-group-count {
+  color: var(--muted);
 }
 
 .pane-manager-row {


### PR DESCRIPTION
Closes #174

## Summary
- add Quick find input to Pane Manager (matches pane title/key, type, target)
- group pane rows by type (Chat/Workqueue/Cron/Timeline) with collapsible section headers
- show per-group counts in each section header
- preserve focus/reorder behavior using filtered visible order
- keep keyboard navigation working over visible filtered rows

## Test
- npx playwright test tests/pane.manager.e2e.spec.js