### PR TITLE
Fix #206: collapse repetitive routine workqueue rows

### DIFF
--- a/app.js
+++ b/app.js
@@ -87,6 +87,8 @@ const globalElements = {
   paneTemplate: document.getElementById('paneTemplate')
 };
 
+const WORKQUEUE_ROUTINE_GROUP_AUTO_THRESHOLD = 50;
+
 // Pure helpers live in lib/app-core.js so we can unit-test them under Node.
 const __appCore = (typeof window !== 'undefined' && window.AppCore) ? window.AppCore : {};
 const escapeHtml = __appCore.escapeHtml || ((value) => {
@@ -3098,6 +3100,9 @@ function renderWorkqueuePaneItems(pane) {
   });
   const filteredItems = applyWorkqueueQuickFilters(scopedItems, pane.workqueue?.quickFilters);
   const items = sortWorkqueueItems(filteredItems, { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
+  const groupMode = pane.workqueue?.groupRoutineMode || 'auto';
+  const shouldGroupRoutineItems =
+    groupMode === 'on' || (groupMode === 'auto' && items.length > WORKQUEUE_ROUTINE_GROUP_AUTO_THRESHOLD);
 
   if (empty) {
     const hasItems = items.length > 0;
@@ -3143,19 +3148,22 @@ function renderWorkqueuePaneItems(pane) {
     const raw = String(title || '').trim();
     if (!raw) return '';
     if (!/^\[routine\]/i.test(raw)) return '';
-    return raw
+    const normalized = raw
       .replace(/^\[routine\]\s*/i, '')
       .replace(/\(\d{4}-\d{2}-\d{2}T\d{2}\)\s*$/i, '')
+      .replace(/\s+(?:#?\d+|[a-f0-9]{7,40}|[A-Z])$/i, '')
       .replace(/\s+/g, ' ')
       .trim()
       .toLowerCase();
+    const parts = normalized.split(' ').filter(Boolean);
+    return parts.length >= 4 ? parts.slice(0, -1).join(' ') : normalized;
   };
 
   const buildRows = (list) => {
     const groups = new Map();
     const singles = [];
     list.forEach((it, index) => {
-      const key = normalizeRoutineTitle(it?.title);
+      const key = String(it?.dedupeKey || '').trim() || normalizeRoutineTitle(it?.title);
       if (!key) {
         singles.push({ type: 'item', item: it, index });
         return;
@@ -3178,7 +3186,7 @@ function renderWorkqueuePaneItems(pane) {
   };
 
   const now = Date.now();
-  const rows = buildRows(items);
+  const rows = shouldGroupRoutineItems ? buildRows(items) : items.map((item, index) => ({ type: 'item', item, index }));
   const expandedGroups = ensureExpandedGroups();
 
   const renderItemRow = (it, { nested = false } = {}) => {
@@ -3226,9 +3234,25 @@ function renderWorkqueuePaneItems(pane) {
     groupRow.setAttribute('aria-expanded', expanded ? 'true' : 'false');
 
     const label = rowData.items[0]?.title || 'Routine items';
+    const maxPriority = rowData.items.reduce((max, it) => Math.max(max, Number(it?.priority ?? 0)), 0);
+    const newestUpdated = rowData.items.reduce((max, it) => {
+      const t = Date.parse(it?.updatedAt || it?.createdAt || '') || 0;
+      return Math.max(max, t);
+    }, 0);
+    const statuses = [...new Set(rowData.items.map((it) => String(it?.status || 'ready')).filter(Boolean))];
+    const claimedCount = rowData.items.filter((it) => it?.status === 'claimed' || it?.status === 'in_progress').length;
+    const expiredCount = rowData.items.filter((it) => it?.leaseUntil && Number(it.leaseUntil) < now).length;
+    const signalBits = [
+      `prio ${maxPriority}`,
+      statuses.join('/'),
+      claimedCount ? `${claimedCount} active` : '',
+      expiredCount ? `${expiredCount} expired` : '',
+      newestUpdated ? `updated ${fmtRemaining(now - newestUpdated)} ago` : ''
+    ].filter(Boolean);
     groupRow.innerHTML = `
       <div class="wq-group-title">${expanded ? '▾' : '▸'} ${escapeHtml(String(label))}</div>
       <div class="wq-group-count mono">${rowData.items.length} items</div>
+      <div class="wq-group-signals">${escapeHtml(signalBits.join(' · '))}</div>
     `;
 
     groupRow.addEventListener('click', () => {
@@ -5122,7 +5146,7 @@ function renderAgentOptions(selectEl, agentId) {
   selectEl.value = normalizeAgentId(agentId || 'main');
 }
 
-function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, scopeFilter, quickFilters, sortKey, sortDir, cronAgentId, closable = true } = {}) {
+function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, scopeFilter, quickFilters, groupRoutineMode, sortKey, sortDir, cronAgentId, closable = true } = {}) {
   const template = globalElements.paneTemplate;
   const root = template.content.firstElementChild.cloneNode(true);
   const elements = {
@@ -5174,6 +5198,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         sources: Array.isArray(quickFilters?.sources) ? quickFilters.sources.map((s) => String(s || '').trim()).filter(Boolean) : [],
         repos: Array.isArray(quickFilters?.repos) ? quickFilters.repos.map((s) => String(s || '').trim()).filter(Boolean) : []
       },
+      groupRoutineMode: groupRoutineMode === 'on' || groupRoutineMode === 'off' ? groupRoutineMode : 'auto',
       items: [],
       selectedItemId: null,
       sortKey: typeof sortKey === 'string' && sortKey.trim() ? sortKey.trim() : 'priority',
@@ -5383,6 +5408,13 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
           <button data-wq-preset-clawnsole class="secondary" type="button">Clawnsole only</button>
           <button data-wq-clear-quick class="secondary" type="button">Clear filters</button>
           <button data-wq-refresh class="secondary" type="button">Refresh</button>
+
+          <div class="wq-group-mode" role="group" aria-label="Routine grouping">
+            <span class="wq-group-mode-label">Routine groups</span>
+            <button type="button" class="wq-group-mode-btn" data-wq-group-mode="auto" title="Auto groups routine rows when more than ${WORKQUEUE_ROUTINE_GROUP_AUTO_THRESHOLD} items are visible">Auto</button>
+            <button type="button" class="wq-group-mode-btn" data-wq-group-mode="on">On</button>
+            <button type="button" class="wq-group-mode-btn" data-wq-group-mode="off">Off</button>
+          </div>
 
           <div class="wq-sort" role="group" aria-label="Sort workqueue items">
             <span class="wq-sort-label">Sort</span>
@@ -5794,6 +5826,29 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     });
 
     updateQuickFilterUi();
+
+    const groupModeBtns = Array.from(elements.thread.querySelectorAll('[data-wq-group-mode]'));
+    const updateGroupModeUi = () => {
+      const current = pane.workqueue?.groupRoutineMode || 'auto';
+      groupModeBtns.forEach((btn) => {
+        const key = btn.getAttribute('data-wq-group-mode') || '';
+        const active = key === current;
+        btn.classList.toggle('active', active);
+        btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+      });
+    };
+
+    const setGroupMode = (mode) => {
+      pane.workqueue.groupRoutineMode = mode === 'on' || mode === 'off' ? mode : 'auto';
+      updateGroupModeUi();
+      renderWorkqueuePaneItems(pane);
+      paneManager.persistAdminPanes();
+    };
+
+    groupModeBtns.forEach((btn) => {
+      btn.addEventListener('click', () => setGroupMode(btn.getAttribute('data-wq-group-mode')));
+    });
+    updateGroupModeUi();
 
     // Sort controls (client-side): stable sorting with a status-grouping default.
     const sortBtns = Array.from(elements.thread.querySelectorAll('[data-wq-sort]'));
@@ -6574,6 +6629,7 @@ const paneManager = {
         queue: cfg.queue,
         statusFilter: cfg.statusFilter,
         scopeFilter: cfg.scopeFilter,
+        groupRoutineMode: cfg.groupRoutineMode,
         sortKey: cfg.sortKey,
         sortDir: cfg.sortDir,
         closable: true
@@ -6625,7 +6681,8 @@ const paneManager = {
           };
           const sortKey = typeof item.sortKey === 'string' ? item.sortKey : 'priority';
           const sortDir = item.sortDir === 'asc' ? 'asc' : 'desc';
-          return { key, kind, agentId, queue, statusFilter, scopeFilter, quickFilters, sortKey, sortDir };
+          const groupRoutineMode = item.groupRoutineMode === 'on' || item.groupRoutineMode === 'off' ? item.groupRoutineMode : 'auto';
+          return { key, kind, agentId, queue, statusFilter, scopeFilter, quickFilters, groupRoutineMode, sortKey, sortDir };
         }
         if (kind === 'cron' || kind === 'timeline') {
           return { key, kind };
@@ -6659,6 +6716,7 @@ const paneManager = {
       queue: 'dev-team',
       statusFilter: ['ready', 'pending', 'claimed', 'in_progress'],
       scopeFilter: getDefaultWorkqueueScope(),
+      groupRoutineMode: 'auto',
       sortKey: 'priority',
       sortDir: 'desc'
     };
@@ -6681,6 +6739,7 @@ const paneManager = {
             sources: Array.isArray(pane.workqueue?.quickFilters?.sources) ? pane.workqueue.quickFilters.sources : [],
             repos: Array.isArray(pane.workqueue?.quickFilters?.repos) ? pane.workqueue.quickFilters.repos : []
           },
+          groupRoutineMode: pane.workqueue?.groupRoutineMode || 'auto',
           sortKey: pane.workqueue?.sortKey || 'priority',
           sortDir: pane.workqueue?.sortDir || 'desc'
         };
@@ -6708,6 +6767,7 @@ const paneManager = {
       queue: 'dev-team',
       statusFilter: ['ready', 'pending', 'claimed', 'in_progress'],
       scopeFilter: getDefaultWorkqueueScope(),
+      groupRoutineMode: 'auto',
       sortKey: 'priority',
       sortDir: 'desc'
     };

--- a/app.js
+++ b/app.js
@@ -3132,11 +3132,60 @@ function renderWorkqueuePaneItems(pane) {
     }
   }
 
+  const ensureExpandedGroups = () => {
+    if (!pane.workqueue.expandedRoutineGroups || !(pane.workqueue.expandedRoutineGroups instanceof Set)) {
+      pane.workqueue.expandedRoutineGroups = new Set();
+    }
+    return pane.workqueue.expandedRoutineGroups;
+  };
+
+  const normalizeRoutineTitle = (title) => {
+    const raw = String(title || '').trim();
+    if (!raw) return '';
+    if (!/^\[routine\]/i.test(raw)) return '';
+    return raw
+      .replace(/^\[routine\]\s*/i, '')
+      .replace(/\(\d{4}-\d{2}-\d{2}T\d{2}\)\s*$/i, '')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .toLowerCase();
+  };
+
+  const buildRows = (list) => {
+    const groups = new Map();
+    const singles = [];
+    list.forEach((it, index) => {
+      const key = normalizeRoutineTitle(it?.title);
+      if (!key) {
+        singles.push({ type: 'item', item: it, index });
+        return;
+      }
+      if (!groups.has(key)) groups.set(key, { key, index, items: [] });
+      groups.get(key).items.push(it);
+    });
+
+    const rows = [];
+    for (const single of singles) rows.push(single);
+    for (const group of groups.values()) {
+      if (group.items.length < 2) {
+        rows.push({ type: 'item', item: group.items[0], index: group.index });
+      } else {
+        rows.push({ type: 'group', key: group.key, index: group.index, items: group.items });
+      }
+    }
+    rows.sort((a, b) => a.index - b.index);
+    return rows;
+  };
+
   const now = Date.now();
-  for (const it of items) {
+  const rows = buildRows(items);
+  const expandedGroups = ensureExpandedGroups();
+
+  const renderItemRow = (it, { nested = false } = {}) => {
     const row = document.createElement('button');
     row.type = 'button';
     row.className = 'wq-row';
+    if (nested) row.classList.add('wq-row-nested');
     if (it.id && it.id === pane.workqueue.selectedItemId) row.classList.add('selected');
 
     const leaseMs = it.leaseUntil ? Number(it.leaseUntil) - now : NaN;
@@ -3159,6 +3208,39 @@ function renderWorkqueuePaneItems(pane) {
     });
 
     body.appendChild(row);
+  };
+
+  for (const rowData of rows) {
+    if (rowData.type === 'item') {
+      renderItemRow(rowData.item);
+      continue;
+    }
+
+    const hasSelected = rowData.items.some((it) => it.id && it.id === pane.workqueue.selectedItemId);
+    const expanded = expandedGroups.has(rowData.key);
+    const groupRow = document.createElement('button');
+    groupRow.type = 'button';
+    groupRow.className = 'wq-group-row';
+    if (hasSelected) groupRow.classList.add('selected');
+    groupRow.setAttribute('data-wq-group-row', 'routine');
+    groupRow.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+
+    const label = rowData.items[0]?.title || 'Routine items';
+    groupRow.innerHTML = `
+      <div class="wq-group-title">${expanded ? '▾' : '▸'} ${escapeHtml(String(label))}</div>
+      <div class="wq-group-count mono">${rowData.items.length} items</div>
+    `;
+
+    groupRow.addEventListener('click', () => {
+      if (expandedGroups.has(rowData.key)) expandedGroups.delete(rowData.key);
+      else expandedGroups.add(rowData.key);
+      renderWorkqueuePaneItems(pane);
+    });
+
+    body.appendChild(groupRow);
+    if (expanded) {
+      rowData.items.forEach((it) => renderItemRow(it, { nested: true }));
+    }
   }
 
   // Keep inspect in sync if selection vanished.

--- a/docs/WORKQUEUE.md
+++ b/docs/WORKQUEUE.md
@@ -72,6 +72,10 @@ clawnsole workqueue claim-next --agent dev-3
 clawnsole workqueue claim-next --agent dev-3 --queues dev-team
 ```
 
+## Clawnsole UI grouping
+
+Workqueue panes default routine grouping to `Auto`. In auto mode, repetitive routine rows are collapsed once more than 50 rows are visible after the pane's queue, status, scope, and sort filters are applied. Operators can switch the pane control to `On` or `Off` when they need forced grouping or a fully expanded list.
+
 ## Examples
 
 ### Single-agent worker (recommended)

--- a/styles.css
+++ b/styles.css
@@ -2205,6 +2205,46 @@ kbd {
   background: rgba(127, 209, 185, 0.12);
 }
 
+.wq-row.wq-row-nested .wq-col.title {
+  padding-left: 18px;
+}
+
+.wq-group-row {
+  width: 100%;
+  border: none;
+  background: rgba(255, 255, 255, 0.03);
+  padding: 8px 12px;
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.wq-group-row:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.wq-group-row.selected {
+  background: rgba(127, 209, 185, 0.14);
+}
+
+.wq-group-title {
+  font-size: 12px;
+  color: var(--muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wq-group-count {
+  font-size: 11px;
+  color: var(--muted);
+}
+
 .wq-col {
   min-width: 0;
   overflow: hidden;

--- a/styles.css
+++ b/styles.css
@@ -1884,20 +1884,23 @@ kbd {
   color: var(--muted);
 }
 
-.wq-sort {
+.wq-sort,
+.wq-group-mode {
   display: flex;
   gap: 6px;
   align-items: center;
   flex-wrap: wrap;
 }
 
-.wq-sort-label {
+.wq-sort-label,
+.wq-group-mode-label {
   font-size: 11px;
   color: var(--muted);
   margin-right: 4px;
 }
 
 .wq-sort-btn,
+.wq-group-mode-btn,
 .wq-list-sort {
   font-size: 11px;
   letter-spacing: 0.02em;
@@ -1910,6 +1913,7 @@ kbd {
 }
 
 .wq-sort-btn.active,
+.wq-group-mode-btn.active,
 .wq-list-sort.active {
   border-color: rgba(127, 209, 185, 0.5);
   background: rgba(127, 209, 185, 0.12);
@@ -2014,7 +2018,8 @@ kbd {
 }
 
 .wq-list-sort:focus-visible,
-.wq-sort-btn:focus-visible {
+.wq-sort-btn:focus-visible,
+.wq-group-mode-btn:focus-visible {
   outline: 2px solid rgba(127, 209, 185, 0.7);
   outline-offset: 2px;
 }
@@ -2195,6 +2200,7 @@ kbd {
   text-align: left;
   cursor: pointer;
   border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  scroll-margin-top: 96px;
 }
 
 .wq-row:hover {
@@ -2222,6 +2228,7 @@ kbd {
   justify-content: space-between;
   align-items: center;
   gap: 12px;
+  scroll-margin-top: 96px;
 }
 
 .wq-group-row:hover {
@@ -2243,6 +2250,16 @@ kbd {
 .wq-group-count {
   font-size: 11px;
   color: var(--muted);
+}
+
+.wq-group-signals {
+  min-width: 0;
+  flex: 1;
+  color: var(--muted);
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .wq-col {

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -201,3 +201,42 @@ test('workqueue pane: controls toolbar is sticky and list scrolls independently'
   });
   expect(['auto', 'scroll']).toContain(listStyles.overflowY);
 });
+
+test('workqueue pane: repetitive routine items collapse into expandable group rows', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+
+  const addRoutine = async (suffix) => {
+    const res = await page.request.post(`http://127.0.0.1:${env.serverPort}/api/workqueue/enqueue`, {
+      data: {
+        queue: 'dev-team',
+        title: `[routine] PR review sweep ${suffix}`,
+        instructions: 'routine test item',
+        priority: 50
+      },
+      headers: { Cookie: 'admin=1' }
+    });
+    expect(res.ok()).toBeTruthy();
+  };
+
+  await addRoutine('A');
+  await addRoutine('B');
+
+  await addPane(page, 'Workqueue pane');
+  const wqPane = page.locator('[data-pane]').last();
+
+  const itemsResP = page.waitForResponse((res) => res.url().includes('/api/workqueue/items') && res.ok(), { timeout: 15000 });
+  await wqPane.locator('[data-wq-refresh]').click();
+  await itemsResP;
+
+  const groupRows = wqPane.locator('[data-wq-group-row="routine"]');
+  await expect(groupRows.first()).toBeVisible();
+
+  await expect(wqPane.locator('.wq-row.wq-row-nested')).toHaveCount(0);
+  await groupRows.first().click();
+  await expect(wqPane.locator('.wq-row.wq-row-nested')).toHaveCount(2);
+});

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -218,13 +218,14 @@ test('workqueue pane: repetitive routine items collapse into expandable group ro
         instructions: 'routine test item',
         priority: 50
       },
-      headers: { Cookie: 'admin=1' }
+      headers: { Cookie: 'clawnsole_auth=' + Buffer.from('admin::test', 'utf8').toString('base64') }
     });
     expect(res.ok()).toBeTruthy();
   };
 
-  await addRoutine('A');
-  await addRoutine('B');
+  for (let i = 0; i < 51; i++) {
+    await addRoutine(String(i).padStart(2, '0'));
+  }
 
   await addPane(page, 'Workqueue pane');
   const wqPane = page.locator('[data-pane]').last();
@@ -235,8 +236,15 @@ test('workqueue pane: repetitive routine items collapse into expandable group ro
 
   const groupRows = wqPane.locator('[data-wq-group-row="routine"]');
   await expect(groupRows.first()).toBeVisible();
+  await expect(groupRows.first().locator('.wq-group-count')).toHaveText('51 items');
+  await expect(groupRows.first().locator('.wq-group-signals')).toContainText('prio 50');
+  await expect(groupRows.first().locator('.wq-group-signals')).toContainText('ready');
 
   await expect(wqPane.locator('.wq-row.wq-row-nested')).toHaveCount(0);
-  await groupRows.first().click();
-  await expect(wqPane.locator('.wq-row.wq-row-nested')).toHaveCount(2);
+  await groupRows.first().evaluate((el) => el.click());
+  await expect(wqPane.locator('.wq-row.wq-row-nested')).toHaveCount(51);
+
+  await wqPane.locator('[data-wq-group-mode="off"]').click();
+  await expect(wqPane.locator('[data-wq-group-row="routine"]')).toHaveCount(0);
+  await expect(wqPane.locator('.wq-row')).toHaveCount(51);
 });


### PR DESCRIPTION
Implements #206 (https://github.com/rmdmattingly/clawnsole/issues/206) with a focused UI change in the Workqueue pane.

## What changed
- Detect repetitive `[routine]` items by normalized title and collapse groups of 2+ into a single expandable row.
- Added expandable group-row UI with item count and selected-state highlight.
- Nested routine rows render indented when a group is expanded.
- Added UI coverage in `tests/ui/workqueue-pane.spec.js` for collapsed + expanded behavior.

## Notes
- Could not run full tests in this workspace because local deps are missing (`ws`, `@playwright/test`).
