### PR TITLE
UX: add MRU pane switcher on Ctrl+Tab / Ctrl+Shift+Tab

### DIFF
--- a/app.js
+++ b/app.js
@@ -6938,7 +6938,6 @@ function cycleUnreadPaneFocus(direction = 1) {
   focusPaneIndex(next);
   return true;
 }
-}
 
 window.addEventListener('keydown', (event) => {
   const isEditableTarget = (() => {

--- a/app.js
+++ b/app.js
@@ -6819,6 +6819,8 @@ globalElements.wqClaimBtn?.addEventListener('click', () => workqueueClaimNextFro
 
 let shortcutState = { lastGAtMs: 0 };
 let paneFocusMru = [];
+let paneMruTraversal = null;
+let suppressPaneFocusRemember = false;
 
 function isTypingContext(target) {
   const el = target || document.activeElement;
@@ -6830,8 +6832,10 @@ function isTypingContext(target) {
 }
 
 function paneRememberFocused(pane) {
+  if (suppressPaneFocusRemember) return;
   const key = String(pane?.key || '').trim();
   if (!key) return;
+  paneMruTraversal = null;
   paneFocusMru = [key, ...paneFocusMru.filter((entry) => entry !== key)].slice(0, 32);
 }
 
@@ -6847,38 +6851,56 @@ function focusPaneIndex(idx, { remember = true } = {}) {
   clearPaneUnread(pane);
 
   if (remember) paneRememberFocused(pane);
+  const previousSuppressPaneFocusRemember = suppressPaneFocusRemember;
+  if (!remember) suppressPaneFocusRemember = true;
 
   try {
-    pane.elements?.root?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
-  } catch {}
+    try {
+      pane.elements?.root?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
+    } catch {}
 
-  // Prefer focusing the chat input when available (and visible).
-  const input = pane.elements?.input;
-  if (input && typeof input.focus === 'function') {
-    const isVisible = (() => {
-      try {
-        if (input.disabled) return false;
-        if (input.hidden) return false;
-        if (input.getClientRects && input.getClientRects().length === 0) return false;
-        return true;
-      } catch {
-        return true;
-      }
-    })();
-    if (isVisible) {
-      input.focus();
+    if (!remember && pane.elements?.root && typeof pane.elements.root.focus === 'function') {
+      if (!pane.elements.root.hasAttribute('tabindex')) pane.elements.root.setAttribute('tabindex', '-1');
+      pane.elements.root.focus({ preventScroll: true });
       return;
     }
-  }
 
-  // Fallback: focus first focusable control inside the pane.
-  const root = pane.elements?.root;
-  const focusable =
-    root &&
-    root.querySelector &&
-    root.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
-  if (focusable && typeof focusable.focus === 'function') {
-    focusable.focus();
+    // Prefer focusing the chat input when available (and visible).
+    const input = pane.elements?.input;
+    if (input && typeof input.focus === 'function') {
+      const isVisible = (() => {
+        try {
+          if (input.disabled) return false;
+          if (input.hidden) return false;
+          if (input.getClientRects && input.getClientRects().length === 0) return false;
+          return true;
+        } catch {
+          return true;
+        }
+      })();
+      if (isVisible) {
+        input.focus();
+        return true;
+      }
+    }
+
+    // Fallback: focus first focusable control inside the pane.
+    const root = pane.elements?.root;
+    const focusable =
+      root &&
+      root.querySelector &&
+      root.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+    if (focusable && typeof focusable.focus === 'function') {
+      focusable.focus();
+    }
+  } finally {
+    if (remember) {
+      suppressPaneFocusRemember = previousSuppressPaneFocusRemember;
+    } else {
+      setTimeout(() => {
+        suppressPaneFocusRemember = previousSuppressPaneFocusRemember;
+      }, 0);
+    }
   }
 }
 
@@ -6904,14 +6926,26 @@ function cyclePaneFocusByMru({ backward = false } = {}) {
   const activePane = panes.find((pane) => pane.elements?.root && (pane.elements.root === active || pane.elements.root.contains(active)));
   const activeKey = String(activePane?.key || mru[0] || '');
   const activePos = Math.max(0, mru.indexOf(activeKey));
-  const nextPos = backward ? (activePos - 1 + mru.length) % mru.length : (activePos + 1) % mru.length;
+  if (
+    !paneMruTraversal ||
+    !Array.isArray(paneMruTraversal.order) ||
+    paneMruTraversal.order.length !== mru.length ||
+    !paneMruTraversal.order.includes(activeKey)
+  ) {
+    paneMruTraversal = { order: mru, index: activePos };
+  }
 
-  const target = paneByKey(mru[nextPos]);
+  const order = paneMruTraversal.order;
+  const currentPos = Math.max(0, order.indexOf(activeKey));
+  const nextPos = backward ? (currentPos - 1 + order.length) % order.length : (currentPos + 1) % order.length;
+  paneMruTraversal.index = nextPos;
+
+  const target = paneByKey(order[nextPos]);
   if (!target) return;
   const targetIdx = panes.indexOf(target);
   if (targetIdx < 0) return;
 
-  focusPaneIndex(targetIdx);
+  focusPaneIndex(targetIdx, { remember: false });
   const summary = paneDestinationSummary(target);
   toast(`${summary.letter} ${summary.kind} · ${summary.target}`, 'info');
 }

--- a/index.html
+++ b/index.html
@@ -236,7 +236,9 @@
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Alt</kbd>/<kbd>Option</kbd>+<kbd>1</kbd>..<kbd>9</kbd></div><div class="shortcut-desc">Focus panes 1-9 by visible order</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>1</kbd>..<kbd>4</kbd></div><div class="shortcut-desc">Focus pane 1-4</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>P</kbd></div><div class="shortcut-desc">Open Pane Manager</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Pane switcher (cycle focus)</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Tab</kbd></div><div class="shortcut-desc">Pane switcher (MRU next)</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Tab</kbd></div><div class="shortcut-desc">Pane switcher (MRU previous)</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Pane switcher (layout cycle)</div></div>
           </div>
 
           <div class="shortcut-group">

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -103,3 +103,57 @@ test('alt+1..3 focuses panes by visible order and does not fire while typing', a
   await page.keyboard.press('Alt+3');
   await expect.poll(activePaneIndex).toBe(0);
 });
+
+test('ctrl/cmd+tab switches panes by MRU and is blocked while typing', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  await page.getByTestId('add-pane-btn').click();
+  await page.getByTestId('pane-add-menu-workqueue').click();
+  await page.getByTestId('add-pane-btn').click();
+  await page.getByTestId('pane-add-menu-cron').click();
+  await expect(page.locator('[data-pane]')).toHaveCount(4);
+
+  const activePaneIndex = async () => page.evaluate(() => {
+    const panes = Array.from(document.querySelectorAll('[data-pane]'));
+    const active = document.activeElement;
+    if (!active) return -1;
+    return panes.findIndex((p) => p === active || p.contains(active));
+  });
+
+  await page.locator('[data-pane]').nth(0).locator('[data-pane-send]').click();
+  await page.evaluate(() => {
+    const pane = document.querySelectorAll('[data-pane]')[1];
+    const target = pane?.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+    target?.focus?.();
+  });
+  await page.evaluate(() => {
+    const pane = document.querySelectorAll('[data-pane]')[2];
+    const target = pane?.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+    target?.focus?.();
+  });
+  await expect.poll(activePaneIndex).toBe(2);
+
+  await page.keyboard.press('ControlOrMeta+Tab');
+  await expect.poll(activePaneIndex).toBe(1);
+
+  await page.keyboard.press('ControlOrMeta+Tab');
+  await expect.poll(activePaneIndex).toBe(2);
+
+  await page.keyboard.press('ControlOrMeta+Shift+Tab');
+  await expect.poll(activePaneIndex).toBe(1);
+
+  const firstPaneInput = page.locator('[data-pane]').first().locator('[data-pane-input]');
+  await firstPaneInput.focus();
+  await expect(firstPaneInput).toBeFocused();
+
+  await page.keyboard.press('ControlOrMeta+Tab');
+  await expect.poll(activePaneIndex).toBe(0);
+});

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -152,11 +152,12 @@ test('ctrl/cmd+tab switches panes by MRU and is blocked while typing', async ({ 
   await page.click('#loginBtn');
   await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
 
+  const panes = page.locator('[data-pane]');
+  await expect(panes).toHaveCount(2);
+
   await page.getByTestId('add-pane-btn').click();
   await page.getByTestId('pane-add-menu-workqueue').click();
-  await page.getByTestId('add-pane-btn').click();
-  await page.getByTestId('pane-add-menu-cron').click();
-  await expect(page.locator('[data-pane]')).toHaveCount(4);
+  await expect(panes).toHaveCount(3);
 
   const activePaneIndex = async () => page.evaluate(() => {
     const panes = Array.from(document.querySelectorAll('[data-pane]'));

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -182,7 +182,7 @@ test('ctrl/cmd+tab switches panes by MRU and is blocked while typing', async ({ 
   await expect.poll(activePaneIndex).toBe(1);
 
   await page.keyboard.press('ControlOrMeta+Tab');
-  await expect.poll(activePaneIndex).toBe(2);
+  await expect.poll(activePaneIndex).toBe(0);
 
   await page.keyboard.press('ControlOrMeta+Shift+Tab');
   await expect.poll(activePaneIndex).toBe(1);

--- a/tests/ui/pane-add-menu.spec.js
+++ b/tests/ui/pane-add-menu.spec.js
@@ -80,8 +80,8 @@ test('pane add shortcuts: Ctrl/Cmd+Shift+T adds a timeline pane', async ({ page 
 
   const countBefore = await page.locator('[data-pane]').count();
 
-  // Use a Playwright-friendly cross-platform modifier.
-  await page.keyboard.press('ControlOrMeta+Shift+T');
+  await page.locator('body').click({ position: { x: 1, y: 1 } });
+  await page.keyboard.press('Control+Shift+T');
 
   const tlPane = page.locator('[data-pane-kind="timeline"]').last();
   await expect(tlPane).toBeVisible();


### PR DESCRIPTION
## Summary
- add MRU pane tracking and switch helpers for pane focus navigation
- wire Ctrl/Cmd+Tab and Ctrl/Cmd+Shift+Tab to MRU next/previous traversal
- show a brief toast with destination pane identity on MRU switch
- update keyboard shortcuts cheatsheet to include new MRU shortcuts
- add e2e coverage for MRU switching across 3 panes and typing guard behavior

## Testing
- node --check app.js && node --check clawnsole-server.js && node --check server.js
- npm test -- tests/pane.shortcuts.e2e.spec.js *(fails in this environment: missing local dependency ws)*
- npx playwright test tests/pane.shortcuts.e2e.spec.js --grep "ctrl/cmd+tab" *(fails in this environment: missing @playwright/test)*



Fixes #212
