### PR TITLE
test(e2e): add workqueue modal golden-path coverage

### DIFF
--- a/app.js
+++ b/app.js
@@ -2491,6 +2491,7 @@ function renderWorkqueueItems() {
     const col = document.createElement('section');
     col.className = 'wq-board-col';
     col.setAttribute('data-wq-col', colDef.status);
+    col.setAttribute('data-testid', `wq-col-${colDef.status}`);
 
     const colItems = Array.isArray(itemsByStatus[colDef.status]) ? itemsByStatus[colDef.status] : [];
 
@@ -2503,6 +2504,7 @@ function renderWorkqueueItems() {
 
     const lane = document.createElement('div');
     lane.className = 'wq-board-lane';
+    lane.setAttribute('data-testid', `wq-lane-${colDef.status}`);
 
     // Drag/drop: drop a card to change status.
     lane.addEventListener('dragover', (e) => {
@@ -2529,6 +2531,7 @@ function renderWorkqueueItems() {
       card.className = 'wq-card';
       if (it.id && it.id === workqueueState.selectedItemId) card.classList.add('selected');
       if (it.id) card.setAttribute('data-wq-item', it.id);
+      card.setAttribute('data-testid', 'wq-card');
 
       // Allow dragging the whole card.
       card.draggable = true;
@@ -2607,8 +2610,8 @@ function renderWorkqueueInspect(item) {
   const actions = document.createElement('div');
   actions.className = 'wq-inspect-actions';
   actions.innerHTML = `
-    <button type="button" class="btn" data-wq-action="edit">Edit</button>
-    <button type="button" class="btn danger" data-wq-action="delete">Delete</button>
+    <button type="button" class="btn" data-wq-action="edit" data-testid="wq-inspect-edit">Edit</button>
+    <button type="button" class="btn danger" data-wq-action="delete" data-testid="wq-inspect-delete">Delete</button>
   `;
 
   const meta = root.querySelector('.wq-inspect-meta');

--- a/index.html
+++ b/index.html
@@ -288,11 +288,11 @@
       </div>
     </div>
 
-    <div id="workqueueModal" class="modal" aria-hidden="true">
+    <div id="workqueueModal" class="modal" aria-hidden="true" data-testid="workqueue-modal">
       <div class="modal-card wide" role="dialog" aria-modal="true" aria-labelledby="workqueueTitle">
         <div class="modal-header">
           <h2 id="workqueueTitle">Workqueue</h2>
-          <button id="workqueueCloseBtn" class="icon-btn" type="button" aria-label="Close workqueue">
+          <button id="workqueueCloseBtn" class="icon-btn" type="button" aria-label="Close workqueue" data-testid="wq-close-btn">
             ✕
           </button>
         </div>
@@ -300,11 +300,11 @@
           <div class="wq-toolbar">
             <label class="wq-field">
               Queue
-              <select id="wqQueueSelect" aria-label="Select workqueue"></select>
+              <select id="wqQueueSelect" aria-label="Select workqueue" data-testid="wq-queue-select"></select>
             </label>
             <div class="wq-field">
               Status
-              <div id="wqStatusFilters" class="wq-status-filters" aria-label="Status filters"></div>
+              <div id="wqStatusFilters" class="wq-status-filters" aria-label="Status filters" data-testid="wq-status-filters"></div>
             </div>
             <label class="wq-field">
               Auto-refresh
@@ -318,7 +318,7 @@
                 </select>
               </div>
             </label>
-            <button id="wqRefreshBtn" class="secondary" type="button">Refresh</button>
+            <button id="wqRefreshBtn" class="secondary" type="button" data-testid="wq-refresh-btn">Refresh</button>
           </div>
 
           <div class="wq-actions" aria-label="Workqueue actions">
@@ -328,7 +328,7 @@
                 <div class="wq-action-grid">
                   <label class="wq-action-field">
                     Title
-                    <input id="wqEnqueueTitle" type="text" placeholder="Short title" />
+                    <input id="wqEnqueueTitle" type="text" placeholder="Short title" data-testid="wq-enqueue-title" />
                   </label>
                   <label class="wq-action-field">
                     Priority
@@ -336,7 +336,7 @@
                   </label>
                   <label class="wq-action-field" style="grid-column: 1 / -1;">
                     Instructions
-                    <textarea id="wqEnqueueInstructions" rows="4" placeholder="What should the worker do?"></textarea>
+                    <textarea id="wqEnqueueInstructions" rows="4" placeholder="What should the worker do?" data-testid="wq-enqueue-instructions"></textarea>
                   </label>
                   <label class="wq-action-field" style="grid-column: 1 / -1;">
                     Dedupe Key (optional)
@@ -344,7 +344,7 @@
                   </label>
                 </div>
                 <div class="wq-action-buttons">
-                  <button id="wqEnqueueBtn" class="primary" type="button">Enqueue</button>
+                  <button id="wqEnqueueBtn" class="primary" type="button" data-testid="wq-enqueue-btn">Enqueue</button>
                 </div>
               </div>
 
@@ -365,7 +365,7 @@
                 </div>
               </div>
             </div>
-            <div id="wqActionStatus" class="wq-action-status" role="status" aria-live="polite"></div>
+            <div id="wqActionStatus" class="wq-action-status" role="status" aria-live="polite" data-testid="wq-action-status"></div>
           </div>
 
           <div class="wq-layout">
@@ -378,13 +378,13 @@
                 <button type="button" class="wq-list-sort" data-wq-modal-sort="claimedBy">Claimed By</button>
                 <button type="button" class="wq-list-sort" data-wq-modal-sort="leaseUntil">Lease</button>
               </div>
-              <div id="wqListBody" class="wq-list-body"></div>
-              <div id="wqListEmpty" class="hint" hidden>No items match.</div>
+              <div id="wqListBody" class="wq-list-body" data-testid="wq-list-body"></div>
+              <div id="wqListEmpty" class="hint" hidden data-testid="wq-list-empty">No items match.</div>
             </div>
 
             <div class="wq-inspect" aria-label="Inspect workqueue item">
               <div class="wq-inspect-header">Item</div>
-              <div id="wqInspectBody" class="wq-inspect-body">
+              <div id="wqInspectBody" class="wq-inspect-body" data-testid="wq-inspect-body">
                 <div class="hint">Select an item to inspect.</div>
               </div>
             </div>

--- a/tests/pane.workqueue.e2e.spec.js
+++ b/tests/pane.workqueue.e2e.spec.js
@@ -192,3 +192,72 @@ test('pane: workqueue scope filter toggles deterministic row counts', async ({ p
   await wqPane.locator('[data-wq-scope="assigned"]').click();
   await expect(rowsWithPrefix()).toHaveCount(0);
 });
+
+test('pane: workqueue modal golden path covers kanban transition + edit/delete', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  // Open a Workqueue pane first (acceptance: pane-first flow).
+  await page.getByTestId('add-pane-btn').click();
+  await page.getByTestId('pane-add-menu-workqueue').click();
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"]').last()).toBeVisible();
+
+  await page.locator('#workqueueBtn').click();
+  const modal = page.getByTestId('workqueue-modal');
+  await expect(modal).toBeVisible();
+  await expect(modal.getByTestId('wq-queue-select')).toBeVisible();
+  await expect(modal.getByTestId('wq-status-filters')).toBeVisible();
+
+  await modal.getByTestId('wq-queue-select').selectOption('dev-team');
+
+  const runId = `modal-${Date.now()}`;
+  const title = `pw-e2e-wq-modal-${runId}`;
+  const editedTitle = `${title}-edited`;
+  const instructions = `instructions ${runId}`;
+  const editedInstructions = `${instructions} (edited)`;
+
+  await modal.getByTestId('wq-enqueue-title').fill(title);
+  await modal.getByTestId('wq-enqueue-instructions').fill(instructions);
+  const enqueueResP = page.waitForResponse((res) => res.url().includes('/api/workqueue/enqueue') && res.ok(), { timeout: 15000 });
+  await modal.getByTestId('wq-enqueue-btn').click();
+  await enqueueResP;
+
+  const card = modal.getByTestId('wq-card').filter({ hasText: title }).first();
+  await expect(card).toBeVisible();
+  await card.click();
+
+  // Edit flow includes status transition (equivalent control for kanban transition).
+  const promptAnswers = [editedTitle, editedInstructions, '123', 'in_progress'];
+  page.on('dialog', async (dialog) => {
+    if (dialog.type() === 'prompt') {
+      await dialog.accept(promptAnswers.shift() || '');
+      return;
+    }
+    if (dialog.type() === 'confirm') {
+      await dialog.accept();
+      return;
+    }
+    await dialog.dismiss();
+  });
+
+  const editResP = page.waitForResponse((res) => res.url().includes('/api/workqueue/update') && res.ok(), { timeout: 15000 });
+  await modal.getByTestId('wq-inspect-edit').click();
+  await editResP;
+
+  await expect(modal.getByTestId('wq-inspect-body')).toContainText(editedTitle);
+  await expect(modal.getByTestId('wq-inspect-body')).toContainText(editedInstructions);
+  await expect(modal.getByTestId('wq-inspect-body')).toContainText('in_progress');
+
+  const deleteResP = page.waitForResponse((res) => res.url().includes('/api/workqueue/delete') && res.ok(), { timeout: 15000 });
+  await modal.getByTestId('wq-inspect-delete').click();
+  await deleteResP;
+
+  await expect(modal.getByTestId('wq-card').filter({ hasText: editedTitle })).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary
- add stable `data-testid` hooks for key Workqueue modal/kanban controls and inspect actions
- extend Playwright workqueue spec with a golden-path modal flow that:
  - opens a Workqueue pane
  - validates queue + status filter controls render
  - enqueues an item
  - performs status transition via the edit flow (equivalent UI control)
  - edits title/instructions and saves
  - deletes the item
  - relies on page failure assertions to catch console/page errors

## Validation
- `npx playwright test tests/pane.workqueue.e2e.spec.js --workers=1`

Closes #123
