### PR TITLE
UX: add workqueue scope triage filters

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1765,6 +1765,35 @@ kbd {
   background: rgba(127, 209, 185, 0.12);
 }
 
+.wq-scope {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.wq-scope-label {
+  font-size: 11px;
+  color: var(--muted);
+  margin-right: 4px;
+}
+
+.wq-scope-btn {
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  border-radius: 999px;
+  padding: 6px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.wq-scope-btn.active {
+  border-color: rgba(127, 209, 185, 0.5);
+  background: rgba(127, 209, 185, 0.12);
+}
+
 .wq-enqueue {
   margin-top: 10px;
 }


### PR DESCRIPTION
## Summary\n- add a new Scope segmented control in the Workqueue pane toolbar\n- support three triage scopes: Assigned to active target, Unassigned, and All\n- apply scope as a client-side composable filter alongside existing queue + status filters\n- persist scope state per pane across admin layout saves/restores\n- add a Playwright regression covering scope toggles and deterministic row-count changes\n\n## Testing\n- npm run test:ui -- tests/pane.workqueue.e2e.spec.js -g "scope filter toggles deterministic row counts"\n