### PR TITLE
Fleet UX: sticky toolbar + frozen identity columns

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1315,6 +1315,12 @@ button.send-btn .btn-icon {
   gap: 12px;
   align-items: end;
   margin-bottom: 14px;
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  padding: 6px 0 10px;
+  background: linear-gradient(180deg, rgba(15, 20, 28, 0.98) 0%, rgba(15, 20, 28, 0.92) 72%, rgba(15, 20, 28, 0.65) 100%);
+  backdrop-filter: blur(4px);
 }
 
 .agents-last-refreshed {
@@ -1380,13 +1386,14 @@ button.send-btn .btn-icon {
 
 .agents-row {
   display: grid;
-  grid-template-columns: 42px 1fr auto;
+  grid-template-columns: 42px minmax(240px, 1fr) auto;
   gap: 10px;
   align-items: center;
   border: 1px solid rgba(255, 255, 255, 0.09);
   border-radius: 14px;
   padding: 10px 12px;
   background: rgba(255, 255, 255, 0.02);
+  min-width: 980px;
 }
 
 .agents-pin {
@@ -1397,11 +1404,22 @@ button.send-btn .btn-icon {
   background: rgba(9, 12, 16, 0.35);
   color: var(--text);
   cursor: pointer;
+  position: sticky;
+  left: 12px;
+  z-index: 4;
 }
 
 .agents-pin[aria-pressed="true"] {
   border-color: rgba(255, 179, 71, 0.55);
   background: rgba(255, 179, 71, 0.12);
+}
+
+.agents-row-main {
+  position: sticky;
+  left: 56px;
+  z-index: 3;
+  padding-right: 8px;
+  background: linear-gradient(90deg, rgba(18, 23, 32, 0.96) 0%, rgba(18, 23, 32, 0.92) 82%, rgba(18, 23, 32, 0) 100%);
 }
 
 .agents-row-title {
@@ -1476,6 +1494,7 @@ button.send-btn .btn-icon {
 @media (max-width: 860px) {
   .agents-row {
     grid-template-columns: 42px 1fr auto;
+    min-width: 0;
   }
 
   .agents-row-actions-inline {

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -83,3 +83,48 @@ test('agents modal quick actions open/reuse chat, timeline, and workqueue contex
   await firstRow.locator('[data-agent-action="open-workqueue"]').first().click();
   await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
 });
+
+test('agents modal keeps sticky toolbar + frozen identity columns when horizontally scrolled', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  await page.setViewportSize({ width: 900, height: 760 });
+  await clawnsole.gotoAndLoginAdmin(page);
+
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsModal')).toHaveClass(/open/);
+
+  const body = page.locator('#agentsModal .modal-body');
+  const toolbar = page.locator('#agentsModal .agents-toolbar');
+  const row = page.locator('#agentsList .agents-row').first();
+  const pin = row.locator('.agents-pin');
+  const identity = row.locator('.agents-row-main');
+
+  await expect(row).toBeVisible();
+  await expect(pin).toBeVisible();
+  await expect(identity).toBeVisible();
+
+  await expect(toolbar).toHaveCSS('position', 'sticky');
+  await expect(pin).toHaveCSS('position', 'sticky');
+  await expect(identity).toHaveCSS('position', 'sticky');
+
+  const before = {
+    pin: await pin.boundingBox(),
+    identity: await identity.boundingBox(),
+  };
+
+  await body.evaluate((el) => {
+    el.scrollLeft = 260;
+  });
+
+  const after = {
+    pin: await pin.boundingBox(),
+    identity: await identity.boundingBox(),
+  };
+
+  expect(before.pin && after.pin).toBeTruthy();
+  expect(before.identity && after.identity).toBeTruthy();
+
+  // Sticky/frozen columns should not drift significantly with horizontal scroll.
+  expect(Math.abs((after.pin?.x || 0) - (before.pin?.x || 0))).toBeLessThan(4);
+  expect(Math.abs((after.identity?.x || 0) - (before.identity?.x || 0))).toBeLessThan(4);
+});


### PR DESCRIPTION
## Summary
- make the Agents/Fleet toolbar sticky so controls remain visible while scrolling
- freeze identity columns (pin + agent identity) for horizontal scans on desktop widths
- add Playwright regression coverage to verify sticky/frozen behavior under horizontal scroll

## Testing
- npm test -- tests/ui/agents-modal.spec.js (fails in this environment before Playwright due missing module "ws" in unit bootstrap)
