### PR TITLE
UX: sticky 'Sending to' strip above composer + draft-change guard

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,6 +119,12 @@
 
             <div class="chat-input-row">
               <div class="chat-input-stack">
+                <div class="destination-strip" data-pane-destination-strip data-testid="pane-destination-strip">
+                  <span class="destination-strip-label">Sending to</span>
+                  <button class="destination-strip-target" type="button" data-pane-destination-button aria-label="Change destination" data-testid="pane-destination-button">
+                    <span data-pane-destination-value data-testid="pane-destination-value">main</span>
+                  </button>
+                </div>
                 <textarea data-pane-input placeholder="Message..." data-testid="pane-input"></textarea>
                 <div data-pane-command-hints class="command-hints" aria-live="polite"></div>
                 <div class="attachment-row">

--- a/styles.css
+++ b/styles.css
@@ -2425,6 +2425,38 @@ kbd {
   gap: 8px;
 }
 
+.destination-strip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.destination-strip-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+}
+
+.destination-strip-target {
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-weight: 600;
+  cursor: pointer;
+  border-radius: 8px;
+  padding: 4px 8px;
+}
+
+.destination-strip-target:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
 .attachment-row {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary\n- add a sticky "Sending to" strip above the composer in chat panes\n- wire strip target button to open the agent chooser (same behavior as header target button)\n- add a draft-change confirmation guard when switching pane destination with unsent draft text/attachments\n- extend agent picker e2e coverage for strip visibility + guard behavior\n\n## Testing\n- npm test -- tests/agent-picker.e2e.spec.js\n- npx playwright test tests/agent-picker.e2e.spec.js\n\nCloses #194