### PR TITLE
Fix #364: reveal pane index badges while holding Option/Alt

### DIFF
--- a/app.js
+++ b/app.js
@@ -6575,6 +6575,7 @@ const paneManager = {
   },
   updatePaneLabels() {
     this.panes.forEach((pane) => renderPaneIdentity(pane));
+    renderPaneShortcutIndexBadges();
     this.updatePaneGridLabel();
   },
   updatePaneGridLabel() {
@@ -6680,6 +6681,10 @@ globalElements.commandPaletteInput?.addEventListener('input', () => {
 globalElements.commandPaletteInput?.addEventListener('keydown', (event) => {
   if (!isCommandPaletteOpen()) return;
   const key = String(event.key || '');
+
+  if (key === 'Alt' && !event.metaKey && !event.ctrlKey && !event.shiftKey) {
+    setPaneShortcutBadgesVisible(true);
+  }
   if (key === 'Escape') {
     event.preventDefault();
     closeCommandPalette();
@@ -6838,6 +6843,32 @@ globalElements.wqEnqueueBtn?.addEventListener('click', () => workqueueEnqueueFro
 globalElements.wqClaimBtn?.addEventListener('click', () => workqueueClaimNextFromUi());
 
 let shortcutState = { lastGAtMs: 0 };
+let paneShortcutBadgesVisible = false;
+
+function renderPaneShortcutIndexBadges() {
+  const panes = Array.from(document.querySelectorAll('[data-pane]'));
+  panes.forEach((paneEl, idx) => {
+    const badge = paneEl.querySelector('[data-pane-shortcut-index-badge]');
+    if (!badge) return;
+    const shortcutIndex = idx + 1;
+    if (paneShortcutBadgesVisible && shortcutIndex <= 9) {
+      badge.hidden = false;
+      badge.textContent = String(shortcutIndex);
+      badge.setAttribute('title', `Direct focus shortcut: Alt/Option+${shortcutIndex}`);
+      return;
+    }
+    badge.hidden = true;
+    badge.textContent = '';
+    badge.removeAttribute('title');
+  });
+}
+
+function setPaneShortcutBadgesVisible(visible) {
+  const next = !!visible;
+  if (paneShortcutBadgesVisible === next) return;
+  paneShortcutBadgesVisible = next;
+  renderPaneShortcutIndexBadges();
+}
 
 function isTypingContext(target) {
   const el = target || document.activeElement;
@@ -7072,6 +7103,14 @@ window.addEventListener('keydown', (event) => {
       return;
     }
   }
+});
+
+window.addEventListener('keyup', (event) => {
+  if (String(event.key || '') === 'Alt') setPaneShortcutBadgesVisible(false);
+});
+
+window.addEventListener('blur', () => {
+  setPaneShortcutBadgesVisible(false);
 });
 
 globalElements.disconnectBtn?.addEventListener('click', () => {

--- a/index.html
+++ b/index.html
@@ -84,6 +84,7 @@
         <template id="paneTemplate">
           <section class="chat-panel pane" data-pane data-testid="pane">
             <div class="pane-header">
+              <span class="pane-shortcut-index-badge" data-pane-shortcut-index-badge hidden aria-hidden="true"></span>
               <div class="pane-header-left">
                 <div class="pane-name" data-pane-name data-testid="pane-type-label">Pane</div>
                 <div class="pane-type-pill" data-pane-type-pill data-testid="pane-type-pill" aria-label="Pane type">

--- a/styles.css
+++ b/styles.css
@@ -424,6 +424,29 @@ body::before {
   min-width: 0;
 }
 
+.pane-shortcut-index-badge {
+  position: absolute;
+  top: -8px;
+  left: -8px;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: 0.01em;
+  color: var(--text, #f5f7fb);
+  background: color-mix(in srgb, var(--pane-accent, rgba(255, 179, 71, 0.95)) 70%, #0f141d 30%);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
+  pointer-events: none;
+  z-index: 3;
+}
+
 .pane-name {
   font-size: 11px;
   text-transform: uppercase;

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -164,6 +164,34 @@ test('add-pane shortcuts do not fire while typing in chat input', async ({ page 
   await expect(panes).toHaveCount(2);
 });
 
+test('holding Alt reveals pane index badges and releasing hides them', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  await page.locator('#addPaneBtn').click();
+  await page.locator('[data-testid="pane-add-menu-cron"]').click();
+  await expect(page.locator('[data-pane]')).toHaveCount(3);
+
+  const visibleBadges = page.locator('[data-pane-shortcut-index-badge]:not([hidden])');
+  await expect(visibleBadges).toHaveCount(0);
+
+  await page.keyboard.down('Alt');
+  await expect(visibleBadges).toHaveCount(3);
+  await expect(visibleBadges.nth(0)).toHaveText('1');
+  await expect(visibleBadges.nth(1)).toHaveText('2');
+  await expect(visibleBadges.nth(2)).toHaveText('3');
+
+  await page.keyboard.up('Alt');
+  await expect(visibleBadges).toHaveCount(0);
+});
+
 test('fleet quick action button + keyboard shortcut focus existing timeline pane without duplicates', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!app?.skipReason, app?.skipReason);


### PR DESCRIPTION
## Summary\n- add temporary pane shortcut index badges (1..9) rendered in pane headers\n- show badges while Option/Alt is held and hide immediately on keyup/blur\n- recompute badges on pane label refresh so open/reorder/close stays in sync\n- add e2e coverage for hold/release behavior\n\n## Test\n- npm test -- tests/pane.shortcuts.e2e.spec.js\n\nCloses #364