### PR TITLE
Testing: add frontend state-transition coverage for app core

### DIFF
--- a/lib/app-core.js
+++ b/lib/app-core.js
@@ -154,6 +154,51 @@
     };
   }
 
+  function deriveGlobalConnectionState({ authed, panes } = {}) {
+    if (!authed) {
+      return { state: 'disconnected', meta: 'sign in required' };
+    }
+
+    const list = Array.isArray(panes) ? panes : [];
+    if (list.length === 0) {
+      return { state: 'disconnected', meta: '' };
+    }
+
+    const connectedCount = list.filter((pane) => !!pane?.connected).length;
+    const total = list.length;
+    const anyConnecting = list.some((pane) => pane?.statusState === 'connecting' || pane?.statusState === 'reconnecting');
+    const anyError = list.some((pane) => pane?.statusState === 'error');
+    const firstError = list.find((pane) => pane?.statusState === 'error' && pane?.statusMeta);
+
+    let state = 'disconnected';
+    if (connectedCount === total) {
+      state = 'connected';
+    } else if (connectedCount > 0 || anyConnecting) {
+      state = 'reconnecting';
+    } else if (anyError) {
+      state = 'error';
+    }
+
+    const meta =
+      connectedCount === 0 && anyError && firstError
+        ? String(firstError.statusMeta || '')
+        : `panes: ${connectedCount}/${total} connected`;
+
+    return { state, meta };
+  }
+
+  function deriveDisconnectButtonState({ authed, panes } = {}) {
+    if (!authed) {
+      return { disabled: true, text: 'Reconnect' };
+    }
+
+    const list = Array.isArray(panes) ? panes : [];
+    const anyActive = list.some((pane) =>
+      pane?.statusState === 'connected' || pane?.statusState === 'connecting' || pane?.statusState === 'reconnecting'
+    );
+    return { disabled: false, text: anyActive ? 'Disconnect' : 'Reconnect' };
+  }
+
   function extractChatText(message) {
     if (!message) return '';
     if (typeof message === 'string') return message;
@@ -276,6 +321,8 @@
     inferPaneCols,
     normalizePaneKind,
     deriveAuthOverlayState,
+    deriveGlobalConnectionState,
+    deriveDisconnectButtonState,
     extractChatText,
     normalizeHistoryEntries,
     renderMarkdown


### PR DESCRIPTION
## Summary
- extract pure helpers for global connection status + disconnect button state from `app.js` into `lib/app-core.js`
- wire `app.js` to use those pure helpers for auth/disconnect UI state updates
- add unit tests for signed-out, reconnecting, and hard-error transitions (including auth-expired style metadata)

## Why
Issue #107 asks for lightweight, fast unit coverage around high-risk frontend state transitions. This adds deterministic tests for core auth/disconnect state logic without introducing browser-only test infrastructure.

## Testing
- `node --check app.js`
- `node --check lib/app-core.js`
- `node --test tests/unit/app-core.test.js`

Closes #107
