### PR TITLE
Fix chat Stop button idle visibility + keyboard accessibility

### DIFF
--- a/app.js
+++ b/app.js
@@ -4008,15 +4008,17 @@ function paneRenderStopControl(pane) {
   const btn = pane?.elements?.stopBtn;
   if (!btn) return;
   const visible = Boolean(
-    uiState.authed &&
-      pane.connected &&
-      (pane.thinking?.active || (pane.chat?.runs && pane.chat.runs.size > 0) || (pane.abortState && pane.abortState.active)
-    )
+    uiState.authed
+      && pane.connected
+      && (pane.thinking?.active || (pane.chat?.runs && pane.chat.runs.size > 0) || (pane.abortState && pane.abortState.active))
   );
   btn.hidden = !visible;
 
   const isCanceling = Boolean(pane.abortState && pane.abortState.active);
-  btn.disabled = !uiState.authed || !pane.connected || isCanceling;
+  const enabled = visible && !isCanceling;
+  btn.disabled = !enabled;
+  btn.tabIndex = enabled ? 0 : -1;
+  btn.setAttribute('aria-hidden', visible ? 'false' : 'true');
   btn.setAttribute('aria-label', isCanceling ? 'Canceling…' : 'Stop generating');
 }
 

--- a/tests/ui/chat-pane.spec.js
+++ b/tests/ui/chat-pane.spec.js
@@ -77,3 +77,35 @@ test('chat pane: stop button can cancel a running response', async ({ page }) =>
   // Cancel should not still emit a completed reply after stream is stopped.
   await expect(pane.locator('.chat-bubble.assistant')).not.toContainText('mock-reply: please stream this', { timeout: 3000 });
 });
+
+test('chat pane: stop control is hidden/untabbable while idle and toggles for active runs', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Chat pane');
+
+  const pane = page.locator('[data-pane][data-pane-kind="chat"]').last();
+  const input = pane.locator('[data-pane-input]');
+  const sendBtn = pane.locator('[data-pane-send]');
+  const stopBtn = pane.locator('[data-pane-stop]');
+
+  await expect(sendBtn).toBeEnabled({ timeout: 90000 });
+  await expect(stopBtn).toBeHidden();
+  await expect(stopBtn).toHaveAttribute('tabindex', '-1');
+
+  await input.fill('normal non-stream reply');
+  await sendBtn.click();
+  await expect(stopBtn).toBeVisible();
+  await expect(stopBtn).toBeEnabled();
+
+  await expect(pane.locator('[data-chat-role="assistant"]').last()).toContainText('mock-reply: normal non-stream reply');
+  await expect(stopBtn).toBeHidden();
+  await expect(stopBtn).toHaveAttribute('tabindex', '-1');
+
+  await input.focus();
+  await page.keyboard.press('Tab');
+  await expect(stopBtn).not.toBeFocused();
+});


### PR DESCRIPTION
Closes #359

## Summary
- Hide Stop generating unless a run is active/canceling
- Make idle Stop non-focusable by keyboard () and disabled
- Add UI regression test for idle -> running -> idle transitions

## Validation
- 
> clawnsole@0.1.0 test
> npm run test:syntax && npm run test:unit && npm run test:proxy tests/ui/chat-pane.spec.js


> clawnsole@0.1.0 test:syntax
> node --check gateway-client.js && node --check app.js && node --check proxy.js && node --check clawnsole-server.js && node --check server.js


> clawnsole@0.1.0 test:unit
> node --test tests/unit/*.test.js

✔ escapeHtml escapes html special chars (2.93725ms)
✔ fmtRemaining formats remaining time (0.824125ms)
✔ sortWorkqueueItems default groups by status then priority then timestamps (1.879959ms)
✔ sortWorkqueueItems supports explicit sort keys and stable ordering fallback (16.227542ms)
✔ sortWorkqueueItems priority sort uses updatedAt desc tie-breaker (0.276083ms)
✔ inferPaneCols maps pane counts to sensible layout widths (0.085ms)
✔ normalizePaneKind handles aliases safely (0.073083ms)
✔ deriveAuthOverlayState captures auth/role transition flags (0.114834ms)
✔ extractChatText converts attachment/file payloads to markdown links (0.149834ms)
✔ normalizeHistoryEntries supports gateway payload variants (0.176584ms)
✔ deriveGlobalConnectionState handles signed-out, reconnecting, and hard error transitions (0.122334ms)
✔ deriveDisconnectButtonState tracks active gateway sessions (0.070541ms)
assignments set requires --queues q1,q2
✔ clawnsole workqueue assignments set/list prints expected json and normalizes queues (124.914875ms)
✔ clawnsole workqueue assignments set requires non-empty queues (51.0345ms)
✔ clawnsole workqueue claim-next: when --queues omitted uses assignments for agent (226.051541ms)
✔ clawnsole workqueue claim-next: returns {ok:true,item:null,reason:'NO_QUEUES'} when no queues resolve (47.663417ms)
✔ GET /meta returns gateway urls and port (2.9395ms)
✔ createClawnsoleServer refuses non-localhost ws:// gatewayWsUrl by default (0.881834ms)
✔ login sets cookies; /auth/role uses auth cookie (0.970083ms)
✔ login scopes cookies by instance name (0.654083ms)
✔ /token requires admin auth (0.838959ms)
✔ /token returns token_not_found when gateway token missing (0.668917ms)
✔ authVersion rotation invalidates existing cookies (0.710709ms)
✔ /upload stores files and /uploads serves them (auth required) (6.297584ms)
✔ /auth/logout clears auth cookies (3.282ms)
✔ GET /admin serves the kiosk shell (index.html); /guest returns 404 (1.057875ms)
✔ GET /agents is admin-only and returns agent ids (8.834417ms)
✔ GET /agents does not apply default workspace IDENTITY.md to all agents (1.081584ms)
✔ recurring prompts list/create responses include admin/system derived fields (1.441125ms)
✔ recurring prompt runs endpoint returns bounded recent rows (0.74925ms)
✔ handshake prefers connect.challenge (no early connect before challenge) (6.968125ms)
✔ handshake falls back to sending connect when no challenge arrives (0.425ms)
✔ handshake timeout schedules reconnect (single timer) (0.532167ms)
✔ manual disconnect does not schedule reconnect (0.346042ms)
✔ buildConnectParams receives connect.challenge payload (0.70825ms)
✔ request times out and clears pending (0.124042ms)
✔ socket close flushes pending requests (0.425375ms)
✔ keepAlive sends periodic requests only while connected (0.584375ms)
✔ maybeReconnect: offline does not schedule reconnect (0.427833ms)
✔ maybeReconnect: auth expired calls onAuthExpired and does not reconnect (0.58325ms)
✔ prepare failure sets error and schedules reconnect (0.644292ms)
✔ connect: sign-in required short-circuits without creating socket (0.372625ms)
✔ unauthorized close triggers onAuthExpired and does not reconnect (0.94925ms)
✔ admin proxy injects token + operator scopes including operator.admin on connect (1.244667ms)
✔ workqueue API: requires auth (25.656167ms)
✔ workqueue API: lists items for admin cookie (10.027292ms)
✔ workqueue API: summary returns counts + active list (3.119708ms)
✔ workqueue API: enqueue creates item (1.628792ms)
✔ workqueue API: claim-next claims a ready item (2.561875ms)
✔ workqueue API: update edits item fields (2.329042ms)
✔ workqueue API: delete removes item (2.739958ms)
✔ workqueue API: item endpoint returns one item (2.138875ms)
✔ workqueue API: transition updates status (5.435625ms)
✔ workqueue-assignments: load normalizes missing/invalid fields (4.009458ms)
✔ workqueue-assignments: save+load roundtrip normalizes queues (0.9385ms)
✔ workqueue-assignments: resolveQueuesForAgent uses agent override then defaults then param fallback (0.899125ms)
✔ resolveClaimQueues: prefers explicitly-requested queues (2.855333ms)
✔ resolveClaimQueues: uses assignments when queues omitted (1.049166ms)
✔ resolveClaimQueues: falls back to defaults when no assignment (0.148708ms)
✔ resolveClaimQueues: returns NO_QUEUES when nothing resolves (0.120125ms)
✔ workqueue: enqueue + claim-next claims distinct items (10.44575ms)
✔ workqueue: priority ordering (higher priority claimed first) (3.313583ms)
✔ workqueue: priority ordering tie-breaker is FIFO by createdAt (1.195625ms)
✔ workqueue: priority tie-breaker is deterministic when createdAt is equal (1.198875ms)
✔ workqueue: claim-next considers all requested queues when ordering (1.383667ms)
✔ workqueue: lease expiry reaps claimed items back to ready (1.420417ms)
✔ workqueue: lease expiry reaps in_progress items back to ready (1.607541ms)
✔ workqueue: claimed-by-other enforced for terminal transitions (done/failed) (1.559458ms)
✔ workqueue: progress/terminal transitions require an explicit claim (0.693084ms)
✔ workqueue: claim-next treats pending as ready (1.089458ms)
✔ workqueue: enqueue supports dedupeKey idempotency (0.745083ms)
ℹ tests 71
ℹ suites 0
ℹ pass 71
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 376.565625

> clawnsole@0.1.0 test:proxy
> node scripts/proxy-self-test.js tests/ui/chat-pane.spec.js

proxy-self-test: ok
