### PR TITLE
UX: agent list quick filter + sort by last active

### DIFF
--- a/index.html
+++ b/index.html
@@ -405,9 +405,8 @@
             <label class="agents-field">
               <span class="agents-label">Sort</span>
               <select id="agentsSort" aria-label="Sort agents">
-                <option value="recent_desc">Recent heartbeat (newest first)</option>
-                <option value="heartbeat_age_oldest">Last heartbeat age (oldest first)</option>
-                <option value="name_asc">Name (A-Z)</option>
+                <option value="recent_desc">Last active (newest first)</option>
+                <option value="agent_id_asc">Agent id (A-Z)</option>
               </select>
             </label>
             <label class="agents-field">

--- a/styles.css
+++ b/styles.css
@@ -1394,6 +1394,10 @@ button.send-btn .btn-icon {
   color: var(--text);
 }
 
+.agents-status-snippet {
+  color: var(--muted);
+}
+
 .agents-row-actions {
   display: inline-flex;
   align-items: center;

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -33,7 +33,29 @@ test('agents modal shows live refresh freshness indicators', async ({ page, claw
   await expect(page.locator('#agentsModal')).toHaveClass(/open/);
 
   await expect(page.locator('#agentsLastRefreshed')).toContainText('Last refreshed:');
-  await expect(page.locator('#agentsList .agents-row-meta').first()).toContainText('last seen');
+  await expect(page.locator('#agentsList .agents-row-meta').first()).toContainText(/\d+[smhd]/);
+});
+
+test('agents modal quick filter narrows list and Esc clears it', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  await clawnsole.gotoAndLoginAdmin(page);
+
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsModal')).toHaveClass(/open/);
+
+  const rows = page.locator('#agentsList .agents-row');
+  const initialCount = await rows.count();
+  expect(initialCount).toBeGreaterThan(0);
+
+  const search = page.locator('#agentsSearch');
+  await search.fill('zzzz-no-agent-match');
+  await expect(rows).toHaveCount(0);
+
+  await search.press('Escape');
+  await expect(search).toBeFocused();
+  await expect(search).toHaveValue('');
+  await expect(rows).toHaveCount(initialCount);
 });
 
 test('agents modal quick actions open/reuse chat, timeline, and workqueue context', async ({ page, clawnsole }) => {


### PR DESCRIPTION
## Summary
- add live quick filter in Agents modal across agent id, display label, and status snippet
- replace sort options with **Last active (newest first)** and **Agent id (A-Z)**
- show compact activity age indicator and optional status snippet in each row
- add keyboard affordances: command palette entry to focus filter and Esc-to-clear while keeping focus
- add Playwright coverage for filter narrowing + Esc clear restore behavior

## Testing
- npm test -- tests/ui/agents-modal.spec.js
- npx playwright test tests/ui/agents-modal.spec.js

Closes #135