### PR TITLE
Fix #169: keep Workqueue header target as Queue

### DIFF
--- a/app.js
+++ b/app.js
@@ -4493,7 +4493,7 @@ function paneSetHeaderTarget(pane, { label, value, ariaLabel, onClick } = {}) {
 }
 
 function renderPaneAgentIdentity(pane) {
-  if (!pane || pane.role !== 'admin') return;
+  if (!pane || pane.role !== 'admin' || pane.kind !== 'chat') return;
   const elements = pane.elements;
   if (!elements) return;
 

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -35,6 +35,13 @@ test('workqueue pane: renders + has queue dropdown + does not show chat composer
   await expect(wqPane.locator('[data-wq-queue-search]')).toBeVisible();
   await expect(wqPane.locator('[data-wq-queue-select]')).toBeVisible();
 
+  // Header target should describe queue context (not agent).
+  await expect(wqPane.locator('[data-pane-target-label]')).toHaveText('Queue');
+
+  // Refreshing agent list should not flip the workqueue header back to Agent.
+  await page.getByLabel('Refresh agent list').click();
+  await expect(wqPane.locator('[data-pane-target-label]')).toHaveText('Queue');
+
   // Workqueue pane should not render the chat composer UI.
   await expect(wqPane.locator('.chat-input-row')).toBeHidden();
   await expect(wqPane.locator('[data-pane-input]')).toBeHidden();


### PR DESCRIPTION
## Summary\n- prevent chat-only agent identity rendering from running on non-chat admin panes\n- this keeps Workqueue pane header target label/value owned by its queue-target logic\n- add UI coverage to assert Workqueue header label is `Queue` and stays `Queue` after agent refresh\n\n## Validation\n- node --check app.js\n- node --test tests/unit/app-core.test.js\n- UI Playwright suite not run locally in this temp clone (`@playwright/test` not installed)\n