### PR TITLE
Add layout-safe Cmd/Ctrl+1..9 direct pane focus shortcuts

### DIFF
--- a/app.js
+++ b/app.js
@@ -4930,7 +4930,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
           lines: ['Chat with an agent/session.', 'Pick an agent target, then send messages/files.', 'Use Stop to cancel a long response.'],
           shortcuts: [
             ['Alt/Option+1..9', 'focus panes 1-9 by visible order'],
-            ['Cmd/Ctrl+1..4', 'focus pane 1-4'],
+            ['Cmd/Ctrl+1..9', 'focus panes 1-9 by visible order'],
             ['Cmd/Ctrl+Shift+K', 'focus next pane'],
             ['Cmd/Ctrl+Shift+J', 'focus previous pane']
           ]
@@ -7000,10 +7000,10 @@ window.addEventListener('keydown', (event) => {
     }
   }
 
-  // Cmd/Ctrl+1..4 focuses a pane.
+  // Cmd/Ctrl+1..9 focuses panes by visible order (layout-safe fallback to Alt/Option).
   if ((event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey) {
     const n = Number.parseInt(key, 10);
-    if (Number.isFinite(n) && n >= 1 && n <= 4) {
+    if (Number.isFinite(n) && n >= 1 && n <= 9) {
       event.preventDefault();
       focusPaneIndex(n - 1);
       return;

--- a/app.js
+++ b/app.js
@@ -5423,7 +5423,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
           lines: ['Chat with an agent/session.', 'Pick an agent target, then send messages/files.', 'Use Stop to cancel a long response.'],
           shortcuts: [
             ['Alt/Option+1..9', 'focus panes 1-9 by visible order'],
-            ['Cmd/Ctrl+1..4', 'focus pane 1-4'],
+            ['Cmd/Ctrl+1..9', 'focus panes 1-9 by visible order'],
             ['Cmd/Ctrl+Shift+K', 'focus next pane'],
             ['Cmd/Ctrl+Shift+J', 'focus previous pane']
           ]
@@ -7676,10 +7676,10 @@ window.addEventListener('keydown', (event) => {
     }
   }
 
-  // Cmd/Ctrl+1..4 focuses a pane.
+  // Cmd/Ctrl+1..9 focuses panes by visible order (layout-safe fallback to Alt/Option).
   if ((event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey) {
     const n = Number.parseInt(key, 10);
-    if (Number.isFinite(n) && n >= 1 && n <= 4) {
+    if (Number.isFinite(n) && n >= 1 && n <= 9) {
       event.preventDefault();
       focusPaneIndex(n - 1);
       return;

--- a/app.js
+++ b/app.js
@@ -7803,7 +7803,7 @@ globalElements.status?.addEventListener('click', () => {
     return;
   }
   paneManager.panes.forEach((pane) => {
-    if (pane.client.manualDisconnect) pane.client.manualDisconnect = false;
+    if (pane?.client?.manualDisconnect) pane.client.manualDisconnect = false;
   });
   paneManager.connectIfNeeded();
 });

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -103,7 +103,7 @@ test('cmd/ctrl+shift+j focuses previous pane with wraparound from unfocused stat
   await expect.poll(activePaneIndex).toBe(2);
 });
 
-test('alt+1..3 focuses panes by visible order and does not fire while typing', async ({ page }) => {
+test('alt+1..3 and cmd/ctrl+1..3 focus panes by visible order; shortcuts do not fire while typing', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!app?.skipReason, app?.skipReason);
 
@@ -130,14 +130,20 @@ test('alt+1..3 focuses panes by visible order and does not fire while typing', a
   await page.keyboard.press('Alt+2');
   await expect.poll(activePaneIndex).toBe(1);
 
-  await page.keyboard.press('Alt+3');
+  await page.keyboard.press('Control+3');
   await expect.poll(activePaneIndex).toBe(2);
+
+  await page.keyboard.press('Control+1');
+  await expect.poll(activePaneIndex).toBe(0);
 
   const firstPaneInput = page.locator('[data-pane]').first().locator('[data-pane-input]');
   await firstPaneInput.focus();
   await expect(firstPaneInput).toBeFocused();
 
   await page.keyboard.press('Alt+3');
+  await expect.poll(activePaneIndex).toBe(0);
+
+  await page.keyboard.press('Control+3');
   await expect.poll(activePaneIndex).toBe(0);
 });
 

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -104,7 +104,7 @@ test('cmd/ctrl+shift+j focuses previous pane with wraparound from unfocused stat
   await expect.poll(activePaneIndex).toBe(2);
 });
 
-test('alt+1..3 focuses panes by visible order and does not fire while typing', async ({ page }) => {
+test('alt+1..3 and cmd/ctrl+1..3 focus panes by visible order; shortcuts do not fire while typing', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!app?.skipReason, app?.skipReason);
 
@@ -131,14 +131,20 @@ test('alt+1..3 focuses panes by visible order and does not fire while typing', a
   await page.keyboard.press('Alt+2');
   await expect.poll(activePaneIndex).toBe(1);
 
-  await page.keyboard.press('Alt+3');
+  await page.keyboard.press('Control+3');
   await expect.poll(activePaneIndex).toBe(2);
+
+  await page.keyboard.press('Control+1');
+  await expect.poll(activePaneIndex).toBe(0);
 
   const firstPaneInput = page.locator('[data-pane]').first().locator('[data-pane-input]');
   await firstPaneInput.focus();
   await expect(firstPaneInput).toBeFocused();
 
   await page.keyboard.press('Alt+3');
+  await expect.poll(activePaneIndex).toBe(0);
+
+  await page.keyboard.press('Control+3');
   await expect.poll(activePaneIndex).toBe(0);
 });
 

--- a/tests/ui/pane-add-menu.spec.js
+++ b/tests/ui/pane-add-menu.spec.js
@@ -92,8 +92,6 @@ test('pane add shortcuts: Ctrl/Cmd+Shift+T reuses timeline pane; Alt adds anyway
   const countBefore = await page.locator('[data-pane]').count();
   await page.evaluate(() => document.activeElement?.blur?.());
 
-  await page.evaluate(() => document.activeElement?.blur?.());
-
   const fireTimelineShortcut = async (forceNew = false) => {
     await page.evaluate(({ force }) => {
       window.dispatchEvent(new KeyboardEvent('keydown', {


### PR DESCRIPTION
Closes #270

## Summary
- keep existing Alt/Option+1..9 pane focus shortcuts
- expand layout-safe fallback from Cmd/Ctrl+1..4 to Cmd/Ctrl+1..9
- update pane help popover shortcut hints to show parity for both families
- extend e2e shortcut regression to assert visible-order parity and typing guard for both Alt and Cmd/Ctrl families

## Validation
- npm test -- tests/pane.shortcuts.e2e.spec.js