### PR TITLE
Fix #282: persist Workqueue sort across reload/reopen

### DIFF
--- a/app.js
+++ b/app.js
@@ -3429,6 +3429,8 @@ const ADMIN_PANES_KEY = 'clawnsole.admin.panes.v1';
 // Layout is inferred from pane count; no manual layout toggle.
 const ADMIN_DEFAULT_AGENT_KEY = 'clawnsole.admin.agentId';
 const WORKQUEUE_SCOPE_PREF_KEY = 'clawnsole.admin.workqueue.scope.v1';
+const WORKQUEUE_SORT_PREFS_KEY = 'clawnsole.admin.workqueue.sortByQueue.v1';
+const WORKQUEUE_ALLOWED_SORT_KEYS = new Set(['default', 'priority', 'updatedAt', 'createdAt', 'title', 'status', 'attempts', 'claimedBy']);
 
 function normalizeWorkqueueScope(scope) {
   return scope === 'assigned' || scope === 'unassigned' ? scope : 'all';
@@ -3437,6 +3439,47 @@ function normalizeWorkqueueScope(scope) {
 function getDefaultWorkqueueScope() {
   // Low-noise triage default: focus on unassigned work first.
   return normalizeWorkqueueScope(storage.get(WORKQUEUE_SCOPE_PREF_KEY, 'unassigned'));
+}
+
+function normalizeWorkqueueSortKey(sortKey) {
+  const key = String(sortKey || '').trim();
+  return WORKQUEUE_ALLOWED_SORT_KEYS.has(key) ? key : 'default';
+}
+
+function normalizeWorkqueueSortDir(sortDir) {
+  return sortDir === 'asc' ? 'asc' : 'desc';
+}
+
+function getWorkqueueSortPrefs() {
+  try {
+    const raw = storage.get(WORKQUEUE_SORT_PREFS_KEY, '');
+    if (!raw) return {};
+    const parsed = JSON.parse(String(raw));
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function getWorkqueueSortPref(queue) {
+  const key = String(queue || 'dev-team').trim() || 'dev-team';
+  const prefs = getWorkqueueSortPrefs();
+  const pref = prefs[key];
+  if (!pref || typeof pref !== 'object') return null;
+  return {
+    sortKey: normalizeWorkqueueSortKey(pref.sortKey),
+    sortDir: normalizeWorkqueueSortDir(pref.sortDir)
+  };
+}
+
+function setWorkqueueSortPref(queue, { sortKey, sortDir }) {
+  const key = String(queue || 'dev-team').trim() || 'dev-team';
+  const prefs = getWorkqueueSortPrefs();
+  prefs[key] = {
+    sortKey: normalizeWorkqueueSortKey(sortKey),
+    sortDir: normalizeWorkqueueSortDir(sortDir)
+  };
+  storage.set(WORKQUEUE_SORT_PREFS_KEY, JSON.stringify(prefs));
 }
 
 function computeBaseDeviceLabel() {
@@ -4835,23 +4878,27 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     stopBtn: root.querySelector('[data-pane-stop]')
   };
 
+  const initialKind = (() => {
+    const allowed = new Set(['chat', 'workqueue', 'cron', 'timeline']);
+    const k = String(kind || 'chat').trim().toLowerCase();
+    return allowed.has(k) ? k : k.startsWith('w') ? 'workqueue' : 'chat';
+  })();
+  const initialQueue = (queue || 'dev-team').trim() || 'dev-team';
+  const queueSortPref = initialKind === 'workqueue' ? getWorkqueueSortPref(initialQueue) : null;
+
   const pane = {
     key,
     role,
-    kind: (() => {
-      const allowed = new Set(['chat', 'workqueue', 'cron', 'timeline']);
-      const k = String(kind || 'chat').trim().toLowerCase();
-      return allowed.has(k) ? k : k.startsWith('w') ? 'workqueue' : 'chat';
-    })(),
+    kind: initialKind,
     agentId: role === 'admin' ? normalizeAgentId(agentId || 'main') : null,
     workqueue: {
-      queue: (queue || 'dev-team').trim() || 'dev-team',
+      queue: initialQueue,
       statusFilter: Array.isArray(statusFilter) ? statusFilter : ['ready', 'pending', 'claimed', 'in_progress'],
       scopeFilter: normalizeWorkqueueScope(scopeFilter ?? getDefaultWorkqueueScope()),
       items: [],
       selectedItemId: null,
-      sortKey: typeof sortKey === 'string' && sortKey.trim() ? sortKey.trim() : 'priority',
-      sortDir: sortDir === 'asc' ? 'asc' : 'desc'
+      sortKey: normalizeWorkqueueSortKey(sortKey ?? queueSortPref?.sortKey ?? 'priority'),
+      sortDir: normalizeWorkqueueSortDir(sortDir ?? queueSortPref?.sortDir ?? 'desc')
     },
     cronAgentId: typeof cronAgentId === 'string' ? cronAgentId.trim() : '',
     connected: false,
@@ -5041,6 +5088,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
             <button type="button" class="wq-sort-btn" data-wq-sort="priority">Priority</button>
             <button type="button" class="wq-sort-btn" data-wq-sort="updatedAt">Updated</button>
             <button type="button" class="wq-sort-btn" data-wq-sort="createdAt">Created</button>
+            <span class="wq-sort-restore hint" data-wq-sort-restore hidden></span>
           </div>
         </div>
 
@@ -5130,6 +5178,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     const statusDetailsEl = elements.thread.querySelector('[data-wq-status-details]');
     const statusClearBtn = elements.thread.querySelector('[data-wq-status-clear]');
     const refreshBtn = elements.thread.querySelector('[data-wq-refresh]');
+    const sortRestoreEl = elements.thread.querySelector('[data-wq-sort-restore]');
 
     const DEFAULT_STATUSES = ['ready', 'pending', 'claimed', 'in_progress'];
 
@@ -5155,10 +5204,27 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       paneManager.persistAdminPanes();
     };
 
+    const setSortRestoreCue = (text = '') => {
+      if (!sortRestoreEl) return;
+      const next = String(text || '').trim();
+      sortRestoreEl.hidden = !next;
+      sortRestoreEl.textContent = next;
+    };
+
     const doRefresh = async () => {
       const q = getQueueValue() || 'dev-team';
       pane.workqueue.queue = q;
       rememberRecentWorkqueueTarget(q);
+
+      const pref = getWorkqueueSortPref(q);
+      if (pref) {
+        pane.workqueue.sortKey = pref.sortKey;
+        pane.workqueue.sortDir = pref.sortDir;
+        setSortRestoreCue(`Restored: ${pref.sortKey}`);
+      } else {
+        setSortRestoreCue('');
+      }
+
       paneSetHeaderTarget(pane, {
         label: 'Queue',
         value: String(q),
@@ -5175,6 +5241,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         pane.workqueue.statusFilter = Array.from(statusSet);
         renderStatusMultiSelect();
       }
+      updateSortUi();
       await fetchAndRenderWorkqueueItemsForPane(pane);
       paneManager.persistAdminPanes();
     };
@@ -5381,13 +5448,15 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     };
 
     const setSort = (key) => {
-      const nextKey = String(key || 'default');
+      const nextKey = normalizeWorkqueueSortKey(key);
       if (pane.workqueue.sortKey === nextKey) {
         pane.workqueue.sortDir = pane.workqueue.sortDir === 'asc' ? 'desc' : 'asc';
       } else {
         pane.workqueue.sortKey = nextKey;
         pane.workqueue.sortDir = nextKey === 'claimedBy' || nextKey === 'title' || nextKey === 'status' ? 'asc' : 'desc';
       }
+      setWorkqueueSortPref(pane.workqueue.queue, { sortKey: pane.workqueue.sortKey, sortDir: pane.workqueue.sortDir });
+      setSortRestoreCue('');
       updateSortUi();
       renderWorkqueuePaneItems(pane);
       paneManager.persistAdminPanes();

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -75,6 +75,27 @@ test('workqueue pane: queue target supports search + recent persistence', async 
   await expect(secondSelect.locator('option', { hasText: '★ qa-hotfix' })).toHaveCount(1);
 });
 
+test('workqueue pane: persists sort preference across reload with restore cue', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  const pane = page.locator('[data-pane]').last();
+  await pane.locator('[data-wq-sort="updatedAt"]').click();
+  await expect(pane.locator('[data-wq-sort="updatedAt"]')).toHaveClass(/active/);
+
+  await page.reload();
+  await page.waitForURL(/\/admin\/?$/, { timeout: 15000 });
+
+  const reloadedPane = page.locator('[data-pane]').filter({ has: page.locator('.wq-pane') }).first();
+  await expect(reloadedPane.locator('[data-wq-sort="updatedAt"]')).toHaveClass(/active/);
+  await expect(reloadedPane.locator('[data-wq-sort-restore]')).toContainText('Restored: updatedAt');
+});
+
 test('workqueue pane: controls toolbar is sticky and list scrolls independently', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);


### PR DESCRIPTION
## Summary
- persist Workqueue sort preference per queue in localStorage
- restore saved sort automatically when queue is (re)opened or reselected
- show a small "Restored: <sort>" cue when a saved preference is applied
- add UI test coverage for reload persistence

## Testing
- `npm test -- tests/unit/app-core.test.js` *(fails in this env because optional deps `ws` are missing for unrelated unit suites)*
- `npx playwright test tests/ui/workqueue-pane.spec.js -g "persists sort preference"` *(fails in this env because `@playwright/test` is not installed)*
