### PR TITLE
Fix #170: keep Workqueue pane status in sync across header + Pane Manager

### DIFF
--- a/app.js
+++ b/app.js
@@ -6075,6 +6075,9 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
 
     pane.client = null;
     pane.connected = true;
+    pane.statusState = 'connected';
+    pane.statusMeta = '';
+    if (pane.elements?.root) pane.elements.root.dataset.connected = 'true';
     return pane;
   }
 

--- a/tests/pane.manager.e2e.spec.js
+++ b/tests/pane.manager.e2e.spec.js
@@ -190,9 +190,13 @@ test('pane manager: status stays in sync with pane header while modal is open', 
 
   const chatHeaderStatus = page.locator('[data-pane][data-pane-kind="chat"]').first().getByTestId('pane-connection-status');
   const chatManagerState = page.locator('.pane-manager-row', { hasText: 'Chat · main' }).first().locator('.pane-manager-state');
+  const workqueueHeaderStatus = page.locator('[data-pane][data-pane-kind="workqueue"]').first().getByTestId('pane-connection-status');
+  const workqueueManagerState = page.locator('.pane-manager-row', { hasText: 'Workqueue' }).first().locator('.pane-manager-state');
 
   await expect(chatHeaderStatus).toContainText(/connected|reconnecting/);
   await expect(chatManagerState).toContainText(/connected|reconnecting/);
+  await expect(workqueueHeaderStatus).toHaveText('connected');
+  await expect(workqueueManagerState).toHaveText('connected');
 
   await page.evaluate(() => {
     const btn = document.getElementById('disconnectBtn');


### PR DESCRIPTION
## Summary
- set Workqueue pane connection state fields (`connected`, `statusState`, `statusMeta`) from the same source used by the header chip
- keep pane root `data-connected` aligned for consistency with other panes
- extend pane-manager e2e regression to assert header/manager parity for Workqueue rows while the modal is open

Fixes #170

## Testing
- `npm test -- tests/pane.manager.e2e.spec.js`
