### PR TITLE
Fix #167: don't trigger add-pane shortcuts while typing

### DIFF
--- a/app.js
+++ b/app.js
@@ -6811,13 +6811,12 @@ window.addEventListener('keydown', (event) => {
   // Ctrl/Cmd+Shift+R → new cron
   // Ctrl/Cmd+Shift+T → new timeline
   const isAccel = (event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey;
-  if (isAccel && roleState.role === 'admin') {
+  if (isAccel && roleState.role === 'admin' && !isTypingContext(event.target)) {
     const key = String(event.key || '').toLowerCase();
     const map = { c: 'chat', w: 'workqueue', r: 'cron', t: 'timeline' };
     const kind = map[key];
     if (kind) {
-      // Don't hijack while typing unless it's a true accelerator.
-      // (We still allow it when focused in an input, but only with Ctrl/Cmd+Shift.)
+      // Don't hijack add-pane shortcuts while typing in inputs/editors.
       event.preventDefault();
       paneManager.closeAddPaneMenu();
       paneManager.addPane(kind);

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -103,3 +103,26 @@ test('alt+1..3 focuses panes by visible order and does not fire while typing', a
   await page.keyboard.press('Alt+3');
   await expect.poll(activePaneIndex).toBe(0);
 });
+
+test('add-pane shortcuts do not fire while typing in chat input', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const panes = page.locator('[data-pane]');
+  await expect(panes).toHaveCount(2);
+
+  const input = page.locator('[data-pane-kind="chat"] [data-pane-input]').first();
+  await input.focus();
+  await input.fill('typing');
+
+  await page.keyboard.press('Control+Shift+W');
+
+  await expect(panes).toHaveCount(2);
+});


### PR DESCRIPTION
## Summary\n- prevent admin add-pane accelerators from firing when focus is inside editable controls\n- keep existing global shortcut behavior elsewhere unchanged\n- add E2E coverage to ensure Ctrl+Shift+W does not create a pane while typing in chat input\n\n## Testing\n- npx playwright test tests/pane.shortcuts.e2e.spec.js --reporter=line\n\nCloses #167