### PR TITLE
UX: labeled admin header actions + shortcut tooltips

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,8 +42,9 @@
           </div>
           <div id="paneControls" class="pane-controls" hidden>
             <div class="pane-add-wrap">
-              <button id="addPaneBtn" class="icon-btn" type="button" aria-haspopup="menu" aria-expanded="false" aria-label="Add pane" data-testid="add-pane-btn">
-                +
+              <button id="addPaneBtn" class="icon-btn action-btn" type="button" aria-haspopup="menu" aria-expanded="false" aria-label="Add pane" title="Add Pane (Ctrl/Cmd+Shift+N)" data-testid="add-pane-btn">
+                <span class="btn-icon" aria-hidden="true">+</span>
+                <span class="btn-label">Add Pane</span>
               </button>
             </div>
             <select id="layoutSelect" aria-label="Pane layout">
@@ -53,26 +54,31 @@
             </select>
           </div>
           <div class="role-pill" id="rolePill" data-testid="role-pill">signed out</div>
-          <button id="refreshAgentsBtn" class="icon-btn" type="button" aria-label="Refresh agent list" hidden>
-            ⟳
+          <button id="refreshAgentsBtn" class="icon-btn action-btn" type="button" aria-label="Refresh agent list" title="Refresh (Ctrl/Cmd+R)" hidden>
+            <span class="btn-icon" aria-hidden="true">⟳</span>
+            <span class="btn-label">Refresh</span>
           </button>
-          <button id="agentsBtn" class="icon-btn" type="button" aria-label="Open agents" hidden>
-            ★
+          <button id="agentsBtn" class="icon-btn action-btn" type="button" aria-label="Open agents" title="Agents" hidden>
+            <span class="btn-icon" aria-hidden="true">★</span>
+            <span class="btn-label">Agents</span>
           </button>
           <button id="fleetBtn" class="icon-btn" type="button" aria-label="Open fleet pane" title="Open Fleet pane (Cmd/Ctrl+Shift+F)" hidden>
             FL
           </button>
-          <button id="workqueueBtn" class="icon-btn" type="button" aria-label="Open workqueue" hidden>
-            WQ
+          <button id="workqueueBtn" class="icon-btn action-btn" type="button" aria-label="Open workqueue" title="Workqueue (g w)" hidden>
+            <span class="btn-icon" aria-hidden="true">WQ</span>
+            <span class="btn-label">Workqueue</span>
           </button>
-          <button id="shortcutsBtn" class="icon-btn" type="button" aria-label="Open keyboard shortcuts" hidden data-testid="shortcuts-btn">
+          <button id="shortcutsBtn" class="icon-btn" type="button" aria-label="Open keyboard shortcuts" title="Keyboard shortcuts (?)" hidden data-testid="shortcuts-btn">
             ?
           </button>
-          <button id="settingsBtn" class="icon-btn" type="button" aria-label="Open settings">
-            ⚙︎
+          <button id="settingsBtn" class="icon-btn action-btn" type="button" aria-label="Open settings" title="Settings">
+            <span class="btn-icon" aria-hidden="true">⚙︎</span>
+            <span class="btn-label">Settings</span>
           </button>
-          <button id="logoutBtn" class="icon-btn" type="button" aria-label="Log out">
-            ⎋
+          <button id="logoutBtn" class="icon-btn action-btn" type="button" aria-label="Log out" title="Logout">
+            <span class="btn-icon" aria-hidden="true">⎋</span>
+            <span class="btn-label">Logout</span>
           </button>
         </div>
       </header>

--- a/styles.css
+++ b/styles.css
@@ -188,7 +188,7 @@ body::before {
   font-size: 12px;
 }
 
-/* addPaneBtn uses default .icon-btn styling */
+/* addPaneBtn uses default .icon-btn styling unless promoted to action-btn. */
 .pane-controls .icon-btn {
   width: 36px;
   height: 36px;
@@ -196,6 +196,12 @@ body::before {
   font-size: 18px;
   min-height: 0;
   padding: 0;
+}
+
+.pane-controls .action-btn {
+  width: auto;
+  min-width: 36px;
+  padding: 0 12px;
 }
 
 .role-pill {
@@ -266,6 +272,38 @@ body::before {
 .icon-btn:hover {
   transform: translateY(-1px);
   box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+}
+
+.action-btn {
+  width: auto;
+  min-width: 40px;
+  height: 40px;
+  gap: 8px;
+  padding: 0 12px;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.action-btn .btn-icon {
+  font-size: 14px;
+  line-height: 1;
+}
+
+.action-btn .btn-label {
+  white-space: nowrap;
+}
+
+@media (max-width: 920px) {
+  .action-btn {
+    width: 36px;
+    min-width: 36px;
+    padding: 0;
+    gap: 0;
+  }
+
+  .action-btn .btn-label {
+    display: none;
+  }
 }
 
 .status-pill {

--- a/tests/ui/pane-add-menu.spec.js
+++ b/tests/ui/pane-add-menu.spec.js
@@ -79,6 +79,7 @@ test('pane add shortcuts: Ctrl/Cmd+Shift+T adds a timeline pane', async ({ page 
   await loginAdmin(page, env.serverPort);
 
   const countBefore = await page.locator('[data-pane]').count();
+  await page.evaluate(() => document.activeElement?.blur?.());
 
   // Use a Playwright-friendly cross-platform modifier.
   await page.keyboard.press('ControlOrMeta+Shift+T');


### PR DESCRIPTION
## Summary
- replace icon-only admin header controls with labeled desktop action buttons
- keep compact icon mode on narrower widths (`max-width: 920px`)
- add explicit tooltips for primary actions with shortcuts where available

## Testing
- npm run test:syntax

Closes #192
