### PR TITLE
Fix #181: standardize pane identity line across pane kinds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "ws": "^8.18.0"
       },
+      "bin": {
+        "clawnsole": "bin/clawnsole.js"
+      },
       "devDependencies": {
         "@playwright/test": "^1.49.0"
       }

--- a/tests/agent-picker.e2e.spec.js
+++ b/tests/agent-picker.e2e.spec.js
@@ -44,6 +44,7 @@ test('agent chooser: opens, shows agents, Esc closes', async ({ page }) => {
   await expect(chooser).toHaveCount(0);
   await expect(btn).toContainText(/dev/i);
   await expect(btn).toHaveAttribute('aria-label', /current:\s*dev/i);
+  await expect(pane.getByTestId('pane-type-label')).toHaveText(/^A Chat · dev/i);
 
   // Re-open and Esc closes.
   await btn.click();

--- a/tests/pane.manager.e2e.spec.js
+++ b/tests/pane.manager.e2e.spec.js
@@ -50,7 +50,7 @@ test('pane manager: lists panes + focuses via keyboard', async ({ page }) => {
   expect(focusedPaneIndex).toBe(1);
 });
 
-test('pane header: target label matches pane kind (agent vs queue vs jobs vs timeline)', async ({ page }) => {
+test('pane header: identity line uses "[Letter] [Type] · [Target]" across pane kinds', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!app?.skipReason, app?.skipReason);
 
@@ -64,20 +64,20 @@ test('pane header: target label matches pane kind (agent vs queue vs jobs vs tim
   const chatPane = page.locator('[data-pane][data-pane-kind="chat"]').first();
   const wqPane = page.locator('[data-pane][data-pane-kind="workqueue"]').first();
 
-  await expect(chatPane.getByTestId('pane-target-label')).toHaveText('Agent');
-  await expect(wqPane.getByTestId('pane-target-label')).toHaveText('Queue');
+  await expect(chatPane.getByTestId('pane-type-label')).toHaveText(/^A Chat · .+/);
+  await expect(wqPane.getByTestId('pane-type-label')).toHaveText(/^B Workqueue · .+/);
 
   await page.getByTestId('add-pane-btn').click();
   await page.getByTestId('pane-add-menu-cron').click();
 
   const cronPane = page.locator('[data-pane][data-pane-kind="cron"]').last();
-  await expect(cronPane.getByTestId('pane-target-label')).toHaveText('Jobs');
+  await expect(cronPane.getByTestId('pane-type-label')).toHaveText(/^C Cron · .+/);
 
   await page.getByTestId('add-pane-btn').click();
   await page.getByTestId('pane-add-menu-timeline').click();
 
   const timelinePane = page.locator('[data-pane][data-pane-kind="timeline"]').last();
-  await expect(timelinePane.getByTestId('pane-target-label')).toHaveText('Timeline');
+  await expect(timelinePane.getByTestId('pane-type-label')).toHaveText(/^D Timeline · .+/);
 });
 
 test('pane manager: quick-find filters and groups by kind', async ({ page }) => {


### PR DESCRIPTION
## Summary
- add a normalized pane identity line in the pane header: `[Letter] [Type] · [Target]`
- render identity for all pane kinds (chat/workqueue/cron/timeline)
- keep identity in sync when targets change (agent selection, queue/filter context updates)
- update e2e coverage for the new identity format and chat target updates

## Testing
- npm test
- npx playwright test tests/pane.manager.e2e.spec.js tests/agent-picker.e2e.spec.js --workers=1
