### PR TITLE
Fix #211: add workqueue triage scope quick filter

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1765,6 +1765,35 @@ kbd {
   background: rgba(127, 209, 185, 0.12);
 }
 
+.wq-scope {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.wq-scope-label {
+  font-size: 11px;
+  color: var(--muted);
+  margin-right: 4px;
+}
+
+.wq-scope-btn {
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  border-radius: 999px;
+  padding: 6px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.wq-scope-btn.active {
+  border-color: rgba(127, 209, 185, 0.5);
+  background: rgba(127, 209, 185, 0.12);
+}
+
 .wq-enqueue {
   margin-top: 10px;
 }


### PR DESCRIPTION
## Summary
- add a quick triage scope segmented control to the Workqueue pane
- support **Assigned to active agent**, **Unassigned**, and **All** scopes
- wire filtering to both grouped and flat list rendering paths
- add/update Workqueue pane e2e coverage for the scope behavior

## Testing
- npm test -- tests/pane.workqueue.e2e.spec.js *(fails in this workspace because `ws` dependency is missing for unit bootstrap; see logs)*

Fixes #211
