### PR TITLE
Fleet UX: sticky selected-agent summary footer with triage actions

### DIFF
--- a/app.js
+++ b/app.js
@@ -35,6 +35,12 @@ const globalElements = {
   agentsLastRefreshed: document.getElementById('agentsLastRefreshed'),
   agentsList: document.getElementById('agentsList'),
   agentsEmpty: document.getElementById('agentsEmpty'),
+  agentsSelectionBar: document.getElementById('agentsSelectionBar'),
+  agentsSelectionTitle: document.getElementById('agentsSelectionTitle'),
+  agentsSelectionDetail: document.getElementById('agentsSelectionDetail'),
+  agentsSelectionOpenChat: document.getElementById('agentsSelectionOpenChat'),
+  agentsSelectionOpenWorkqueue: document.getElementById('agentsSelectionOpenWorkqueue'),
+  agentsSelectionOpenTimeline: document.getElementById('agentsSelectionOpenTimeline'),
   toastHost: document.getElementById('toastHost'),
   commandPaletteModal: document.getElementById('commandPaletteModal'),
   commandPaletteCloseBtn: document.getElementById('commandPaletteCloseBtn'),
@@ -397,6 +403,7 @@ let agentAutoRefreshInterval = null;
 let agentsModalAutoRefreshInterval = null;
 let agentsModalFreshnessTicker = null;
 let agentsLastRefreshedAtMs = 0;
+let selectedFleetAgentId = '';
 
 function startAgentAutoRefresh() {
   if (roleState.role !== 'admin') return;
@@ -2156,6 +2163,8 @@ function renderAgentsModalList() {
 
   root.innerHTML = '';
 
+  const visibleAgentInfo = new Map();
+
   const renderSection = (title, agents) => {
     if (!agents || agents.length === 0) return;
     const section = document.createElement('div');
@@ -2178,6 +2187,12 @@ function renderAgentsModalList() {
       const bucketLabel = triage.bucket === 'offline_error' ? 'offline/error' : triage.bucket;
       const statusSnippet = String(statusSnippetMap[id] || '').trim();
       const statusSnippetHtml = statusSnippet ? ` · <span class="agents-status-snippet">${escapeHtml(statusSnippet)}</span>` : '';
+      visibleAgentInfo.set(id, {
+        id,
+        label,
+        bucketLabel,
+        heartbeatAge
+      });
 
       row.innerHTML = `
         <button type="button" class="agents-pin" aria-label="${pinnedNow ? 'Unpin agent' : 'Pin agent'}" aria-pressed="${pinnedNow ? 'true' : 'false'}" data-agent-pin="${escapeHtml(id)}">${pinnedNow ? '★' : '☆'}</button>
@@ -2199,6 +2214,24 @@ function renderAgentsModalList() {
           </div>
         </details>
       `;
+
+      row.tabIndex = 0;
+      row.setAttribute('role', 'button');
+      row.setAttribute('aria-label', `Select ${label}`);
+      row.classList.toggle('is-selected', selectedFleetAgentId === id);
+
+      const selectThisRow = () => {
+        selectedFleetAgentId = id;
+        renderAgentsModalList();
+      };
+
+      row.addEventListener('click', () => selectThisRow());
+      row.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          selectThisRow();
+        }
+      });
 
       const pinBtn = row.querySelector('[data-agent-pin]');
       pinBtn?.addEventListener('click', (e) => {
@@ -2234,6 +2267,41 @@ function renderAgentsModalList() {
 
   const empty = pinned.length === 0 && rest.length === 0;
   if (globalElements.agentsEmpty) globalElements.agentsEmpty.hidden = !empty;
+
+  if (selectedFleetAgentId && !visibleAgentInfo.has(selectedFleetAgentId)) {
+    selectedFleetAgentId = '';
+  }
+  renderFleetSelectionBar(visibleAgentInfo.get(selectedFleetAgentId) || null);
+}
+
+function renderFleetSelectionBar(agentInfo) {
+  const bar = globalElements.agentsSelectionBar;
+  if (!bar) return;
+  bar.hidden = false;
+
+  const hasSelection = !!agentInfo?.id;
+  if (globalElements.agentsSelectionTitle) {
+    globalElements.agentsSelectionTitle.textContent = hasSelection
+      ? agentInfo.label
+      : 'No agent selected';
+  }
+  if (globalElements.agentsSelectionDetail) {
+    globalElements.agentsSelectionDetail.textContent = hasSelection
+      ? `${agentInfo.bucketLabel} · heartbeat ${agentInfo.heartbeatAge}`
+      : 'Select an agent row to open Chat, Workqueue, or Timeline faster.';
+  }
+
+  const chatBtn = globalElements.agentsSelectionOpenChat;
+  const workqueueBtn = globalElements.agentsSelectionOpenWorkqueue;
+  const timelineBtn = globalElements.agentsSelectionOpenTimeline;
+
+  if (chatBtn) chatBtn.disabled = !hasSelection;
+  if (workqueueBtn) workqueueBtn.disabled = !hasSelection;
+  if (timelineBtn) timelineBtn.disabled = !hasSelection;
+
+  if (chatBtn) chatBtn.onclick = hasSelection ? () => openAgentChatFromFleet(agentInfo.id) : null;
+  if (workqueueBtn) workqueueBtn.onclick = hasSelection ? () => openAgentWorkqueueFromFleet() : null;
+  if (timelineBtn) timelineBtn.onclick = hasSelection ? () => openAgentTimelineFromFleet(agentInfo.id) : null;
 }
 
 // Workqueue (admin-only)

--- a/index.html
+++ b/index.html
@@ -432,6 +432,17 @@
 
           <div id="agentsList" class="agents-list" aria-label="Agent list"></div>
           <div id="agentsEmpty" class="hint" hidden>No agents match.</div>
+          <div id="agentsSelectionBar" class="agents-selection-bar" role="region" aria-label="Selected agent quick actions" hidden>
+            <div class="agents-selection-meta">
+              <div id="agentsSelectionTitle" class="agents-selection-title">No agent selected</div>
+              <div id="agentsSelectionDetail" class="agents-selection-detail">Select an agent row to open Chat, Workqueue, or Timeline faster.</div>
+            </div>
+            <div class="agents-selection-actions" role="group" aria-label="Selected agent actions">
+              <button id="agentsSelectionOpenChat" class="secondary" type="button" disabled>Open Chat</button>
+              <button id="agentsSelectionOpenWorkqueue" class="secondary" type="button" disabled>Open Workqueue</button>
+              <button id="agentsSelectionOpenTimeline" class="secondary" type="button" disabled>Open Timeline</button>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -1364,6 +1364,46 @@ button.send-btn .btn-icon {
   gap: 12px;
 }
 
+.agents-selection-bar {
+  position: sticky;
+  bottom: 0;
+  margin-top: 12px;
+  z-index: 3;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid rgba(77, 196, 255, 0.35);
+  border-radius: 12px;
+  background: rgba(8, 14, 22, 0.95);
+  box-shadow: 0 -6px 18px rgba(0, 0, 0, 0.35);
+}
+
+.agents-selection-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.agents-selection-detail {
+  font-size: 12px;
+  color: var(--muted);
+  margin-top: 2px;
+}
+
+.agents-selection-actions {
+  display: inline-flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.agents-row.is-selected {
+  border-color: rgba(77, 196, 255, 0.62);
+  box-shadow: 0 0 0 1px rgba(77, 196, 255, 0.15) inset;
+}
+
 .agents-section-title {
   font-size: 11px;
   text-transform: uppercase;
@@ -1484,6 +1524,10 @@ button.send-btn .btn-icon {
 
   .agents-row-actions-overflow {
     display: block;
+  }
+
+  .agents-selection-bar {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -83,3 +83,22 @@ test('agents modal quick actions open/reuse chat, timeline, and workqueue contex
   await firstRow.locator('[data-agent-action="open-workqueue"]').first().click();
   await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
 });
+
+test('agents modal sticky selection bar follows selected row and keeps actions available', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  await clawnsole.gotoAndLoginAdmin(page);
+
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsModal')).toHaveClass(/open/);
+
+  const firstRow = page.locator('#agentsList .agents-row').first();
+  await firstRow.click();
+
+  await expect(firstRow).toHaveClass(/is-selected/);
+  await expect(page.locator('#agentsSelectionTitle')).not.toContainText('No agent selected');
+  await expect(page.locator('#agentsSelectionDetail')).toContainText(/heartbeat/i);
+
+  await page.locator('#agentsSelectionOpenTimeline').click();
+  await expect(page.locator('[data-pane][data-pane-kind="timeline"]')).toHaveCount(1);
+});


### PR DESCRIPTION
## Summary\n- add sticky selected-agent summary footer to the Agents/Fleet modal\n- keep footer visible while scrolling and show selected agent label, health bucket, and heartbeat age\n- add one-click footer actions for Chat, Workqueue, and Timeline\n- clear selection safely when filtered/refresh removes the selected row\n- add keyboard selection support (Enter/Space) and a UI test covering footer behavior\n\n## Testing\n- npm run test:syntax\n- npx playwright test tests/ui/agents-modal.spec.js --reporter=line\n\nCloses #366