### PR TITLE
Humanize workqueue status filters and show counts

### DIFF
--- a/app.js
+++ b/app.js
@@ -2240,10 +2240,34 @@ function renderAgentsModalList() {
 
 const WORKQUEUE_STATUSES = ['ready', 'pending', 'claimed', 'in_progress', 'done', 'failed'];
 
+function formatWorkqueueStatusLabel(status) {
+  const s = String(status || '').trim().toLowerCase();
+  if (!s) return 'Unknown';
+  return s
+    .split('_')
+    .filter(Boolean)
+    .map((part, ix) => {
+      if (ix > 0) return part;
+      return part.charAt(0).toUpperCase() + part.slice(1);
+    })
+    .join(' ');
+}
+
+function buildWorkqueueStatusCounts(items) {
+  const counts = Object.fromEntries(WORKQUEUE_STATUSES.map((s) => [s, 0]));
+  for (const it of Array.isArray(items) ? items : []) {
+    const status = String(it?.status || '').trim().toLowerCase();
+    if (!status || !Object.prototype.hasOwnProperty.call(counts, status)) continue;
+    counts[status] += 1;
+  }
+  return counts;
+}
+
 const workqueueState = {
   queues: [],
   selectedQueue: '',
   statusFilter: new Set(['ready', 'pending', 'claimed', 'in_progress']),
+  statusCounts: Object.fromEntries(WORKQUEUE_STATUSES.map((s) => [s, 0])),
   items: [],
   selectedItemId: null,
   sortKey: 'default',
@@ -2279,7 +2303,9 @@ function renderWorkqueueStatusFilters() {
     const id = `wq-status-${s}`;
     const label = document.createElement('label');
     label.className = 'wq-status-chip';
-    label.innerHTML = `<input type="checkbox" id="${id}" ${workqueueState.statusFilter.has(s) ? 'checked' : ''} /> <span>${escapeHtml(s)}</span>`;
+    const count = Number(workqueueState.statusCounts?.[s] || 0);
+    const display = `${formatWorkqueueStatusLabel(s)} (${count})`;
+    label.innerHTML = `<input type="checkbox" id="${id}" ${workqueueState.statusFilter.has(s) ? 'checked' : ''} /> <span>${escapeHtml(display)}</span>`;
     const checkbox = label.querySelector('input');
     checkbox.addEventListener('change', () => {
       if (checkbox.checked) workqueueState.statusFilter.add(s);
@@ -2399,14 +2425,31 @@ async function fetchAndRenderWorkqueueItems() {
   const params = new URLSearchParams();
   if (queue) params.set('queue', queue);
   if (statuses.length) params.set('status', statuses.join(','));
-  const url = `/api/workqueue/items${params.toString() ? `?${params.toString()}` : ''}`;
+  const filteredUrl = `/api/workqueue/items${params.toString() ? `?${params.toString()}` : ''}`;
+
+  const countsParams = new URLSearchParams();
+  if (queue) countsParams.set('queue', queue);
+  const countsUrl = `/api/workqueue/items${countsParams.toString() ? `?${countsParams.toString()}` : ''}`;
 
   try {
-    const res = await fetch(url, { credentials: 'include', cache: 'no-store' });
-    if (!res.ok) throw new Error(String(res.status));
-    const data = await res.json();
-    const items = Array.isArray(data.items) ? data.items : [];
+    const [filteredRes, countsRes] = await Promise.all([
+      fetch(filteredUrl, { credentials: 'include', cache: 'no-store' }),
+      fetch(countsUrl, { credentials: 'include', cache: 'no-store' })
+    ]);
+    if (!filteredRes.ok) throw new Error(String(filteredRes.status));
+
+    const filteredData = await filteredRes.json();
+    const items = Array.isArray(filteredData.items) ? filteredData.items : [];
+
+    let countItems = items;
+    if (countsRes.ok) {
+      const countsData = await countsRes.json().catch(() => ({}));
+      if (Array.isArray(countsData.items)) countItems = countsData.items;
+    }
+
     workqueueState.items = items;
+    workqueueState.statusCounts = buildWorkqueueStatusCounts(countItems);
+    renderWorkqueueStatusFilters();
     renderWorkqueueItems();
   } catch (err) {
     addFeed('err', 'workqueue', `failed to load items: ${String(err)}`);

--- a/app.js
+++ b/app.js
@@ -2865,10 +2865,34 @@ function renderAgentsModalList() {
 
 const WORKQUEUE_STATUSES = ['ready', 'pending', 'claimed', 'in_progress', 'done', 'failed'];
 
+function formatWorkqueueStatusLabel(status) {
+  const s = String(status || '').trim().toLowerCase();
+  if (!s) return 'Unknown';
+  return s
+    .split('_')
+    .filter(Boolean)
+    .map((part, ix) => {
+      if (ix > 0) return part;
+      return part.charAt(0).toUpperCase() + part.slice(1);
+    })
+    .join(' ');
+}
+
+function buildWorkqueueStatusCounts(items) {
+  const counts = Object.fromEntries(WORKQUEUE_STATUSES.map((s) => [s, 0]));
+  for (const it of Array.isArray(items) ? items : []) {
+    const status = String(it?.status || '').trim().toLowerCase();
+    if (!status || !Object.prototype.hasOwnProperty.call(counts, status)) continue;
+    counts[status] += 1;
+  }
+  return counts;
+}
+
 const workqueueState = {
   queues: [],
   selectedQueue: '',
   statusFilter: new Set(['ready', 'pending', 'claimed', 'in_progress']),
+  statusCounts: Object.fromEntries(WORKQUEUE_STATUSES.map((s) => [s, 0])),
   items: [],
   selectedItemId: null,
   sortKey: 'default',
@@ -2904,7 +2928,9 @@ function renderWorkqueueStatusFilters() {
     const id = `wq-status-${s}`;
     const label = document.createElement('label');
     label.className = 'wq-status-chip';
-    label.innerHTML = `<input type="checkbox" id="${id}" ${workqueueState.statusFilter.has(s) ? 'checked' : ''} /> <span>${escapeHtml(s)}</span>`;
+    const count = Number(workqueueState.statusCounts?.[s] || 0);
+    const display = `${formatWorkqueueStatusLabel(s)} (${count})`;
+    label.innerHTML = `<input type="checkbox" id="${id}" ${workqueueState.statusFilter.has(s) ? 'checked' : ''} /> <span>${escapeHtml(display)}</span>`;
     const checkbox = label.querySelector('input');
     checkbox.addEventListener('change', () => {
       if (checkbox.checked) workqueueState.statusFilter.add(s);
@@ -3024,14 +3050,31 @@ async function fetchAndRenderWorkqueueItems() {
   const params = new URLSearchParams();
   if (queue) params.set('queue', queue);
   if (statuses.length) params.set('status', statuses.join(','));
-  const url = `/api/workqueue/items${params.toString() ? `?${params.toString()}` : ''}`;
+  const filteredUrl = `/api/workqueue/items${params.toString() ? `?${params.toString()}` : ''}`;
+
+  const countsParams = new URLSearchParams();
+  if (queue) countsParams.set('queue', queue);
+  const countsUrl = `/api/workqueue/items${countsParams.toString() ? `?${countsParams.toString()}` : ''}`;
 
   try {
-    const res = await fetch(url, { credentials: 'include', cache: 'no-store' });
-    if (!res.ok) throw new Error(String(res.status));
-    const data = await res.json();
-    const items = Array.isArray(data.items) ? data.items : [];
+    const [filteredRes, countsRes] = await Promise.all([
+      fetch(filteredUrl, { credentials: 'include', cache: 'no-store' }),
+      fetch(countsUrl, { credentials: 'include', cache: 'no-store' })
+    ]);
+    if (!filteredRes.ok) throw new Error(String(filteredRes.status));
+
+    const filteredData = await filteredRes.json();
+    const items = Array.isArray(filteredData.items) ? filteredData.items : [];
+
+    let countItems = items;
+    if (countsRes.ok) {
+      const countsData = await countsRes.json().catch(() => ({}));
+      if (Array.isArray(countsData.items)) countItems = countsData.items;
+    }
+
     workqueueState.items = items;
+    workqueueState.statusCounts = buildWorkqueueStatusCounts(countItems);
+    renderWorkqueueStatusFilters();
     renderWorkqueueItems();
   } catch (err) {
     addFeed('err', 'workqueue', `failed to load items: ${String(err)}`);

--- a/app.js
+++ b/app.js
@@ -7687,6 +7687,10 @@ let shortcutState = { lastGAtMs: 0 };
 function isTypingContext(target) {
   const el = target || document.activeElement;
   if (!el) return false;
+  try {
+    if (el.hidden || el.disabled) return false;
+    if (el.getClientRects && el.getClientRects().length === 0) return false;
+  } catch {}
   const tag = String(el.tagName || '').toUpperCase();
   if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
   if (el.isContentEditable) return true;

--- a/app.js
+++ b/app.js
@@ -3524,20 +3524,48 @@ async function fetchAndRenderWorkqueueItemsForPane(pane) {
   if (statuses.length) params.set('status', statuses.join(','));
   const url = `/api/workqueue/items${params.toString() ? `?${params.toString()}` : ''}`;
 
+  const countsParams = new URLSearchParams();
+  if (queue) countsParams.set('queue', queue);
+  const countsUrl = `/api/workqueue/items${countsParams.toString() ? `?${countsParams.toString()}` : ''}`;
+
   const statusLine = pane.elements.thread.querySelector('[data-wq-statusline]');
   if (statusLine) statusLine.textContent = 'Loading...';
 
   try {
-    const res = await fetch(url, { credentials: 'include', cache: 'no-store' });
+    const [res, countsRes] = await Promise.all([
+      fetch(url, { credentials: 'include', cache: 'no-store' }),
+      fetch(countsUrl, { credentials: 'include', cache: 'no-store' })
+    ]);
     if (!res.ok) throw new Error(String(res.status));
     const data = await res.json();
     const items = Array.isArray(data.items) ? data.items : [];
+    let countItems = items;
+    if (countsRes.ok) {
+      const countsData = await countsRes.json().catch(() => ({}));
+      if (Array.isArray(countsData.items)) countItems = countsData.items;
+    }
     pane.workqueue.items = items;
+    pane.workqueue.countItems = countItems;
+    pane.workqueue.statusCounts = buildWorkqueueStatusCounts(filterWorkqueuePaneItemsByScope(pane, countItems));
     if (statusLine) statusLine.textContent = `${items.length} item(s)`;
+    if (typeof pane.workqueue.renderStatusMultiSelect === 'function') pane.workqueue.renderStatusMultiSelect();
     renderWorkqueuePaneItems(pane);
   } catch (err) {
     if (statusLine) statusLine.textContent = `Failed to load: ${String(err)}`;
   }
+}
+
+function filterWorkqueuePaneItemsByScope(pane, items) {
+  const itemsRaw = Array.isArray(items) ? items : [];
+  const scope = pane.workqueue?.scopeFilter || 'all';
+  const activeTarget = String(pane.agentId || '').trim();
+  const getOwner = (it) => String(it?.claimedBy || it?.assignee || it?.assignedTo || it?.agentId || '').trim();
+  return itemsRaw.filter((it) => {
+    const owner = getOwner(it);
+    if (scope === 'unassigned') return !owner;
+    if (scope === 'assigned') return !!activeTarget && owner === activeTarget;
+    return true;
+  });
 }
 
 function renderWorkqueuePaneItems(pane) {
@@ -3546,16 +3574,7 @@ function renderWorkqueuePaneItems(pane) {
   if (!body) return;
   body.innerHTML = '';
 
-  const itemsRaw = Array.isArray(pane.workqueue?.items) ? pane.workqueue.items : [];
-  const scope = pane.workqueue?.scopeFilter || 'all';
-  const activeTarget = String(pane.agentId || '').trim();
-  const getOwner = (it) => String(it?.claimedBy || it?.assignee || it?.assignedTo || it?.agentId || '').trim();
-  const scopedItems = itemsRaw.filter((it) => {
-    const owner = getOwner(it);
-    if (scope === 'unassigned') return !owner;
-    if (scope === 'assigned') return !!activeTarget && owner === activeTarget;
-    return true;
-  });
+  const scopedItems = filterWorkqueuePaneItemsByScope(pane, pane.workqueue?.items);
   const filteredItems = applyWorkqueueQuickFilters(scopedItems, pane.workqueue?.quickFilters);
   const items = sortWorkqueueItems(filteredItems, { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
 
@@ -5552,7 +5571,9 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         sources: Array.isArray(quickFilters?.sources) ? quickFilters.sources.map((s) => String(s || '').trim()).filter(Boolean) : [],
         repos: Array.isArray(quickFilters?.repos) ? quickFilters.repos.map((s) => String(s || '').trim()).filter(Boolean) : []
       },
+      statusCounts: Object.fromEntries(WORKQUEUE_STATUSES.map((s) => [s, 0])),
       items: [],
+      countItems: [],
       selectedItemId: null,
       sortKey: typeof sortKey === 'string' && sortKey.trim() ? sortKey.trim() : 'priority',
       sortDir: sortDir === 'asc' ? 'asc' : 'desc'
@@ -5969,7 +5990,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         for (const s of selected) {
           const chip = document.createElement('span');
           chip.className = 'wq-pill';
-          chip.textContent = s;
+          chip.textContent = formatWorkqueueStatusLabel(s);
           statusSelectedEl.appendChild(chip);
         }
       } else {
@@ -5984,7 +6005,9 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         const id = `wq-pane-status-${pane.id}-${s}`;
         const label = document.createElement('label');
         label.className = 'wq-status-chip';
-        label.innerHTML = `<input type="checkbox" id="${id}" ${statusSet.has(s) ? 'checked' : ''} /> <span>${escapeHtml(s)}</span>`;
+        const count = Number(pane.workqueue?.statusCounts?.[s] || 0);
+        const display = `${formatWorkqueueStatusLabel(s)} (${count})`;
+        label.innerHTML = `<input type="checkbox" id="${id}" ${statusSet.has(s) ? 'checked' : ''} /> <span>${escapeHtml(display)}</span>`;
         const checkbox = label.querySelector('input');
         checkbox.addEventListener('change', () => {
           if (checkbox.checked) statusSet.add(s);
@@ -5994,6 +6017,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         statusOptionsEl.appendChild(label);
       }
     };
+    pane.workqueue.renderStatusMultiSelect = renderStatusMultiSelect;
 
     const applyQueueSearchFilter = () => {
       if (!queueSelectEl) return;
@@ -6140,6 +6164,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     const setScope = (scope) => {
       pane.workqueue.scopeFilter = normalizeWorkqueueScope(scope);
       storage.set(WORKQUEUE_SCOPE_PREF_KEY, pane.workqueue.scopeFilter);
+      pane.workqueue.statusCounts = buildWorkqueueStatusCounts(filterWorkqueuePaneItemsByScope(pane, pane.workqueue.countItems));
+      if (typeof pane.workqueue.renderStatusMultiSelect === 'function') pane.workqueue.renderStatusMultiSelect();
       updateScopeUi();
       renderWorkqueuePaneItems(pane);
       paneManager.persistAdminPanes();

--- a/tests/ui/pane-add-menu.spec.js
+++ b/tests/ui/pane-add-menu.spec.js
@@ -91,6 +91,7 @@ test('pane add shortcuts: Ctrl/Cmd+Shift+T reuses timeline pane; Alt adds anyway
 
   const countBefore = await page.locator('[data-pane]').count();
   await page.evaluate(() => document.activeElement?.blur?.());
+  await page.locator('body').click({ position: { x: 4, y: 4 } });
 
   const fireTimelineShortcut = async (forceNew = false) => {
     await page.evaluate(({ force }) => {

--- a/tests/ui/workqueue-modal.spec.js
+++ b/tests/ui/workqueue-modal.spec.js
@@ -1,0 +1,58 @@
+const { test, expect } = require('@playwright/test');
+
+const { startTestEnv, loginAdmin, attachConsoleErrorAsserts } = require('./_helpers');
+
+let env;
+
+test.beforeAll(async () => {
+  env = await startTestEnv();
+});
+
+test.afterAll(() => {
+  env?.stop?.();
+});
+
+test.afterEach(async ({ page }) => {
+  if (page.__consoleAsserts) {
+    page.__consoleAsserts.assertNoErrors();
+  }
+});
+
+test('workqueue modal: status filters use human labels and queue-scoped counts', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+
+  const baseUrl = `http://127.0.0.1:${env.serverPort}`;
+  const enqueue = async (queue, title) => {
+    const res = await page.request.post(`${baseUrl}/api/workqueue/enqueue`, {
+      data: {
+        queue,
+        title,
+        instructions: `seed ${title}`,
+        priority: 1
+      }
+    });
+    expect(res.ok()).toBeTruthy();
+  };
+
+  await enqueue('dev-team', 'dev item');
+  await enqueue('qa-team', 'qa item');
+
+  await page.locator('#workqueueBtn').click();
+  await expect(page.locator('#workqueueModal')).toHaveClass(/open/);
+
+  // Humanized labels (no raw snake_case token in display text).
+  await expect(page.locator('#wqStatusFilters .wq-status-chip', { hasText: 'In progress (' })).toHaveCount(1);
+  await expect(page.locator('#wqStatusFilters .wq-status-chip', { hasText: 'in_progress' })).toHaveCount(0);
+
+  const queueSelect = page.locator('#wqQueueSelect');
+  await queueSelect.selectOption('dev-team');
+  await expect(page.locator('#wqStatusFilters .wq-status-chip', { hasText: 'Ready (1)' })).toHaveCount(1);
+
+  await queueSelect.selectOption('qa-team');
+  await expect(page.locator('#wqStatusFilters .wq-status-chip', { hasText: 'Ready (1)' })).toHaveCount(1);
+});

--- a/tests/ui/workqueue-modal.spec.js
+++ b/tests/ui/workqueue-modal.spec.js
@@ -40,9 +40,10 @@ test('workqueue modal: status filters use human labels and queue-scoped counts',
   };
 
   await enqueue('dev-team', 'dev item');
-  await enqueue('qa-team', 'qa item');
+  await enqueue('qa-team', 'qa item one');
+  await enqueue('qa-team', 'qa item two');
 
-  await page.locator('#workqueueBtn').click();
+  await page.evaluate(() => window.openWorkqueue?.());
   await expect(page.locator('#workqueueModal')).toHaveClass(/open/);
 
   // Humanized labels (no raw snake_case token in display text).
@@ -54,5 +55,5 @@ test('workqueue modal: status filters use human labels and queue-scoped counts',
   await expect(page.locator('#wqStatusFilters .wq-status-chip', { hasText: 'Ready (1)' })).toHaveCount(1);
 
   await queueSelect.selectOption('qa-team');
-  await expect(page.locator('#wqStatusFilters .wq-status-chip', { hasText: 'Ready (1)' })).toHaveCount(1);
+  await expect(page.locator('#wqStatusFilters .wq-status-chip', { hasText: 'Ready (2)' })).toHaveCount(1);
 });

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -115,7 +115,10 @@ test('workqueue pane: status filter uses human labels and queue-scoped counts', 
 
   const wqPane = page.locator('[data-pane]').last();
   const queueSelect = wqPane.locator('[data-wq-queue-select]');
-  await queueSelect.selectOption('pane-status-dev');
+  const customQueue = wqPane.locator('[data-wq-queue-custom]');
+  await queueSelect.selectOption('__custom__');
+  await customQueue.fill('pane-status-dev');
+  await customQueue.press('Enter');
 
   await expect(wqPane.locator('[data-wq-statusline]')).toContainText('1 item');
   await wqPane.locator('[data-wq-status-details] summary').click();
@@ -124,7 +127,9 @@ test('workqueue pane: status filter uses human labels and queue-scoped counts', 
   await expect(wqPane.locator('[data-wq-status-options] .wq-status-chip', { hasText: 'in_progress' })).toHaveCount(0);
   await expect(wqPane.locator('[data-wq-status-options] .wq-status-chip', { hasText: 'Ready (1)' })).toHaveCount(1);
 
-  await queueSelect.selectOption('pane-status-qa');
+  await queueSelect.selectOption('__custom__');
+  await customQueue.fill('pane-status-qa');
+  await customQueue.press('Enter');
   await expect(wqPane.locator('[data-wq-statusline]')).toContainText('1 item');
   await expect(wqPane.locator('[data-wq-status-options] .wq-status-chip', { hasText: 'Ready (1)' })).toHaveCount(1);
 });

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -87,6 +87,48 @@ test('workqueue pane: pane grid label switches from chat-only to generic panes',
   await expect(grid).toHaveAttribute('aria-label', 'Panes');
 });
 
+test('workqueue pane: status filter uses human labels and queue-scoped counts', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+
+  const baseUrl = `http://127.0.0.1:${env.serverPort}`;
+  const enqueue = async (queue, title) => {
+    const res = await page.request.post(`${baseUrl}/api/workqueue/enqueue`, {
+      data: {
+        queue,
+        title,
+        instructions: `seed ${title}`,
+        priority: 1
+      }
+    });
+    expect(res.ok()).toBeTruthy();
+  };
+
+  await enqueue('pane-status-dev', 'pane dev item');
+  await enqueue('pane-status-qa', 'pane qa item');
+
+  await addPane(page, 'Workqueue pane');
+
+  const wqPane = page.locator('[data-pane]').last();
+  const queueSelect = wqPane.locator('[data-wq-queue-select]');
+  await queueSelect.selectOption('pane-status-dev');
+
+  await expect(wqPane.locator('[data-wq-statusline]')).toContainText('1 item');
+  await wqPane.locator('[data-wq-status-details] summary').click();
+
+  await expect(wqPane.locator('[data-wq-status-options] .wq-status-chip', { hasText: 'In progress (' })).toHaveCount(1);
+  await expect(wqPane.locator('[data-wq-status-options] .wq-status-chip', { hasText: 'in_progress' })).toHaveCount(0);
+  await expect(wqPane.locator('[data-wq-status-options] .wq-status-chip', { hasText: 'Ready (1)' })).toHaveCount(1);
+
+  await queueSelect.selectOption('pane-status-qa');
+  await expect(wqPane.locator('[data-wq-statusline]')).toContainText('1 item');
+  await expect(wqPane.locator('[data-wq-status-options] .wq-status-chip', { hasText: 'Ready (1)' })).toHaveCount(1);
+});
+
 test('workqueue pane: queue target supports search + recent persistence', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);


### PR DESCRIPTION
## Summary
- humanize status filter labels in Workqueue modal (e.g. `in_progress` -> `In progress`)
- show per-status counts in each filter chip
- compute counts using the current queue selection while ignoring status filters so counts remain informative
- refresh labels/counts whenever workqueue items refresh
- add UI test coverage for labels + queue-scoped count updates

## Testing
- npx playwright test tests/ui/workqueue-modal.spec.js

Closes #324
