### PR TITLE
Issue #56: add recurring prompt API serialization + runs endpoint

### DIFF
--- a/scripts/recurring-prompts-scheduler.js
+++ b/scripts/recurring-prompts-scheduler.js
@@ -188,6 +188,9 @@ async function runOnce({ promptsPath, openclawConfigPath, deviceLabel, dryRun = 
     due.forEach((p) => {
       p.lastStatus = 'error';
       p.lastError = message;
+      if (!Array.isArray(p.runHistory)) p.runHistory = [];
+      p.runHistory.unshift({ ts: now, status: 'error', error: message });
+      if (p.runHistory.length > 200) p.runHistory = p.runHistory.slice(0, 200);
       p.lastRunAt = now;
       p.updatedAt = now;
       const minutes = Number(p.intervalMinutes) || 60;
@@ -213,6 +216,14 @@ async function runOnce({ promptsPath, openclawConfigPath, deviceLabel, dryRun = 
       prompt.lastStatus = 'error';
       prompt.lastError = String(err || 'delivery failed');
     }
+
+    if (!Array.isArray(prompt.runHistory)) prompt.runHistory = [];
+    prompt.runHistory.unshift({
+      ts: now,
+      status: prompt.lastStatus,
+      error: String(prompt.lastError || '')
+    });
+    if (prompt.runHistory.length > 200) prompt.runHistory = prompt.runHistory.slice(0, 200);
 
     prompt.lastRunAt = now;
     prompt.nextRunAt = nextRunAt;


### PR DESCRIPTION
## Summary
Implements a focused API slice for #56 so external schedulers/UI clients have the fields and endpoint shape they need without waiting on the full UI/worker rollout.

### What changed
- Serialize recurring prompts with derived admin/system fields:
  - `source`, `target`, `timezone`, `scheduleSummary`, `promptText`, `nextRun`, `lastRun`
- Add run history normalization + fallback from legacy `lastRun*` fields
- Add `GET /api/recurring-prompts/:id/runs?limit=` (admin-only, bounded)
- Ensure scheduler writes bounded `runHistory` rows on success/failure
- Add unit tests for serialization fields and runs endpoint behavior

## Why this helps #56
- External scheduler can now expose and consume recent run status cleanly
- UI can render required last/next/status fields from stable API responses
- Backward-compatible migration path from existing prompt records

## Testing
- `npm test -- --runInBand tests/unit/clawnsole-server.test.js`

Refs #56
