### PR TITLE
UX: persistent pane-kind color accents across panes + pane manager

### DIFF
--- a/app.js
+++ b/app.js
@@ -1517,9 +1517,11 @@ function renderPaneManager() {
         const idx = panes.findIndex((p) => p.key === pane.key);
         const row = document.createElement('div');
         row.className = 'pane-manager-row';
+        row.classList.add(`pane-kind-${pane.kind || 'chat'}`);
         row.setAttribute('role', 'option');
         row.dataset.index = String(idx);
         row.dataset.paneKey = String(pane.key || '');
+        row.dataset.paneKind = String(pane.kind || 'chat');
         row.dataset.visibleIndex = String(visibleIdx);
         row.setAttribute('aria-selected', visibleIdx === paneManagerUiState.selectedIndex ? 'true' : 'false');
 
@@ -1532,6 +1534,7 @@ function renderPaneManager() {
         row.innerHTML = `
           <div class="pane-manager-main">
             <div class="pane-manager-kind" title="${escapeHtml(paneIdentity)}">
+              <span class="pane-manager-accent" data-pane-manager-accent="${escapeHtml(String(pane.kind || 'chat'))}" aria-hidden="true"></span>
               <span class="pane-manager-kind-label">${escapeHtml(paneIdentity)}</span>
               <span class="pane-manager-pane-id" title="Internal pane id">${escapeHtml(String(pane?.key || ''))}</span>
               ${isDuplicate ? `<span class="pane-manager-duplicate-badge" data-testid="pane-manager-duplicate-badge" title="${escapeHtml(`${duplicateCount} duplicate panes`)}">duplicate</span>` : ''}
@@ -4879,6 +4882,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
   // Mark pane kind on root for CSS + debugging.
   try {
     elements.root.dataset.paneKind = pane.kind;
+    elements.root.dataset.paneAccentKind = pane.kind;
     elements.root.classList.add(`pane-kind-${pane.kind}`);
   } catch {}
 
@@ -4887,7 +4891,12 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     if (elements.name) elements.name.textContent = paneLabel(pane);
     if (elements.typeIcon) elements.typeIcon.textContent = paneIcon(pane);
     if (elements.typeText) elements.typeText.textContent = String(paneLabel(pane) || pane.kind || 'chat').toUpperCase();
-    if (elements.typePill) elements.typePill.setAttribute('aria-label', `Pane type: ${paneLabel(pane)}`);
+    if (elements.typePill) {
+      elements.typePill.setAttribute('aria-label', `Pane type: ${paneLabel(pane)}`);
+      elements.typePill.classList.add(`pane-type-${pane.kind}`);
+      elements.typePill.dataset.paneAccent = pane.kind;
+      elements.typePill.dataset.testid = 'pane-type-accent';
+    }
   } catch {}
 
   // Per-pane inline help popover ("What is this pane?")

--- a/docs/pane-accent-tokens.md
+++ b/docs/pane-accent-tokens.md
@@ -1,0 +1,22 @@
+# Pane accent tokens
+
+Persistent pane-kind accents use the following dark-theme tokens in `styles.css`:
+
+- `--pane-accent-chat-rgb`: `127, 209, 185`
+- `--pane-accent-workqueue-rgb`: `255, 179, 71`
+- `--pane-accent-cron-rgb`: `162, 155, 254`
+- `--pane-accent-timeline-rgb`: `86, 204, 242`
+- `--pane-accent-fleet-rgb`: `244, 114, 182` (reserved for Fleet surfaces)
+
+These feed per-pane variables (`--pane-accent-rgb`, `--pane-accent`, `--pane-header-tint`) used consistently in:
+
+1. Pane container/card chrome (`.chat-panel.pane`)
+2. Pane header accent bar (`.pane-header`)
+3. Pane type pill (`.pane-type-*`)
+4. Pane Manager rows and swatch dots (`.pane-manager-row`, `.pane-manager-accent`)
+
+Testing hook selectors:
+
+- Pane root: `[data-pane][data-pane-kind="<kind>"][data-pane-accent-kind="<kind>"]`
+- Type pill: `[data-pane-type-pill][data-pane-accent="<kind>"]`
+- Pane Manager row swatch: `[data-pane-manager-accent="<kind>"]`

--- a/styles.css
+++ b/styles.css
@@ -9,6 +9,13 @@
   --accent: #ffb347;
   --accent-2: #7fd1b9;
   --warning: #ff6b6b;
+
+  /* Pane-kind accent tokens (AA-conscious in dark mode). */
+  --pane-accent-chat-rgb: 127, 209, 185;
+  --pane-accent-workqueue-rgb: 255, 179, 71;
+  --pane-accent-cron-rgb: 162, 155, 254;
+  --pane-accent-timeline-rgb: 86, 204, 242;
+  --pane-accent-fleet-rgb: 244, 114, 182;
   --glow: rgba(255, 179, 71, 0.35);
   --shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
 }
@@ -378,6 +385,8 @@ body::before {
   gap: 10px;
   padding: 14px;
   padding-bottom: 6px;
+  border-color: rgba(var(--pane-accent-rgb, 255, 255, 255), 0.28);
+  box-shadow: inset 0 0 0 1px rgba(var(--pane-accent-rgb, 255, 255, 255), 0.14), var(--shadow);
 }
 
 /* Workqueue pane should be full-height: never show chat composer UI in this pane. */
@@ -459,43 +468,47 @@ body::before {
 
 /* Per-pane subtle treatment */
 .pane-kind-chat {
-  --pane-accent: rgba(127, 209, 185, 0.75);
-  --pane-header-tint: rgba(127, 209, 185, 0.08);
+  --pane-accent-rgb: var(--pane-accent-chat-rgb);
+  --pane-accent: rgba(var(--pane-accent-rgb), 0.78);
+  --pane-header-tint: rgba(var(--pane-accent-rgb), 0.1);
 }
 
 .pane-kind-workqueue {
-  --pane-accent: rgba(255, 179, 71, 0.8);
-  --pane-header-tint: rgba(255, 179, 71, 0.09);
+  --pane-accent-rgb: var(--pane-accent-workqueue-rgb);
+  --pane-accent: rgba(var(--pane-accent-rgb), 0.82);
+  --pane-header-tint: rgba(var(--pane-accent-rgb), 0.11);
 }
 
 .pane-kind-cron {
-  --pane-accent: rgba(162, 155, 254, 0.8);
-  --pane-header-tint: rgba(162, 155, 254, 0.09);
+  --pane-accent-rgb: var(--pane-accent-cron-rgb);
+  --pane-accent: rgba(var(--pane-accent-rgb), 0.82);
+  --pane-header-tint: rgba(var(--pane-accent-rgb), 0.1);
 }
 
 .pane-kind-timeline {
-  --pane-accent: rgba(86, 204, 242, 0.78);
-  --pane-header-tint: rgba(86, 204, 242, 0.08);
+  --pane-accent-rgb: var(--pane-accent-timeline-rgb);
+  --pane-accent: rgba(var(--pane-accent-rgb), 0.8);
+  --pane-header-tint: rgba(var(--pane-accent-rgb), 0.1);
 }
 
 .pane-type-chat {
-  border-color: rgba(127, 209, 185, 0.45);
-  background: rgba(127, 209, 185, 0.12);
+  border-color: rgba(var(--pane-accent-chat-rgb), 0.5);
+  background: rgba(var(--pane-accent-chat-rgb), 0.14);
 }
 
 .pane-type-workqueue {
-  border-color: rgba(255, 179, 71, 0.55);
-  background: rgba(255, 179, 71, 0.12);
+  border-color: rgba(var(--pane-accent-workqueue-rgb), 0.58);
+  background: rgba(var(--pane-accent-workqueue-rgb), 0.14);
 }
 
 .pane-type-cron {
-  border-color: rgba(162, 155, 254, 0.55);
-  background: rgba(162, 155, 254, 0.12);
+  border-color: rgba(var(--pane-accent-cron-rgb), 0.58);
+  background: rgba(var(--pane-accent-cron-rgb), 0.14);
 }
 
 .pane-type-timeline {
-  border-color: rgba(86, 204, 242, 0.55);
-  background: rgba(86, 204, 242, 0.12);
+  border-color: rgba(var(--pane-accent-timeline-rgb), 0.58);
+  background: rgba(var(--pane-accent-timeline-rgb), 0.14);
 }
 
 .pane-agent {
@@ -1211,7 +1224,8 @@ button.send-btn .btn-icon {
   padding: 10px 12px;
   border-radius: 12px;
   border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(255, 255, 255, 0.02);
+  border-left: 3px solid var(--pane-accent, rgba(255, 255, 255, 0.2));
+  background: linear-gradient(90deg, rgba(var(--pane-accent-rgb, 255, 255, 255), 0.08), rgba(255, 255, 255, 0.02));
 }
 
 .pane-manager-row[aria-selected="true"] {
@@ -1232,6 +1246,15 @@ button.send-btn .btn-icon {
   gap: 8px;
   align-items: center;
   min-width: 0;
+}
+
+.pane-manager-accent {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  flex: 0 0 auto;
+  background: rgba(var(--pane-accent-rgb, 255, 255, 255), 0.95);
+  box-shadow: 0 0 0 1px rgba(8, 10, 14, 0.55);
 }
 
 .pane-manager-letter {

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -155,7 +155,7 @@ test('add-pane shortcuts do not fire while typing in chat input', async ({ page 
   const panes = page.locator('[data-pane]');
   await expect(panes).toHaveCount(2);
 
-  const input = page.locator('[data-pane-kind="chat"] [data-pane-input]').first();
+  const input = page.locator('[data-pane][data-pane-kind="chat"] [data-pane-input]').first();
   await input.focus();
   await input.fill('typing');
 
@@ -176,7 +176,7 @@ test('fleet quick action button + keyboard shortcut focus existing timeline pane
   await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
 
   const panes = page.locator('[data-pane]');
-  const timelinePanes = page.locator('[data-pane-kind="timeline"]');
+  const timelinePanes = page.locator('[data-pane][data-pane-kind="timeline"]');
   const fleetBtn = page.locator('#fleetBtn');
 
   await expect(panes).toHaveCount(2);

--- a/tests/ui/command-palette.spec.js
+++ b/tests/ui/command-palette.spec.js
@@ -40,7 +40,7 @@ test('command palette: keyboard flow can open a targeted pane and focus by pane 
   await input.type('open workqueue: dev-team');
   await page.keyboard.press('Enter');
 
-  const wqPane = page.locator('[data-pane-kind="workqueue"]').last();
+  const wqPane = page.locator('[data-pane][data-pane-kind="workqueue"]').last();
   await expect(wqPane).toBeVisible();
 
   const countAfter = await page.locator('[data-pane]').count();

--- a/tests/ui/pane-accents.spec.js
+++ b/tests/ui/pane-accents.spec.js
@@ -1,0 +1,42 @@
+const { test, expect } = require('@playwright/test');
+
+const { startTestEnv, loginAdmin, attachConsoleErrorAsserts, addPane } = require('./_helpers');
+
+let env;
+
+test.beforeAll(async () => {
+  env = await startTestEnv();
+});
+
+test.afterAll(() => {
+  env?.stop?.();
+});
+
+test.afterEach(async ({ page }) => {
+  if (page.__consoleAsserts) page.__consoleAsserts.assertNoErrors();
+});
+
+test('pane accents: each pane kind exposes deterministic accent selectors', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+
+  // Default layout includes chat + workqueue; add the remaining kinds.
+  await addPane(page, 'Cron pane');
+  await addPane(page, 'Timeline pane');
+
+  for (const kind of ['chat', 'workqueue', 'cron', 'timeline']) {
+    await expect(page.locator(`[data-pane][data-pane-kind="${kind}"][data-pane-accent-kind="${kind}"]`)).toHaveCount(1);
+    await expect(page.locator(`[data-pane][data-pane-kind="${kind}"] [data-pane-type-pill][data-pane-accent="${kind}"]`)).toHaveCount(1);
+  }
+
+  await page.locator('#paneManagerBtn').click();
+  await expect(page.locator('#paneManagerModal')).toHaveClass(/open/);
+
+  for (const kind of ['chat', 'workqueue', 'cron', 'timeline']) {
+    await expect(page.locator(`[data-pane-manager-accent="${kind}"]`)).toHaveCount(1);
+  }
+});

--- a/tests/ui/pane-add-menu.spec.js
+++ b/tests/ui/pane-add-menu.spec.js
@@ -41,7 +41,7 @@ test('pane add menu: opens + adds explicit pane kinds + focuses sane defaults', 
   // Add a workqueue pane and ensure it exists + focus lands on primary control.
   await menu.locator('[data-testid="pane-add-menu-workqueue"]').click();
 
-  const wqPane = page.locator('[data-pane-kind="workqueue"]').last();
+  const wqPane = page.locator('[data-pane][data-pane-kind="workqueue"]').last();
   await expect(wqPane).toBeVisible();
 
   const queueSelect = wqPane.locator('[data-wq-queue-select]');
@@ -80,10 +80,12 @@ test('pane add shortcuts: Ctrl/Cmd+Shift+T adds a timeline pane', async ({ page 
 
   const countBefore = await page.locator('[data-pane]').count();
 
+  await page.evaluate(() => document.activeElement?.blur?.());
+
   // Use a Playwright-friendly cross-platform modifier.
   await page.keyboard.press('ControlOrMeta+Shift+T');
 
-  const tlPane = page.locator('[data-pane-kind="timeline"]').last();
+  const tlPane = page.locator('[data-pane][data-pane-kind="timeline"]').last();
   await expect(tlPane).toBeVisible();
 
   const countAfter = await page.locator('[data-pane]').count();


### PR DESCRIPTION
## Summary\n- add explicit pane-kind accent tokens (chat/workqueue/cron/timeline + reserved fleet token)\n- apply accents consistently to pane container chrome, header accents, and pane type pills\n- add pane manager row accent cues (left border + swatch) tied to the same pane-kind tokens\n- add deterministic accent selector hooks and Playwright coverage for each pane kind\n- document pane accent tokens and testing selectors\n\n## Testing\n- npm run test:syntax\n- npm run test:unit\n- npx playwright test tests/ui/pane-accents.spec.js --workers=1\n\nCloses #204