### PR TITLE
Add shortcut conflict warnings + one-click safe fallback apply

### DIFF
--- a/app.js
+++ b/app.js
@@ -72,6 +72,12 @@ const globalElements = {
   settingsBtn: document.getElementById('settingsBtn'),
   settingsModal: document.getElementById('settingsModal'),
   settingsCloseBtn: document.getElementById('settingsCloseBtn'),
+  keyboardShortcutRows: document.getElementById('keyboardShortcutRows'),
+  keyboardShortcutEmpty: document.getElementById('keyboardShortcutEmpty'),
+  shortcutAddChat: document.getElementById('shortcutAddChat'),
+  shortcutAddWorkqueue: document.getElementById('shortcutAddWorkqueue'),
+  shortcutAddCron: document.getElementById('shortcutAddCron'),
+  shortcutAddTimeline: document.getElementById('shortcutAddTimeline'),
   rolePill: document.getElementById('rolePill'),
   loginOverlay: document.getElementById('loginOverlay'),
   loginPassword: document.getElementById('loginPassword'),
@@ -217,6 +223,25 @@ const ADMIN_AGENT_SORT_KEY = 'clawnsole.admin.agents.sort';
 const ADMIN_AGENT_ACTIVE_MINUTES_KEY = 'clawnsole.admin.agents.activeMinutes';
 const WQ_RECENT_TARGETS_KEY = 'clawnsole.wq.recentTargets';
 const WQ_RECENT_TARGETS_MAX = 6;
+const ADD_PANE_SHORTCUTS_KEY = 'clawnsole.shortcuts.addPane.v1';
+const ADD_PANE_DEFAULT_BINDINGS = {
+  chat: 'c',
+  workqueue: 'w',
+  cron: 'r',
+  timeline: 't'
+};
+const ADD_PANE_SAFE_FALLBACKS = {
+  chat: ['a', 'h', 'y'],
+  workqueue: ['q', 'u', 'x'],
+  cron: ['e', 'o', 'm'],
+  timeline: ['l', 'i', 'p']
+};
+const RESERVED_SHORTCUT_RISKS = {
+  'accel+shift+t': 'Reserved by browser tab restore / reopen closed tab.',
+  'accel+shift+w': 'Reserved by browser window close in many environments.',
+  'accel+shift+c': 'Often reserved by browser devtools/inspector.',
+  'accel+shift+r': 'Can trigger hard reload in some browsers.'
+};
 
 function readJsonFromStorage(key, fallback) {
   try {
@@ -234,6 +259,99 @@ function writeJsonToStorage(key, value) {
   } catch {
     // ignore storage failures
   }
+}
+
+function normalizeShortcutKey(value) {
+  const s = String(value || '').trim().toLowerCase();
+  return /^[a-z0-9]$/.test(s) ? s : '';
+}
+
+function readAddPaneShortcutBindings() {
+  const stored = readJsonFromStorage(ADD_PANE_SHORTCUTS_KEY, {});
+  const next = { ...ADD_PANE_DEFAULT_BINDINGS };
+  Object.keys(ADD_PANE_DEFAULT_BINDINGS).forEach((kind) => {
+    const parsed = normalizeShortcutKey(stored?.[kind]);
+    if (parsed) next[kind] = parsed;
+  });
+  return next;
+}
+
+let addPaneShortcutBindings = readAddPaneShortcutBindings();
+
+setTimeout(() => {
+  renderShortcutCheatsheetBindings();
+}, 0);
+
+function persistAddPaneShortcutBindings() {
+  writeJsonToStorage(ADD_PANE_SHORTCUTS_KEY, addPaneShortcutBindings);
+}
+
+function detectShortcutRisk(binding) {
+  const normalized = String(binding || '').toLowerCase();
+  if (RESERVED_SHORTCUT_RISKS[normalized]) return RESERVED_SHORTCUT_RISKS[normalized];
+  if (normalized.startsWith('alt+') && /\d$/.test(normalized)) {
+    return 'Layout-sensitive combo (Alt+number can be unavailable on some keyboard layouts).';
+  }
+  return '';
+}
+
+function renderKeyboardShortcutSettings() {
+  const body = globalElements.keyboardShortcutRows;
+  const empty = globalElements.keyboardShortcutEmpty;
+  if (!body) return;
+  body.innerHTML = '';
+  const rows = [
+    ['chat', 'New Chat pane'],
+    ['workqueue', 'New Workqueue pane'],
+    ['cron', 'New Cron pane'],
+    ['timeline', 'New Timeline pane']
+  ];
+  if (!rows.length) {
+    if (empty) empty.hidden = false;
+    return;
+  }
+  if (empty) empty.hidden = true;
+
+  rows.forEach(([kind, label]) => {
+    const key = normalizeShortcutKey(addPaneShortcutBindings[kind]) || ADD_PANE_DEFAULT_BINDINGS[kind];
+    const binding = `Accel+Shift+${key.toUpperCase()}`;
+    const risk = detectShortcutRisk(binding);
+    const fallback = (ADD_PANE_SAFE_FALLBACKS[kind] || []).find((candidate) => {
+      const candidateBinding = `Accel+Shift+${String(candidate).toUpperCase()}`;
+      return !detectShortcutRisk(candidateBinding);
+    }) || '';
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${escapeHtml(label)}</td>
+      <td><code>${escapeHtml(binding.replace('Accel', 'Ctrl/Cmd'))}</code></td>
+      <td>${escapeHtml(risk || 'OK')}</td>
+      <td>${fallback ? `<button type="button" class="secondary" data-shortcut-apply="${escapeHtml(kind)}" data-shortcut-key="${escapeHtml(fallback)}">Use Ctrl/Cmd+Shift+${escapeHtml(String(fallback).toUpperCase())}</button>` : '—'}</td>
+    `;
+    body.appendChild(tr);
+  });
+}
+
+function applySuggestedShortcut(kind, nextKey) {
+  const normalizedKind = String(kind || '').trim();
+  const normalizedKey = normalizeShortcutKey(nextKey);
+  if (!normalizedKind || !normalizedKey || !ADD_PANE_DEFAULT_BINDINGS[normalizedKind]) return;
+  addPaneShortcutBindings = { ...addPaneShortcutBindings, [normalizedKind]: normalizedKey };
+  persistAddPaneShortcutBindings();
+  renderKeyboardShortcutSettings();
+  renderShortcutCheatsheetBindings();
+}
+
+function renderShortcutCheatsheetBindings() {
+  const bindings = {
+    chat: normalizeShortcutKey(addPaneShortcutBindings.chat) || ADD_PANE_DEFAULT_BINDINGS.chat,
+    workqueue: normalizeShortcutKey(addPaneShortcutBindings.workqueue) || ADD_PANE_DEFAULT_BINDINGS.workqueue,
+    cron: normalizeShortcutKey(addPaneShortcutBindings.cron) || ADD_PANE_DEFAULT_BINDINGS.cron,
+    timeline: normalizeShortcutKey(addPaneShortcutBindings.timeline) || ADD_PANE_DEFAULT_BINDINGS.timeline
+  };
+  if (globalElements.shortcutAddChat) globalElements.shortcutAddChat.textContent = `Cmd/Ctrl+Shift+${bindings.chat.toUpperCase()}`;
+  if (globalElements.shortcutAddWorkqueue) globalElements.shortcutAddWorkqueue.textContent = `Cmd/Ctrl+Shift+${bindings.workqueue.toUpperCase()}`;
+  if (globalElements.shortcutAddCron) globalElements.shortcutAddCron.textContent = `Cmd/Ctrl+Shift+${bindings.cron.toUpperCase()}`;
+  if (globalElements.shortcutAddTimeline) globalElements.shortcutAddTimeline.textContent = `Cmd/Ctrl+Shift+${bindings.timeline.toUpperCase()}`;
 }
 
 function readRecentWorkqueueTargets() {
@@ -989,6 +1107,7 @@ function openSettings() {
 
   loadRecurringPromptAgents();
   loadRecurringPrompts();
+  renderKeyboardShortcutSettings();
 }
 
 function closeSettings() {
@@ -6718,6 +6837,14 @@ globalElements.recurringPromptHistoryFilter?.addEventListener('change', () => {
   recurringPromptState.historyFilterId = String(globalElements.recurringPromptHistoryFilter?.value || 'all');
   loadRecurringPromptHistory();
 });
+globalElements.keyboardShortcutRows?.addEventListener('click', (event) => {
+  const btn = event.target?.closest?.('[data-shortcut-apply]');
+  if (!btn) return;
+  const kind = String(btn.getAttribute('data-shortcut-apply') || '');
+  const nextKey = String(btn.getAttribute('data-shortcut-key') || '');
+  applySuggestedShortcut(kind, nextKey);
+  toast(`Updated shortcut for ${kind} pane.`, 'info');
+});
 globalElements.recurringPromptRows?.addEventListener('click', (event) => {
   const btn = event.target instanceof HTMLElement ? event.target.closest('[data-rp-action]') : null;
   if (!btn) return;
@@ -6940,7 +7067,11 @@ window.addEventListener('keydown', (event) => {
   const isAccel = (event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey;
   if (isAccel && roleState.role === 'admin' && !isTypingContext(event.target)) {
     const key = String(event.key || '').toLowerCase();
-    const map = { c: 'chat', w: 'workqueue', r: 'cron', t: 'timeline' };
+    const map = Object.entries(addPaneShortcutBindings).reduce((acc, [kind, binding]) => {
+      const k = normalizeShortcutKey(binding);
+      if (k) acc[k] = kind;
+      return acc;
+    }, {});
     const kind = map[key];
     if (kind) {
       // Don't hijack add-pane shortcuts while typing in inputs/editors.

--- a/app.js
+++ b/app.js
@@ -78,6 +78,12 @@ const globalElements = {
   settingsModal: document.getElementById('settingsModal'),
   settingsCloseBtn: document.getElementById('settingsCloseBtn'),
   paneSwitchHudEnabled: document.getElementById('paneSwitchHudEnabled'),
+  keyboardShortcutRows: document.getElementById('keyboardShortcutRows'),
+  keyboardShortcutEmpty: document.getElementById('keyboardShortcutEmpty'),
+  shortcutAddChat: document.getElementById('shortcutAddChat'),
+  shortcutAddWorkqueue: document.getElementById('shortcutAddWorkqueue'),
+  shortcutAddCron: document.getElementById('shortcutAddCron'),
+  shortcutAddTimeline: document.getElementById('shortcutAddTimeline'),
   rolePill: document.getElementById('rolePill'),
   loginOverlay: document.getElementById('loginOverlay'),
   loginPassword: document.getElementById('loginPassword'),
@@ -261,6 +267,25 @@ const ADMIN_AUTH_DESTINATION_TTL_MS = 10 * 60 * 1000;
 const WQ_RECENT_TARGETS_KEY = 'clawnsole.wq.recentTargets';
 const WQ_RECENT_ENQUEUE_AGENTS_KEY = 'clawnsole.wq.recentEnqueueAgents';
 const WQ_RECENT_TARGETS_MAX = 6;
+const ADD_PANE_SHORTCUTS_KEY = 'clawnsole.shortcuts.addPane.v1';
+const ADD_PANE_DEFAULT_BINDINGS = {
+  chat: 'c',
+  workqueue: 'w',
+  cron: 'r',
+  timeline: 't'
+};
+const ADD_PANE_SAFE_FALLBACKS = {
+  chat: ['a', 'h', 'y'],
+  workqueue: ['q', 'u', 'x'],
+  cron: ['e', 'o', 'm'],
+  timeline: ['l', 'i', 'p']
+};
+const RESERVED_SHORTCUT_RISKS = {
+  'accel+shift+t': 'Reserved by browser tab restore / reopen closed tab.',
+  'accel+shift+w': 'Reserved by browser window close in many environments.',
+  'accel+shift+c': 'Often reserved by browser devtools/inspector.',
+  'accel+shift+r': 'Can trigger hard reload in some browsers.'
+};
 
 function readJsonFromStorage(key, fallback) {
   try {
@@ -278,6 +303,102 @@ function writeJsonToStorage(key, value) {
   } catch {
     // ignore storage failures
   }
+}
+
+function normalizeShortcutKey(value) {
+  const s = String(value || '').trim().toLowerCase();
+  return /^[a-z0-9]$/.test(s) ? s : '';
+}
+
+function readAddPaneShortcutBindings() {
+  const stored = readJsonFromStorage(ADD_PANE_SHORTCUTS_KEY, {});
+  const next = { ...ADD_PANE_DEFAULT_BINDINGS };
+  Object.keys(ADD_PANE_DEFAULT_BINDINGS).forEach((kind) => {
+    const parsed = normalizeShortcutKey(stored?.[kind]);
+    if (parsed) next[kind] = parsed;
+  });
+  return next;
+}
+
+let addPaneShortcutBindings = readAddPaneShortcutBindings();
+
+setTimeout(() => {
+  renderShortcutCheatsheetBindings();
+}, 0);
+
+function persistAddPaneShortcutBindings() {
+  writeJsonToStorage(ADD_PANE_SHORTCUTS_KEY, addPaneShortcutBindings);
+}
+
+function detectShortcutRisk(binding) {
+  const normalized = String(binding || '').toLowerCase();
+  if (RESERVED_SHORTCUT_RISKS[normalized]) return RESERVED_SHORTCUT_RISKS[normalized];
+  if (normalized.startsWith('alt+') && /\d$/.test(normalized)) {
+    return 'Layout-sensitive combo (Alt+number can be unavailable on some keyboard layouts).';
+  }
+  return '';
+}
+
+function renderKeyboardShortcutSettings() {
+  const body = globalElements.keyboardShortcutRows;
+  const empty = globalElements.keyboardShortcutEmpty;
+  if (!body) return;
+  body.innerHTML = '';
+  const rows = [
+    ['chat', 'New Chat pane'],
+    ['workqueue', 'New Workqueue pane'],
+    ['cron', 'New Cron pane'],
+    ['timeline', 'New Timeline pane']
+  ];
+  if (!rows.length) {
+    if (empty) empty.hidden = false;
+    return;
+  }
+  if (empty) empty.hidden = true;
+
+  rows.forEach(([kind, label]) => {
+    const key = normalizeShortcutKey(addPaneShortcutBindings[kind]) || ADD_PANE_DEFAULT_BINDINGS[kind];
+    const binding = `Accel+Shift+${key.toUpperCase()}`;
+    const risk = detectShortcutRisk(binding);
+    const fallback = (ADD_PANE_SAFE_FALLBACKS[kind] || []).find((candidate) => {
+      const candidateBinding = `Accel+Shift+${String(candidate).toUpperCase()}`;
+      return !detectShortcutRisk(candidateBinding);
+    }) || '';
+    const suggestion = risk && fallback
+      ? `<button type="button" class="secondary" data-shortcut-apply="${escapeHtml(kind)}" data-shortcut-key="${escapeHtml(fallback)}">Use Ctrl/Cmd+Shift+${escapeHtml(String(fallback).toUpperCase())}</button>`
+      : '-';
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${escapeHtml(label)}</td>
+      <td><code>${escapeHtml(binding.replace('Accel', 'Ctrl/Cmd'))}</code></td>
+      <td>${escapeHtml(risk || 'OK')}</td>
+      <td>${suggestion}</td>
+    `;
+    body.appendChild(tr);
+  });
+}
+
+function applySuggestedShortcut(kind, nextKey) {
+  const normalizedKind = String(kind || '').trim();
+  const normalizedKey = normalizeShortcutKey(nextKey);
+  if (!normalizedKind || !normalizedKey || !ADD_PANE_DEFAULT_BINDINGS[normalizedKind]) return;
+  addPaneShortcutBindings = { ...addPaneShortcutBindings, [normalizedKind]: normalizedKey };
+  persistAddPaneShortcutBindings();
+  renderKeyboardShortcutSettings();
+  renderShortcutCheatsheetBindings();
+}
+
+function renderShortcutCheatsheetBindings() {
+  const bindings = {
+    chat: normalizeShortcutKey(addPaneShortcutBindings.chat) || ADD_PANE_DEFAULT_BINDINGS.chat,
+    workqueue: normalizeShortcutKey(addPaneShortcutBindings.workqueue) || ADD_PANE_DEFAULT_BINDINGS.workqueue,
+    cron: normalizeShortcutKey(addPaneShortcutBindings.cron) || ADD_PANE_DEFAULT_BINDINGS.cron,
+    timeline: normalizeShortcutKey(addPaneShortcutBindings.timeline) || ADD_PANE_DEFAULT_BINDINGS.timeline
+  };
+  if (globalElements.shortcutAddChat) globalElements.shortcutAddChat.textContent = `Cmd/Ctrl+Shift+${bindings.chat.toUpperCase()}`;
+  if (globalElements.shortcutAddWorkqueue) globalElements.shortcutAddWorkqueue.textContent = `Cmd/Ctrl+Shift+${bindings.workqueue.toUpperCase()}`;
+  if (globalElements.shortcutAddCron) globalElements.shortcutAddCron.textContent = `Cmd/Ctrl+Shift+${bindings.cron.toUpperCase()}`;
+  if (globalElements.shortcutAddTimeline) globalElements.shortcutAddTimeline.textContent = `Cmd/Ctrl+Shift+${bindings.timeline.toUpperCase()}`;
 }
 
 function getActiveAdminPaneKey() {
@@ -1397,6 +1518,7 @@ function openSettings() {
 
   loadRecurringPromptAgents();
   loadRecurringPrompts();
+  renderKeyboardShortcutSettings();
 }
 
 function closeSettings() {
@@ -8865,6 +8987,14 @@ globalElements.recurringPromptHistoryFilter?.addEventListener('change', () => {
   recurringPromptState.historyFilterId = String(globalElements.recurringPromptHistoryFilter?.value || 'all');
   loadRecurringPromptHistory();
 });
+globalElements.keyboardShortcutRows?.addEventListener('click', (event) => {
+  const btn = event.target?.closest?.('[data-shortcut-apply]');
+  if (!btn) return;
+  const kind = String(btn.getAttribute('data-shortcut-apply') || '');
+  const nextKey = String(btn.getAttribute('data-shortcut-key') || '');
+  applySuggestedShortcut(kind, nextKey);
+  toast(`Updated shortcut for ${kind} pane.`, 'info');
+});
 globalElements.recurringPromptRows?.addEventListener('click', (event) => {
   const btn = event.target instanceof HTMLElement ? event.target.closest('[data-rp-action]') : null;
   if (!btn) return;
@@ -9380,7 +9510,11 @@ window.addEventListener('keydown', (event) => {
   const isAccel = (event.metaKey || event.ctrlKey) && event.shiftKey;
   if (isAccel && roleState.role === 'admin' && !isTypingContext(event.target) && !isAnyOverlayOpen()) {
     const key = String(event.key || '').toLowerCase();
-    const map = { c: 'chat', w: 'workqueue', r: 'cron', t: 'timeline' };
+    const map = Object.entries(addPaneShortcutBindings).reduce((acc, [kind, binding]) => {
+      const k = normalizeShortcutKey(binding);
+      if (k) acc[k] = kind;
+      return acc;
+    }, {});
     const kind = map[key];
     if (kind) {
       // Don't hijack add-pane shortcuts while typing or while overlays are active.

--- a/index.html
+++ b/index.html
@@ -255,6 +255,10 @@
             <h3 class="shortcut-group-title">Pane actions</h3>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Open command palette</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd></div><div class="shortcut-desc">Add pane</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys" id="shortcutAddChat">Cmd/Ctrl+Shift+C</div><div class="shortcut-desc">New Chat pane</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys" id="shortcutAddWorkqueue">Cmd/Ctrl+Shift+W</div><div class="shortcut-desc">New Workqueue pane</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys" id="shortcutAddCron">Cmd/Ctrl+Shift+R</div><div class="shortcut-desc">New Cron pane</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys" id="shortcutAddTimeline">Cmd/Ctrl+Shift+T</div><div class="shortcut-desc">New Timeline pane</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd></div><div class="shortcut-desc">Open/focus Fleet pane</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>R</kbd></div><div class="shortcut-desc">Refresh agent list</div></div>
           </div>
@@ -541,13 +545,24 @@
             </div>
           </section>
 
-          <div class="hint" style="margin-top: 12px;">
-            <div style="font-weight: 600; margin-bottom: 6px;">Keyboard shortcuts (admin)</div>
-            <div>New Chat pane: <code>Ctrl/Cmd</code> + <code>Shift</code> + <code>C</code></div>
-            <div>New Workqueue pane: <code>Ctrl/Cmd</code> + <code>Shift</code> + <code>W</code></div>
-            <div>New Cron pane: <code>Ctrl/Cmd</code> + <code>Shift</code> + <code>R</code></div>
-            <div>New Timeline pane: <code>Ctrl/Cmd</code> + <code>Shift</code> + <code>T</code></div>
-          </div>
+          <section class="settings-section" aria-label="Keyboard shortcuts">
+            <h3 style="margin: 0 0 6px;">Keyboard shortcuts (admin)</h3>
+            <p class="hint" style="margin: 0 0 10px;">Conflicts are detected against known browser/OS reservations and layout-sensitive combinations.</p>
+            <div class="settings-rp-table-wrap">
+              <table class="settings-rp-table">
+                <thead>
+                  <tr>
+                    <th>Action</th>
+                    <th>Binding</th>
+                    <th>Risk</th>
+                    <th>Suggestion</th>
+                  </tr>
+                </thead>
+                <tbody id="keyboardShortcutRows"></tbody>
+              </table>
+              <div id="keyboardShortcutEmpty" class="hint">No keyboard shortcut rows to show.</div>
+            </div>
+          </section>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -268,7 +268,10 @@
             <h3 class="shortcut-group-title">Pane actions</h3>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Open command palette</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd></div><div class="shortcut-desc">Add pane</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>C/W/R/T</kbd></div><div class="shortcut-desc">Add Chat/Workqueue/Cron/Timeline pane (workspace only)</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys" id="shortcutAddChat">Cmd/Ctrl+Shift+C</div><div class="shortcut-desc">New Chat pane (workspace only)</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys" id="shortcutAddWorkqueue">Cmd/Ctrl+Shift+W</div><div class="shortcut-desc">New Workqueue pane (workspace only)</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys" id="shortcutAddCron">Cmd/Ctrl+Shift+R</div><div class="shortcut-desc">New Cron pane (workspace only)</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys" id="shortcutAddTimeline">Cmd/Ctrl+Shift+T</div><div class="shortcut-desc">New Timeline pane (workspace only)</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd></div><div class="shortcut-desc">Open/focus Fleet pane</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>R</kbd></div><div class="shortcut-desc">Refresh agent list</div></div>
           </div>
@@ -586,13 +589,24 @@
             </div>
           </section>
 
-          <div class="hint" style="margin-top: 12px;">
-            <div style="font-weight: 600; margin-bottom: 6px;">Keyboard shortcuts (admin)</div>
-            <div>New Chat pane: <code>Ctrl/Cmd</code> + <code>Shift</code> + <code>C</code></div>
-            <div>New Workqueue pane: <code>Ctrl/Cmd</code> + <code>Shift</code> + <code>W</code></div>
-            <div>New Cron pane: <code>Ctrl/Cmd</code> + <code>Shift</code> + <code>R</code></div>
-            <div>New Timeline pane: <code>Ctrl/Cmd</code> + <code>Shift</code> + <code>T</code></div>
-          </div>
+          <section class="settings-section" aria-label="Keyboard shortcuts">
+            <h3 style="margin: 0 0 6px;">Keyboard shortcuts (admin)</h3>
+            <p class="hint" style="margin: 0 0 10px;">Conflicts are detected against known browser/OS reservations and layout-sensitive combinations.</p>
+            <div class="settings-rp-table-wrap">
+              <table class="settings-rp-table">
+                <thead>
+                  <tr>
+                    <th>Action</th>
+                    <th>Binding</th>
+                    <th>Risk</th>
+                    <th>Suggestion</th>
+                  </tr>
+                </thead>
+                <tbody id="keyboardShortcutRows"></tbody>
+              </table>
+              <div id="keyboardShortcutEmpty" class="hint">No keyboard shortcut rows to show.</div>
+            </div>
+          </section>
         </div>
       </div>
     </div>

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -117,6 +117,53 @@ test('pane-add shortcuts are scoped to workspace and blocked by overlays', async
   await expect(panes).toHaveCount(initialCount + 1);
 });
 
+test('keyboard settings flags risky add-pane shortcuts and applies safe replacement', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  await page.locator('#settingsBtn').click();
+  await expect(page.locator('#keyboardShortcutRows')).toContainText('Often reserved by browser devtools/inspector.');
+  await page.locator('[data-shortcut-apply="chat"]').click();
+  await expect(page.locator('#keyboardShortcutRows')).toContainText('Ctrl/Cmd+Shift+A');
+  await expect(page.locator('#keyboardShortcutRows')).toContainText('OK');
+  await page.keyboard.press('Escape');
+
+  await page.click('#connectionStatus');
+  await page.keyboard.press('Shift+/');
+  await expect(page.locator('#shortcutAddChat')).toHaveText('Cmd/Ctrl+Shift+A');
+  await page.keyboard.press('Escape');
+
+  const panes = page.locator('[data-pane]');
+  const initialCount = await panes.count();
+  await page.evaluate(() => {
+    window.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'C',
+      ctrlKey: true,
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true
+    }));
+  });
+  await expect(panes).toHaveCount(initialCount);
+  await page.evaluate(() => {
+    window.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'A',
+      ctrlKey: true,
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true
+    }));
+  });
+  await expect(panes).toHaveCount(initialCount + 1);
+});
+
 test('shortcuts modal restores prior focus on close', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!app?.skipReason, app?.skipReason);


### PR DESCRIPTION
## Summary\n- add Keyboard settings table that evaluates add-pane shortcuts for known browser/OS reserved conflicts and layout-sensitive patterns\n- show clear per-shortcut risk reasons and one-click safe fallback recommendation\n- persist applied fallback bindings in local storage and wire runtime shortcut handler to updated bindings\n- update keyboard shortcuts modal rows immediately after a fallback is applied\n\n## Testing\n- npm run test:syntax ✅\n- npm run test:unit ⚠️ fails in this environment due missing `ws` module dependency