### PR TITLE
Normalize issue-backed workqueue row titles in UI

### DIFF
--- a/app.js
+++ b/app.js
@@ -108,6 +108,7 @@ const fmtRemaining = __appCore.fmtRemaining || ((msUntil) => {
   if (min > 0) return `${min}m ${sec % 60}s`;
   return `${sec}s`;
 });
+const normalizeWorkqueueTitle = __appCore.normalizeWorkqueueTitle || ((item) => String(item?.title || ''));
 const sortWorkqueueItems = __appCore.sortWorkqueueItems || ((items, opts) => (Array.isArray(items) ? items.slice() : []));
 const inferPaneCols = __appCore.inferPaneCols || ((count) => {
   const n = Number(count);
@@ -2545,7 +2546,7 @@ function renderWorkqueueItems() {
       const next = String(it.lastNote || '').trim();
 
       card.innerHTML = `
-        <div class="wq-card-title">${escapeHtml(String(it.title || ''))}</div>
+        <div class="wq-card-title">${escapeHtml(normalizeWorkqueueTitle(it))}</div>
         <div class="wq-card-meta">
           <span class="wq-badge wq-badge-${escapeHtml(status)}">${escapeHtml(status)}</span>
           ${age ? `<span class="wq-card-chip mono">age ${escapeHtml(age)}</span>` : ''}
@@ -2595,7 +2596,7 @@ function renderWorkqueueInspect(item) {
     </div>
     <div class="wq-inspect-block">
       <div class="wq-inspect-label">Title</div>
-      <div class="wq-inspect-pre">${escapeHtml(String(item.title || ''))}</div>
+      <div class="wq-inspect-pre">${escapeHtml(normalizeWorkqueueTitle(item))}</div>
     </div>
     <div class="wq-inspect-block">
       <div class="wq-inspect-label">Instructions</div>
@@ -2750,7 +2751,7 @@ function renderWorkqueueSimpleList(rootEl, items, { emptyText }) {
   for (const it of items) {
     const li = document.createElement('li');
     const lease = it.leaseUntil ? new Date(Number(it.leaseUntil)).toISOString() : '';
-    li.innerHTML = `<div><strong>${escapeHtml(String(it.title || ''))}</strong></div>
+    li.innerHTML = `<div><strong>${escapeHtml(normalizeWorkqueueTitle(it))}</strong></div>
 <div class="meta">${escapeHtml(String(it.status || ''))}${it.claimedBy ? ` • ${escapeHtml(String(it.claimedBy))}` : ''}${lease ? ` • lease ${escapeHtml(lease)}` : ''}</div>`;
     ul.appendChild(li);
   }
@@ -2904,7 +2905,7 @@ function renderWorkqueuePaneItems(pane) {
     const status = String(it.status || '');
 
     row.innerHTML = `
-      <div class="wq-col title">${escapeHtml(String(it.title || ''))}</div>
+      <div class="wq-col title">${escapeHtml(normalizeWorkqueueTitle(it))}</div>
       <div class="wq-col status"><span class="wq-badge wq-badge-${escapeHtml(status)}">${escapeHtml(status)}</span></div>
       <div class="wq-col prio mono">${escapeHtml(String(it.priority ?? ''))}</div>
       <div class="wq-col attempts mono">${escapeHtml(String(it.attempts ?? ''))}</div>
@@ -2949,7 +2950,7 @@ function renderWorkqueuePaneInspect(pane, item) {
     </div>
     <div class="wq-inspect-block">
       <div class="wq-inspect-label">Title</div>
-      <div class="wq-inspect-pre">${escapeHtml(String(item.title || ''))}</div>
+      <div class="wq-inspect-pre">${escapeHtml(normalizeWorkqueueTitle(item))}</div>
     </div>
     <div class="wq-inspect-block">
       <div class="wq-inspect-label">Instructions</div>

--- a/lib/app-core.js
+++ b/lib/app-core.js
@@ -25,6 +25,30 @@
     return `${sec}s`;
   }
 
+  function normalizeWorkqueueTitle(item) {
+    const title = String(item?.title || '').trim();
+    if (!title) return '';
+
+    const repoFromMeta = String(item?.meta?.repo || item?.repo || '').trim();
+    const issueFromMeta = Number(item?.meta?.issueNumber ?? item?.issueNumber);
+
+    const strippedPrefix = title.replace(/^\s*(?:\[(?:issue|ISSUE)\]\s*|Open issue:\s*|Issue coverage:\s*)/i, '').trim();
+    const refMatch = strippedPrefix.match(/^([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)\s*#(\d+)\s*(?:[:\-—–]\s*)?(.*)$/);
+
+    const repo = refMatch?.[1] || repoFromMeta;
+    const issueNumber = refMatch?.[2] || (Number.isFinite(issueFromMeta) && issueFromMeta > 0 ? String(issueFromMeta) : '');
+    if (!repo || !issueNumber) return title;
+
+    let rest = String(refMatch?.[3] || '').trim();
+    if (!rest) {
+      rest = strippedPrefix
+        .replace(new RegExp(`^${repo.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*#${issueNumber}\\s*(?:[:\\-—–]\\s*)?`, 'i'), '')
+        .trim();
+    }
+
+    return `[ISSUE] ${repo}#${issueNumber}${rest ? ` — ${rest}` : ''}`;
+  }
+
   function sortWorkqueueItems(items, { sortKey = 'default', sortDir = 'desc' } = {}) {
     const dir = sortDir === 'asc' ? 1 : -1;
     const statusRank = (s) => {
@@ -109,8 +133,8 @@
         }
 
         if (sortKey === 'title') {
-          const av = String(A.title || '');
-          const bv = String(B.title || '');
+          const av = normalizeWorkqueueTitle(A);
+          const bv = normalizeWorkqueueTitle(B);
           const r = av.localeCompare(bv);
           if (r) return r * dir;
         }
@@ -323,6 +347,7 @@
   const AppCore = {
     escapeHtml,
     fmtRemaining,
+    normalizeWorkqueueTitle,
     sortWorkqueueItems,
     inferPaneCols,
     normalizePaneKind,

--- a/tests/unit/app-core.test.js
+++ b/tests/unit/app-core.test.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict');
 const {
   escapeHtml,
   fmtRemaining,
+  normalizeWorkqueueTitle,
   sortWorkqueueItems,
   inferPaneCols,
   normalizePaneKind,
@@ -44,11 +45,24 @@ test('sortWorkqueueItems default groups by status then priority then timestamps'
   assert.deepEqual(sorted.map((it) => it.id), ['b', 'c', 'd', 'e', 'a']);
 });
 
+test('normalizeWorkqueueTitle canonicalizes mixed legacy issue prefixes', () => {
+  const rows = [
+    { title: '[issue] rmdmattingly/clawnsole#280: Normalize titles' },
+    { title: 'Open issue: rmdmattingly/clawnsole#280 - Normalize titles' },
+    { title: 'Issue coverage: rmdmattingly/clawnsole#280 — Normalize titles' },
+    { title: 'Normalize titles', meta: { repo: 'rmdmattingly/clawnsole', issueNumber: 280 } }
+  ];
+
+  for (const row of rows) {
+    assert.equal(normalizeWorkqueueTitle(row), '[ISSUE] rmdmattingly/clawnsole#280 — Normalize titles');
+  }
+});
+
 test('sortWorkqueueItems supports explicit sort keys and stable ordering fallback', () => {
   const items = [
-    { id: 'a', title: 'b', priority: 1 },
-    { id: 'b', title: 'a', priority: 1 },
-    { id: 'c', title: 'a', priority: 1 }
+    { id: 'a', title: 'Open issue: rmdmattingly/clawnsole#282 - zzz', priority: 1 },
+    { id: 'b', title: '[issue] rmdmattingly/clawnsole#280: aaa', priority: 1 },
+    { id: 'c', title: 'Issue coverage: rmdmattingly/clawnsole#281 — bbb', priority: 1 }
   ];
 
   const byTitleAsc = sortWorkqueueItems(items, { sortKey: 'title', sortDir: 'asc' });


### PR DESCRIPTION
Closes #280

## Summary
- add shared normalizeWorkqueueTitle helper in lib/app-core.js
- render normalized issue titles in workqueue modal cards, list rows, and inspect panels
- apply normalization to title sorting so mixed legacy prefixes sort consistently
- add unit regression coverage for mixed legacy title prefixes

## Canonical format
[ISSUE] owner/repo#123 — Title

## Test
- node --test tests/unit/app-core.test.js
