### PR TITLE
Topbar pane summary: add disconnected + attention counts

### DIFF
--- a/app.js
+++ b/app.js
@@ -142,22 +142,21 @@ const deriveAuthOverlayState = __appCore.deriveAuthOverlayState || ((state) => (
   logoutOpacity: !!state?.authed ? '1' : '0.5'
 }));
 const deriveGlobalConnectionState = __appCore.deriveGlobalConnectionState || ((state) => {
-  if (!state?.authed) return { state: 'disconnected', meta: 'sign in required' };
+  if (!state?.authed) return { state: 'disconnected', meta: 'sign in required', connectedCount: 0, disconnectedCount: 0, attentionCount: 0, total: 0 };
   const panes = Array.isArray(state?.panes) ? state.panes : [];
-  if (panes.length === 0) return { state: 'disconnected', meta: '' };
+  if (panes.length === 0) return { state: 'disconnected', meta: '', connectedCount: 0, disconnectedCount: 0, attentionCount: 0, total: 0 };
   const connectedCount = panes.filter((pane) => !!pane?.connected).length;
   const total = panes.length;
+  const disconnectedCount = Math.max(0, total - connectedCount);
+  const attentionCount = panes.filter((pane) => Number(pane?.unreadCount || 0) > 0 || !pane?.connected).length;
   const anyConnecting = panes.some((pane) => pane?.statusState === 'connecting' || pane?.statusState === 'reconnecting');
   const anyError = panes.some((pane) => pane?.statusState === 'error');
-  const firstError = panes.find((pane) => pane?.statusState === 'error' && pane?.statusMeta);
   let nextState = 'disconnected';
   if (connectedCount === total) nextState = 'connected';
   else if (connectedCount > 0 || anyConnecting) nextState = 'reconnecting';
   else if (anyError) nextState = 'error';
-  const meta = connectedCount === 0 && anyError && firstError
-    ? String(firstError.statusMeta || '')
-    : `panes: ${connectedCount}/${total} connected`;
-  return { state: nextState, meta };
+  const meta = `panes: ${connectedCount}/${total} connected • ${disconnectedCount} disconnected • ${attentionCount} attention`;
+  return { state: nextState, meta, connectedCount, disconnectedCount, attentionCount, total };
 });
 const deriveDisconnectButtonState = __appCore.deriveDisconnectButtonState || ((state) => {
   if (!state?.authed) return { disabled: true, text: 'Reconnect' };
@@ -838,7 +837,14 @@ function setStatusPill(el, state, meta = '') {
 function updateGlobalStatus() {
   const status = deriveGlobalConnectionState({ authed: uiState.authed, panes: paneManager.panes });
   setStatusPill(globalElements.status, status.state, status.meta);
-  if (globalElements.paneManagerBtn) globalElements.paneManagerBtn.textContent = status.meta;
+  if (globalElements.paneManagerBtn) {
+    globalElements.paneManagerBtn.textContent = status.meta;
+    globalElements.paneManagerBtn.dataset.attention = status.attentionCount > 0 ? 'true' : 'false';
+    globalElements.paneManagerBtn.setAttribute(
+      'aria-label',
+      `Open pane manager. ${status.connectedCount} connected, ${status.disconnectedCount} disconnected, ${status.attentionCount} need attention.`
+    );
+  }
 }
 
 function updateConnectionControls() {
@@ -1606,7 +1612,7 @@ function renderPaneManager() {
   });
 }
 
-function openPaneManager() {
+function openPaneManager({ attentionOnly = false } = {}) {
   if (roleState.role !== 'admin') return;
   if (!uiState.authed) {
     showLogin('Please sign in to continue.');
@@ -1617,7 +1623,11 @@ function openPaneManager() {
   paneManagerUiState.open = true;
   paneManagerUiState.selectedIndex = 0;
   paneManagerUiState.query = String(globalElements.paneManagerSearch?.value || '').trim();
-  paneManagerUiState.unreadOnly = !!globalElements.paneManagerUnreadOnly?.checked;
+  paneManagerUiState.unreadOnly = attentionOnly || !!globalElements.paneManagerUnreadOnly?.checked;
+
+  if (globalElements.paneManagerUnreadOnly) {
+    globalElements.paneManagerUnreadOnly.checked = paneManagerUiState.unreadOnly;
+  }
 
   globalElements.paneManagerModal.classList.add('open');
   globalElements.paneManagerModal.setAttribute('aria-hidden', 'false');
@@ -7094,7 +7104,8 @@ globalElements.resetLayoutBtn?.addEventListener('click', () => {
 
 globalElements.paneManagerBtn?.addEventListener('click', (event) => {
   event?.preventDefault?.();
-  openPaneManager();
+  const attentionOnly = globalElements.paneManagerBtn?.dataset?.attention === 'true';
+  openPaneManager({ attentionOnly });
 });
 
 globalElements.paneManagerCloseBtn?.addEventListener('click', () => closePaneManager());

--- a/lib/app-core.js
+++ b/lib/app-core.js
@@ -162,19 +162,23 @@
 
   function deriveGlobalConnectionState({ authed, panes } = {}) {
     if (!authed) {
-      return { state: 'disconnected', meta: 'sign in required' };
+      return { state: 'disconnected', meta: 'sign in required', connectedCount: 0, disconnectedCount: 0, attentionCount: 0, total: 0 };
     }
 
     const list = Array.isArray(panes) ? panes : [];
     if (list.length === 0) {
-      return { state: 'disconnected', meta: '' };
+      return { state: 'disconnected', meta: '', connectedCount: 0, disconnectedCount: 0, attentionCount: 0, total: 0 };
     }
 
     const connectedCount = list.filter((pane) => !!pane?.connected).length;
     const total = list.length;
+    const disconnectedCount = Math.max(0, total - connectedCount);
+    const attentionCount = list.filter((pane) => {
+      const unread = Number(pane?.unreadCount || 0);
+      return unread > 0 || !pane?.connected;
+    }).length;
     const anyConnecting = list.some((pane) => pane?.statusState === 'connecting' || pane?.statusState === 'reconnecting');
     const anyError = list.some((pane) => pane?.statusState === 'error');
-    const firstError = list.find((pane) => pane?.statusState === 'error' && pane?.statusMeta);
 
     let state = 'disconnected';
     if (connectedCount === total) {
@@ -185,12 +189,9 @@
       state = 'error';
     }
 
-    const meta =
-      connectedCount === 0 && anyError && firstError
-        ? String(firstError.statusMeta || '')
-        : `panes: ${connectedCount}/${total} connected`;
+    const meta = `panes: ${connectedCount}/${total} connected • ${disconnectedCount} disconnected • ${attentionCount} attention`;
 
-    return { state, meta };
+    return { state, meta, connectedCount, disconnectedCount, attentionCount, total };
   }
 
   function deriveDisconnectButtonState({ authed, panes } = {}) {

--- a/tests/unit/app-core.test.js
+++ b/tests/unit/app-core.test.js
@@ -142,34 +142,56 @@ test('normalizeHistoryEntries supports gateway payload variants', () => {
 test('deriveGlobalConnectionState handles signed-out, reconnecting, and hard error transitions', () => {
   assert.deepEqual(deriveGlobalConnectionState({ authed: false, panes: [{ connected: true }] }), {
     state: 'disconnected',
-    meta: 'sign in required'
+    meta: 'sign in required',
+    connectedCount: 0,
+    disconnectedCount: 0,
+    attentionCount: 0,
+    total: 0
   });
 
   assert.deepEqual(deriveGlobalConnectionState({ authed: true, panes: [] }), {
     state: 'disconnected',
-    meta: ''
+    meta: '',
+    connectedCount: 0,
+    disconnectedCount: 0,
+    attentionCount: 0,
+    total: 0
   });
 
   assert.deepEqual(
     deriveGlobalConnectionState({
       authed: true,
       panes: [
-        { connected: true, statusState: 'connected' },
-        { connected: false, statusState: 'reconnecting' }
+        { connected: true, statusState: 'connected', unreadCount: 0 },
+        { connected: false, statusState: 'reconnecting', unreadCount: 3 }
       ]
     }),
-    { state: 'reconnecting', meta: 'panes: 1/2 connected' }
+    {
+      state: 'reconnecting',
+      meta: 'panes: 1/2 connected • 1 disconnected • 1 attention',
+      connectedCount: 1,
+      disconnectedCount: 1,
+      attentionCount: 1,
+      total: 2
+    }
   );
 
   assert.deepEqual(
     deriveGlobalConnectionState({
       authed: true,
       panes: [
-        { connected: false, statusState: 'error', statusMeta: 'auth expired' },
-        { connected: false, statusState: 'error', statusMeta: 'gateway disconnected' }
+        { connected: false, statusState: 'error', statusMeta: 'auth expired', unreadCount: 0 },
+        { connected: false, statusState: 'error', statusMeta: 'gateway disconnected', unreadCount: 0 }
       ]
     }),
-    { state: 'error', meta: 'auth expired' }
+    {
+      state: 'error',
+      meta: 'panes: 0/2 connected • 2 disconnected • 2 attention',
+      connectedCount: 0,
+      disconnectedCount: 2,
+      attentionCount: 2,
+      total: 2
+    }
   );
 });
 


### PR DESCRIPTION
## Summary\n- upgrade topbar pane summary to include connected, disconnected, and attention counts\n- treat panes as attention-needed when disconnected or unread\n- add screen-reader label on the summary button with all counts\n- clicking the topbar summary now opens Pane Manager with attention filter pre-enabled when attention exists\n- extend unit coverage for deriveGlobalConnectionState transitions\n\n## Testing\n- node --test tests/unit/app-core.test.js\n\nCloses #307