### PR TITLE
Fix #312: auth-first signed-out admin state hides pane workspace chrome

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,5 @@
 const globalElements = {
+  appRoot: document.querySelector('.app'),
   wsUrl: document.getElementById('wsUrl'),
   clientId: document.getElementById('clientId'),
   deviceId: document.getElementById('deviceId'),
@@ -851,6 +852,9 @@ function updateConnectionControls() {
 function setAuthState(authed) {
   uiState.authed = authed;
   const authUi = deriveAuthOverlayState({ authed, role: roleState.role });
+  if (globalElements.appRoot) {
+    globalElements.appRoot.classList.toggle('auth-locked', !!authUi.isAdmin && !authed);
+  }
   updateGlobalStatus();
   updateConnectionControls();
   paneManager.refreshChatEnabled();

--- a/styles.css
+++ b/styles.css
@@ -340,6 +340,14 @@ body::before {
   overflow: hidden;
 }
 
+.app.auth-locked .chat-page {
+  display: none;
+}
+
+.app.auth-locked .topbar-actions > :not(#rolePill) {
+  display: none !important;
+}
+
 .pane-grid {
   position: relative;
   z-index: 1;

--- a/tests/ui/auth-lifecycle.spec.js
+++ b/tests/ui/auth-lifecycle.spec.js
@@ -8,6 +8,7 @@ test('visiting /admin without auth shows login overlay', async ({ page, clawnsol
   await page.goto(clawnsole.adminUrl);
   await expect(page.getByTestId('login-overlay')).toHaveClass(/open/);
   await expect(page.getByTestId('role-pill')).toContainText('signed out');
+  await expect(page.getByTestId('pane-grid')).toBeHidden();
 });
 
 test('after successful login, reload stays authed; clearing cookies forces re-login', async ({ page, context, clawnsole }) => {


### PR DESCRIPTION
## Summary
- add `auth-locked` app state when admin is signed out
- hide pane workspace and topbar action chrome in locked state so signed-out view is auth-first
- add UI assertion to auth lifecycle test that pane grid is hidden when login overlay is open

## Validation
- npm run test:syntax
- playwright test not run in this pass (missing local @playwright/test install in temp clone)

Closes #312.