### PR TITLE
UX: Fleet row quick action preselects Workqueue target agent

### DIFF
--- a/app.js
+++ b/app.js
@@ -2089,7 +2089,22 @@ function openFleetPane({ forceNew = false } = {}) {
   paneManager.focusPanePrimary(pane);
 }
 
-function openAgentWorkqueueFromFleet() {
+function setWorkqueueEnqueueTargetAgent(pane, agentId) {
+  if (!pane || pane.kind !== 'workqueue') return;
+  const target = normalizeAgentId(agentId || 'main');
+  pane.workqueue.enqueueAssignTo = target;
+
+  try {
+    const claimAgentSelect = pane.elements?.thread?.querySelector?.('[data-wq-claim-agent]');
+    if (!claimAgentSelect) return;
+    const exists = Array.from(claimAgentSelect.options || []).some((opt) => String(opt.value || '') === target);
+    if (!exists) return;
+    claimAgentSelect.value = target;
+  } catch {}
+}
+
+function openAgentWorkqueueFromFleet(agentId) {
+  const target = normalizeAgentId(agentId || 'main');
   const preferredQueue =
     String(workqueueState?.selectedQueue || '').trim() ||
     String(findExistingPane('workqueue')?.workqueue?.queue || '').trim() ||
@@ -2098,9 +2113,10 @@ function openAgentWorkqueueFromFleet() {
   const pane =
     findExistingPane('workqueue', (p) => String(p.workqueue?.queue || '').trim() === preferredQueue) ||
     findExistingPane('workqueue') ||
-    paneManager.addPane('workqueue', { queue: preferredQueue });
+    paneManager.addPane('workqueue', { queue: preferredQueue, enqueueAssignTo: target });
   if (!pane) return;
 
+  setWorkqueueEnqueueTargetAgent(pane, target);
   paneManager.focusPanePrimary(pane);
 }
 
@@ -2218,7 +2234,7 @@ function renderAgentsModalList() {
           const action = String(btn.getAttribute('data-agent-action') || '').trim();
           if (action === 'open-chat') openAgentChatFromFleet(id);
           else if (action === 'open-timeline') openAgentTimelineFromFleet(id);
-          else if (action === 'open-workqueue') openAgentWorkqueueFromFleet();
+          else if (action === 'open-workqueue') openAgentWorkqueueFromFleet(id);
         });
       });
 
@@ -4787,7 +4803,7 @@ function renderAgentOptions(selectEl, agentId) {
   selectEl.value = normalizeAgentId(agentId || 'main');
 }
 
-function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, scopeFilter, sortKey, sortDir, cronAgentId, closable = true } = {}) {
+function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, scopeFilter, sortKey, sortDir, cronAgentId, enqueueAssignTo, closable = true } = {}) {
   const template = globalElements.paneTemplate;
   const root = template.content.firstElementChild.cloneNode(true);
   const elements = {
@@ -4838,7 +4854,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       items: [],
       selectedItemId: null,
       sortKey: typeof sortKey === 'string' && sortKey.trim() ? sortKey.trim() : 'priority',
-      sortDir: sortDir === 'asc' ? 'asc' : 'desc'
+      sortDir: sortDir === 'asc' ? 'asc' : 'desc',
+      enqueueAssignTo: normalizeAgentId(enqueueAssignTo || 'main')
     },
     cronAgentId: typeof cronAgentId === 'string' ? cronAgentId.trim() : '',
     connected: false,
@@ -5399,6 +5416,10 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         opt.textContent = formatAgentLabel(a);
         claimAgentSelect.appendChild(opt);
       }
+
+      const preferred = normalizeAgentId(pane.workqueue.enqueueAssignTo || 'main');
+      const hasPreferred = Array.from(claimAgentSelect.options || []).some((opt) => String(opt.value || '') === preferred);
+      claimAgentSelect.value = hasPreferred ? preferred : '';
     }
 
     // Enqueue (inline form).

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -80,6 +80,9 @@ test('agents modal quick actions open/reuse chat, timeline, and workqueue contex
   await firstRow.locator('[data-agent-action="open-timeline"]').first().click();
   await expect(page.locator('[data-pane][data-pane-kind="timeline"]')).toHaveCount(1);
 
+  const firstAgentId = await firstRow.locator('[data-agent-action="open-workqueue"]').first().getAttribute('data-agent-id');
   await firstRow.locator('[data-agent-action="open-workqueue"]').first().click();
-  await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
+  const wqPane = page.locator('[data-pane][data-pane-kind="workqueue"]');
+  await expect(wqPane).toHaveCount(1);
+  await expect(wqPane.locator('[data-wq-claim-agent]')).toHaveValue(firstAgentId || 'main');
 });


### PR DESCRIPTION
## Summary
- wire Fleet row "Open Workqueue" action to pass the selected agent id
- reuse/focus existing Workqueue pane as before, but now preselect enqueue "Assign to" with that agent
- keep this preference on the pane model so new/existing panes sync the selector consistently
- extend agents modal Playwright spec to assert the assign target is prefilled from the clicked row

## Testing
- 
> clawnsole@0.1.0 test:proxy
> node scripts/proxy-self-test.js tests/ui/agents-modal.spec.js

proxy-self-test: ok

Closes #210