### PR TITLE
UX: reuse matching non-chat pane targets by default

### DIFF
--- a/app.js
+++ b/app.js
@@ -1759,16 +1759,28 @@ function buildCommandPaletteItems() {
       '⌘/Ctrl+Shift+C'
     ),
     withShortcut(
-      { id: 'cmd:add-workqueue', label: 'Open pane: Workqueue', detail: 'Create a new Workqueue pane', run: () => paneManager.addPane('workqueue') },
+      { id: 'cmd:add-workqueue', label: 'Open pane: Workqueue', detail: 'Focus matching Workqueue pane target (or create one)', run: () => paneManager.addPane('workqueue') },
       '⌘/Ctrl+Shift+W'
     ),
     withShortcut(
-      { id: 'cmd:add-cron', label: 'Open pane: Cron', detail: 'Create a new Cron pane', run: () => paneManager.addPane('cron') },
+      { id: 'cmd:add-workqueue-force', label: 'Open pane: Workqueue (open anyway)', detail: 'Create a new Workqueue pane even if matching target exists', run: () => paneManager.addPane('workqueue', { forceNew: true }) },
+      ''
+    ),
+    withShortcut(
+      { id: 'cmd:add-cron', label: 'Open pane: Cron', detail: 'Focus matching Cron pane target (or create one)', run: () => paneManager.addPane('cron') },
       '⌘/Ctrl+Shift+R'
     ),
     withShortcut(
-      { id: 'cmd:add-timeline', label: 'Open pane: Timeline', detail: 'Create a new Timeline pane', run: () => paneManager.addPane('timeline') },
+      { id: 'cmd:add-cron-force', label: 'Open pane: Cron (open anyway)', detail: 'Create a new Cron pane even if matching target exists', run: () => paneManager.addPane('cron', { forceNew: true }) },
+      ''
+    ),
+    withShortcut(
+      { id: 'cmd:add-timeline', label: 'Open pane: Timeline', detail: 'Focus matching Timeline pane target (or create one)', run: () => paneManager.addPane('timeline') },
       '⌘/Ctrl+Shift+T'
+    ),
+    withShortcut(
+      { id: 'cmd:add-timeline-force', label: 'Open pane: Timeline (open anyway)', detail: 'Create a new Timeline pane even if matching target exists', run: () => paneManager.addPane('timeline', { forceNew: true }) },
+      ''
     ),
     withShortcut(
       { id: 'cmd:open-fleet', label: 'Open pane: Fleet', detail: 'Focus existing Fleet pane or open one', run: () => openFleetPane() },
@@ -6273,11 +6285,31 @@ const paneManager = {
   },
   addPane(kind = 'chat', options = {}) {
     if (roleState.role !== 'admin') return;
-    if (this.panes.length >= this.maxPanes) return;
 
     const normalizedKind = normalizePaneKind(kind);
     const nextQueue = String(options?.queue || 'dev-team').trim() || 'dev-team';
     const nextCronAgentId = String(options?.cronAgentId || '').trim();
+    const forceNew = Boolean(options?.forceNew);
+
+    const findMatchingPane = () => {
+      if (normalizedKind === 'workqueue') {
+        return this.panes.find((p) => p?.role === 'admin' && p.kind === 'workqueue' && String(p.workqueue?.queue || '').trim() === nextQueue) || null;
+      }
+      if (normalizedKind === 'cron' || normalizedKind === 'timeline') {
+        return this.panes.find((p) => p?.role === 'admin' && p.kind === normalizedKind && String(p.cronAgentId || '').trim() === nextCronAgentId) || null;
+      }
+      return null;
+    };
+
+    if (!forceNew) {
+      const existing = findMatchingPane();
+      if (existing) {
+        this.focusPanePrimary(existing);
+        return existing;
+      }
+    }
+
+    if (this.panes.length >= this.maxPanes) return;
 
     if (normalizedKind === 'workqueue') {
       const pane = createPane({
@@ -6398,21 +6430,21 @@ const paneManager = {
       wqBtn.className = 'pane-add-menu__item';
       wqBtn.textContent = 'New Workqueue pane';
       wqBtn.dataset.testid = 'pane-add-menu-workqueue';
-      wqBtn.title = 'Shortcut: Ctrl/Cmd+Shift+W';
+      wqBtn.title = 'Shortcut: Ctrl/Cmd+Shift+W (Alt/Option+click = Open anyway)';
 
       const cronBtn = document.createElement('button');
       cronBtn.type = 'button';
       cronBtn.className = 'pane-add-menu__item';
       cronBtn.textContent = 'New Cron pane';
       cronBtn.dataset.testid = 'pane-add-menu-cron';
-      cronBtn.title = 'Shortcut: Ctrl/Cmd+Shift+R';
+      cronBtn.title = 'Shortcut: Ctrl/Cmd+Shift+R (Alt/Option+click = Open anyway)';
 
       const timelineBtn = document.createElement('button');
       timelineBtn.type = 'button';
       timelineBtn.className = 'pane-add-menu__item';
       timelineBtn.textContent = 'New Timeline pane';
       timelineBtn.dataset.testid = 'pane-add-menu-timeline';
-      timelineBtn.title = 'Shortcut: Ctrl/Cmd+Shift+T';
+      timelineBtn.title = 'Shortcut: Ctrl/Cmd+Shift+T (Alt/Option+click = Open anyway)';
 
       menu.appendChild(chatBtn);
       menu.appendChild(wqBtn);
@@ -6426,7 +6458,7 @@ const paneManager = {
         if (event?.stopPropagation) event.stopPropagation();
 
         this.closeAddPaneMenu();
-        this.addPane(kind);
+        this.addPane(kind, { forceNew: !!event?.altKey });
 
         queueMicrotask(() => {
           state.menuActionInFlight = false;
@@ -6923,10 +6955,10 @@ window.addEventListener('keydown', (event) => {
 
   // Add-pane shortcuts (admin-only)
   // Ctrl/Cmd+Shift+C → new chat
-  // Ctrl/Cmd+Shift+W → new workqueue
-  // Ctrl/Cmd+Shift+R → new cron
-  // Ctrl/Cmd+Shift+T → new timeline
-  const isAccel = (event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey;
+  // Ctrl/Cmd+Shift+W → focus matching workqueue target (Alt/Option adds anyway)
+  // Ctrl/Cmd+Shift+R → focus matching cron target (Alt/Option adds anyway)
+  // Ctrl/Cmd+Shift+T → focus matching timeline target (Alt/Option adds anyway)
+  const isAccel = (event.metaKey || event.ctrlKey) && event.shiftKey;
   if (isAccel && roleState.role === 'admin' && !isTypingContext(event.target)) {
     const key = String(event.key || '').toLowerCase();
     const map = { c: 'chat', w: 'workqueue', r: 'cron', t: 'timeline' };
@@ -6935,7 +6967,7 @@ window.addEventListener('keydown', (event) => {
       // Don't hijack add-pane shortcuts while typing in inputs/editors.
       event.preventDefault();
       paneManager.closeAddPaneMenu();
-      paneManager.addPane(kind);
+      paneManager.addPane(kind, { forceNew: !!event.altKey });
       return;
     }
   }

--- a/app.js
+++ b/app.js
@@ -2255,7 +2255,7 @@ function openAgentTimelineFromFleet(agentId) {
 function openFleetPane({ forceNew = false } = {}) {
   const target = 'all';
   const pane = forceNew
-    ? paneManager.addPane('timeline', { cronAgentId: target })
+    ? paneManager.addPane('timeline', { cronAgentId: target, forceNew: true })
     : findExistingPane('timeline', (p) => String(p.cronAgentId || '').trim() === target) ||
       findExistingPane('timeline') ||
       paneManager.addPane('timeline', { cronAgentId: target });

--- a/app.js
+++ b/app.js
@@ -1776,16 +1776,28 @@ function buildCommandPaletteItems() {
       '⌘/Ctrl+Shift+C'
     ),
     withShortcut(
-      { id: 'cmd:add-workqueue', label: 'Open pane: Workqueue', detail: 'Create a new Workqueue pane', run: () => paneManager.addPane('workqueue') },
+      { id: 'cmd:add-workqueue', label: 'Open pane: Workqueue', detail: 'Focus matching Workqueue pane target (or create one)', run: () => paneManager.addPane('workqueue') },
       '⌘/Ctrl+Shift+W'
     ),
     withShortcut(
-      { id: 'cmd:add-cron', label: 'Open pane: Cron', detail: 'Create a new Cron pane', run: () => paneManager.addPane('cron') },
+      { id: 'cmd:add-workqueue-force', label: 'Open pane: Workqueue (open anyway)', detail: 'Create a new Workqueue pane even if matching target exists', run: () => paneManager.addPane('workqueue', { forceNew: true }) },
+      ''
+    ),
+    withShortcut(
+      { id: 'cmd:add-cron', label: 'Open pane: Cron', detail: 'Focus matching Cron pane target (or create one)', run: () => paneManager.addPane('cron') },
       '⌘/Ctrl+Shift+R'
     ),
     withShortcut(
-      { id: 'cmd:add-timeline', label: 'Open pane: Timeline', detail: 'Create a new Timeline pane', run: () => paneManager.addPane('timeline') },
+      { id: 'cmd:add-cron-force', label: 'Open pane: Cron (open anyway)', detail: 'Create a new Cron pane even if matching target exists', run: () => paneManager.addPane('cron', { forceNew: true }) },
+      ''
+    ),
+    withShortcut(
+      { id: 'cmd:add-timeline', label: 'Open pane: Timeline', detail: 'Focus matching Timeline pane target (or create one)', run: () => paneManager.addPane('timeline') },
       '⌘/Ctrl+Shift+T'
+    ),
+    withShortcut(
+      { id: 'cmd:add-timeline-force', label: 'Open pane: Timeline (open anyway)', detail: 'Create a new Timeline pane even if matching target exists', run: () => paneManager.addPane('timeline', { forceNew: true }) },
+      ''
     ),
     withShortcut(
       { id: 'cmd:open-fleet', label: 'Open pane: Fleet', detail: 'Focus existing Fleet pane or open one', run: () => openFleetPane() },
@@ -6476,11 +6488,31 @@ const paneManager = {
   },
   addPane(kind = 'chat', options = {}) {
     if (roleState.role !== 'admin') return;
-    if (this.panes.length >= this.maxPanes) return;
 
     const normalizedKind = normalizePaneKind(kind);
     const nextQueue = String(options?.queue || 'dev-team').trim() || 'dev-team';
     const nextCronAgentId = String(options?.cronAgentId || '').trim();
+    const forceNew = Boolean(options?.forceNew);
+
+    const findMatchingPane = () => {
+      if (normalizedKind === 'workqueue') {
+        return this.panes.find((p) => p?.role === 'admin' && p.kind === 'workqueue' && String(p.workqueue?.queue || '').trim() === nextQueue) || null;
+      }
+      if (normalizedKind === 'cron' || normalizedKind === 'timeline') {
+        return this.panes.find((p) => p?.role === 'admin' && p.kind === normalizedKind && String(p.cronAgentId || '').trim() === nextCronAgentId) || null;
+      }
+      return null;
+    };
+
+    if (!forceNew) {
+      const existing = findMatchingPane();
+      if (existing) {
+        this.focusPanePrimary(existing);
+        return existing;
+      }
+    }
+
+    if (this.panes.length >= this.maxPanes) return;
 
     if (normalizedKind === 'workqueue') {
       const pane = createPane({
@@ -6601,21 +6633,21 @@ const paneManager = {
       wqBtn.className = 'pane-add-menu__item';
       wqBtn.textContent = 'New Workqueue pane';
       wqBtn.dataset.testid = 'pane-add-menu-workqueue';
-      wqBtn.title = 'Shortcut: Ctrl/Cmd+Shift+W';
+      wqBtn.title = 'Shortcut: Ctrl/Cmd+Shift+W (Alt/Option+click = Open anyway)';
 
       const cronBtn = document.createElement('button');
       cronBtn.type = 'button';
       cronBtn.className = 'pane-add-menu__item';
       cronBtn.textContent = 'New Cron pane';
       cronBtn.dataset.testid = 'pane-add-menu-cron';
-      cronBtn.title = 'Shortcut: Ctrl/Cmd+Shift+R';
+      cronBtn.title = 'Shortcut: Ctrl/Cmd+Shift+R (Alt/Option+click = Open anyway)';
 
       const timelineBtn = document.createElement('button');
       timelineBtn.type = 'button';
       timelineBtn.className = 'pane-add-menu__item';
       timelineBtn.textContent = 'New Timeline pane';
       timelineBtn.dataset.testid = 'pane-add-menu-timeline';
-      timelineBtn.title = 'Shortcut: Ctrl/Cmd+Shift+T';
+      timelineBtn.title = 'Shortcut: Ctrl/Cmd+Shift+T (Alt/Option+click = Open anyway)';
 
       menu.appendChild(chatBtn);
       menu.appendChild(wqBtn);
@@ -6629,7 +6661,7 @@ const paneManager = {
         if (event?.stopPropagation) event.stopPropagation();
 
         this.closeAddPaneMenu();
-        this.addPane(kind);
+        this.addPane(kind, { forceNew: !!event?.altKey });
 
         queueMicrotask(() => {
           state.menuActionInFlight = false;
@@ -7127,10 +7159,10 @@ window.addEventListener('keydown', (event) => {
 
   // Add-pane shortcuts (admin-only)
   // Ctrl/Cmd+Shift+C → new chat
-  // Ctrl/Cmd+Shift+W → new workqueue
-  // Ctrl/Cmd+Shift+R → new cron
-  // Ctrl/Cmd+Shift+T → new timeline
-  const isAccel = (event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey;
+  // Ctrl/Cmd+Shift+W → focus matching workqueue target (Alt/Option adds anyway)
+  // Ctrl/Cmd+Shift+R → focus matching cron target (Alt/Option adds anyway)
+  // Ctrl/Cmd+Shift+T → focus matching timeline target (Alt/Option adds anyway)
+  const isAccel = (event.metaKey || event.ctrlKey) && event.shiftKey;
   if (isAccel && roleState.role === 'admin' && !isTypingContext(event.target)) {
     const key = String(event.key || '').toLowerCase();
     const map = { c: 'chat', w: 'workqueue', r: 'cron', t: 'timeline' };
@@ -7139,7 +7171,7 @@ window.addEventListener('keydown', (event) => {
       // Don't hijack add-pane shortcuts while typing in inputs/editors.
       event.preventDefault();
       paneManager.closeAddPaneMenu();
-      paneManager.addPane(kind);
+      paneManager.addPane(kind, { forceNew: !!event.altKey });
       return;
     }
   }

--- a/tests/ui/command-palette.spec.js
+++ b/tests/ui/command-palette.spec.js
@@ -18,7 +18,7 @@ test.afterEach(async ({ page }) => {
   }
 });
 
-test('command palette: keyboard flow can open a targeted pane and focus by pane letter', async ({ page }) => {
+test('command palette: keyboard flow can reuse a targeted pane and focus by pane letter', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);
 
@@ -42,9 +42,10 @@ test('command palette: keyboard flow can open a targeted pane and focus by pane 
 
   const wqPane = page.locator('[data-pane][data-pane-kind="workqueue"]').last();
   await expect(wqPane).toBeVisible();
+  await expect(wqPane.locator('[data-wq-queue-select]')).toBeFocused();
 
   const countAfter = await page.locator('[data-pane]').count();
-  expect(countAfter).toBeGreaterThan(countBefore);
+  expect(countAfter).toBe(countBefore);
 
   await page.keyboard.press('ControlOrMeta+K');
   await expect(input).toBeVisible();

--- a/tests/ui/pane-add-menu.spec.js
+++ b/tests/ui/pane-add-menu.spec.js
@@ -83,11 +83,24 @@ test('pane add shortcuts: Ctrl/Cmd+Shift+T reuses timeline pane; Alt adds anyway
   page.__consoleAsserts = attachConsoleErrorAsserts(page);
 
   await loginAdmin(page, env.serverPort);
+  await expect(page.locator('#addPaneBtn')).toBeVisible();
 
   const countBefore = await page.locator('[data-pane]').count();
 
-  // Use a Playwright-friendly cross-platform modifier.
-  await page.keyboard.press('ControlOrMeta+Shift+T');
+  const fireTimelineShortcut = async (forceNew = false) => {
+    await page.evaluate(({ force }) => {
+      window.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'T',
+        ctrlKey: true,
+        shiftKey: true,
+        altKey: !!force,
+        bubbles: true,
+        cancelable: true
+      }));
+    }, { force: forceNew });
+  };
+
+  await fireTimelineShortcut(false);
 
   const tlPane = page.locator('[data-pane-kind="timeline"]').last();
   await expect(tlPane).toBeVisible();
@@ -95,11 +108,11 @@ test('pane add shortcuts: Ctrl/Cmd+Shift+T reuses timeline pane; Alt adds anyway
   const countAfter = await page.locator('[data-pane]').count();
   expect(countAfter).toBeGreaterThan(countBefore);
 
-  await page.keyboard.press('ControlOrMeta+Shift+T');
+  await fireTimelineShortcut(false);
   const countAfterReuse = await page.locator('[data-pane]').count();
   expect(countAfterReuse).toBe(countAfter);
 
-  await page.keyboard.press('Alt+ControlOrMeta+Shift+T');
+  await fireTimelineShortcut(true);
   const countAfterForce = await page.locator('[data-pane]').count();
   expect(countAfterForce).toBe(countAfter + 1);
 });

--- a/tests/ui/pane-add-menu.spec.js
+++ b/tests/ui/pane-add-menu.spec.js
@@ -49,7 +49,7 @@ test('pane add menu: opens + adds explicit pane kinds + focuses sane defaults', 
   await expect(queueSelect).toBeFocused();
 });
 
-test('pane add menu: single click on item adds exactly one pane', async ({ page }) => {
+test('pane add menu: single click reuses matching non-chat pane target', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);
 
@@ -67,10 +67,16 @@ test('pane add menu: single click on item adds exactly one pane', async ({ page 
 
   await menu.locator('[data-testid="pane-add-menu-workqueue"]').click();
   const countAfter = await page.locator('[data-pane]').count();
-  expect(countAfter).toBe(countBefore + 1);
+  expect(countAfter).toBe(countBefore);
+
+  await addBtn.click();
+  await expect(menu).toBeVisible();
+  await menu.locator('[data-testid="pane-add-menu-workqueue"]').click({ modifiers: ['Alt'] });
+  const countAfterAlt = await page.locator('[data-pane]').count();
+  expect(countAfterAlt).toBe(countBefore + 1);
 });
 
-test('pane add shortcuts: Ctrl/Cmd+Shift+T adds a timeline pane', async ({ page }) => {
+test('pane add shortcuts: Ctrl/Cmd+Shift+T reuses timeline pane; Alt adds anyway', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);
 
@@ -88,4 +94,12 @@ test('pane add shortcuts: Ctrl/Cmd+Shift+T adds a timeline pane', async ({ page 
 
   const countAfter = await page.locator('[data-pane]').count();
   expect(countAfter).toBeGreaterThan(countBefore);
+
+  await page.keyboard.press('ControlOrMeta+Shift+T');
+  const countAfterReuse = await page.locator('[data-pane]').count();
+  expect(countAfterReuse).toBe(countAfter);
+
+  await page.keyboard.press('Alt+ControlOrMeta+Shift+T');
+  const countAfterForce = await page.locator('[data-pane]').count();
+  expect(countAfterForce).toBe(countAfter + 1);
 });

--- a/tests/ui/pane-add-menu.spec.js
+++ b/tests/ui/pane-add-menu.spec.js
@@ -83,6 +83,7 @@ test('pane add shortcuts: Ctrl/Cmd+Shift+T reuses timeline pane; Alt adds anyway
   page.__consoleAsserts = attachConsoleErrorAsserts(page);
 
   await loginAdmin(page, env.serverPort);
+  await expect(page.locator('#addPaneBtn')).toBeVisible();
 
   while (await page.locator('[data-pane]').count() > 1) {
     await page.locator('[data-pane] button[aria-label="Close pane"]').last().click();
@@ -93,8 +94,20 @@ test('pane add shortcuts: Ctrl/Cmd+Shift+T reuses timeline pane; Alt adds anyway
 
   await page.evaluate(() => document.activeElement?.blur?.());
 
-  // Use a Playwright-friendly cross-platform modifier.
-  await page.keyboard.press('ControlOrMeta+Shift+T');
+  const fireTimelineShortcut = async (forceNew = false) => {
+    await page.evaluate(({ force }) => {
+      window.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'T',
+        ctrlKey: true,
+        shiftKey: true,
+        altKey: !!force,
+        bubbles: true,
+        cancelable: true
+      }));
+    }, { force: forceNew });
+  };
+
+  await fireTimelineShortcut(false);
 
   const tlPane = page.locator('[data-pane][data-pane-kind="timeline"]').last();
   await expect(tlPane).toBeVisible();
@@ -102,11 +115,11 @@ test('pane add shortcuts: Ctrl/Cmd+Shift+T reuses timeline pane; Alt adds anyway
   const countAfter = await page.locator('[data-pane]').count();
   expect(countAfter).toBeGreaterThan(countBefore);
 
-  await page.keyboard.press('ControlOrMeta+Shift+T');
+  await fireTimelineShortcut(false);
   const countAfterReuse = await page.locator('[data-pane]').count();
   expect(countAfterReuse).toBe(countAfter);
 
-  await page.keyboard.press('Alt+ControlOrMeta+Shift+T');
+  await fireTimelineShortcut(true);
   const countAfterForce = await page.locator('[data-pane]').count();
   expect(countAfterForce).toBe(countAfter + 1);
 });

--- a/tests/ui/pane-add-menu.spec.js
+++ b/tests/ui/pane-add-menu.spec.js
@@ -49,7 +49,7 @@ test('pane add menu: opens + adds explicit pane kinds + focuses sane defaults', 
   await expect(queueSelect).toBeFocused();
 });
 
-test('pane add menu: single click on item adds exactly one pane', async ({ page }) => {
+test('pane add menu: single click reuses matching non-chat pane target', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);
 
@@ -67,10 +67,16 @@ test('pane add menu: single click on item adds exactly one pane', async ({ page 
 
   await menu.locator('[data-testid="pane-add-menu-workqueue"]').click();
   const countAfter = await page.locator('[data-pane]').count();
-  expect(countAfter).toBe(countBefore + 1);
+  expect(countAfter).toBe(countBefore);
+
+  await addBtn.click();
+  await expect(menu).toBeVisible();
+  await menu.locator('[data-testid="pane-add-menu-workqueue"]').click({ modifiers: ['Alt'] });
+  const countAfterAlt = await page.locator('[data-pane]').count();
+  expect(countAfterAlt).toBe(countBefore + 1);
 });
 
-test('pane add shortcuts: Ctrl/Cmd+Shift+T adds a timeline pane', async ({ page }) => {
+test('pane add shortcuts: Ctrl/Cmd+Shift+T reuses timeline pane; Alt adds anyway', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);
 
@@ -95,4 +101,12 @@ test('pane add shortcuts: Ctrl/Cmd+Shift+T adds a timeline pane', async ({ page 
 
   const countAfter = await page.locator('[data-pane]').count();
   expect(countAfter).toBeGreaterThan(countBefore);
+
+  await page.keyboard.press('ControlOrMeta+Shift+T');
+  const countAfterReuse = await page.locator('[data-pane]').count();
+  expect(countAfterReuse).toBe(countAfter);
+
+  await page.keyboard.press('Alt+ControlOrMeta+Shift+T');
+  const countAfterForce = await page.locator('[data-pane]').count();
+  expect(countAfterForce).toBe(countAfter + 1);
 });


### PR DESCRIPTION
Closes #179

## Summary
- update admin addPane flow to first look for an existing non-chat pane with matching (kind, target)
- focus the existing pane instead of creating a duplicate when a match is found
- add explicit **open anyway** behavior via Alt/Option modifier:
  - Add Pane menu: Alt/Option+click
  - keyboard shortcuts: Alt/Option+Ctrl/Cmd+Shift+{W,R,T}
- add command-palette actions for explicit "open anyway" on Workqueue/Cron/Timeline
- extend Playwright UI coverage for reuse + explicit force-new behavior

## Testing
- node --check app.js
- node --check tests/ui/pane-add-menu.spec.js

Full Playwright run not executed in this environment (missing @playwright/test).
