### PR TITLE
Fix #186: make Workqueue enqueue target explicit

### DIFF
--- a/app.js
+++ b/app.js
@@ -2377,7 +2377,8 @@ async function workqueueEnqueueFromUi() {
     }
 
     const item = data.item || null;
-    setWorkqueueActionStatus(item && item._deduped ? `Deduped (already exists): ${item.id}` : `Enqueued: ${item?.id || ''}`);
+    const assignLabel = 'Queued as Unassigned';
+    setWorkqueueActionStatus(item && item._deduped ? `Deduped (already exists): ${item.id} (${assignLabel})` : assignLabel);
 
     await fetchAndRenderWorkqueueItems();
     if (item?.id) {
@@ -4339,8 +4340,9 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
 
             <div class="wq-enqueue-actions">
               <label class="wq-field">
-                <span class="wq-label">Claim as (optional)</span>
+                <span class="wq-label">Assign to</span>
                 <select data-wq-claim-agent></select>
+                <span class="hint">Who should pick this up</span>
               </label>
               <label class="wq-field">
                 <span class="wq-label">Lease ms</span>
@@ -4617,6 +4619,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
     const enqueueInstructions = elements.thread.querySelector('[data-wq-enqueue-instructions]');
     const enqueuePriority = elements.thread.querySelector('[data-wq-enqueue-priority]');
     const enqueueDedupe = elements.thread.querySelector('[data-wq-enqueue-dedupe]');
+    const enqueueAssignTo = elements.thread.querySelector('[data-wq-claim-agent]');
 
     const setEnqueueStatus = (text) => {
       if (!enqueueStatus) return;
@@ -4656,7 +4659,11 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
         }
 
         const item = data.item || null;
-        setEnqueueStatus(item && item._deduped ? 'Deduped: ' + item.id : 'Enqueued: ' + String(item?.id || ''));
+        const assignToAgentId = String(enqueueAssignTo?.value || '').trim();
+        const assignLabel = assignToAgentId
+          ? `Queued for ${formatAgentLabel(getAgentRecord(assignToAgentId), { includeId: false })}`
+          : 'Queued as Unassigned';
+        setEnqueueStatus(item && item._deduped ? `Deduped: ${item.id} (${assignLabel})` : assignLabel);
         if (enqueueTitle) enqueueTitle.value = '';
         if (enqueueInstructions) enqueueInstructions.value = '';
         if (enqueueDedupe) enqueueDedupe.value = '';

--- a/tests/pane.workqueue.e2e.spec.js
+++ b/tests/pane.workqueue.e2e.spec.js
@@ -101,6 +101,8 @@ test('pane: workqueue golden path (list + inspect)', async ({ page }) => {
   const instructions = `instructions ${runId}`;
 
   await wqPane.locator('details.wq-enqueue > summary').click();
+  await expect(wqPane.locator('.wq-enqueue .wq-label', { hasText: 'Assign to' })).toBeVisible();
+  await expect(wqPane.locator('.wq-enqueue .hint', { hasText: 'Who should pick this up' })).toBeVisible();
   await wqPane.locator('[data-wq-enqueue-title]').fill(title);
   await wqPane.locator('[data-wq-enqueue-instructions]').fill(instructions);
 
@@ -111,6 +113,7 @@ test('pane: workqueue golden path (list + inspect)', async ({ page }) => {
   await wqPane.locator('[data-wq-enqueue-submit]').click();
   const enqueueRes = await enqueueResP;
   expect(enqueueRes.ok()).toBeTruthy();
+  await expect(wqPane.locator('[data-wq-enqueue-status]')).toContainText('Queued as Unassigned');
 
   // Close the enqueue details so it can't block clicks on the list.
   await wqPane.locator('details.wq-enqueue > summary').click();


### PR DESCRIPTION
## Summary\n- relabel the enqueue target control to **Assign to**\n- add helper copy: "Who should pick this up"\n- update enqueue success status to include target intent (e.g. "Queued as Unassigned")\n- keep enqueue API payload unchanged\n- extend workqueue pane e2e test to cover the new label/helper/status text\n\n## Testing\n- \n- 
Running 2 tests using 1 worker

  ✓  1 tests/pane.workqueue.e2e.spec.js:15:1 › pane: workqueue renders + core controls visible (1.5s)
  ✓  2 tests/pane.workqueue.e2e.spec.js:78:1 › pane: workqueue golden path (list + inspect) (1.6s)

  2 passed (4.2s)\n\nCloses #186