### PR TITLE
Fix pane identity labels + duplicate close-others targeting

### DIFF
--- a/app.js
+++ b/app.js
@@ -905,6 +905,24 @@ function paneTargetLabel(pane) {
   return String(pane.agentId || 'main');
 }
 
+function paneSummaryLabel(pane) {
+  return `${paneLabel(pane)} · ${paneTargetLabel(pane)}`;
+}
+
+function paneDuplicateKey(pane) {
+  return `${String(pane?.kind || 'chat')}::${String(paneTargetLabel(pane) || '').trim().toLowerCase()}`;
+}
+
+function focusedPaneKey() {
+  const active = document.activeElement;
+  const panes = paneManager?.panes || [];
+  const pane = panes.find((entry) => {
+    const root = entry?.elements?.root;
+    return !!(root && active && (root === active || root.contains(active)));
+  });
+  return pane?.key || '';
+}
+
 function paneSearchText(pane) {
   return [
     pane?.elements?.name?.textContent || '',
@@ -968,6 +986,12 @@ function renderPaneManager() {
   });
   paneManagerUiState.visiblePaneKeys = visibleKeys;
 
+  const duplicateCounts = new Map();
+  filtered.forEach((pane) => {
+    const key = paneDuplicateKey(pane);
+    duplicateCounts.set(key, (duplicateCounts.get(key) || 0) + 1);
+  });
+
   list.innerHTML = '';
   empty.hidden = filtered.length > 0;
   if (!filtered.length) return;
@@ -1009,19 +1033,23 @@ function renderPaneManager() {
         row.setAttribute('aria-selected', visibleIdx === paneManagerUiState.selectedIndex ? 'true' : 'false');
 
         const state = String(pane.statusState || (pane.connected ? 'connected' : 'disconnected'));
+        const duplicateCount = duplicateCounts.get(paneDuplicateKey(pane)) || 0;
+        const isDuplicate = duplicateCount > 1;
+        const paneLetter = String(pane?.key || '').toUpperCase();
 
         row.innerHTML = `
           <div class="pane-manager-main">
-            <div class="pane-manager-kind" title="${escapeHtml(paneLabel(pane))}">
-              <span class="pane-manager-icon" aria-hidden="true">${escapeHtml(paneIcon(pane))}</span>
-              <span class="pane-manager-kind-label">${escapeHtml(paneLabel(pane))}</span>
+            <div class="pane-manager-kind" title="${escapeHtml(paneSummaryLabel(pane))}">
+              <span class="pane-manager-letter" aria-label="Pane ${escapeHtml(paneLetter)}">${escapeHtml(paneLetter)}</span>
+              <span class="pane-manager-kind-label">${escapeHtml(paneSummaryLabel(pane))}</span>
+              ${isDuplicate ? `<span class="pane-manager-duplicate-badge" data-testid="pane-manager-duplicate-badge" title="${escapeHtml(`${duplicateCount} duplicate panes`)}">duplicate</span>` : ''}
             </div>
-            <div class="pane-manager-target" title="${escapeHtml(paneTargetLabel(pane))}">${escapeHtml(paneTargetLabel(pane))}</div>
             <div class="pane-manager-state" data-state="${escapeHtml(state)}">${escapeHtml(state)}</div>
           </div>
           <div class="pane-manager-actions">
             <button class="secondary pane-manager-up" type="button" data-action="move-up" data-testid="pane-manager-move-up" title="Move pane up" aria-label="Move pane up" ${visibleIdx === 0 ? 'disabled' : ''}>↑</button>
             <button class="secondary pane-manager-down" type="button" data-action="move-down" data-testid="pane-manager-move-down" title="Move pane down" aria-label="Move pane down" ${visibleIdx === visibleKeys.length - 1 ? 'disabled' : ''}>↓</button>
+            ${isDuplicate ? '<button class="secondary pane-manager-close-others" type="button" data-action="close-others" data-testid="pane-manager-close-others">Close others</button>' : ''}
             <button class="secondary pane-manager-focus" type="button" data-action="focus">Focus</button>
             <button class="secondary pane-manager-close" type="button" data-action="close">Close</button>
           </div>
@@ -1057,6 +1085,18 @@ function renderPaneManager() {
               paneManagerUiState.selectedIndex = Math.min(paneManagerUiState.visiblePaneKeys.length - 1, selectedVisible + 1);
               renderPaneManager();
             }
+            return;
+          }
+          if (action === 'close-others') {
+            const keepKey = pane.key || focusedPaneKey();
+            const dupKey = paneDuplicateKey(pane);
+            const duplicates = (paneManager?.panes || []).filter((entry) => paneDuplicateKey(entry) === dupKey && entry.key !== keepKey);
+            duplicates.forEach((entry) => {
+              try {
+                paneManager.removePane(entry.key);
+              } catch {}
+            });
+            renderPaneManager();
             return;
           }
           closePaneManager();

--- a/app.js
+++ b/app.js
@@ -3789,6 +3789,24 @@ function agentIdExists(agentId) {
   return uiState.agents.some((a) => String(a?.id || '').trim() === id);
 }
 
+function paneHeaderLetter(pane) {
+  try {
+    const idx = paneManager?.panes?.indexOf?.(pane) ?? -1;
+    return idx >= 0 ? String.fromCharCode(65 + (idx % 26)) : '?';
+  } catch {
+    return '?';
+  }
+}
+
+function renderPaneIdentity(pane) {
+  if (!pane?.elements?.name) return;
+  const letter = paneHeaderLetter(pane);
+  const type = paneLabel(pane);
+  const target = String(pane?.elements?.agentLabel?.textContent || '').trim() ||
+    (pane.kind === 'workqueue' ? String(pane?.workqueue?.queue || 'dev-team') : pane.kind === 'chat' ? 'main' : pane.kind === 'timeline' ? 'Last 24h' : 'Cron');
+  pane.elements.name.textContent = `${letter} ${type} · ${target}`;
+}
+
 function paneSetHeaderTarget(pane, { label, value, ariaLabel, onClick } = {}) {
   if (!pane?.elements) return;
   const { targetLabel, agentButton, agentLabel, agentSelect, agentWarning } = pane.elements;
@@ -3820,6 +3838,8 @@ function paneSetHeaderTarget(pane, { label, value, ariaLabel, onClick } = {}) {
       agentButton.addEventListener('click', handler);
     }
   }
+
+  renderPaneIdentity(pane);
 }
 
 function renderPaneAgentIdentity(pane) {
@@ -3863,6 +3883,8 @@ function renderPaneAgentIdentity(pane) {
       elements.agentWarning.textContent = `Selected agent “${agentId}” is unavailable — choose a replacement.`;
     }
   }
+
+  renderPaneIdentity(pane);
 }
 
 let agentChooserState = { openForPaneKey: null, el: null };
@@ -5164,6 +5186,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
 
     pane.client = buildClientForPane(pane);
     setStatusPill(elements.status, 'disconnected', '');
+    renderPaneIdentity(pane);
     return pane;
   }
 
@@ -5232,6 +5255,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
 
   pane.client = buildClientForPane(pane);
   setStatusPill(elements.status, 'disconnected', '');
+  renderPaneIdentity(pane);
   return pane;
 }
 
@@ -5684,10 +5708,7 @@ const paneManager = {
     return true;
   },
   updatePaneLabels() {
-    this.panes.forEach((pane, index) => {
-      const letter = String.fromCharCode(65 + (index % 26));
-      if (pane.elements.name) pane.elements.name.textContent = letter;
-    });
+    this.panes.forEach((pane) => renderPaneIdentity(pane));
   },
   updateCloseButtons() {
     const allowClose = roleState.role === 'admin' && this.panes.length > 1;

--- a/styles.css
+++ b/styles.css
@@ -1212,7 +1212,7 @@ button.send-btn .btn-icon {
 
 .pane-manager-main {
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: 1fr auto;
   gap: 10px;
   align-items: center;
   min-width: 0;
@@ -1222,15 +1222,45 @@ button.send-btn .btn-icon {
   display: inline-flex;
   gap: 8px;
   align-items: center;
-  font-weight: 600;
-  white-space: nowrap;
+  min-width: 0;
 }
 
-.pane-manager-target {
+.pane-manager-letter {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.05);
+  font-size: 11px;
+  font-weight: 700;
   color: var(--muted);
+}
+
+.pane-manager-kind-label {
+  font-weight: 600;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.pane-manager-duplicate-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 18px;
+  padding: 0 7px;
+  border-radius: 999px;
+  border: 1px solid rgba(245, 158, 11, 0.4);
+  background: rgba(245, 158, 11, 0.12);
+  color: #fbbf24;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
 }
 
 .pane-manager-state {
@@ -1242,6 +1272,8 @@ button.send-btn .btn-icon {
 
 .pane-manager-actions {
   display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
   gap: 8px;
 }
 

--- a/tests/agent-picker.e2e.spec.js
+++ b/tests/agent-picker.e2e.spec.js
@@ -44,6 +44,7 @@ test('agent chooser: opens, shows agents, Esc closes', async ({ page }) => {
   await expect(chooser).toHaveCount(0);
   await expect(btn).toContainText(/dev/i);
   await expect(btn).toHaveAttribute('aria-label', /current:\s*dev/i);
+  await expect(pane.getByTestId('pane-type-label')).toHaveText(/^A Chat · dev/i);
 
   // Re-open and Esc closes.
   await btn.click();

--- a/tests/pane.manager.e2e.spec.js
+++ b/tests/pane.manager.e2e.spec.js
@@ -50,7 +50,7 @@ test('pane manager: lists panes + focuses via keyboard', async ({ page }) => {
   expect(focusedPaneIndex).toBe(1);
 });
 
-test('pane header: target label matches pane kind (agent vs queue vs jobs vs timeline)', async ({ page }) => {
+test('pane header: identity line uses "[Letter] [Type] · [Target]" across pane kinds', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!app?.skipReason, app?.skipReason);
 
@@ -64,20 +64,20 @@ test('pane header: target label matches pane kind (agent vs queue vs jobs vs tim
   const chatPane = page.locator('[data-pane][data-pane-kind="chat"]').first();
   const wqPane = page.locator('[data-pane][data-pane-kind="workqueue"]').first();
 
-  await expect(chatPane.getByTestId('pane-target-label')).toHaveText('Agent');
-  await expect(wqPane.getByTestId('pane-target-label')).toHaveText('Queue');
+  await expect(chatPane.getByTestId('pane-type-label')).toHaveText(/^A Chat · .+/);
+  await expect(wqPane.getByTestId('pane-type-label')).toHaveText(/^B Workqueue · .+/);
 
   await page.getByTestId('add-pane-btn').click();
   await page.getByTestId('pane-add-menu-cron').click();
 
   const cronPane = page.locator('[data-pane][data-pane-kind="cron"]').last();
-  await expect(cronPane.getByTestId('pane-target-label')).toHaveText('Jobs');
+  await expect(cronPane.getByTestId('pane-type-label')).toHaveText(/^C Cron · .+/);
 
   await page.getByTestId('add-pane-btn').click();
   await page.getByTestId('pane-add-menu-timeline').click();
 
   const timelinePane = page.locator('[data-pane][data-pane-kind="timeline"]').last();
-  await expect(timelinePane.getByTestId('pane-target-label')).toHaveText('Timeline');
+  await expect(timelinePane.getByTestId('pane-type-label')).toHaveText(/^D Timeline · .+/);
 });
 
 test('pane manager: quick-find filters and groups by kind', async ({ page }) => {
@@ -134,7 +134,7 @@ test('pane manager: shows summary + duplicate badge and supports close others', 
   await expect(duplicateRows).toHaveCount(2);
   await expect(duplicateRows.first().getByTestId('pane-manager-duplicate-badge')).toHaveText('duplicate');
 
-  const chatRowWithCloseOthers = page.locator('.pane-manager-row', { has: page.getByTestId('pane-manager-close-others') }).first();
+  const chatRowWithCloseOthers = duplicateRows.first();
   await chatRowWithCloseOthers.getByTestId('pane-manager-close-others').click();
 
   await expect(page.locator('[data-pane][data-pane-kind="chat"]')).toHaveCount(1);


### PR DESCRIPTION
## Summary
- render pane headers as `[Letter] [Type] · [Target]` so pane manager rows expose actionable context
- keep identity labels in sync when agent/queue target changes and when panes are relabeled
- tighten duplicate-row action test to invoke **Close others** from a known duplicate row

## Validation
- `npm test -- tests/pane.manager.e2e.spec.js tests/agent-picker.e2e.spec.js`
