### PR TITLE
Fix pane grid heading when non-chat panes are present

### DIFF
--- a/app.js
+++ b/app.js
@@ -6561,6 +6561,13 @@ const paneManager = {
   },
   updatePaneLabels() {
     this.panes.forEach((pane) => renderPaneIdentity(pane));
+    this.updatePaneGridLabel();
+  },
+  updatePaneGridLabel() {
+    const grid = globalElements.paneGrid;
+    if (!grid) return;
+    const hasNonChat = this.panes.some((pane) => pane?.kind && pane.kind !== 'chat');
+    grid.setAttribute('aria-label', hasNonChat ? 'Panes' : 'Chat panes');
   },
   updateCloseButtons() {
     const allowClose = roleState.role === 'admin' && this.panes.length > 1;

--- a/tests/pane.workqueue.e2e.spec.js
+++ b/tests/pane.workqueue.e2e.spec.js
@@ -18,14 +18,25 @@ test('pane: workqueue renders + core controls visible', async ({ page }) => {
 
   installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
 
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'clawnsole.admin.panes.v1',
+      JSON.stringify([{ key: 'ptestchat01', kind: 'chat', agentId: 'main' }])
+    );
+  });
+
   await page.goto(`http://127.0.0.1:${app.serverPort}/`);
   await page.fill('#loginPassword', 'admin');
   await page.click('#loginBtn');
   await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
 
   await expect(page.getByTestId('add-pane-btn')).toBeVisible();
+  const paneGrid = page.getByTestId('pane-grid');
+  await expect(paneGrid).toHaveAttribute('aria-label', 'Chat panes');
+
   await page.getByTestId('add-pane-btn').click();
   await page.getByTestId('pane-add-menu-workqueue').click();
+  await expect(paneGrid).toHaveAttribute('aria-label', 'Panes');
 
   const panes = page.locator('[data-pane]');
   const wqPane = panes.last();


### PR DESCRIPTION
## Summary\n- update pane grid aria-label dynamically based on active pane kinds\n- keep label as `Chat panes` for all-chat layouts\n- switch label to neutral `Panes` as soon as any non-chat pane exists\n- add Playwright coverage that starts with chat-only layout, opens a Workqueue pane, and asserts heading changes\n\n## Testing\n- `node --check app.js`\n- `node --check tests/pane.workqueue.e2e.spec.js`\n\nCloses #156