### PR TITLE
UX: collapse repetitive routine workqueue rows into expandable groups

### DIFF
--- a/app.js
+++ b/app.js
@@ -109,6 +109,23 @@ const fmtRemaining = __appCore.fmtRemaining || ((msUntil) => {
   return `${sec}s`;
 });
 const sortWorkqueueItems = __appCore.sortWorkqueueItems || ((items, opts) => (Array.isArray(items) ? items.slice() : []));
+const WORKQUEUE_GROUP_AUTO_THRESHOLD = 10;
+function normalizeWorkqueueGroupTitle(title) {
+  const t = String(title || '').trim();
+  if (!t) return '(untitled)';
+  return t
+    .replace(/\(\d{4}-\d{2}-\d{2}T\d{2}\)/g, '')
+    .replace(/\(\d{4}-\d{2}-\d{2}\)/g, '')
+    .replace(/\[\d{4}-\d{2}-\d{2}[^\]]*\]/g, '')
+    .replace(/\s*×\d+$/g, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+}
+function workqueueGroupSignature(item) {
+  const key = String(item?.dedupeKey || '').trim();
+  if (key) return `dedupe:${key}`;
+  return `title:${normalizeWorkqueueGroupTitle(item?.title || '')}`;
+}
 const inferPaneCols = __appCore.inferPaneCols || ((count) => {
   const n = Number(count);
   if (!Number.isFinite(n) || n <= 1) return 1;
@@ -2893,7 +2910,7 @@ function renderWorkqueuePaneItems(pane) {
   }
 
   const now = Date.now();
-  for (const it of items) {
+  const renderItemRow = (it) => {
     const row = document.createElement('button');
     row.type = 'button';
     row.className = 'wq-row';
@@ -2919,6 +2936,33 @@ function renderWorkqueuePaneItems(pane) {
     });
 
     body.appendChild(row);
+  };
+
+  const mode = pane.workqueue.groupMode || 'auto';
+  const shouldGroup = mode === 'on' || (mode === 'auto' && items.length > WORKQUEUE_GROUP_AUTO_THRESHOLD);
+  if (!shouldGroup) {
+    for (const it of items) renderItemRow(it);
+  } else {
+    const grouped = new Map();
+    for (const it of items) {
+      const sig = workqueueGroupSignature(it);
+      if (!grouped.has(sig)) grouped.set(sig, { key: sig, label: normalizeWorkqueueGroupTitle(it.title || ''), items: [] });
+      grouped.get(sig).items.push(it);
+    }
+    for (const group of grouped.values()) {
+      const expanded = !!pane.workqueue.expandedGroups?.[group.key] || group.items.length === 1;
+      const gRow = document.createElement('button');
+      gRow.type = 'button';
+      gRow.className = 'wq-group-row';
+      gRow.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+      gRow.innerHTML = `<span class="wq-group-caret">${expanded ? '▾' : '▸'}</span><span class="wq-group-title">${escapeHtml(group.label)}</span><span class="wq-group-count">×${group.items.length}</span>`;
+      gRow.addEventListener('click', () => {
+        pane.workqueue.expandedGroups[group.key] = !expanded;
+        renderWorkqueuePaneItems(pane);
+      });
+      body.appendChild(gRow);
+      if (expanded) group.items.forEach((it) => renderItemRow(it));
+    }
   }
 
   // Keep inspect in sync if selection vanished.
@@ -4787,7 +4831,7 @@ function renderAgentOptions(selectEl, agentId) {
   selectEl.value = normalizeAgentId(agentId || 'main');
 }
 
-function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, scopeFilter, sortKey, sortDir, cronAgentId, closable = true } = {}) {
+function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, scopeFilter, sortKey, sortDir, groupMode, cronAgentId, closable = true } = {}) {
   const template = globalElements.paneTemplate;
   const root = template.content.firstElementChild.cloneNode(true);
   const elements = {
@@ -4838,7 +4882,9 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       items: [],
       selectedItemId: null,
       sortKey: typeof sortKey === 'string' && sortKey.trim() ? sortKey.trim() : 'priority',
-      sortDir: sortDir === 'asc' ? 'asc' : 'desc'
+      sortDir: sortDir === 'asc' ? 'asc' : 'desc',
+      groupMode: groupMode === 'off' ? 'off' : groupMode === 'on' ? 'on' : 'auto',
+      expandedGroups: {}
     },
     cronAgentId: typeof cronAgentId === 'string' ? cronAgentId.trim() : '',
     connected: false,
@@ -5021,6 +5067,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
           </div>
 
           <button data-wq-refresh class="secondary" type="button">Refresh</button>
+          <button data-wq-group-toggle class="secondary" type="button" aria-pressed="false">Grouping: Auto</button>
 
           <div class="wq-sort" role="group" aria-label="Sort workqueue items">
             <span class="wq-sort-label">Sort</span>
@@ -5353,6 +5400,23 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       btn.addEventListener('click', () => setScope(btn.getAttribute('data-wq-scope')));
     });
     updateScopeUi();
+
+    const groupToggleBtn = elements.thread.querySelector('[data-wq-group-toggle]');
+    const updateGroupToggleUi = () => {
+      const mode = pane.workqueue.groupMode || 'auto';
+      if (!groupToggleBtn) return;
+      groupToggleBtn.textContent = mode === 'on' ? 'Grouping: On' : mode === 'off' ? 'Grouping: Off' : 'Grouping: Auto';
+      groupToggleBtn.setAttribute('aria-pressed', mode === 'on' ? 'true' : 'false');
+    };
+    const cycleGroupMode = () => {
+      const cur = pane.workqueue.groupMode || 'auto';
+      pane.workqueue.groupMode = cur === 'auto' ? 'on' : cur === 'on' ? 'off' : 'auto';
+      updateGroupToggleUi();
+      renderWorkqueuePaneItems(pane);
+      paneManager.persistAdminPanes();
+    };
+    groupToggleBtn?.addEventListener('click', cycleGroupMode);
+    updateGroupToggleUi();
 
     // Sort controls (client-side): stable sorting with a status-grouping default.
     const sortBtns = Array.from(elements.thread.querySelectorAll('[data-wq-sort]'));
@@ -6131,6 +6195,7 @@ const paneManager = {
         scopeFilter: cfg.scopeFilter,
         sortKey: cfg.sortKey,
         sortDir: cfg.sortDir,
+        groupMode: cfg.groupMode,
         closable: true
       })
     );
@@ -6175,7 +6240,8 @@ const paneManager = {
           const scopeFilter = item.scopeFilter === 'assigned' || item.scopeFilter === 'unassigned' ? item.scopeFilter : 'all';
           const sortKey = typeof item.sortKey === 'string' ? item.sortKey : 'priority';
           const sortDir = item.sortDir === 'asc' ? 'asc' : 'desc';
-          return { key, kind, queue, statusFilter, scopeFilter, sortKey, sortDir };
+          const groupMode = item.groupMode === 'on' || item.groupMode === 'off' ? item.groupMode : 'auto';
+          return { key, kind, queue, statusFilter, scopeFilter, sortKey, sortDir, groupMode };
         }
         if (kind === 'cron' || kind === 'timeline') {
           return { key, kind };
@@ -6227,7 +6293,8 @@ const paneManager = {
           statusFilter: Array.isArray(pane.workqueue?.statusFilter) ? pane.workqueue.statusFilter : [],
           scopeFilter: pane.workqueue?.scopeFilter || 'all',
           sortKey: pane.workqueue?.sortKey || 'priority',
-          sortDir: pane.workqueue?.sortDir || 'desc'
+          sortDir: pane.workqueue?.sortDir || 'desc',
+          groupMode: pane.workqueue?.groupMode || 'auto'
         };
       }
       if (pane.kind === 'cron' || pane.kind === 'timeline') {

--- a/styles.css
+++ b/styles.css
@@ -2089,6 +2089,25 @@ kbd {
   background: rgba(127, 209, 185, 0.12);
 }
 
+.wq-group-row {
+  width: 100%;
+  border: none;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+  padding: 8px 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+}
+.wq-group-row:hover { background: rgba(255, 255, 255, 0.06); }
+.wq-group-caret { width: 12px; color: var(--muted); }
+.wq-group-title { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.wq-group-count { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; color: var(--muted); }
+
 .wq-col {
   min-width: 0;
   overflow: hidden;

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -116,3 +116,39 @@ test('workqueue pane: controls toolbar is sticky and list scrolls independently'
   });
   expect(['auto', 'scroll']).toContain(listStyles.overflowY);
 });
+
+test('workqueue pane: groups repetitive routine rows and expands on click', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  const wqPane = page.locator('[data-pane]').last();
+
+  await page.evaluate(async () => {
+    const mk = (n) => fetch('/api/workqueue/enqueue', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({
+        queue: 'dev-team',
+        title: `[routine] PR review sweep (${n})`,
+        instructions: 'smoke',
+        priority: 10,
+        dedupeKey: ''
+      })
+    });
+    for (let i = 0; i < 12; i += 1) await mk(i);
+  });
+
+  await wqPane.locator('[data-wq-refresh]').click();
+  const groupRow = wqPane.locator('.wq-group-row').first();
+  await expect(groupRow).toBeVisible();
+  await expect(groupRow).toContainText('PR review sweep');
+
+  await groupRow.click();
+  await expect(wqPane.locator('.wq-row')).toHaveCount(12, { timeout: 15000 });
+});


### PR DESCRIPTION
Closes #206

## Summary
- Add routine grouping for Workqueue pane rows using dedupeKey when present, with normalized title fallback
- Add grouped header rows with count badges (×N) and click-to-expand behavior
- Add grouping mode toggle: Auto / On / Off (Auto enables grouping when list size > 10)
- Preserve existing sort + scope filters and item inspect behavior
- Persist group mode in admin pane config

## Validation
- node --check app.js ✅
- Added Playwright regression test for grouped + expanded states in tests/ui/workqueue-pane.spec.js
- Full npm test currently fails in this environment due to missing ws dependency in unit suite bootstrap
