### PR TITLE
UX: add one-click Open Fleet action + Cmd/Ctrl+Shift+F shortcut

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,9 @@
           <button id="agentsBtn" class="icon-btn" type="button" aria-label="Open agents" hidden>
             ★
           </button>
+          <button id="fleetBtn" class="icon-btn" type="button" aria-label="Open fleet pane" title="Open Fleet pane (Cmd/Ctrl+Shift+F)" hidden>
+            FL
+          </button>
           <button id="workqueueBtn" class="icon-btn" type="button" aria-label="Open workqueue" hidden>
             WQ
           </button>
@@ -246,6 +249,7 @@
             <h3 class="shortcut-group-title">Pane actions</h3>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Open command palette</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd></div><div class="shortcut-desc">Add pane</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd></div><div class="shortcut-desc">Open/focus Fleet pane</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>R</kbd></div><div class="shortcut-desc">Refresh agent list</div></div>
           </div>
 

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -163,3 +163,33 @@ test('add-pane shortcuts do not fire while typing in chat input', async ({ page 
 
   await expect(panes).toHaveCount(2);
 });
+
+test('fleet quick action button + keyboard shortcut focus existing timeline pane without duplicates', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const panes = page.locator('[data-pane]');
+  const timelinePanes = page.locator('[data-pane-kind="timeline"]');
+  const fleetBtn = page.locator('#fleetBtn');
+
+  await expect(panes).toHaveCount(2);
+  await expect(timelinePanes).toHaveCount(0);
+
+  await fleetBtn.click();
+  await expect(panes).toHaveCount(3);
+  await expect(timelinePanes).toHaveCount(1);
+
+  await page.keyboard.press('Control+Shift+F');
+  await expect(panes).toHaveCount(3);
+  await expect(timelinePanes).toHaveCount(1);
+
+  await fleetBtn.click({ modifiers: ['Alt'] });
+  await expect(timelinePanes).toHaveCount(2);
+});


### PR DESCRIPTION
## Summary
- add a new admin-header **FL** quick action that opens/focuses a Fleet pane
- wire **Cmd/Ctrl+Shift+F** to open/focus Fleet
- add explicit "open anyway" path via **Alt+click** on FL (forces a new Fleet pane) and command palette item
- document the new shortcut in the keyboard shortcuts cheatsheet

## Behavior
- default action focuses an existing Fleet/Timeline pane (prefers the all-agents filter) before creating one
- no duplicate pane is created by default
- Alt+click on FL creates a new Fleet pane even if one already exists

## Tests
- `npm run test:syntax`
- `npx playwright test tests/pane.shortcuts.e2e.spec.js --workers=1`

Closes #205
