### PR TITLE
Fix #173: fleet triage filters + heartbeat-age sort

### DIFF
--- a/index.html
+++ b/index.html
@@ -390,13 +390,26 @@
               <span class="agents-label">Search</span>
               <input id="agentsSearch" type="text" placeholder="Filter agents…" />
             </label>
-            <label class="agents-field agents-active-only">
-              <span class="agents-label">Active only</span>
-              <div class="agents-active-controls">
-                <label class="agents-toggle"><input id="agentsActiveOnly" type="checkbox" /> <span>On</span></label>
-                <input id="agentsActiveMinutes" type="number" min="1" step="1" value="10" aria-label="Active within minutes" />
-                <span class="hint">min</span>
+            <div class="agents-field agents-triage">
+              <span class="agents-label">Triage</span>
+              <div class="agents-filter-chips" role="group" aria-label="Fleet triage filters">
+                <button type="button" class="agents-chip" data-agents-filter="all" aria-pressed="true">All</button>
+                <button type="button" class="agents-chip" data-agents-filter="active" aria-pressed="false">Active</button>
+                <button type="button" class="agents-chip" data-agents-filter="stale" aria-pressed="false">Stale</button>
+                <button type="button" class="agents-chip" data-agents-filter="offline_error" aria-pressed="false">Offline/Error</button>
               </div>
+            </div>
+            <label class="agents-field">
+              <span class="agents-label">Sort</span>
+              <select id="agentsSort" aria-label="Sort agents">
+                <option value="recent_desc">Recent heartbeat (newest first)</option>
+                <option value="heartbeat_age_oldest">Last heartbeat age (oldest first)</option>
+                <option value="name_asc">Name (A-Z)</option>
+              </select>
+            </label>
+            <label class="agents-field">
+              <span class="agents-label">Active window (min)</span>
+              <input id="agentsActiveMinutes" type="number" min="1" step="1" value="10" aria-label="Active within minutes" />
             </label>
           </div>
 

--- a/styles.css
+++ b/styles.css
@@ -1274,22 +1274,26 @@ button.send-btn .btn-icon {
   color: var(--muted);
 }
 
-.agents-active-controls {
-  display: inline-flex;
-  gap: 10px;
-  align-items: center;
+.agents-filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
-.agents-toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 12px;
+.agents-chip {
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.03);
   color: var(--text);
+  border-radius: 999px;
+  padding: 6px 10px;
+  font-size: 12px;
+  cursor: pointer;
 }
 
-.agents-active-controls input[type="number"] {
-  width: 72px;
+.agents-chip.active,
+.agents-chip[aria-pressed="true"] {
+  border-color: rgba(77, 196, 255, 0.6);
+  background: rgba(77, 196, 255, 0.16);
 }
 
 .agents-list {
@@ -1348,6 +1352,14 @@ button.send-btn .btn-icon {
   margin-top: 2px;
   font-size: 12px;
   color: var(--muted);
+}
+
+.agents-age-chip {
+  display: inline-block;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 999px;
+  padding: 1px 8px;
+  color: var(--text);
 }
 
 /* Shortcuts modal */


### PR DESCRIPTION
Implements #173.\n\n### What changed\n- Added triage quick filters in Agents modal: **All, Active, Stale, Offline/Error**\n- Added sort modes, including **Last heartbeat age (oldest first)**\n- Added explicit heartbeat age chip on each agent row: 
wtmp begins Mon Nov 10 00:27:59 EST 2025\n- Persisted filter/sort selections in localStorage\n- Kept filter chips keyboard-accessible (native buttons with aria-pressed state)\n\n### Notes\n- Agent freshness now updates from gateway events for each pane's selected agent\n- Existing  input still controls active/stale cutoff\n\n### Validation\n- \n- \n- \n