### PR TITLE
Add layout mode chip with one-click restore and revert

### DIFF
--- a/app.js
+++ b/app.js
@@ -80,6 +80,8 @@ const globalElements = {
   logoutBtn: document.getElementById('logoutBtn'),
   paneControls: document.getElementById('paneControls'),
   addPaneBtn: document.getElementById('addPaneBtn'),
+  layoutModeChip: document.getElementById('layoutModeChip'),
+  layoutRevertBtn: document.getElementById('layoutRevertBtn'),
   addChatPaneBtn: document.getElementById('addChatPaneBtn'),
   addQueuePaneBtn: document.getElementById('addQueuePaneBtn'),
   layoutSelect: document.getElementById('layoutSelect'),
@@ -6118,6 +6120,56 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
 
 
 /* inlined to AppCore */
+let lastLayoutRestoreSnapshot = null;
+
+function serializeAdminPanes() {
+  return paneManager.panes.map((pane) => {
+    if (pane.kind === 'workqueue') {
+      return {
+        key: pane.key,
+        kind: 'workqueue',
+        queue: pane.workqueue?.queue || 'dev-team',
+        statusFilter: Array.isArray(pane.workqueue?.statusFilter) ? pane.workqueue.statusFilter : [],
+        sortKey: pane.workqueue?.sortKey || 'priority',
+        sortDir: pane.workqueue?.sortDir || 'desc'
+      };
+    }
+    if (pane.kind === 'cron' || pane.kind === 'timeline') return { key: pane.key, kind: pane.kind };
+    return { key: pane.key, kind: 'chat', agentId: pane.agentId || 'main' };
+  });
+}
+
+function detectLayoutMode() {
+  const panes = Array.isArray(paneManager?.panes) ? paneManager.panes : [];
+  if (panes.length === 2) {
+    const kinds = panes.map((p) => p?.kind).sort();
+    if (kinds[0] === 'chat' && kinds[1] === 'workqueue') return 'recommended';
+  }
+  return 'custom';
+}
+
+function updateLayoutModeChip() {
+  const chip = globalElements.layoutModeChip;
+  const revertBtn = globalElements.layoutRevertBtn;
+  if (!chip) return;
+  const show = roleState.role === 'admin';
+  chip.hidden = !show;
+  chip.disabled = !show;
+  if (!show) {
+    if (revertBtn) revertBtn.hidden = true;
+    return;
+  }
+  const mode = detectLayoutMode();
+  chip.textContent = mode === 'recommended' ? 'Chat+Workqueue' : 'Custom';
+  chip.dataset.layoutMode = mode;
+  chip.title = mode === 'recommended' ? 'Layout matches recommended preset' : 'Restore recommended preset';
+  if (mode === 'recommended' && revertBtn) {
+    revertBtn.hidden = !lastLayoutRestoreSnapshot;
+  } else if (revertBtn) {
+    revertBtn.hidden = true;
+  }
+}
+
 const paneManager = {
   panes: [],
   maxPanes: 6,
@@ -6166,8 +6218,13 @@ const paneManager = {
     this.panes = [];
   },
   loadAdminPanes() {
+    const activeChat = preserveActiveTarget
+      ? this.mruPaneKeys
+          .map((key) => this.findPaneByKey(key))
+          .find((pane) => pane && pane.kind === 'chat' && pane.agentId)
+      : null;
     const storedDefault = storage.get(ADMIN_DEFAULT_AGENT_KEY, 'main');
-    const defaultAgent = normalizeAgentId(storedDefault || 'main');
+    const defaultAgent = normalizeAgentId(activeChat?.agentId || storedDefault || 'main');
 
     const coerce = (item) => {
       // Legacy format: { key, agentId }
@@ -6251,7 +6308,7 @@ const paneManager = {
     });
     storage.set(ADMIN_PANES_KEY, JSON.stringify(payload));
   },
-  resetAdminLayoutToDefault({ confirm = true } = {}) {
+  resetAdminLayoutToDefault({ confirm = true, preserveActiveTarget = true } = {}) {
     if (roleState.role !== 'admin') return;
     if (confirm) {
       const ok = window.confirm('Reset layout to default (Chat + Workqueue)?');
@@ -7090,6 +7147,26 @@ globalElements.disconnectBtn?.addEventListener('click', () => {
 
 globalElements.resetLayoutBtn?.addEventListener('click', () => {
   paneManager.resetAdminLayoutToDefault({ confirm: true });
+});
+
+globalElements.layoutModeChip?.addEventListener('click', () => {
+  if (roleState.role !== 'admin') return;
+  if (detectLayoutMode() === 'recommended') return;
+  lastLayoutRestoreSnapshot = serializeAdminPanes();
+  paneManager.resetAdminLayoutToDefault({ confirm: false, preserveActiveTarget: true });
+  showToast('Layout restored to Chat+Workqueue. Use Revert to undo.', { kind: 'info', timeoutMs: 5000 });
+  updateLayoutModeChip();
+});
+
+globalElements.layoutRevertBtn?.addEventListener('click', () => {
+  if (roleState.role !== 'admin') return;
+  if (!lastLayoutRestoreSnapshot || !Array.isArray(lastLayoutRestoreSnapshot) || !lastLayoutRestoreSnapshot.length) return;
+  storage.set(ADMIN_PANES_KEY, JSON.stringify(lastLayoutRestoreSnapshot));
+  lastLayoutRestoreSnapshot = null;
+  paneManager.init();
+  paneManager.connectAll();
+  showToast('Layout reverted.', { kind: 'info', timeoutMs: 3200 });
+  updateLayoutModeChip();
 });
 
 globalElements.paneManagerBtn?.addEventListener('click', (event) => {

--- a/app.js
+++ b/app.js
@@ -6218,13 +6218,8 @@ const paneManager = {
     this.panes = [];
   },
   loadAdminPanes() {
-    const activeChat = preserveActiveTarget
-      ? this.mruPaneKeys
-          .map((key) => this.findPaneByKey(key))
-          .find((pane) => pane && pane.kind === 'chat' && pane.agentId)
-      : null;
     const storedDefault = storage.get(ADMIN_DEFAULT_AGENT_KEY, 'main');
-    const defaultAgent = normalizeAgentId(activeChat?.agentId || storedDefault || 'main');
+    const defaultAgent = normalizeAgentId(storedDefault || 'main');
 
     const coerce = (item) => {
       // Legacy format: { key, agentId }
@@ -6316,7 +6311,15 @@ const paneManager = {
     }
 
     const storedDefault = storage.get(ADMIN_DEFAULT_AGENT_KEY, 'main');
-    const defaultAgent = normalizeAgentId(storedDefault || 'main');
+    const active = document.activeElement;
+    const activeChat = preserveActiveTarget
+      ? this.panes.find((pane) => (
+          pane && pane.kind === 'chat' && pane.agentId &&
+          pane.elements?.root &&
+          (pane.elements.root === active || pane.elements.root.contains(active))
+        )) || this.panes.find((pane) => pane && pane.kind === 'chat' && pane.agentId)
+      : null;
+    const defaultAgent = normalizeAgentId(activeChat?.agentId || storedDefault || 'main');
     const paneA = { key: `p${randomId().slice(0, 8)}`, kind: 'chat', agentId: defaultAgent };
     const paneB = {
       key: `p${randomId().slice(0, 8)}`,
@@ -6657,6 +6660,7 @@ const paneManager = {
     if (!globalElements.paneGrid) return;
     const cols = inferPaneCols(this.panes.length);
     this.applyLayout(cols);
+    updateLayoutModeChip();
   },
   connectAll() {
     this.panes.forEach((pane, index) => {

--- a/index.html
+++ b/index.html
@@ -46,6 +46,12 @@
                 +
               </button>
             </div>
+            <button id="layoutModeChip" class="layout-mode-chip" type="button" aria-label="Layout mode" data-testid="layout-mode-chip" hidden>
+              Chat+Workqueue
+            </button>
+            <button id="layoutRevertBtn" class="layout-revert-btn" type="button" aria-label="Revert layout restore" data-testid="layout-revert-btn" hidden>
+              Revert
+            </button>
             <select id="layoutSelect" aria-label="Pane layout">
               <option value="1">1-up</option>
               <option value="2" selected>2-up</option>

--- a/styles.css
+++ b/styles.css
@@ -198,6 +198,28 @@ body::before {
   padding: 0;
 }
 
+.layout-mode-chip,
+.layout-revert-btn {
+  min-height: 30px;
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 11px;
+  letter-spacing: 0.03em;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(9, 12, 16, 0.45);
+  color: var(--text);
+}
+
+.layout-mode-chip[data-layout-mode="custom"] {
+  border-color: rgba(255, 179, 71, 0.5);
+  color: var(--accent);
+}
+
+.layout-mode-chip:hover,
+.layout-revert-btn:hover {
+  background: rgba(9, 12, 16, 0.68);
+}
+
 .role-pill {
   padding: 6px 12px;
   border-radius: 999px;

--- a/tests/pane.layout.e2e.spec.js
+++ b/tests/pane.layout.e2e.spec.js
@@ -64,3 +64,42 @@ test('layout: reset layout restores default (Chat + Workqueue)', async ({ page }
   await expect(panes).toHaveCount(2);
   await expect(panes.nth(1)).toHaveAttribute('data-pane-kind', 'workqueue');
 });
+
+test('layout: chip shows mode, restores recommended preset, and reverts', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const chip = page.getByTestId('layout-mode-chip');
+  const revert = page.getByTestId('layout-revert-btn');
+  await expect(chip).toBeVisible();
+  await expect(chip).toHaveText('Chat+Workqueue');
+  await expect(chip).toHaveAttribute('data-layout-mode', 'recommended');
+  await expect(revert).toBeHidden();
+
+  await page.getByRole('button', { name: 'Add pane' }).click();
+  await page.getByRole('button', { name: 'Cron pane' }).click();
+  await expect(page.locator('[data-pane]')).toHaveCount(3);
+  await expect(chip).toHaveText('Custom');
+  await expect(chip).toHaveAttribute('data-layout-mode', 'custom');
+
+  await chip.click();
+  const panes = page.locator('[data-pane]');
+  await expect(panes).toHaveCount(2);
+  await expect(panes.first()).toHaveAttribute('data-pane-kind', 'chat');
+  await expect(panes.nth(1)).toHaveAttribute('data-pane-kind', 'workqueue');
+  await expect(chip).toHaveText('Chat+Workqueue');
+  await expect(revert).toBeVisible();
+
+  await revert.click();
+  await expect(page.locator('[data-pane]')).toHaveCount(3);
+  await expect(page.locator('[data-pane]').nth(2)).toHaveAttribute('data-pane-kind', 'cron');
+  await expect(chip).toHaveText('Custom');
+  await expect(revert).toBeHidden();
+});


### PR DESCRIPTION
Fixes #365

## Summary
- add admin topbar layout-state chip showing `Chat+Workqueue` vs `Custom`
- update chip state immediately as pane composition changes
- clicking chip in `Custom` restores the recommended Chat+Workqueue preset
- preserve active chat target when restoring
- provide undo safety via a `Revert` action after restore

## Validation
- npm test
