### PR TITLE
fix: pane manager shows user-facing pane identity labels

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1256,6 +1256,12 @@ button.send-btn .btn-icon {
   white-space: nowrap;
 }
 
+.pane-manager-pane-id {
+  font-size: 11px;
+  color: var(--muted);
+  opacity: 0.7;
+}
+
 .pane-manager-duplicate-badge {
   display: inline-flex;
   align-items: center;

--- a/tests/pane.manager.e2e.spec.js
+++ b/tests/pane.manager.e2e.spec.js
@@ -78,6 +78,11 @@ test('pane header: identity line uses "[Letter] [Type] · [Target]" across pane 
 
   const timelinePane = page.locator('[data-pane][data-pane-kind="timeline"]').last();
   await expect(timelinePane.getByTestId('pane-type-label')).toHaveText(/^D Timeline · .+/);
+
+  await page.keyboard.press('Control+P');
+  const firstPaneHeaderIdentity = await page.locator('[data-pane]').first().getByTestId('pane-type-label').textContent();
+  await expect(page.locator('.pane-manager-row .pane-manager-kind-label').first()).toHaveText(String(firstPaneHeaderIdentity || '').trim());
+  await expect(page.locator('.pane-manager-row .pane-manager-pane-id').first()).toHaveText(/^[a-zA-Z0-9]+$/);
 });
 
 test('pane manager: quick-find filters and groups by kind', async ({ page }) => {
@@ -104,9 +109,13 @@ test('pane manager: quick-find filters and groups by kind', async ({ page }) => 
   await expect(page.locator('.pane-manager-group-header').nth(2)).toContainText('Cron (1)');
 
   const search = page.getByTestId('pane-manager-search');
-  await search.fill('gateway');
+  await search.fill('cron');
   await expect(page.locator('.pane-manager-row')).toHaveCount(1);
   await expect(page.locator('.pane-manager-row').first()).toContainText('Cron');
+
+  await search.fill('B');
+  await expect(page.locator('.pane-manager-row')).toHaveCount(1);
+  await expect(page.locator('.pane-manager-row').first()).toContainText('Workqueue');
 });
 
 test('pane manager: shows summary + duplicate badge and supports close others', async ({ page }) => {


### PR DESCRIPTION
Closes #213

## Summary
- switched Pane Manager primary row label to the same identity format used in pane headers: `[Letter] [Type] · [Target]`
- stopped using opaque pane keys as the primary label
- kept internal pane IDs visible only as muted secondary/debug text
- updated quick-find matching to index letter/type/target identity text
- added/updated Playwright coverage to guard identity parity + letter search

## Validation
- `npm run test:syntax`
- `npm run test:unit`
- `npx playwright test tests/pane.manager.e2e.spec.js --workers=1`

## Risk
- low: UI-only changes scoped to pane-manager labeling and filtering paths; pane actions still operate on pane keys under the hood.
