### PR TITLE
Workqueue: canonicalize issue-backed row titles

### DIFF
--- a/app.js
+++ b/app.js
@@ -5284,25 +5284,27 @@ const paneManager = {
       menu.appendChild(cronBtn);
       menu.appendChild(timelineBtn);
 
-      chatBtn.addEventListener('click', () => {
-        this.closeAddPaneMenu();
-        this.addPane('chat');
-      });
+      const onMenuAdd = (kind) => (event) => {
+        if (state.menuActionInFlight) return;
+        state.menuActionInFlight = true;
+        if (event?.preventDefault) event.preventDefault();
+        if (event?.stopPropagation) event.stopPropagation();
 
-      wqBtn.addEventListener('click', () => {
         this.closeAddPaneMenu();
-        this.addPane('workqueue');
-      });
+        this.addPane(kind);
 
-      cronBtn.addEventListener('click', () => {
-        this.closeAddPaneMenu();
-        this.addPane('cron');
-      });
+        queueMicrotask(() => {
+          state.menuActionInFlight = false;
+        });
+      };
 
-      timelineBtn.addEventListener('click', () => {
-        this.closeAddPaneMenu();
-        this.addPane('timeline');
-      });
+      chatBtn.addEventListener('click', onMenuAdd('chat'));
+
+      wqBtn.addEventListener('click', onMenuAdd('workqueue'));
+
+      cronBtn.addEventListener('click', onMenuAdd('cron'));
+
+      timelineBtn.addEventListener('click', onMenuAdd('timeline'));
 
       state.menuEl = menu;
       state.chatBtn = chatBtn;

--- a/app.js
+++ b/app.js
@@ -5099,7 +5099,12 @@ const paneManager = {
       if (item && typeof item === 'object') {
         const key = typeof item.key === 'string' && item.key ? item.key : '';
         const rawKind = typeof item.kind === 'string' ? item.kind.trim().toLowerCase() : '';
-        const kind = rawKind === 'workqueue' || rawKind === 'cron' || rawKind === 'timeline' ? rawKind : 'chat';
+        const rawMode = typeof item.mode === 'string' ? item.mode.trim().toLowerCase() : '';
+        const kind = rawKind === 'workqueue' || rawKind === 'cron' || rawKind === 'timeline'
+          ? rawKind
+          : rawMode === 'workqueue' || rawMode === 'cron' || rawMode === 'timeline'
+            ? rawMode
+            : 'chat';
         if (!key) return null;
         if (kind === 'workqueue') {
           const queue = typeof item.queue === 'string' && item.queue.trim() ? item.queue.trim() : 'dev-team';

--- a/app.js
+++ b/app.js
@@ -3106,7 +3106,12 @@ function paneIsAbortable(pane) {
 function paneRenderStopControl(pane) {
   const btn = pane?.elements?.stopBtn;
   if (!btn) return;
-  const visible = Boolean(uiState.authed && pane.connected && (pane.thinking?.active || (pane.chat?.runs && pane.chat.runs.size > 0) || (pane.abortState && pane.abortState.active)));
+  const visible = Boolean(
+    uiState.authed &&
+      pane.connected &&
+      (pane.thinking?.active || (pane.chat?.runs && pane.chat.runs.size > 0) || (pane.abortState && pane.abortState.active)
+    )
+  );
   btn.hidden = !visible;
 
   const isCanceling = Boolean(pane.abortState && pane.abortState.active);
@@ -3114,59 +3119,105 @@ function paneRenderStopControl(pane) {
   btn.setAttribute('aria-label', isCanceling ? 'Canceling…' : 'Stop generating');
 }
 
+function paneRecentRunId(pane) {
+  if (!pane?.chat?.runs) return null;
+  let latest = null;
+  for (const key of pane.chat.runs.keys()) {
+    latest = key;
+  }
+  return latest;
+}
+
+function paneFinishCanceledRun(pane, { runId = null, resetSession = false, fallbackText = '' } = {}) {
+  if (!pane?.abortState) return;
+  if (pane.abortState.finished) return;
+  pane.abortState.finished = true;
+
+  if (pane.abortState.timer) {
+    clearTimeout(pane.abortState.timer);
+    pane.abortState.timer = null;
+  }
+
+  const targetRunId = runId || pane.abortState.targetRunId || pane.activeRunId;
+  const rid = targetRunId;
+  if (rid) {
+    try {
+      const entry = pane.chat?.runs?.get(rid);
+      const current = entry?.body?.textContent || '';
+      const nextText = current ? `${current}\n\n${fallbackText || '_(canceled)_'}` : `${fallbackText || '_(canceled)_'}`;
+      paneUpdateChatRun(pane, rid, nextText, true);
+    } catch {
+      paneAddChatMessage(pane, {
+        role: 'assistant',
+        text: fallbackText || '_Canceled._',
+        persist: true,
+        state: 'canceled',
+        metaLabel: `${paneAssistantLabel(pane)} · Canceled`
+      });
+    }
+    pane.abortState.canceledRunIds.add(String(rid));
+  } else {
+    paneAddChatMessage(pane, {
+      role: 'assistant',
+      text: fallbackText || '_Canceled._',
+      persist: true,
+      state: 'canceled',
+      metaLabel: `${paneAssistantLabel(pane)} · Canceled`
+    });
+  }
+
+  paneStopThinking(pane);
+  pane.activeRunId = null;
+
+  // Stop processing the active queue item and allow next messages to flow.
+  pane.pendingSend = null;
+  pane.inFlight = null;
+  panePumpOutbox(pane);
+
+  pane.abortState.targetRunId = null;
+  pane.abortState.active = false;
+  if (resetSession) {
+    try {
+      pane.client.request('sessions.reset', { key: pane.sessionKey() });
+    } catch {}
+  }
+  paneRenderStopControl(pane);
+}
+
+function paneIsAbortCanceledEvent(payload = {}) {
+  const state = String(payload.state || '').toLowerCase();
+  if (state !== 'error') return false;
+  const text = String(payload.errorMessage || '').toLowerCase();
+  return ['cancel', 'canceled', 'cancelled', 'aborted', 'interrupt'].some((needle) => text.includes(needle));
+}
 
 async function paneAbortRun(pane) {
   if (!pane || !uiState.authed || !pane.connected) return;
   if (pane.abortState && pane.abortState.active) return;
 
   pane.abortState.active = true;
+  pane.abortState.finished = false;
   pane.abortState.requestedAt = Date.now();
+  pane.abortState.targetRunId = pane.activeRunId || paneRecentRunId(pane) || null;
   paneRenderStopControl(pane);
 
   const sessionKey = pane.sessionKey();
-  const runId = pane.activeRunId;
+  const runId = pane.abortState.targetRunId;
 
-  const finishLocalCanceled = () => {
-    const rid = pane.activeRunId || runId;
-    if (rid) {
-      try {
-        const entry = pane.chat?.runs?.get(rid);
-        const current = entry?.body?.textContent || '';
-        const nextText = current ? `${current}\n\n_(canceled)_` : '_(canceled)_';
-        paneUpdateChatRun(pane, rid, nextText, true);
-      } catch {}
-    } else {
-      paneAddChatMessage(pane, { role: 'assistant', text: '_Canceled._', persist: true, state: 'canceled', metaLabel: `${paneAssistantLabel(pane)} · Canceled` });
-    }
-    paneStopThinking(pane);
-    pane.activeRunId = null;
-  };
-
-  // Fallback: if we don't get a terminal event quickly, reset the session.
+  // If we don't get a terminal event quickly, reset the session and force a canceled marker locally.
   if (pane.abortState.timer) {
     clearTimeout(pane.abortState.timer);
     pane.abortState.timer = null;
   }
   pane.abortState.timer = setTimeout(() => {
-    try {
-      pane.client.request('sessions.reset', { key: sessionKey });
-    } catch {}
-    finishLocalCanceled();
-    pane.abortState.active = false;
-    paneRenderStopControl(pane);
+    paneFinishCanceledRun(pane, { runId, resetSession: true, fallbackText: '_(canceled)_' });
   }, 2000);
 
   try {
     await pane.client.request('chat.abort', { sessionKey, runId: runId || undefined });
   } catch (err) {
     addFeed('err', 'chat.abort', String(err));
-  } finally {
-    if (pane.abortState.timer) {
-      clearTimeout(pane.abortState.timer);
-      pane.abortState.timer = null;
-    }
-    pane.abortState.active = false;
-    paneRenderStopControl(pane);
+    paneFinishCanceledRun(pane, { runId, resetSession: true, fallbackText: '_(canceled)_' });
   }
 }
 
@@ -3412,6 +3463,15 @@ function handleGatewayFrame(pane, data) {
     }
     const runId = payload.runId;
     const text = extractChatText(payload.message);
+    const abortedRun = runId && pane.abortState?.canceledRunIds?.has(String(runId));
+    if (abortedRun) {
+      pane.pendingSend = null;
+      pane.inFlight = null;
+      panePumpOutbox(pane);
+      paneStopThinking(pane);
+      paneRenderStopControl(pane);
+      return;
+    }
     if (payload.state === 'delta') {
       paneStopThinking(pane);
       pane.activeRunId = runId || pane.activeRunId;
@@ -3428,6 +3488,19 @@ function handleGatewayFrame(pane, data) {
       panePumpOutbox(pane);
       triggerFiring(1.2, 2);
     } else if (payload.state === 'error') {
+      const shouldMarkCanceled =
+        pane.abortState?.active &&
+        (Boolean(!pane.abortState.targetRunId || !runId || String(pane.abortState.targetRunId) === String(runId)) && paneIsAbortCanceledEvent(payload));
+
+      if (shouldMarkCanceled) {
+        paneFinishCanceledRun(pane, {
+          runId,
+          resetSession: false,
+          fallbackText: '_(canceled)_'
+        });
+        return;
+      }
+
       paneStopThinking(pane);
       paneUpdateChatRun(pane, runId, payload.errorMessage || 'Chat error', true);
       pane.activeRunId = null;
@@ -3820,7 +3893,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
     scroll: { pinned: true },
     thinking: { active: false, timer: null, dotsTimer: null, bubble: null },
     activeRunId: null,
-    abortState: { active: false, requestedAt: 0, timer: null },
+    abortState: { active: false, requestedAt: 0, targetRunId: null, timer: null, finished: false, canceledRunIds: new Set() },
     attachments: { files: [] },
     pendingSend: null,
     catchUp: { active: false, attemptsLeft: 0, timer: null },

--- a/app.js
+++ b/app.js
@@ -5606,6 +5606,10 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
             <input data-wq-queue-custom type="text" value="${escapeHtml(pane.workqueue.queue)}" placeholder="Custom viewing queue" hidden />
             <span class="hint">Affects which queue items are shown in this pane.</span>
           </label>
+          <label class="wq-field">
+            <span class="wq-label">Search queues</span>
+            <input data-wq-queue-search type="search" placeholder="Search queues…" aria-label="Search available queues" />
+          </label>
           </div>
 
           <div class="wq-field wq-status-field">
@@ -5760,6 +5764,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
 
     const queueSelectEl = elements.thread.querySelector('[data-wq-queue-select]');
     const queueCustomEl = elements.thread.querySelector('[data-wq-queue-custom]');
+    const queueSearchEl = elements.thread.querySelector('[data-wq-queue-search]');
     const enqueueQueueSelectEl = elements.thread.querySelector('[data-wq-enqueue-queue-select]');
     const enqueueQueueCustomEl = elements.thread.querySelector('[data-wq-enqueue-queue-custom]');
 
@@ -5973,6 +5978,61 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
       }
     };
 
+    let queueCatalog = [];
+
+    const renderQueueOptions = (allQueues) => {
+      const current = (pane.workqueue.queue || 'dev-team').trim();
+      const queueQuery = String(queueSearchEl?.value || '').trim().toLowerCase();
+      const filtered = !queueQuery
+        ? [...allQueues]
+        : allQueues.filter((q) => String(q || '').toLowerCase().includes(queueQuery));
+      if (current && !filtered.includes(current)) filtered.unshift(current);
+
+      queueSelectEl.innerHTML = '';
+      if (enqueueQueueSelectEl) enqueueQueueSelectEl.innerHTML = '';
+      for (const q of filtered) {
+        const opt = document.createElement('option');
+        opt.value = q;
+        opt.textContent = q;
+        queueSelectEl.appendChild(opt);
+        if (enqueueQueueSelectEl) {
+          const enqueueOpt = document.createElement('option');
+          enqueueOpt.value = q;
+          enqueueOpt.textContent = q;
+          enqueueQueueSelectEl.appendChild(enqueueOpt);
+        }
+      }
+
+      const customOpt = document.createElement('option');
+      customOpt.value = '__custom__';
+      customOpt.textContent = 'Custom…';
+      queueSelectEl.appendChild(customOpt);
+      if (enqueueQueueSelectEl) {
+        const enqueueCustomOpt = document.createElement('option');
+        enqueueCustomOpt.value = '__custom__';
+        enqueueCustomOpt.textContent = 'Custom…';
+        enqueueQueueSelectEl.appendChild(enqueueCustomOpt);
+      }
+
+      if (filtered.includes(current)) {
+        queueSelectEl.value = current;
+        if (queueCustomEl) queueCustomEl.hidden = true;
+        if (enqueueQueueSelectEl) enqueueQueueSelectEl.value = current;
+        if (enqueueQueueCustomEl) enqueueQueueCustomEl.hidden = true;
+      } else {
+        queueSelectEl.value = '__custom__';
+        if (queueCustomEl) {
+          queueCustomEl.hidden = false;
+          queueCustomEl.value = current;
+        }
+        if (enqueueQueueSelectEl) enqueueQueueSelectEl.value = '__custom__';
+        if (enqueueQueueCustomEl) {
+          enqueueQueueCustomEl.hidden = false;
+          enqueueQueueCustomEl.value = current;
+        }
+      }
+    };
+
     const populateQueueSelect = async () => {
       if (!queueSelectEl) return;
       try {
@@ -5982,78 +6042,14 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
         const queues = Array.isArray(data?.queues) ? data.queues : [];
 
         const current = (pane.workqueue.queue || 'dev-team').trim();
-        const unique = Array.from(new Set([current, ...queues].map((q) => String(q).trim()).filter(Boolean)));
-        unique.sort((a, b) => a.localeCompare(b));
-
-        queueSelectEl.innerHTML = '';
-        if (enqueueQueueSelectEl) enqueueQueueSelectEl.innerHTML = '';
-        for (const q of unique) {
-          const opt = document.createElement('option');
-          opt.value = q;
-          opt.textContent = q;
-          queueSelectEl.appendChild(opt);
-          if (enqueueQueueSelectEl) {
-            const enqueueOpt = document.createElement('option');
-            enqueueOpt.value = q;
-            enqueueOpt.textContent = q;
-            enqueueQueueSelectEl.appendChild(enqueueOpt);
-          }
-        }
-
-        const customOpt = document.createElement('option');
-        customOpt.value = '__custom__';
-        customOpt.textContent = 'Custom…';
-        queueSelectEl.appendChild(customOpt);
-        if (enqueueQueueSelectEl) {
-          const enqueueCustomOpt = document.createElement('option');
-          enqueueCustomOpt.value = '__custom__';
-          enqueueCustomOpt.textContent = 'Custom…';
-          enqueueQueueSelectEl.appendChild(enqueueCustomOpt);
-        }
-
-        if (unique.includes(current)) {
-          queueSelectEl.value = current;
-          if (queueCustomEl) queueCustomEl.hidden = true;
-          if (enqueueQueueSelectEl) enqueueQueueSelectEl.value = current;
-          if (enqueueQueueCustomEl) enqueueQueueCustomEl.hidden = true;
-        } else {
-          queueSelectEl.value = '__custom__';
-          if (queueCustomEl) {
-            queueCustomEl.hidden = false;
-            queueCustomEl.value = current;
-          }
-          if (enqueueQueueSelectEl) enqueueQueueSelectEl.value = '__custom__';
-          if (enqueueQueueCustomEl) {
-            enqueueQueueCustomEl.hidden = false;
-            enqueueQueueCustomEl.value = current;
-          }
-        }
+        queueCatalog = Array.from(new Set([current, ...queues].map((q) => String(q).trim()).filter(Boolean)));
+        queueCatalog.sort((a, b) => a.localeCompare(b));
+        renderQueueOptions(queueCatalog);
       } catch {
         // fallback: keep current queue editable
-        queueSelectEl.innerHTML = '';
-        if (enqueueQueueSelectEl) enqueueQueueSelectEl.innerHTML = '';
-        const opt = document.createElement('option');
-        opt.value = pane.workqueue.queue || 'dev-team';
-        opt.textContent = pane.workqueue.queue || 'dev-team';
-        queueSelectEl.appendChild(opt);
-        if (enqueueQueueSelectEl) {
-          const enqueueOpt = document.createElement('option');
-          enqueueOpt.value = opt.value;
-          enqueueOpt.textContent = opt.textContent;
-          enqueueQueueSelectEl.appendChild(enqueueOpt);
-        }
-        const customOpt = document.createElement('option');
-        customOpt.value = '__custom__';
-        customOpt.textContent = 'Custom…';
-        queueSelectEl.appendChild(customOpt);
-        if (enqueueQueueSelectEl) {
-          const enqueueCustomOpt = document.createElement('option');
-          enqueueCustomOpt.value = '__custom__';
-          enqueueCustomOpt.textContent = 'Custom…';
-          enqueueQueueSelectEl.appendChild(enqueueCustomOpt);
-        }
-        queueSelectEl.value = opt.value;
-        if (enqueueQueueSelectEl) enqueueQueueSelectEl.value = opt.value;
+        const fallback = String(pane.workqueue.queue || 'dev-team').trim() || 'dev-team';
+        queueCatalog = [fallback];
+        renderQueueOptions(queueCatalog);
       }
     };
 
@@ -6088,6 +6084,10 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
       pane.workqueue.searchQuery = String(itemSearchEl.value || '').trim();
       renderWorkqueuePaneItems(pane);
       paneManager.persistAdminPanes();
+    });
+
+    queueSearchEl?.addEventListener('input', () => {
+      renderQueueOptions(queueCatalog);
     });
 
     quickSourceEl?.addEventListener('change', () => {

--- a/app.js
+++ b/app.js
@@ -16,6 +16,11 @@ const globalElements = {
   agentsActiveMinutes: document.getElementById('agentsActiveMinutes'),
   agentsFilterGroup: document.getElementById('agentsFilterGroup'),
   agentsSortMode: document.getElementById('agentsSortMode'),
+  agentsDensityMode: document.getElementById('agentsDensityMode'),
+  agentsColumns: document.getElementById('agentsColumns'),
+  agentsColId: document.getElementById('agentsColId'),
+  agentsColHealth: document.getElementById('agentsColHealth'),
+  agentsColReason: document.getElementById('agentsColReason'),
   agentsResetTriageBtn: document.getElementById('agentsResetTriageBtn'),
   agentsList: document.getElementById('agentsList'),
   agentsEmpty: document.getElementById('agentsEmpty'),
@@ -27,6 +32,9 @@ const globalElements = {
   commandPaletteEmpty: document.getElementById('commandPaletteEmpty'),
   shortcutsModal: document.getElementById('shortcutsModal'),
   shortcutsCloseBtn: document.getElementById('shortcutsCloseBtn'),
+  shortcutsSearchInput: document.getElementById('shortcutsSearchInput'),
+  shortcutsFilterChips: document.getElementById('shortcutsFilterChips'),
+  shortcutsEmpty: document.getElementById('shortcutsEmpty'),
   paneManagerModal: document.getElementById('paneManagerModal'),
   paneManagerCloseBtn: document.getElementById('paneManagerCloseBtn'),
   paneManagerList: document.getElementById('paneManagerList'),
@@ -54,6 +62,7 @@ const globalElements = {
   settingsBtn: document.getElementById('settingsBtn'),
   settingsModal: document.getElementById('settingsModal'),
   settingsCloseBtn: document.getElementById('settingsCloseBtn'),
+  sendGuardRecentFocusEnabled: document.getElementById('sendGuardRecentFocusEnabled'),
   rolePill: document.getElementById('rolePill'),
   loginOverlay: document.getElementById('loginOverlay'),
   instanceIdentity: document.getElementById('instanceIdentity'),
@@ -95,6 +104,7 @@ const fmtRemaining = __appCore.fmtRemaining || ((msUntil) => {
   return `${sec}s`;
 });
 const sortWorkqueueItems = __appCore.sortWorkqueueItems || ((items, opts) => (Array.isArray(items) ? items.slice() : []));
+const detectShortcutConflict = __appCore.detectShortcutConflict || (() => null);
 const inferPaneCols = __appCore.inferPaneCols || ((count) => {
   const n = Number(count);
   if (!Number.isFinite(n) || n <= 1) return 1;
@@ -188,6 +198,29 @@ const ADMIN_AGENT_ACTIVE_MINUTES_KEY = 'clawnsole.admin.agents.activeMinutes';
 const ADMIN_AGENT_FILTER_KEY = 'clawnsole.admin.agents.filter';
 const ADMIN_AGENT_QUERY_KEY = 'clawnsole.admin.agents.query';
 const ADMIN_AGENT_SORT_KEY = 'clawnsole.admin.agents.sort';
+const ADMIN_AGENT_DENSITY_KEY = 'clawnsole.admin.agents.density';
+const ADMIN_AGENT_COLUMNS_KEY = 'clawnsole.admin.agents.columns';
+
+function getAgentColumnsConfig() {
+  const raw = readJsonFromStorage(ADMIN_AGENT_COLUMNS_KEY, null);
+  return {
+    id: raw?.id !== false,
+    health: raw?.health !== false,
+    reason: raw?.reason !== false
+  };
+}
+
+function applyAgentColumnsConfigToControls(cfg) {
+  if (globalElements.agentsColId) globalElements.agentsColId.checked = !!cfg.id;
+  if (globalElements.agentsColHealth) globalElements.agentsColHealth.checked = !!cfg.health;
+  if (globalElements.agentsColReason) globalElements.agentsColReason.checked = !!cfg.reason;
+}
+const SEND_GUARD_RECENT_FOCUS_ENABLED_KEY = 'clawnsole.sendGuard.recentFocus.enabled';
+const SEND_GUARD_RECENT_FOCUS_WINDOW_MS = 5000;
+
+const uiPrefs = {
+  recentFocusSendGuardEnabled: String(storage.get(SEND_GUARD_RECENT_FOCUS_ENABLED_KEY, '1')) !== '0'
+};
 
 function readJsonFromStorage(key, fallback) {
   try {
@@ -268,15 +301,22 @@ function sortAgentsByLastSeen(agents, { mode = 'recent' } = {}) {
 
 function formatAgeChip(lastSeenAtMs) {
   const ts = Number(lastSeenAtMs) || 0;
-  if (!ts) return 'never seen';
+  if (!ts) return 'heartbeat: never';
   const ageMs = Math.max(0, Date.now() - ts);
   const mins = Math.floor(ageMs / 60_000);
-  if (mins < 1) return 'last seen now';
-  if (mins < 60) return `last seen ${mins}m`;
+  if (mins < 1) return 'heartbeat: now';
+  if (mins < 60) return `heartbeat: ${mins}m`;
   const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `last seen ${hrs}h`;
+  if (hrs < 24) return `heartbeat: ${hrs}h`;
   const days = Math.floor(hrs / 24);
-  return `last seen ${days}d`;
+  return `heartbeat: ${days}d`;
+}
+
+function formatHealthChip(state) {
+  if (!state?.connected) return 'health: offline';
+  if (state?.busy) return 'health: busy';
+  if (state?.health === 'stale') return 'health: stale';
+  return 'health: connected';
 }
 
 function getAgentHealth(agentId, { withinMinutes = 10 } = {}) {
@@ -1007,6 +1047,10 @@ function openSettings() {
   globalElements.settingsModal.classList.add('open');
   globalElements.settingsModal.setAttribute('aria-hidden', 'false');
 
+  if (globalElements.sendGuardRecentFocusEnabled) {
+    globalElements.sendGuardRecentFocusEnabled.checked = !!uiPrefs.recentFocusSendGuardEnabled;
+  }
+
   // Guest mode removed.
 
   loadRecurringPromptAgents();
@@ -1018,14 +1062,118 @@ function closeSettings() {
   globalElements.settingsModal.setAttribute('aria-hidden', 'true');
 }
 
+const shortcutsUiState = {
+  query: '',
+  filter: 'all',
+  rows: [],
+  groups: [],
+  previousFocus: null
+};
+
+function deriveShortcutCategory(groupTitle) {
+  const name = String(groupTitle || '').trim().toLowerCase();
+  if (name === 'help') return 'global';
+  if (name === 'panes') return 'pane';
+  if (name === 'workqueue') return 'workqueue';
+  if (name === 'agents') return 'fleet';
+  return name || 'other';
+}
+
+function initShortcutsSearchIndex() {
+  const modal = globalElements.shortcutsModal;
+  if (!modal) return;
+  const groups = Array.from(modal.querySelectorAll('.shortcut-group'));
+  shortcutsUiState.groups = groups.map((groupEl) => {
+    const titleEl = groupEl.querySelector('.shortcut-group-title');
+    const titleText = String(titleEl?.textContent || '').trim();
+    const category = deriveShortcutCategory(titleText);
+    const rows = Array.from(groupEl.querySelectorAll('.shortcut-row')).map((rowEl) => {
+      const keysTextRaw = String(rowEl.querySelector('.shortcut-keys')?.textContent || '').trim();
+      const keysText = keysTextRaw.toLowerCase();
+      const descText = String(rowEl.querySelector('.shortcut-desc')?.textContent || '').trim().toLowerCase();
+      const conflict = detectShortcutConflict(keysTextRaw, { platform: navigator.platform || '' });
+      if (conflict) {
+        rowEl.classList.add('shortcut-row-conflict');
+        rowEl.setAttribute('title', `${conflict.reason} ${conflict.suggestion}`.trim());
+        let badge = rowEl.querySelector('.shortcut-conflict-badge');
+        if (!badge) {
+          badge = document.createElement('span');
+          badge.className = 'shortcut-conflict-badge';
+          badge.textContent = 'May conflict';
+          badge.setAttribute('aria-label', 'This shortcut may conflict with browser or OS-reserved keybinds');
+          rowEl.querySelector('.shortcut-desc')?.append(' ', badge);
+        }
+      }
+      const searchText = `${keysText} ${descText} ${titleText.toLowerCase()} ${category}`;
+      return { rowEl, searchText };
+    });
+    return { groupEl, category, rows };
+  });
+  shortcutsUiState.rows = shortcutsUiState.groups.flatMap((group) => group.rows);
+}
+
+function setShortcutsFilter(filter) {
+  shortcutsUiState.filter = String(filter || 'all').toLowerCase();
+  const chips = globalElements.shortcutsFilterChips?.querySelectorAll?.('[data-shortcuts-filter]') || [];
+  chips.forEach((chip) => {
+    const active = String(chip.dataset.shortcutsFilter || '').toLowerCase() === shortcutsUiState.filter;
+    chip.classList.toggle('is-active', active);
+    chip.setAttribute('aria-pressed', active ? 'true' : 'false');
+  });
+  filterShortcuts();
+}
+
+function shortcutRowMatchesFilter(group, row) {
+  const filter = shortcutsUiState.filter;
+  if (!filter || filter === 'all') return true;
+  if (filter === 'chat') return row.searchText.includes('chat');
+  if (filter === group.category) return true;
+  return row.searchText.includes(filter);
+}
+
+function filterShortcuts() {
+  const query = String(shortcutsUiState.query || '').trim().toLowerCase();
+  let visibleRows = 0;
+  shortcutsUiState.groups.forEach((group) => {
+    let visibleInGroup = 0;
+    group.rows.forEach((row) => {
+      const matchesFilter = shortcutRowMatchesFilter(group, row);
+      const matchesQuery = !query || row.searchText.includes(query);
+      const show = matchesFilter && matchesQuery;
+      row.rowEl.hidden = !show;
+      if (show) visibleInGroup += 1;
+    });
+    group.groupEl.hidden = visibleInGroup === 0;
+    visibleRows += visibleInGroup;
+  });
+  if (globalElements.shortcutsEmpty) {
+    globalElements.shortcutsEmpty.hidden = visibleRows !== 0;
+  }
+}
+
 function openShortcuts() {
+  if (!shortcutsUiState.groups.length) initShortcutsSearchIndex();
+  shortcutsUiState.previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
   globalElements.shortcutsModal?.classList.add('open');
   globalElements.shortcutsModal?.setAttribute('aria-hidden', 'false');
+  setShortcutsFilter('all');
+  shortcutsUiState.query = '';
+  if (globalElements.shortcutsSearchInput) {
+    globalElements.shortcutsSearchInput.value = '';
+    setTimeout(() => {
+      try { globalElements.shortcutsSearchInput.focus(); } catch {}
+    }, 0);
+  }
+  filterShortcuts();
 }
 
 function closeShortcuts() {
+  const wasOpen = !!globalElements.shortcutsModal?.classList.contains('open');
   globalElements.shortcutsModal?.classList.remove('open');
   globalElements.shortcutsModal?.setAttribute('aria-hidden', 'true');
+  if (wasOpen && shortcutsUiState.previousFocus && document.contains(shortcutsUiState.previousFocus)) {
+    try { shortcutsUiState.previousFocus.focus(); } catch {}
+  }
 }
 
 // Pane Manager (admin-only)
@@ -1089,11 +1237,39 @@ function paneRenderTypePill(pane) {
   if (pane?.elements?.typeIcon) pane.elements.typeIcon.textContent = icon;
 }
 
-function paneTargetLabel(pane) {
+function paneTargetBaseLabel(pane) {
   if (!pane) return '';
   if (pane.kind === 'workqueue') return String(pane.workqueue?.queue || 'dev-team');
   if (pane.kind === 'cron' || pane.kind === 'timeline') return 'gateway';
   return String(pane.agentId || 'main');
+}
+
+function paneIdentityKey(pane) {
+  if (!pane) return '';
+  return `${String(pane.kind || 'chat')}::${paneTargetBaseLabel(pane)}`;
+}
+
+function paneIdentityOrdinal(pane) {
+  const panes = Array.isArray(paneManager?.panes) ? paneManager.panes : [];
+  const key = paneIdentityKey(pane);
+  if (!key) return { index: 1, total: 1 };
+  const peers = panes
+    .filter((p) => paneIdentityKey(p) === key)
+    .sort((a, b) => String(a?.key || '').localeCompare(String(b?.key || '')));
+  const at = peers.findIndex((p) => String(p?.key || '') === String(pane?.key || ''));
+  return {
+    index: at >= 0 ? (at + 1) : 1,
+    total: Math.max(1, peers.length)
+  };
+}
+
+function paneTargetLabel(pane, opts = {}) {
+  const base = paneTargetBaseLabel(pane);
+  const disambiguate = !!opts?.disambiguate;
+  if (!disambiguate) return base;
+  const ord = paneIdentityOrdinal(pane);
+  if (ord.total <= 1) return base;
+  return `${base} (${ord.index})`;
 }
 
 function paneLetterLabel(pane) {
@@ -1107,7 +1283,7 @@ function paneDestinationSummary(pane) {
   return {
     letter: paneLetterLabel(pane),
     kind: paneLabel(pane),
-    target: paneTargetLabel(pane)
+    target: paneTargetLabel(pane, { disambiguate: true })
   };
 }
 
@@ -1127,7 +1303,11 @@ function paneRenderDestinationStrip(pane) {
   const valueEl = row.querySelector('[data-pane-destination-value]');
   if (!valueEl) return;
   const summary = paneDestinationSummary(pane);
-  valueEl.textContent = `${summary.letter} ${summary.kind} · ${summary.target}`;
+  if (pane?.kind === 'chat') {
+    valueEl.textContent = `Chat · ${summary.target}`;
+  } else {
+    valueEl.textContent = `${summary.kind} · messaging disabled`;
+  }
   row.dataset.warning = 'false';
 }
 
@@ -1228,6 +1408,7 @@ function renderPaneManager() {
     const unread = Math.max(0, Number(pane?.activity?.unread || 0));
     const unreadLabel = paneActivityLabel(pane);
     const hasDraft = paneHasUnsentDraft(pane);
+    const isPinned = !!pane?.pinned;
 
     row.innerHTML = `
       <div class="pane-manager-main">
@@ -1238,9 +1419,10 @@ function renderPaneManager() {
             <span class="pane-manager-kind-label">${escapeHtml(paneLabel(pane))}</span>
           </span>
         </div>
-        <div class="pane-manager-target" title="${escapeHtml(paneTargetLabel(pane))}">${escapeHtml(paneTargetLabel(pane))}</div>
+        <div class="pane-manager-target" title="${escapeHtml(paneTargetLabel(pane, { disambiguate: true }))}">${escapeHtml(paneTargetLabel(pane, { disambiguate: true }))}</div>
         <div class="pane-manager-state-chips">
           ${isDisconnected ? '<div class="pane-manager-state pane-manager-state--disconnected" data-state="disconnected" aria-label="Disconnected">Disconnected</div>' : ''}
+          ${isPinned ? '<div class="pane-manager-state" data-state="pinned" aria-label="Pinned">Pinned</div>' : ''}
           ${hasDraft ? '<div class="pane-draft-badge" aria-label="Has unsent draft">Draft</div>' : ''}
           ${unread ? `<div class="pane-activity-badge" data-kind="${escapeHtml(String(pane?.activity?.kind || 'chat'))}" aria-label="${escapeHtml(unreadLabel)}">${escapeHtml(unread > 99 ? '99+' : String(unread))}</div>` : ''}
         </div>
@@ -1248,8 +1430,9 @@ function renderPaneManager() {
       <div class="pane-manager-actions">
         <button class="secondary pane-manager-up" type="button" data-action="move-up" data-testid="pane-manager-move-up" title="Move pane up" aria-label="Move pane up" ${idx === 0 ? 'disabled' : ''}>↑</button>
         <button class="secondary pane-manager-down" type="button" data-action="move-down" data-testid="pane-manager-move-down" title="Move pane down" aria-label="Move pane down" ${idx === panes.length - 1 ? 'disabled' : ''}>↓</button>
+        <button class="secondary pane-manager-pin" type="button" data-action="pin" aria-pressed="${isPinned ? 'true' : 'false'}">${isPinned ? 'Unpin' : 'Pin'}</button>
         <button class="secondary pane-manager-focus" type="button" data-action="focus">Focus</button>
-        <button class="secondary pane-manager-close" type="button" data-action="close">Close</button>
+        <button class="secondary pane-manager-close" type="button" data-action="close" ${isPinned ? 'disabled' : ''}>Close</button>
       </div>
     `;
 
@@ -1265,6 +1448,15 @@ function renderPaneManager() {
         try {
           paneManager.removePane(pane.key);
         } catch {}
+        renderPaneManager();
+        return;
+      }
+      if (action === 'pin') {
+        pane.pinned = !pane.pinned;
+        pane.elements?.pinBtn?.setAttribute('aria-pressed', pane.pinned ? 'true' : 'false');
+        if (pane.elements?.pinBtn) pane.elements.pinBtn.textContent = pane.pinned ? '📌' : '📍';
+        paneManager.updateCloseButtons();
+        paneManager.persistAdminPanes();
         renderPaneManager();
         return;
       }
@@ -1950,6 +2142,11 @@ function openAgentsModal() {
     const sortMode = String(storage.get(ADMIN_AGENT_SORT_KEY, 'attention') || 'attention');
     globalElements.agentsSortMode.value = ['attention', 'recent', 'oldest'].includes(sortMode) ? sortMode : 'attention';
   }
+  if (globalElements.agentsDensityMode) {
+    const density = String(storage.get(ADMIN_AGENT_DENSITY_KEY, 'cozy') || 'cozy');
+    globalElements.agentsDensityMode.value = density === 'compact' ? 'compact' : 'cozy';
+  }
+  applyAgentColumnsConfigToControls(getAgentColumnsConfig());
   if (globalElements.agentsSearch) {
     globalElements.agentsSearch.value = String(storage.get(ADMIN_AGENT_QUERY_KEY, '') || '');
   }
@@ -1981,6 +2178,8 @@ function renderAgentsModalList({ fallbackToFirst = true } = {}) {
   const search = String(globalElements.agentsSearch?.value || '').trim().toLowerCase();
   const selectedFilter = String(storage.get(ADMIN_AGENT_FILTER_KEY, 'all') || 'all');
   const sortMode = String(globalElements.agentsSortMode?.value || storage.get(ADMIN_AGENT_SORT_KEY, 'attention') || 'attention');
+  const density = String(globalElements.agentsDensityMode?.value || storage.get(ADMIN_AGENT_DENSITY_KEY, 'cozy') || 'cozy');
+  const columns = getAgentColumnsConfig();
   const withinMinutes = Math.max(1, Number(globalElements.agentsActiveMinutes?.value) || 10);
   const pins = getPinnedAgentIds();
   const lastSeenMap = getAgentLastSeenMap();
@@ -2031,6 +2230,11 @@ function renderAgentsModalList({ fallbackToFirst = true } = {}) {
   const rest = sortEntries(filteredRest);
 
   root.innerHTML = '';
+  root.classList.toggle('agents-density-compact', density === 'compact');
+  root.classList.toggle('agents-density-cozy', density !== 'compact');
+  root.classList.toggle('agents-hide-id', !columns.id);
+  root.classList.toggle('agents-hide-health', !columns.health);
+  root.classList.toggle('agents-hide-reason', !columns.reason);
   globalElements.agentsFilterGroup?.querySelectorAll?.('[data-agents-filter]')?.forEach((btn) => {
     const value = String(btn.getAttribute('data-agents-filter') || 'all');
     const on = value === selectedFilter;
@@ -2062,8 +2266,9 @@ function renderAgentsModalList({ fallbackToFirst = true } = {}) {
       row.innerHTML = `
         <button type="button" class="agents-pin" aria-label="${pinnedNow ? 'Unpin agent' : 'Pin agent'}" aria-pressed="${pinnedNow ? 'true' : 'false'}" data-agent-pin="${escapeHtml(id)}">${pinnedNow ? '★' : '☆'}</button>
         <div class="agents-row-main">
-          <div class="agents-row-title-wrap"><div class="agents-row-title">${escapeHtml(label)}</div><span class="agents-age-chip">${escapeHtml(formatAgeChip(lastSeenAtMs))}</span></div>
-          <div class="agents-row-meta">${escapeHtml(id)} · ${triage.connected ? (triage.busy ? 'busy' : triage.health === 'stale' ? 'stale' : 'connected') : 'disconnected/error'}</div>
+          <div class="agents-row-title-wrap"><div class="agents-row-title">${escapeHtml(label)}</div></div>
+          <div class="agents-row-meta">${escapeHtml(id)}</div>
+          <div class="agents-row-chips"><span class="agents-health-chip">${escapeHtml(formatHealthChip(triage))}</span><span class="agents-age-chip">${escapeHtml(formatAgeChip(lastSeenAtMs))}</span></div>
           <div class="agents-row-reason"><span class="agents-reason-chip">${escapeHtml(triage.attentionReason)}</span></div>
         </div>
       `;
@@ -2367,7 +2572,9 @@ function getWorkqueueDedupeIdentity(item) {
   const key = String(item?.dedupeKey || item?.meta?.dedupeKey || '').trim();
   if (!key) return '';
   const queue = String(item?.queue || '').trim() || '__default__';
-  return `${queue}::dedupe::${key}`;
+  const title = String(item?.title || '').trim().toLowerCase().replace(/\s+/g, ' ');
+  const status = String(item?.status || '').trim().toLowerCase() || 'ready';
+  return `${queue}::dedupe::${key}::${status}::${title}`;
 }
 
 function getWorkqueueFallbackGroupIdentity(item) {
@@ -2413,13 +2620,20 @@ function finalizeWorkqueueGroup(group) {
   return group;
 }
 
+function workqueueItemUpdatedAtMs(item) {
+  const t = Date.parse(String(item?.updatedAt || item?.createdAt || ''));
+  return Number.isFinite(t) ? t : 0;
+}
+
 function groupWorkqueueItemsByDedupe(sortedItems, opts = {}) {
   const groupingEnabled = resolveWorkqueueGroupingEnabled(opts.groupingMode, Array.isArray(sortedItems) ? sortedItems.length : 0);
   const groups = [];
   const groupMap = new Map();
 
   for (const it of Array.isArray(sortedItems) ? sortedItems : []) {
-    const identity = groupingEnabled ? (getWorkqueueDedupeIdentity(it) || getWorkqueueFallbackGroupIdentity(it)) : '';
+    const strictIdentity = getWorkqueueDedupeIdentity(it);
+    const fallbackIdentity = groupingEnabled ? getWorkqueueFallbackGroupIdentity(it) : '';
+    const identity = strictIdentity || fallbackIdentity;
     if (!identity) {
       groups.push(finalizeWorkqueueGroup({ canonical: it, siblings: [] }));
       continue;
@@ -2431,7 +2645,13 @@ function groupWorkqueueItemsByDedupe(sortedItems, opts = {}) {
       groupMap.set(identity, group);
       groups.push(group);
     } else {
-      groupMap.get(identity).siblings.push(it);
+      const group = groupMap.get(identity);
+      if (workqueueItemUpdatedAtMs(it) > workqueueItemUpdatedAtMs(group.canonical)) {
+        group.siblings.push(group.canonical);
+        group.canonical = it;
+      } else {
+        group.siblings.push(it);
+      }
     }
   }
 
@@ -4477,7 +4697,11 @@ function paneShowSendGuard(pane, { origin, current, onConfirm } = {}) {
   if (!row) return;
   const msg = row.querySelector('[data-pane-send-guard-msg]');
   if (msg) {
-    msg.textContent = `You started this draft in ${paneDraftOriginLabel(origin)}, now sending to ${paneDraftOriginLabel(current)}.`;
+    if (String(origin?.paneType || '') === 'recent focus') {
+      msg.textContent = `Focus switched recently from ${String(origin?.targetAgent || 'another pane')}. Send to ${paneDraftOriginLabel(current)}?`;
+    } else {
+      msg.textContent = `You started this draft in ${paneDraftOriginLabel(origin)}, now sending to ${paneDraftOriginLabel(current)}.`;
+    }
   }
   if (pane.sendGuard) {
     pane.sendGuard.open = true;
@@ -4568,6 +4792,12 @@ async function paneSendChat(pane) {
 
   const currentOrigin = paneDraftCurrentOrigin(pane);
   const origin = pane.draftOrigin;
+  const recentFocusGuard = Boolean(
+    uiPrefs.recentFocusSendGuardEnabled &&
+    Number(pane?.lastFocusSwitchAtMs || 0) > 0 &&
+    (Date.now() - Number(pane.lastFocusSwitchAtMs || 0)) <= SEND_GUARD_RECENT_FOCUS_WINDOW_MS &&
+    !pane?.typedSinceLastFocusSwitch
+  );
   const draftMismatch = Boolean(
     origin && (
       String(origin.paneId || '') !== String(currentOrigin.paneId || '') ||
@@ -4582,6 +4812,19 @@ async function paneSendChat(pane) {
       onConfirm: () => {
         paneDismissSendGuard(pane);
         pane.draftOrigin = paneDraftCurrentOrigin(pane);
+        paneSendChat(pane);
+      }
+    });
+    return;
+  }
+
+  if (recentFocusGuard) {
+    paneShowSendGuard(pane, {
+      origin: { paneType: 'recent focus', targetAgent: pane.lastFocusedFromPaneLabel || 'another pane' },
+      current: currentOrigin,
+      onConfirm: () => {
+        paneDismissSendGuard(pane);
+        pane.typedSinceLastFocusSwitch = true;
         paneSendChat(pane);
       }
     });
@@ -5082,7 +5325,7 @@ function renderAgentOptions(selectEl, agentId) {
   selectEl.value = normalizeAgentId(agentId || 'main');
 }
 
-function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, quickFilters, scope, sortKey, sortDir, closable = true } = {}) {
+function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, quickFilters, scope, sortKey, sortDir, closable = true, pinned = false } = {}) {
   const template = globalElements.paneTemplate;
   const root = template.content.firstElementChild.cloneNode(true);
   const elements = {
@@ -5102,6 +5345,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
     status: root.querySelector('[data-pane-status]'),
     helpDetails: root.querySelector('[data-pane-help]'),
     helpPopover: root.querySelector('[data-pane-help-popover]'),
+    pinBtn: root.querySelector('[data-pane-pin]'),
     closeBtn: root.querySelector('[data-pane-close]'),
     thread: root.querySelector('[data-pane-thread]'),
     scrollDownBtn: root.querySelector('[data-pane-scroll-down]'),
@@ -5145,6 +5389,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
     statusState: 'disconnected',
     activity: { unread: 0, kind: '' },
     statusMeta: '',
+    pinned: !!pinned,
     elements,
     chat: { runs: new Map(), history: [] },
     scroll: { pinned: true },
@@ -5158,6 +5403,9 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
     inFlight: null,
     draftOrigin: null,
     sendGuard: { open: false, onConfirm: null },
+    lastFocusSwitchAtMs: 0,
+    lastFocusedFromPaneLabel: '',
+    typedSinceLastFocusSwitch: false,
     chatKey: () => computeChatKey({ role: pane.role, agentId: pane.agentId }),
     legacySessionKey: () => computeLegacySessionKey({ role: pane.role, agentId: pane.agentId }),
     sessionKey: () => computeSessionKey({ role: pane.role, agentId: pane.agentId, paneKey: pane.key }),
@@ -5209,6 +5457,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
             lines: ['Shows queued work items, grouped by status.', 'Drag cards between columns to change status.', 'Use Refresh when another worker updates the queue.'],
             shortcuts: [
               ['g w', 'open Workqueue modal'],
+              ['Ctrl+Tab / Ctrl+Shift+Tab', 'switch panes by recent focus (MRU)'],
               ['Cmd/Ctrl+Shift+K', 'focus next pane'],
               ['Cmd/Ctrl+Shift+J', 'focus previous pane']
             ]
@@ -5220,6 +5469,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
             lines: ['Shows scheduled jobs in the Gateway cron scheduler.', 'Use filters to find failing/disabled jobs.', 'Use Run/Edit/Disable for quick ops.'],
             shortcuts: [
               ['?', 'keyboard shortcuts overlay'],
+              ['Ctrl+Tab / Ctrl+Shift+Tab', 'switch panes by recent focus (MRU)'],
               ['Cmd/Ctrl+Shift+K', 'focus next pane'],
               ['Cmd/Ctrl+Shift+J', 'focus previous pane']
             ]
@@ -5231,6 +5481,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
             lines: ['Shows recent cron run history (best-effort).', 'Adjust range/status/search to find events.', 'Click View to inspect the underlying job.'],
             shortcuts: [
               ['?', 'keyboard shortcuts overlay'],
+              ['Ctrl+Tab / Ctrl+Shift+Tab', 'switch panes by recent focus (MRU)'],
               ['Cmd/Ctrl+Shift+K', 'focus next pane'],
               ['Cmd/Ctrl+Shift+J', 'focus previous pane']
             ]
@@ -5241,6 +5492,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
           lines: ['Chat with an agent/session.', 'Pick an agent target, then send messages/files.', 'Use Stop to cancel a long response.'],
           shortcuts: [
             ['Alt/Option+1..9 or Cmd/Ctrl+Shift+1..9', 'focus visible pane by order'],
+            ['Ctrl+Tab / Ctrl+Shift+Tab', 'switch panes by recent focus (MRU)'],
             ['Cmd/Ctrl+1..4', 'focus a pane (legacy index)'],
             ['Cmd/Ctrl+Shift+K', 'focus next pane'],
             ['Cmd/Ctrl+Shift+J', 'focus previous pane']
@@ -5280,6 +5532,28 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
     });
   }
 
+  const renderPanePinButton = () => {
+    if (!elements.pinBtn) return;
+    elements.pinBtn.hidden = role !== 'admin';
+    if (role !== 'admin') return;
+    const pinnedNow = !!pane.pinned;
+    elements.pinBtn.setAttribute('aria-pressed', pinnedNow ? 'true' : 'false');
+    elements.pinBtn.setAttribute('aria-label', pinnedNow ? 'Unpin pane' : 'Pin pane');
+    elements.pinBtn.setAttribute('title', pinnedNow ? 'Pinned: click to unpin' : 'Pin pane to prevent accidental close');
+    elements.pinBtn.textContent = pinnedNow ? '📌' : '📍';
+  };
+  renderPanePinButton();
+  elements.pinBtn?.addEventListener('click', () => {
+    if (role !== 'admin') return;
+    pane.pinned = !pane.pinned;
+    renderPanePinButton();
+    paneManager.updateCloseButtons();
+    paneManager.persistAdminPanes();
+    try {
+      showToast(pane.pinned ? 'Pane pinned' : 'Pane unpinned', { kind: 'info', timeoutMs: 1500 });
+    } catch {}
+  });
+
   if (elements.stopBtn) {
     elements.stopBtn.addEventListener('click', (e) => {
       e.preventDefault();
@@ -5289,6 +5563,14 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
   }
 
   elements.root.addEventListener('focusin', () => {
+    const prev = paneManager.lastFocusedPaneKey || null;
+    paneManager.notePaneFocused(pane);
+    if (prev && String(prev) !== String(pane.key || '')) {
+      pane.lastFocusSwitchAtMs = Date.now();
+      const fromPane = paneManager.panes.find((candidate) => String(candidate?.key || '') === String(prev));
+      pane.lastFocusedFromPaneLabel = paneManager.formatPaneIdentity(fromPane);
+      pane.typedSinceLastFocusSwitch = false;
+    }
     paneClearUnread(pane);
     renderPaneShortcutHints(pane);
   });
@@ -6664,6 +6946,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
   });
 
   elements.input.addEventListener('input', () => {
+    pane.typedSinceLastFocusSwitch = true;
     paneSyncDraftOrigin(pane);
     paneUpdateCommandHints(pane);
   });
@@ -6707,6 +6990,41 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
 const paneManager = {
   panes: [],
   maxPanes: 6,
+  mruPaneKeys: [],
+  lastFocusedPaneKey: null,
+  notePaneFocused(pane) {
+    if (!pane?.key) return;
+    const key = String(pane.key);
+    this.mruPaneKeys = [key, ...this.mruPaneKeys.filter((candidate) => candidate !== key)].slice(0, this.maxPanes * 2);
+    this.lastFocusedPaneKey = key;
+  },
+  getPaneMRUOrder() {
+    const byKey = new Map(this.panes.map((pane) => [String(pane?.key || ''), pane]));
+    const ordered = this.mruPaneKeys.map((key) => byKey.get(key)).filter(Boolean);
+    const seen = new Set(ordered.map((pane) => String(pane.key)));
+    for (const pane of this.panes) {
+      const key = String(pane?.key || '');
+      if (!key || seen.has(key)) continue;
+      ordered.push(pane);
+      seen.add(key);
+    }
+    return ordered;
+  },
+  formatPaneIdentity(pane) {
+    if (!pane?.key) return 'Pane';
+    const idx = this.panes.findIndex((candidate) => candidate?.key === pane.key);
+    const letter = idx >= 0 ? String.fromCharCode(65 + (idx % 26)) : '?';
+    const type = pane.kind === 'workqueue' ? 'Workqueue' : pane.kind === 'timeline' ? 'Timeline' : pane.kind === 'cron' ? 'Cron' : 'Chat';
+    if (pane.kind === 'workqueue') {
+      const queue = String(pane.workqueue?.queue || 'dev-team').trim() || 'dev-team';
+      return `${letter} ${type} · ${queue}`;
+    }
+    if (pane.kind === 'chat') {
+      const target = String(pane.agentId || 'main').trim() || 'main';
+      return `${letter} ${type} · ${target}`;
+    }
+    return `${letter} ${type}`;
+  },
   init() {
     this.destroyAll();
 
@@ -6726,6 +7044,7 @@ const paneManager = {
         role: 'admin',
         kind: cfg.kind || 'chat',
         agentId: cfg.agentId,
+        pinned: !!cfg.pinned,
         queue: cfg.queue,
         statusFilter: cfg.statusFilter,
         quickFilters: cfg.quickFilters,
@@ -6765,6 +7084,7 @@ const paneManager = {
       } catch {}
     });
     this.panes = [];
+    this.mruPaneKeys = [];
   },
   loadAdminPanes() {
     const storedDefault = storage.get(ADMIN_DEFAULT_AGENT_KEY, 'main');
@@ -6808,15 +7128,15 @@ const paneManager = {
                 actionableOnly: !!item.quickFilters.actionableOnly
               }
             : { source: '', repo: '', actionableOnly: false };
-          return { key, kind, queue, statusFilter, scope, sortKey, sortDir, quickFilters };
+          return { key, kind, pinned: !!item.pinned, queue, statusFilter, scope, sortKey, sortDir, quickFilters };
         }
 
         if (kind === 'cron' || kind === 'timeline') {
-          return { key, kind };
+          return { key, kind, pinned: !!item.pinned };
         }
 
         const agentId = normalizeAgentId(typeof item.agentId === 'string' ? item.agentId : defaultAgent);
-        return { key, kind, agentId };
+        return { key, kind, pinned: !!item.pinned, agentId };
       }
 
       // Super-legacy format: ['pabc','pdef'] (treat as chat panes)
@@ -6862,6 +7182,7 @@ const paneManager = {
         return {
           key: pane.key,
           kind: 'workqueue',
+          pinned: !!pane.pinned,
           queue: pane.workqueue?.queue || 'dev-team',
           statusFilter: Array.isArray(pane.workqueue?.statusFilter) ? pane.workqueue.statusFilter : [],
           quickFilters: {
@@ -6875,9 +7196,9 @@ const paneManager = {
         };
       }
       if (pane.kind === 'cron' || pane.kind === 'timeline') {
-        return { key: pane.key, kind: pane.kind };
+        return { key: pane.key, kind: pane.kind, pinned: !!pane.pinned };
       }
-      return { key: pane.key, kind: 'chat', agentId: pane.agentId || 'main' };
+      return { key: pane.key, kind: 'chat', pinned: !!pane.pinned, agentId: pane.agentId || 'main' };
     });
     storage.set(ADMIN_PANES_KEY, JSON.stringify(payload));
   },
@@ -7220,6 +7541,10 @@ const paneManager = {
   canRemovePane(pane, { silent = false } = {}) {
     if (roleState.role !== 'admin') return false;
     if (!pane) return false;
+    if (pane.pinned) {
+      if (!silent) showToast('This pane is pinned. Unpin it before closing.', { kind: 'info', timeoutMs: 2200 });
+      return false;
+    }
     if (this.panes.length <= 1) return false;
 
     const kind = normalizePaneKind(pane.kind);
@@ -7244,6 +7569,7 @@ const paneManager = {
     if (!this.canRemovePane(pane)) return;
     if (!paneCloseGuardPrompt(pane)) return;
     this.panes.splice(idx, 1);
+    this.mruPaneKeys = this.mruPaneKeys.filter((candidate) => candidate !== String(key));
     try {
       pane.client?.disconnect(true);
     } catch {}
@@ -7366,10 +7692,23 @@ globalElements.settingsCloseBtn?.addEventListener('click', () => closeSettings()
 globalElements.settingsModal?.addEventListener('click', (event) => {
   if (event.target === globalElements.settingsModal) closeSettings();
 });
+globalElements.sendGuardRecentFocusEnabled?.addEventListener('change', () => {
+  uiPrefs.recentFocusSendGuardEnabled = !!globalElements.sendGuardRecentFocusEnabled.checked;
+  storage.set(SEND_GUARD_RECENT_FOCUS_ENABLED_KEY, uiPrefs.recentFocusSendGuardEnabled ? '1' : '0');
+});
 
 globalElements.shortcutsCloseBtn?.addEventListener('click', () => closeShortcuts());
 globalElements.shortcutsModal?.addEventListener('click', (event) => {
   if (event.target === globalElements.shortcutsModal) closeShortcuts();
+});
+globalElements.shortcutsSearchInput?.addEventListener('input', () => {
+  shortcutsUiState.query = globalElements.shortcutsSearchInput.value || '';
+  filterShortcuts();
+});
+globalElements.shortcutsFilterChips?.addEventListener('click', (event) => {
+  const target = event.target instanceof HTMLElement ? event.target.closest('[data-shortcuts-filter]') : null;
+  if (!target) return;
+  setShortcutsFilter(target.dataset.shortcutsFilter || 'all');
 });
 globalElements.commandPaletteCloseBtn?.addEventListener('click', () => closeCommandPalette());
 globalElements.commandPaletteModal?.addEventListener('click', (event) => {
@@ -7466,12 +7805,32 @@ globalElements.agentsSortMode?.addEventListener('change', () => {
   renderAgentsModalList();
 });
 
+globalElements.agentsDensityMode?.addEventListener('change', () => {
+  const mode = String(globalElements.agentsDensityMode.value || 'cozy');
+  storage.set(ADMIN_AGENT_DENSITY_KEY, mode === 'compact' ? 'compact' : 'cozy');
+  renderAgentsModalList();
+});
+
+globalElements.agentsColumns?.addEventListener('change', () => {
+  const cfg = {
+    id: !!globalElements.agentsColId?.checked,
+    health: !!globalElements.agentsColHealth?.checked,
+    reason: !!globalElements.agentsColReason?.checked
+  };
+  writeJsonToStorage(ADMIN_AGENT_COLUMNS_KEY, cfg);
+  renderAgentsModalList();
+});
+
 globalElements.agentsResetTriageBtn?.addEventListener('click', () => {
   if (globalElements.agentsSearch) globalElements.agentsSearch.value = '';
   if (globalElements.agentsSortMode) globalElements.agentsSortMode.value = 'attention';
   storage.remove(ADMIN_AGENT_QUERY_KEY);
   storage.remove(ADMIN_AGENT_SORT_KEY);
   storage.remove(ADMIN_AGENT_FILTER_KEY);
+  storage.remove(ADMIN_AGENT_DENSITY_KEY);
+  storage.remove(ADMIN_AGENT_COLUMNS_KEY);
+  if (globalElements.agentsDensityMode) globalElements.agentsDensityMode.value = 'cozy';
+  applyAgentColumnsConfigToControls({ id: true, health: true, reason: true });
   renderAgentsModalList();
   try {
     globalElements.agentsSearch?.focus?.();
@@ -7639,6 +7998,22 @@ function cyclePaneFocusBackward() {
   const idx = panes.findIndex((p) => p.elements?.root && (p.elements.root === active || p.elements.root.contains(active)));
   const prev = idx >= 0 ? (idx - 1 + panes.length) % panes.length : panes.length - 1;
   focusPaneIndex(prev);
+}
+
+function cyclePaneFocusMRU(direction = 'backward') {
+  const panes = paneManager.panes;
+  if (!panes || panes.length < 2) return;
+
+  const ordered = paneManager.getPaneMRUOrder();
+  if (ordered.length < 2) return;
+
+  const target = direction === 'forward' ? (ordered[2] || ordered[ordered.length - 1]) : ordered[1];
+  if (!target) return;
+
+  const idx = panes.findIndex((pane) => pane?.key === target.key);
+  if (idx < 0) return;
+  focusPaneIndex(idx);
+  showToast(`Switched to ${paneManager.formatPaneIdentity(target)}`, { kind: 'info', timeoutMs: 1200 });
 }
 
 function cyclePaneFocusByKind(kind, direction = 'next') {
@@ -7835,6 +8210,13 @@ window.addEventListener('keydown', (event) => {
   if ((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey && key.toLowerCase() === 'j') {
     event.preventDefault();
     cyclePaneFocusBackward();
+    return;
+  }
+
+  // Ctrl+Tab / Ctrl+Shift+Tab switches panes by MRU order.
+  if (event.ctrlKey && !event.metaKey && !event.altKey && key === 'Tab') {
+    event.preventDefault();
+    cyclePaneFocusMRU(event.shiftKey ? 'forward' : 'backward');
     return;
   }
 

--- a/app.js
+++ b/app.js
@@ -13,8 +13,9 @@ const globalElements = {
   agentsModal: document.getElementById('agentsModal'),
   agentsCloseBtn: document.getElementById('agentsCloseBtn'),
   agentsSearch: document.getElementById('agentsSearch'),
-  agentsActiveOnly: document.getElementById('agentsActiveOnly'),
   agentsActiveMinutes: document.getElementById('agentsActiveMinutes'),
+  agentsFilterGroup: document.getElementById('agentsFilterGroup'),
+  agentsSortMode: document.getElementById('agentsSortMode'),
   agentsList: document.getElementById('agentsList'),
   agentsEmpty: document.getElementById('agentsEmpty'),
   toastHost: document.getElementById('toastHost'),
@@ -35,6 +36,7 @@ const globalElements = {
   wqStatusFilters: document.getElementById('wqStatusFilters'),
   wqAutoRefreshEnabled: document.getElementById('wqAutoRefreshEnabled'),
   wqAutoRefreshInterval: document.getElementById('wqAutoRefreshInterval'),
+  wqGroupingMode: document.getElementById('wqGroupingMode'),
   wqRefreshBtn: document.getElementById('wqRefreshBtn'),
   wqListBody: document.getElementById('wqListBody'),
   wqListEmpty: document.getElementById('wqListEmpty'),
@@ -59,6 +61,7 @@ const globalElements = {
   logoutBtn: document.getElementById('logoutBtn'),
   paneControls: document.getElementById('paneControls'),
   addPaneBtn: document.getElementById('addPaneBtn'),
+  resetLayoutQuickBtn: document.getElementById('resetLayoutQuickBtn'),
   addChatPaneBtn: document.getElementById('addChatPaneBtn'),
   addQueuePaneBtn: document.getElementById('addQueuePaneBtn'),
   layoutSelect: document.getElementById('layoutSelect'),
@@ -162,11 +165,12 @@ const storage = {
   }
 };
 
-// Agent list UX (pins + active-only)
+// Agent list UX (pins + triage)
 const ADMIN_AGENT_PINS_KEY = 'clawnsole.admin.agentPins';
 const ADMIN_AGENT_LAST_SEEN_KEY = 'clawnsole.admin.agentLastSeenAtMs';
-const ADMIN_AGENT_ACTIVE_ONLY_KEY = 'clawnsole.admin.agents.activeOnly';
 const ADMIN_AGENT_ACTIVE_MINUTES_KEY = 'clawnsole.admin.agents.activeMinutes';
+const ADMIN_AGENT_FILTER_KEY = 'clawnsole.admin.agents.filter';
+const ADMIN_AGENT_SORT_KEY = 'clawnsole.admin.agents.sort';
 
 function readJsonFromStorage(key, fallback) {
   try {
@@ -230,14 +234,85 @@ function isAgentActive(agentId, { withinMinutes = 10 } = {}) {
   return Date.now() - ts <= windowMs;
 }
 
-function sortAgentsByLastSeen(agents) {
+function sortAgentsByLastSeen(agents, { mode = 'recent' } = {}) {
   const map = getAgentLastSeenMap();
   const ts = (a) => Number(map[String(a?.id || '').trim()]) || 0;
+  const dir = String(mode || 'recent') === 'oldest' ? 1 : -1;
   return (Array.isArray(agents) ? agents : []).slice().sort((a, b) => {
-    const dt = ts(b) - ts(a);
+    const at = ts(a);
+    const bt = ts(b);
+    if (!at && bt) return 1;
+    if (at && !bt) return -1;
+    const dt = (at - bt) * dir;
     if (dt) return dt;
     return formatAgentLabel(a, { includeId: true }).localeCompare(formatAgentLabel(b, { includeId: true }));
   });
+}
+
+function formatAgeChip(lastSeenAtMs) {
+  const ts = Number(lastSeenAtMs) || 0;
+  if (!ts) return 'never seen';
+  const ageMs = Math.max(0, Date.now() - ts);
+  const mins = Math.floor(ageMs / 60_000);
+  if (mins < 1) return 'last seen now';
+  if (mins < 60) return `last seen ${mins}m`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `last seen ${hrs}h`;
+  const days = Math.floor(hrs / 24);
+  return `last seen ${days}d`;
+}
+
+function getAgentHealth(agentId, { withinMinutes = 10 } = {}) {
+  const id = String(agentId || '').trim();
+  if (!id) return 'offline_error';
+  const map = getAgentLastSeenMap();
+  const ts = Number(map[id]) || 0;
+  const status = paneManager?.panes?.find((p) => p?.kind === 'chat' && String(p?.agentId || '') === id)?.statusState || '';
+  if (status === 'offline' || status === 'error') return 'offline_error';
+  if (!ts) return 'offline_error';
+  if (isAgentActive(id, { withinMinutes })) return 'active';
+  return 'stale';
+}
+
+function getAgentConnectionState(agentId, { withinMinutes = 10 } = {}) {
+  const id = String(agentId || '').trim();
+  const pane = paneManager?.panes?.find((p) => p?.kind === 'chat' && String(p?.agentId || '') === id) || null;
+  const status = String(pane?.statusState || '');
+  const health = getAgentHealth(id, { withinMinutes });
+  const connected = health !== 'offline_error';
+  const busy = status === 'connecting' || status === 'reconnecting';
+  return { status, health, connected, busy };
+}
+
+function getAgentTriageMeta(agentId, { withinMinutes = 10 } = {}) {
+  const id = String(agentId || '').trim();
+  const map = getAgentLastSeenMap();
+  const ts = Number(map[id]) || 0;
+  const ageMs = ts ? Math.max(0, Date.now() - ts) : null;
+  const state = getAgentConnectionState(id, { withinMinutes });
+
+  let attentionScore = 0;
+  let reason = 'Healthy';
+
+  if (!state.connected) {
+    attentionScore = 300;
+    reason = 'Disconnected';
+  } else if (state.busy) {
+    attentionScore = 220;
+    reason = 'Busy';
+  } else if (state.health === 'stale') {
+    const staleMinutes = Math.max(1, Math.floor((ageMs || 0) / 60_000));
+    attentionScore = 120 + Math.min(120, staleMinutes);
+    reason = `Stale ${staleMinutes}m`;
+  }
+
+  return {
+    ...state,
+    ageMs,
+    attentionScore,
+    attentionReason: reason,
+    needsAttention: attentionScore > 0
+  };
 }
 
 const roleState = {
@@ -883,11 +958,17 @@ function isPaneManagerOpen() {
   return !!globalElements.paneManagerModal?.classList.contains('open');
 }
 
+function refreshPaneManagerIfOpen() {
+  if (!isPaneManagerOpen()) return;
+  renderPaneManager();
+}
+
 function paneLabel(pane) {
   const kind = pane?.kind || 'chat';
   if (kind === 'workqueue') return 'Workqueue';
   if (kind === 'cron') return 'Cron';
   if (kind === 'timeline') return 'Timeline';
+  if (kind === 'fleet') return 'Fleet';
   return 'Chat';
 }
 
@@ -896,7 +977,31 @@ function paneIcon(pane) {
   if (kind === 'workqueue') return 'WQ';
   if (kind === 'cron') return '⏰';
   if (kind === 'timeline') return '🕒';
+  if (kind === 'fleet') return '🛰️';
   return '💬';
+}
+
+function paneTypePresentation(pane) {
+  const kind = String(pane?.kind || 'chat');
+  return {
+    kind,
+    text: paneLabel(pane).toUpperCase(),
+    icon: paneIcon(pane)
+  };
+}
+
+function paneRenderTypePill(pane) {
+  const pill = pane?.elements?.typePill;
+  if (!pill) return;
+  const { kind, text, icon } = paneTypePresentation(pane);
+
+  const knownKinds = ['chat', 'workqueue', 'cron', 'timeline', 'fleet'];
+  for (const name of knownKinds) pill.classList.remove(`pane-type-${name}`);
+  pill.classList.add(`pane-type-${knownKinds.includes(kind) ? kind : 'chat'}`);
+  pill.setAttribute('aria-label', `Pane type ${paneLabel(pane)}`);
+
+  if (pane?.elements?.typeText) pane.elements.typeText.textContent = text;
+  if (pane?.elements?.typeIcon) pane.elements.typeIcon.textContent = icon;
 }
 
 function paneTargetLabel(pane) {
@@ -904,6 +1009,95 @@ function paneTargetLabel(pane) {
   if (pane.kind === 'workqueue') return String(pane.workqueue?.queue || 'dev-team');
   if (pane.kind === 'cron' || pane.kind === 'timeline') return 'gateway';
   return String(pane.agentId || 'main');
+}
+
+function paneLetterLabel(pane) {
+  const idx = paneManager?.panes?.findIndex?.((p) => String(p?.key || '') === String(pane?.key || ''));
+  if (!Number.isFinite(idx) || idx < 0) return '?';
+  return String.fromCharCode(65 + (idx % 26));
+}
+
+function paneDestinationSummary(pane) {
+  if (!pane) return { letter: '?', kind: 'Chat', target: 'main' };
+  return {
+    letter: paneLetterLabel(pane),
+    kind: paneLabel(pane),
+    target: paneTargetLabel(pane)
+  };
+}
+
+function paneOpenInManager(pane) {
+  if (!pane) return;
+  const panes = paneManager?.panes || [];
+  const idx = panes.findIndex((p) => String(p?.key || '') === String(pane.key || ''));
+  if (idx < 0) return;
+  paneManagerUiState.selectedIndex = idx;
+  openPaneManager();
+  renderPaneManager();
+}
+
+function paneRenderDestinationStrip(pane) {
+  const row = pane?.elements?.root?.querySelector('[data-pane-destination-strip]');
+  if (!row) return;
+  const valueEl = row.querySelector('[data-pane-destination-value]');
+  if (!valueEl) return;
+  const summary = paneDestinationSummary(pane);
+  valueEl.textContent = `${summary.letter} ${summary.kind} · ${summary.target}`;
+  row.dataset.warning = 'false';
+}
+
+function paneSetDestinationWarning(pane, warning) {
+  const row = pane?.elements?.root?.querySelector('[data-pane-destination-strip]');
+  if (!row) return;
+  row.dataset.warning = warning ? 'true' : 'false';
+}
+
+function paneIsFocused(pane) {
+  const root = pane?.elements?.root;
+  if (!root) return false;
+  const active = document.activeElement;
+  return !!active && root.contains(active);
+}
+
+function paneActivityLabel(pane) {
+  const unread = Math.max(0, Number(pane?.activity?.unread || 0));
+  if (!unread) return '';
+  const kind = String(pane?.activity?.kind || '').trim();
+  if (kind === 'workqueue') return `${unread} unread workqueue update${unread === 1 ? '' : 's'}`;
+  return `${unread} unread chat message${unread === 1 ? '' : 's'}`;
+}
+
+function paneRenderActivityBadge(pane) {
+  const badge = pane?.elements?.activityBadge;
+  if (!badge) return;
+  const unread = Math.max(0, Number(pane?.activity?.unread || 0));
+  if (!unread) {
+    badge.hidden = true;
+    badge.textContent = '';
+    badge.removeAttribute('aria-label');
+    return;
+  }
+  badge.hidden = false;
+  badge.dataset.kind = String(pane?.activity?.kind || 'chat');
+  badge.textContent = unread > 99 ? '99+' : String(unread);
+  badge.setAttribute('aria-label', paneActivityLabel(pane));
+}
+
+function paneMarkUnread(pane, kind = 'chat') {
+  if (!pane || paneIsFocused(pane)) return;
+  pane.activity = pane.activity || { unread: 0, kind: '' };
+  pane.activity.unread = Math.min(999, Math.max(0, Number(pane.activity.unread || 0)) + 1);
+  pane.activity.kind = kind === 'workqueue' ? 'workqueue' : 'chat';
+  paneRenderActivityBadge(pane);
+  refreshPaneManagerIfOpen();
+}
+
+function paneClearUnread(pane) {
+  if (!pane?.activity?.unread) return;
+  pane.activity.unread = 0;
+  pane.activity.kind = '';
+  paneRenderActivityBadge(pane);
+  refreshPaneManagerIfOpen();
 }
 
 function renderPaneManager() {
@@ -924,18 +1118,24 @@ function renderPaneManager() {
     row.setAttribute('role', 'option');
     row.dataset.index = String(idx);
     row.dataset.paneKey = String(pane.key || '');
+    row.dataset.paneAccentKind = String(pane?.kind || 'chat');
     row.setAttribute('aria-selected', idx === selected ? 'true' : 'false');
 
     const state = String(pane.statusState || (pane.connected ? 'connected' : 'disconnected'));
+    const letter = paneLetterLabel(pane);
+    const unread = Math.max(0, Number(pane?.activity?.unread || 0));
+    const unreadLabel = paneActivityLabel(pane);
 
     row.innerHTML = `
       <div class="pane-manager-main">
         <div class="pane-manager-kind" title="${escapeHtml(paneLabel(pane))}">
+          <span class="pane-manager-letter" aria-label="Pane ${escapeHtml(letter)}">${escapeHtml(letter)}</span>
           <span class="pane-manager-icon" aria-hidden="true">${escapeHtml(paneIcon(pane))}</span>
           <span class="pane-manager-kind-label">${escapeHtml(paneLabel(pane))}</span>
         </div>
         <div class="pane-manager-target" title="${escapeHtml(paneTargetLabel(pane))}">${escapeHtml(paneTargetLabel(pane))}</div>
         <div class="pane-manager-state" data-state="${escapeHtml(state)}">${escapeHtml(state)}</div>
+        ${unread ? `<div class="pane-activity-badge" data-kind="${escapeHtml(String(pane?.activity?.kind || 'chat'))}" aria-label="${escapeHtml(unreadLabel)}">${escapeHtml(unread > 99 ? '99+' : String(unread))}</div>` : ''}
       </div>
       <div class="pane-manager-actions">
         <button class="secondary pane-manager-up" type="button" data-action="move-up" data-testid="pane-manager-move-up" title="Move pane up" aria-label="Move pane up" ${idx === 0 ? 'disabled' : ''}>↑</button>
@@ -1053,12 +1253,24 @@ function paneManagerHandleKeydown(event) {
 
 // Command palette (admin-only)
 
+const COMMAND_PALETTE_GROUPS = [
+  { id: 'panes', label: 'Panes', rank: 100 },
+  { id: 'navigation', label: 'Navigation', rank: 90 },
+  { id: 'layout', label: 'Layout', rank: 85 },
+  { id: 'workqueue', label: 'Workqueue', rank: 80 },
+  { id: 'agents', label: 'Agents', rank: 70 },
+  { id: 'advanced', label: 'Advanced / All agents', rank: 40 }
+];
+
 const commandPaletteState = {
   open: false,
   query: '',
   items: [],
   filtered: [],
-  selectedIndex: 0
+  visible: [],
+  selectedIndex: 0,
+  expandedSubgroups: new Set(),
+  autoExpandedSubgroups: new Set()
 };
 
 function isCommandPaletteOpen() {
@@ -1096,111 +1308,108 @@ function scoreFuzzy(hay, needle) {
   return Math.max(1, score);
 }
 
+function commandGroupRank(groupId) {
+  const group = COMMAND_PALETTE_GROUPS.find((x) => x.id === groupId);
+  return group?.rank || 0;
+}
+
+function getFocusedPane() {
+  const active = document.activeElement;
+  if (!active) return null;
+  return (paneManager?.panes || []).find((pane) => pane?.elements?.root && (pane.elements.root === active || pane.elements.root.contains(active))) || null;
+}
+
+function openWorkqueueForActiveChatAgent() {
+  const focused = getFocusedPane();
+  if (!focused || focused.kind !== 'chat') {
+    showToast('No active chat agent selected', { kind: 'error', timeoutMs: 2200 });
+    return null;
+  }
+
+  const agentId = normalizeAgentId(focused.agentId || 'main');
+  const existing = (paneManager?.panes || []).find((pane) => {
+    if (!pane || pane.kind !== 'workqueue') return false;
+    return normalizeAgentId(pane.agentId || 'main') === agentId;
+  });
+
+  const pane = existing || paneManager.addPane('workqueue', { forceNew: true, queue: 'dev-team' });
+  if (!pane) return null;
+
+  pane.agentId = agentId;
+  pane.workqueue.scope = 'assigned';
+  if (typeof paneManager?.persistAdminPanes === 'function') paneManager.persistAdminPanes();
+
+  if (pane.kind === 'workqueue') {
+    renderWorkqueuePaneItems(pane);
+    renderWorkqueuePaneInspect(pane, (pane.workqueue?.items || []).find((it) => it?.id === pane.workqueue?.selectedItemId) || null);
+    paneManager.focusPanePrimary(pane);
+  }
+
+  return pane;
+}
+
 function buildCommandPaletteItems() {
   const items = [];
 
-  // Core commands
-  items.push(
-    {
-      id: 'cmd:add-chat',
-      label: 'Add pane: Chat',
-      detail: 'Create a new Chat pane',
-      run: () => paneManager.addPane('chat')
-    },
-    {
-      id: 'cmd:add-workqueue',
-      label: 'Add pane: Workqueue',
-      detail: 'Create a new Workqueue pane',
-      run: () => paneManager.addPane('workqueue')
-    },
-    {
-      id: 'cmd:add-cron',
-      label: 'Add pane: Cron',
-      detail: 'Create a new Cron pane',
-      run: () => paneManager.addPane('cron')
-    },
-    {
-      id: 'cmd:add-timeline',
-      label: 'Add pane: Timeline',
-      detail: 'Create a new Timeline pane',
-      run: () => paneManager.addPane('timeline')
-    },
-    {
-      id: 'cmd:reset-layout',
-      label: 'Layout: Reset panes',
-      detail: 'Reset admin layout to default',
-      run: () => paneManager.resetAdminLayoutToDefault({ confirm: true })
-    },
-    {
-      id: 'cmd:toggle-shortcuts',
-      label: 'Help: Toggle shortcuts overlay',
-      detail: 'Show/hide keyboard shortcuts',
-      run: () => {
-        if (globalElements.shortcutsModal?.classList.contains('open')) closeShortcuts();
-        else openShortcuts();
-      }
-    },
-    {
-      id: 'cmd:open-workqueue',
-      label: 'Workqueue: Open modal',
-      detail: 'Open the Workqueue modal (g w)',
-      run: () => openWorkqueue()
-    },
-    {
-      id: 'cmd:refresh-agents',
-      label: 'Agents: Refresh',
-      detail: 'Refresh agent list',
-      run: () => globalElements.refreshAgentsBtn?.click?.()
-    },
-    {
-      id: 'cmd:pane-cycle',
-      label: 'Panes: Cycle focus',
-      detail: 'Move focus to next pane',
-      run: () => cyclePaneFocus()
-    },
-    {
-      id: 'cmd:focus-pane-1',
-      label: 'Panes: Focus pane 1',
-      detail: 'Focus the first pane',
-      run: () => focusPaneIndex(0)
-    },
-    {
-      id: 'cmd:focus-pane-2',
-      label: 'Panes: Focus pane 2',
-      detail: 'Focus the second pane',
-      run: () => focusPaneIndex(1)
-    },
-    {
-      id: 'cmd:focus-pane-3',
-      label: 'Panes: Focus pane 3',
-      detail: 'Focus the third pane',
-      run: () => focusPaneIndex(2)
-    },
-    {
-      id: 'cmd:focus-pane-4',
-      label: 'Panes: Focus pane 4',
-      detail: 'Focus the fourth pane',
-      run: () => focusPaneIndex(3)
-    }
-  );
+  const pushItem = (item) => items.push({
+    group: 'advanced',
+    rank: 10,
+    ...item
+  });
 
-  // Agents (admin-only)
+  // Core commands
+  pushItem({ id: 'cmd:add-chat', group: 'panes', rank: 90, label: 'Add pane: Chat', detail: 'Create a new Chat pane', run: () => paneManager.addPane('chat') });
+  pushItem({ id: 'cmd:add-workqueue', group: 'panes', rank: 90, label: 'Add pane: Workqueue', detail: 'Create a new Workqueue pane', run: () => paneManager.addPane('workqueue') });
+  pushItem({ id: 'cmd:add-cron', group: 'panes', rank: 90, label: 'Add pane: Cron', detail: 'Create a new Cron pane', run: () => paneManager.addPane('cron') });
+  pushItem({ id: 'cmd:add-timeline', group: 'panes', rank: 90, label: 'Add pane: Timeline', detail: 'Create a new Timeline pane', run: () => paneManager.addPane('timeline') });
+  pushItem({ id: 'cmd:pane-cycle', group: 'navigation', rank: 90, label: 'Panes: Cycle focus', detail: 'Move focus to next pane', run: () => cyclePaneFocus() });
+  pushItem({ id: 'cmd:focus-pane-1', group: 'navigation', rank: 85, label: 'Panes: Focus pane 1', detail: 'Focus the first pane', run: () => focusPaneIndex(0) });
+  pushItem({ id: 'cmd:focus-pane-2', group: 'navigation', rank: 84, label: 'Panes: Focus pane 2', detail: 'Focus the second pane', run: () => focusPaneIndex(1) });
+  pushItem({ id: 'cmd:focus-pane-3', group: 'navigation', rank: 83, label: 'Panes: Focus pane 3', detail: 'Focus the third pane', run: () => focusPaneIndex(2) });
+  pushItem({ id: 'cmd:focus-pane-4', group: 'navigation', rank: 82, label: 'Panes: Focus pane 4', detail: 'Focus the fourth pane', run: () => focusPaneIndex(3) });
+  pushItem({ id: 'cmd:reset-layout', group: 'layout', rank: 95, label: 'Layout: Reset panes', detail: 'Reset admin layout to default', run: () => paneManager.resetAdminLayoutToDefault({ confirm: true }) });
+  pushItem({
+    id: 'cmd:toggle-shortcuts', group: 'navigation', rank: 88, label: 'Help: Toggle shortcuts overlay', detail: 'Show/hide keyboard shortcuts',
+    run: () => { if (globalElements.shortcutsModal?.classList.contains('open')) closeShortcuts(); else openShortcuts(); }
+  });
+  pushItem({ id: 'cmd:open-workqueue', group: 'workqueue', rank: 90, label: 'Workqueue: Open modal', detail: 'Open the Workqueue modal (g w)', run: () => openWorkqueue() });
+  pushItem({ id: 'cmd:open-workqueue-active-agent', group: 'workqueue', rank: 89, label: 'Workqueue for active chat agent', detail: 'Open/focus Workqueue pane scoped to assigned items for active chat agent', run: () => openWorkqueueForActiveChatAgent() });
+  pushItem({ id: 'cmd:refresh-agents', group: 'agents', rank: 88, label: 'Agents: Refresh', detail: 'Refresh agent list', run: () => globalElements.refreshAgentsBtn?.click?.() });
+
+  for (const pane of (paneManager?.panes || [])) {
+    if (!pane?.key) continue;
+    const summary = paneDestinationSummary(pane);
+    pushItem({
+      id: `pane:focus:${pane.key}`,
+      group: 'navigation',
+      rank: 87,
+      label: `Pane ${summary.letter}: Focus`,
+      detail: `${summary.kind.toUpperCase()} · ${summary.target}`,
+      run: () => {
+        const livePane = (paneManager?.panes || []).find((p) => String(p?.key || '') === String(pane.key));
+        if (livePane) paneManager.focusPanePrimary(livePane);
+      }
+    });
+  }
+
   const agents = uiState.agents.length > 0 ? uiState.agents : [{ id: 'main', name: 'main', displayName: 'main', emoji: '' }];
   for (const agent of agents) {
     const agentId = normalizeAgentId(agent?.id || 'main');
-    const label = `Agent: ${formatAgentLabel(agent, { includeId: false })}`;
-    items.push({
+    pushItem({
       id: `agent:${agentId}`,
-      label,
-      detail: agentId,
+      group: 'advanced',
+      subgroup: 'agent-targets',
+      subgroupLabel: 'Agent targets',
+      rank: 40,
+      label: `Agent: ${formatAgentLabel(agent, { includeId: false })}`,
+      detail: `CHAT · ${agentId}`,
       run: () => {
-        // Focus an existing chat pane if possible; otherwise create one.
-        let pane = paneManager.panes.find((p) => p.kind === 'chat');
-        if (!pane) pane = paneManager.addPane('chat');
-        if (pane) {
-          paneSetAgent(pane, agentId);
-          paneManager.focusPanePrimary(pane);
+        let pane = paneManager.panes.find((p) => p?.kind === 'chat' && normalizeAgentId(p?.agentId || 'main') === agentId);
+        if (!pane) {
+          pane = paneManager.addPane('chat');
+          if (pane && normalizeAgentId(pane.agentId || 'main') !== agentId) paneSetAgent(pane, agentId);
         }
+        if (pane) paneManager.focusPanePrimary(pane);
       }
     });
   }
@@ -1215,42 +1424,87 @@ function renderCommandPalette() {
 
   list.innerHTML = '';
 
-  const items = commandPaletteState.filtered;
-  if (!items.length) {
+  const grouped = new Map();
+  for (const groupMeta of COMMAND_PALETTE_GROUPS) grouped.set(groupMeta.id, []);
+  for (const item of commandPaletteState.filtered) {
+    if (!grouped.has(item.group)) grouped.set(item.group, []);
+    grouped.get(item.group).push(item);
+  }
+
+  const visible = [];
+  for (const groupMeta of COMMAND_PALETTE_GROUPS) {
+    const groupItems = grouped.get(groupMeta.id) || [];
+    if (!groupItems.length) continue;
+
+    const title = document.createElement('div');
+    title.className = 'command-palette-group-title';
+    title.textContent = groupMeta.label;
+    list.appendChild(title);
+
+    const direct = groupItems.filter((x) => !x.subgroup);
+    const subgroupMap = new Map();
+    for (const item of groupItems.filter((x) => x.subgroup)) {
+      if (!subgroupMap.has(item.subgroup)) subgroupMap.set(item.subgroup, []);
+      subgroupMap.get(item.subgroup).push(item);
+    }
+
+    for (const item of direct) visible.push({ kind: 'item', item });
+    for (const [subgroupId, subgroupItems] of subgroupMap.entries()) {
+      visible.push({ kind: 'toggle', subgroupId, label: subgroupItems[0]?.subgroupLabel || subgroupId, count: subgroupItems.length });
+      const expanded = commandPaletteState.expandedSubgroups.has(subgroupId) || commandPaletteState.autoExpandedSubgroups.has(subgroupId);
+      if (expanded) for (const item of subgroupItems) visible.push({ kind: 'item', item, subgroupId });
+    }
+  }
+
+  commandPaletteState.visible = visible;
+  if (!visible.length) {
     if (empty) empty.hidden = false;
     return;
   }
   if (empty) empty.hidden = true;
 
-  const selected = Math.max(0, Math.min(items.length - 1, commandPaletteState.selectedIndex));
+  const selected = Math.max(0, Math.min(visible.length - 1, commandPaletteState.selectedIndex));
   commandPaletteState.selectedIndex = selected;
 
-  items.forEach((item, idx) => {
+  visible.forEach((entry, idx) => {
     const btn = document.createElement('button');
     btn.type = 'button';
-    btn.className = 'command-palette-item';
+    btn.className = `command-palette-item${entry.kind === 'toggle' ? ' command-palette-subgroup' : ''}${entry.subgroupId ? ' command-palette-subitem' : ''}`;
     btn.setAttribute('role', 'option');
     btn.setAttribute('aria-selected', idx === selected ? 'true' : 'false');
-    btn.dataset.commandPaletteId = item.id;
-    btn.innerHTML = `
-      <div class="command-palette-item-main">
-        <div class="command-palette-item-label">${escapeHtml(item.label)}</div>
-        <div class="command-palette-item-detail">${escapeHtml(item.detail || '')}</div>
-      </div>
-      <div class="command-palette-item-meta">${idx === selected ? '↵' : ''}</div>
-    `;
+
+    if (entry.kind === 'toggle') {
+      const expanded = commandPaletteState.expandedSubgroups.has(entry.subgroupId) || commandPaletteState.autoExpandedSubgroups.has(entry.subgroupId);
+      btn.innerHTML = `
+        <div class="command-palette-item-main">
+          <div class="command-palette-item-label">${escapeHtml(entry.label)} (${entry.count})</div>
+          <div class="command-palette-item-detail">${expanded ? 'Hide generated actions' : 'Show generated actions'}</div>
+        </div>
+        <div class="command-palette-item-meta">${expanded ? '▾' : '▸'}</div>
+      `;
+      btn.addEventListener('click', () => {
+        if (commandPaletteState.expandedSubgroups.has(entry.subgroupId)) commandPaletteState.expandedSubgroups.delete(entry.subgroupId);
+        else commandPaletteState.expandedSubgroups.add(entry.subgroupId);
+        renderCommandPalette();
+      });
+    } else {
+      const item = entry.item;
+      btn.dataset.commandPaletteId = item.id;
+      btn.innerHTML = `
+        <div class="command-palette-item-main">
+          <div class="command-palette-item-label">${escapeHtml(item.label)}</div>
+          <div class="command-palette-item-detail">${escapeHtml(item.detail || '')}</div>
+        </div>
+        <div class="command-palette-item-meta">${idx === selected ? '↵' : ''}</div>
+      `;
+      btn.addEventListener('click', () => {
+        try { item.run?.(); } finally { closeCommandPalette({ restoreFocus: false }); }
+      });
+    }
 
     btn.addEventListener('mouseenter', () => {
       commandPaletteState.selectedIndex = idx;
       renderCommandPalette();
-    });
-
-    btn.addEventListener('click', () => {
-      try {
-        item.run?.();
-      } finally {
-        closeCommandPalette({ restoreFocus: false });
-      }
     });
 
     list.appendChild(btn);
@@ -1265,16 +1519,24 @@ function renderCommandPalette() {
 function filterCommandPalette(query) {
   commandPaletteState.query = String(query || '');
   const q = commandPaletteState.query.trim();
+  const matchedSubgroups = new Set();
   const scored = commandPaletteState.items
     .map((item) => {
       const hay = `${item.label || ''} ${item.detail || ''} ${item.id || ''}`;
-      return { item, score: scoreFuzzy(hay, q) };
+      const score = scoreFuzzy(hay, q);
+      if (score > 0 && q && item.subgroup) matchedSubgroups.add(item.subgroup);
+      return { item, score };
     })
     .filter((x) => x.score > 0)
-    .sort((a, b) => b.score - a.score)
+    .sort((a, b) => {
+      const aTotal = (a.score || 0) + (a.item.rank || 0) * 1000 + commandGroupRank(a.item.group || 'advanced') * 10000;
+      const bTotal = (b.score || 0) + (b.item.rank || 0) * 1000 + commandGroupRank(b.item.group || 'advanced') * 10000;
+      return bTotal - aTotal;
+    })
     .map((x) => x.item);
 
   commandPaletteState.filtered = scored;
+  commandPaletteState.autoExpandedSubgroups = matchedSubgroups;
   commandPaletteState.selectedIndex = 0;
   renderCommandPalette();
 }
@@ -1287,20 +1549,23 @@ function openCommandPalette() {
   commandPaletteState.open = true;
   commandPaletteState.items = buildCommandPaletteItems();
   commandPaletteState.filtered = commandPaletteState.items.slice();
+  commandPaletteState.visible = commandPaletteState.filtered.slice();
   commandPaletteState.selectedIndex = 0;
+  commandPaletteState.expandedSubgroups = new Set();
+  commandPaletteState.autoExpandedSubgroups = new Set();
 
   globalElements.commandPaletteModal.classList.add('open');
   globalElements.commandPaletteModal.setAttribute('aria-hidden', 'false');
 
   if (globalElements.commandPaletteInput) {
     globalElements.commandPaletteInput.value = '';
-    // Defer focus until after the modal is painted so browsers reliably move focus.
     const focus = () => {
       try {
         globalElements.commandPaletteInput?.focus?.({ preventScroll: true });
         globalElements.commandPaletteInput?.select?.();
       } catch {}
     };
+    focus();
     try {
       requestAnimationFrame(() => requestAnimationFrame(focus));
     } catch {
@@ -1313,20 +1578,152 @@ function openCommandPalette() {
 
 // Agents (admin-only)
 
+const agentsModalState = {
+  selectedAgentId: ''
+};
+
+function getAgentsModalRows() {
+  return Array.from(globalElements.agentsList?.querySelectorAll?.('.agents-row[data-agent-id]') || []);
+}
+
+function selectAgentsModalRowByIndex(index, { scroll = true } = {}) {
+  const rows = getAgentsModalRows();
+  if (!rows.length) {
+    agentsModalState.selectedAgentId = '';
+    return null;
+  }
+  const safe = Math.max(0, Math.min(rows.length - 1, Number(index) || 0));
+  const next = rows[safe];
+  const agentId = String(next?.dataset?.agentId || '').trim();
+  agentsModalState.selectedAgentId = agentId;
+
+  rows.forEach((row, idx) => {
+    const selected = idx === safe;
+    row.classList.toggle('is-selected', selected);
+    row.setAttribute('aria-selected', selected ? 'true' : 'false');
+  });
+
+  if (scroll) {
+    try {
+      next?.scrollIntoView?.({ block: 'nearest' });
+    } catch {}
+  }
+  return next || null;
+}
+
+function selectAgentsModalRowByAgentId(agentId, { fallbackToFirst = true, scroll = false } = {}) {
+  const rows = getAgentsModalRows();
+  if (!rows.length) {
+    agentsModalState.selectedAgentId = '';
+    return null;
+  }
+  const id = String(agentId || '').trim();
+  let index = rows.findIndex((row) => String(row.dataset.agentId || '').trim() === id);
+  if (index < 0 && fallbackToFirst) index = 0;
+  if (index < 0) {
+    agentsModalState.selectedAgentId = '';
+    return null;
+  }
+  return selectAgentsModalRowByIndex(index, { scroll });
+}
+
+function focusOrCreateAgentChatPane(agentId) {
+  const id = normalizeAgentId(agentId || 'main');
+  let pane = paneManager.panes.find((p) => p?.kind === 'chat' && normalizeAgentId(p?.agentId || 'main') === id) || null;
+  if (!pane) {
+    pane = paneManager.addPane('chat');
+  }
+  if (!pane) return false;
+  if (normalizeAgentId(pane.agentId || 'main') !== id) paneSetAgent(pane, id);
+  paneManager.focusPanePrimary(pane);
+  return true;
+}
+
+function runAgentsModalTriageAction({ openWorkqueue = false, openTimeline = false } = {}) {
+  const row = selectAgentsModalRowByAgentId(agentsModalState.selectedAgentId, { fallbackToFirst: true });
+  const agentId = String(row?.dataset?.agentId || '').trim();
+  if (!agentId) return false;
+
+  if (!focusOrCreateAgentChatPane(agentId)) return false;
+
+  if (openWorkqueue) {
+    openWorkqueue();
+    if (globalElements.wqClaimAgentId) {
+      globalElements.wqClaimAgentId.value = agentId;
+      try {
+        globalElements.wqClaimAgentId.dispatchEvent(new Event('input', { bubbles: true }));
+      } catch {}
+    }
+  }
+
+  if (openTimeline) {
+    paneManager.addPane('timeline');
+  }
+
+  closeAgentsModal({ restoreFocus: false });
+  return true;
+}
+
+function agentsModalHandleKeydown(event) {
+  if (!globalElements.agentsModal?.classList.contains('open')) return false;
+  if (!event || event.defaultPrevented) return false;
+
+  const key = String(event.key || '');
+  const lower = key.toLowerCase();
+
+  if (key === 'Escape') {
+    event.preventDefault();
+    closeAgentsModal();
+    return true;
+  }
+
+  const target = event.target;
+  if (isTypingContext(target)) {
+    return false;
+  }
+
+  if (!event.metaKey && !event.ctrlKey && !event.altKey && (lower === 'j' || lower === 'k' || key === 'ArrowDown' || key === 'ArrowUp')) {
+    event.preventDefault();
+    const rows = getAgentsModalRows();
+    if (!rows.length) return true;
+    const currentIndex = Math.max(0, rows.findIndex((row) => String(row.dataset.agentId || '').trim() === String(agentsModalState.selectedAgentId || '').trim()));
+    const delta = (lower === 'j' || key === 'ArrowDown') ? 1 : -1;
+    const nextIndex = Math.max(0, Math.min(rows.length - 1, currentIndex + delta));
+    selectAgentsModalRowByIndex(nextIndex);
+    return true;
+  }
+
+  if (!event.metaKey && !event.ctrlKey && !event.altKey && key === 'Enter') {
+    event.preventDefault();
+    runAgentsModalTriageAction({ openWorkqueue: !!event.shiftKey });
+    return true;
+  }
+
+  if (!event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey && key === '.') {
+    event.preventDefault();
+    runAgentsModalTriageAction({ openTimeline: true });
+    return true;
+  }
+
+  return false;
+}
+
 function openAgentsModal() {
   if (roleState.role !== 'admin') return;
   globalElements.agentsModal?.classList.add('open');
   globalElements.agentsModal?.setAttribute('aria-hidden', 'false');
 
   // Bootstrap persisted controls.
-  if (globalElements.agentsActiveOnly) {
-    globalElements.agentsActiveOnly.checked = storage.get(ADMIN_AGENT_ACTIVE_ONLY_KEY, 'false') === 'true';
-  }
   if (globalElements.agentsActiveMinutes) {
     const minutes = Number(storage.get(ADMIN_AGENT_ACTIVE_MINUTES_KEY, '10')) || 10;
     globalElements.agentsActiveMinutes.value = String(Math.max(1, minutes));
   }
+  if (globalElements.agentsSortMode) {
+    const sortMode = String(storage.get(ADMIN_AGENT_SORT_KEY, 'attention') || 'attention');
+    globalElements.agentsSortMode.value = ['attention', 'recent', 'oldest'].includes(sortMode) ? sortMode : 'attention';
+  }
 
+  agentsModalState.selectedAgentId = '';
   renderAgentsModalList();
 
   // Focus search by default for fast filtering.
@@ -1335,9 +1732,15 @@ function openAgentsModal() {
   } catch {}
 }
 
-function closeAgentsModal() {
+function closeAgentsModal({ restoreFocus = true } = {}) {
   globalElements.agentsModal?.classList.remove('open');
   globalElements.agentsModal?.setAttribute('aria-hidden', 'true');
+  if (restoreFocus) {
+    try {
+      const pane = paneManager?.panes?.[0];
+      pane?.elements?.input?.focus?.();
+    } catch {}
+  }
 }
 
 function renderAgentsModalList() {
@@ -1345,27 +1748,67 @@ function renderAgentsModalList() {
   if (!root) return;
 
   const search = String(globalElements.agentsSearch?.value || '').trim().toLowerCase();
-  const activeOnly = !!globalElements.agentsActiveOnly?.checked;
+  const selectedFilter = String(storage.get(ADMIN_AGENT_FILTER_KEY, 'all') || 'all');
+  const sortMode = String(globalElements.agentsSortMode?.value || storage.get(ADMIN_AGENT_SORT_KEY, 'attention') || 'attention');
   const withinMinutes = Math.max(1, Number(globalElements.agentsActiveMinutes?.value) || 10);
-
   const pins = getPinnedAgentIds();
+  const lastSeenMap = getAgentLastSeenMap();
   const baseAgents = uiState.agents.length > 0 ? uiState.agents : [{ id: 'main', name: 'main', displayName: 'main', emoji: '' }];
 
-  const matches = (agent) => {
-    const label = formatAgentLabel(agent, { includeId: true }).toLowerCase();
-    if (search && !label.includes(search)) return false;
-    if (activeOnly && !isAgentActive(agent.id, { withinMinutes })) return false;
+  const matchesFilter = (triage) => {
+    if (selectedFilter === 'all') return true;
+    if (selectedFilter === 'needs_attention') return triage.needsAttention;
+    if (selectedFilter === 'connected') return triage.connected;
+    if (selectedFilter === 'disconnected') return !triage.connected;
+    if (selectedFilter === 'busy') return triage.busy;
     return true;
   };
 
-  const filtered = baseAgents.filter(matches);
-  const pinned = sortAgentsByLastSeen(filtered.filter((a) => pins.has(String(a?.id || '').trim())));
-  const rest = sortAgentsByLastSeen(filtered.filter((a) => !pins.has(String(a?.id || '').trim())));
+  const enriched = baseAgents
+    .map((agent) => ({
+      agent,
+      id: String(agent?.id || '').trim(),
+      label: formatAgentLabel(agent, { includeId: true }),
+      triage: getAgentTriageMeta(agent?.id, { withinMinutes })
+    }))
+    .filter((entry) => {
+      if (search && !entry.label.toLowerCase().includes(search)) return false;
+      return matchesFilter(entry.triage);
+    });
+
+  const compareByAttention = (a, b) => {
+    const score = Number(b?.triage?.attentionScore || 0) - Number(a?.triage?.attentionScore || 0);
+    if (score) return score;
+    const at = Number(lastSeenMap[a.id]) || 0;
+    const bt = Number(lastSeenMap[b.id]) || 0;
+    if (!at && bt) return 1;
+    if (at && !bt) return -1;
+    const dt = bt - at;
+    if (dt) return dt;
+    return a.label.localeCompare(b.label);
+  };
+
+  const sortEntries = (entries) => {
+    if (sortMode === 'oldest') return entries.slice().sort((a, b) => (Number(lastSeenMap[a.id]) || 0) - (Number(lastSeenMap[b.id]) || 0));
+    if (sortMode === 'recent') return entries.slice().sort((a, b) => (Number(lastSeenMap[b.id]) || 0) - (Number(lastSeenMap[a.id]) || 0));
+    return entries.slice().sort(compareByAttention);
+  };
+
+  const filteredPinned = enriched.filter((e) => pins.has(e.id));
+  const filteredRest = enriched.filter((e) => !pins.has(e.id));
+  const pinned = sortEntries(filteredPinned);
+  const rest = sortEntries(filteredRest);
 
   root.innerHTML = '';
+  globalElements.agentsFilterGroup?.querySelectorAll?.('[data-agents-filter]')?.forEach((btn) => {
+    const value = String(btn.getAttribute('data-agents-filter') || 'all');
+    const on = value === selectedFilter;
+    btn.setAttribute('aria-pressed', on ? 'true' : 'false');
+    btn.classList.toggle('is-active', on);
+  });
 
-  const renderSection = (title, agents) => {
-    if (!agents || agents.length === 0) return;
+  const renderSection = (title, entries) => {
+    if (!entries || entries.length === 0) return;
     const section = document.createElement('div');
     section.className = 'agents-section';
     section.innerHTML = `<div class="agents-section-title">${escapeHtml(title)}</div>`;
@@ -1373,19 +1816,23 @@ function renderAgentsModalList() {
     const list = document.createElement('div');
     list.className = 'agents-rows';
 
-    for (const agent of agents) {
-      const id = String(agent?.id || '').trim();
+    for (const entry of entries) {
+      const { id, label, triage } = entry;
       const row = document.createElement('div');
-      row.className = 'agents-row';
-
-      const label = formatAgentLabel(agent, { includeId: true });
       const pinnedNow = pins.has(id);
+      const lastSeenAtMs = Number(lastSeenMap[id]) || 0;
+      row.className = `agents-row ${triage.health === 'active' ? 'is-active' : triage.health === 'stale' ? 'is-stale' : 'is-offline'}`;
+      row.dataset.agentId = id;
+      row.setAttribute('role', 'option');
+      row.setAttribute('tabindex', '-1');
+      row.setAttribute('aria-selected', 'false');
 
       row.innerHTML = `
         <button type="button" class="agents-pin" aria-label="${pinnedNow ? 'Unpin agent' : 'Pin agent'}" aria-pressed="${pinnedNow ? 'true' : 'false'}" data-agent-pin="${escapeHtml(id)}">${pinnedNow ? '★' : '☆'}</button>
         <div class="agents-row-main">
-          <div class="agents-row-title">${escapeHtml(label)}</div>
-          <div class="agents-row-meta">${escapeHtml(id)}${isAgentActive(id, { withinMinutes }) ? ' · active' : ''}</div>
+          <div class="agents-row-title-wrap"><div class="agents-row-title">${escapeHtml(label)}</div><span class="agents-age-chip">${escapeHtml(formatAgeChip(lastSeenAtMs))}</span></div>
+          <div class="agents-row-meta">${escapeHtml(id)} · ${triage.connected ? (triage.busy ? 'busy' : triage.health === 'stale' ? 'stale' : 'connected') : 'disconnected/error'}</div>
+          <div class="agents-row-reason"><span class="agents-reason-chip">${escapeHtml(triage.attentionReason)}</span></div>
         </div>
       `;
 
@@ -1397,6 +1844,15 @@ function renderAgentsModalList() {
         // Refresh both the modal list and any agent <select>s.
         paneManager.panes.forEach((p) => renderAgentOptions(p.elements?.agentSelect, p.agentId));
         renderAgentsModalList();
+      });
+
+      row.addEventListener('click', () => {
+        selectAgentsModalRowByAgentId(id, { fallbackToFirst: true, scroll: false });
+      });
+
+      row.addEventListener('dblclick', () => {
+        selectAgentsModalRowByAgentId(id, { fallbackToFirst: true, scroll: false });
+        runAgentsModalTriageAction();
       });
 
       list.appendChild(row);
@@ -1411,11 +1867,15 @@ function renderAgentsModalList() {
 
   const empty = pinned.length === 0 && rest.length === 0;
   if (globalElements.agentsEmpty) globalElements.agentsEmpty.hidden = !empty;
+
+  if (!empty) selectAgentsModalRowByAgentId(agentsModalState.selectedAgentId, { fallbackToFirst: true, scroll: false });
+  else agentsModalState.selectedAgentId = '';
 }
 
 // Workqueue (admin-only)
 
 const WORKQUEUE_STATUSES = ['ready', 'pending', 'claimed', 'in_progress', 'done', 'failed'];
+const WORKQUEUE_GROUPING_AUTO_THRESHOLD = 12;
 
 const workqueueState = {
   queues: [],
@@ -1428,6 +1888,7 @@ const workqueueState = {
   leaseTicker: null,
   autoRefreshEnabled: true,
   autoRefreshIntervalMs: 15000,
+  groupingMode: 'auto',
   autoRefreshTimer: null,
   sortingBootstrapped: false
 };
@@ -1511,8 +1972,10 @@ async function ensureWorkqueueBootstrapped() {
   try {
     const enabled = storage.get('clawnsole.wq.autorefresh.enabled');
     const interval = storage.get('clawnsole.wq.autorefresh.intervalMs');
+    const groupingMode = String(storage.get('clawnsole.wq.grouping.mode') || '').toLowerCase();
     if (enabled !== null) workqueueState.autoRefreshEnabled = Boolean(enabled);
     if (interval !== null && Number(interval) > 0) workqueueState.autoRefreshIntervalMs = Number(interval);
+    if (['auto', 'on', 'off'].includes(groupingMode)) workqueueState.groupingMode = groupingMode;
   } catch {
     // ignore
   }
@@ -1522,6 +1985,9 @@ async function ensureWorkqueueBootstrapped() {
   }
   if (globalElements.wqAutoRefreshInterval) {
     globalElements.wqAutoRefreshInterval.value = String(workqueueState.autoRefreshIntervalMs);
+  }
+  if (globalElements.wqGroupingMode) {
+    globalElements.wqGroupingMode.value = workqueueState.groupingMode;
   }
 
   renderWorkqueueStatusFilters();
@@ -1631,6 +2097,81 @@ function getWorkqueueBoardColumns() {
   return defs.filter((d) => workqueueState.statusFilter.has(d.status));
 }
 
+function getWorkqueueDedupeIdentity(item) {
+  const key = String(item?.dedupeKey || item?.meta?.dedupeKey || '').trim();
+  if (!key) return '';
+  const queue = String(item?.queue || '').trim() || '__default__';
+  return `${queue}::dedupe::${key}`;
+}
+
+function getWorkqueueFallbackGroupIdentity(item) {
+  const queue = String(item?.queue || '').trim() || '__default__';
+  const dedupeKey = String(item?.dedupeKey || item?.meta?.dedupeKey || '').trim();
+  if (dedupeKey) return '';
+
+  const title = String(item?.title || '').trim().toLowerCase();
+  const kind = String(item?.meta?.kind || '').trim().toLowerCase();
+  const isRoutine = kind.includes('pr-review') || title.includes('pr review sweep') || title.startsWith('[routine]');
+  if (!isRoutine) return '';
+
+  const normalized = title
+    .replace(/^\[[^\]]+\]\s*/g, '')
+    .replace(/\([^)]*\)\s*$/g, '')
+    .replace(/\b\d{4}-\d{2}-\d{2}(?:[ t]\d{2}(?::\d{2})?)?\b/g, '')
+    .replace(/\b[0-9a-f]{8,}\b/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  const prefix = (normalized.split(/\s[:\-–—]\s/, 1)[0] || normalized).trim();
+  if (prefix.length < 8) return '';
+  return `${queue}::fallback::${prefix}`;
+}
+
+function resolveWorkqueueGroupingEnabled(mode, itemCount) {
+  const normalized = String(mode || 'auto').toLowerCase();
+  if (normalized === 'on') return true;
+  if (normalized === 'off') return false;
+  return Number(itemCount) > WORKQUEUE_GROUPING_AUTO_THRESHOLD;
+}
+
+function finalizeWorkqueueGroup(group) {
+  const members = [group.canonical, ...(Array.isArray(group.siblings) ? group.siblings : [])];
+  group.count = members.length;
+  group.maxPriority = members.reduce((acc, it) => Math.max(acc, Number(it?.priority ?? -Infinity)), -Infinity);
+  group.latestUpdatedAtMs = members.reduce((acc, it) => {
+    const t = Date.parse(String(it?.updatedAt || it?.createdAt || ''));
+    return Number.isFinite(t) ? Math.max(acc, t) : acc;
+  }, 0);
+  group.hasClaimed = members.some((it) => String(it?.status || '') === 'claimed' || String(it?.claimedBy || '').trim());
+  group.hasExpiredLease = members.some((it) => Number(it?.leaseUntil || 0) > 0 && Number(it.leaseUntil) < Date.now());
+  return group;
+}
+
+function groupWorkqueueItemsByDedupe(sortedItems, opts = {}) {
+  const groupingEnabled = resolveWorkqueueGroupingEnabled(opts.groupingMode, Array.isArray(sortedItems) ? sortedItems.length : 0);
+  const groups = [];
+  const groupMap = new Map();
+
+  for (const it of Array.isArray(sortedItems) ? sortedItems : []) {
+    const identity = groupingEnabled ? (getWorkqueueDedupeIdentity(it) || getWorkqueueFallbackGroupIdentity(it)) : '';
+    if (!identity) {
+      groups.push(finalizeWorkqueueGroup({ canonical: it, siblings: [] }));
+      continue;
+    }
+
+    if (!groupMap.has(identity)) {
+      const key = String(it?.dedupeKey || it?.meta?.dedupeKey || '').trim();
+      const group = { canonical: it, siblings: [], dedupeKey: key, identity };
+      groupMap.set(identity, group);
+      groups.push(group);
+    } else {
+      groupMap.get(identity).siblings.push(it);
+    }
+  }
+
+  return groups.map(finalizeWorkqueueGroup);
+}
+
 function renderWorkqueueItems() {
   const body = globalElements.wqListBody;
   if (!body) return;
@@ -1648,18 +2189,20 @@ function renderWorkqueueItems() {
 
   const itemsRaw = Array.isArray(workqueueState.items) ? workqueueState.items : [];
   const items = sortWorkqueueItems(itemsRaw, { sortKey: workqueueState.sortKey, sortDir: workqueueState.sortDir });
+  const groups = groupWorkqueueItemsByDedupe(items, { groupingMode: workqueueState.groupingMode });
+  const visibleItems = groups.map((g) => g.canonical);
 
-  if (!items.length) {
+  if (!visibleItems.length) {
     globalElements.wqListEmpty.hidden = false;
   } else {
     globalElements.wqListEmpty.hidden = true;
   }
 
   const cols = getWorkqueueBoardColumns();
-  const itemsByStatus = items.reduce((acc, it) => {
-    const st = String(it?.status || 'ready');
+  const groupsByStatus = groups.reduce((acc, g) => {
+    const st = String(g?.canonical?.status || 'ready');
     if (!acc[st]) acc[st] = [];
-    acc[st].push(it);
+    acc[st].push(g);
     return acc;
   }, {});
 
@@ -1669,7 +2212,7 @@ function renderWorkqueueItems() {
     col.className = 'wq-board-col';
     col.setAttribute('data-wq-col', colDef.status);
 
-    const colItems = Array.isArray(itemsByStatus[colDef.status]) ? itemsByStatus[colDef.status] : [];
+    const colItems = Array.isArray(groupsByStatus[colDef.status]) ? groupsByStatus[colDef.status] : [];
 
     const head = document.createElement('div');
     head.className = 'wq-board-col-header';
@@ -1700,11 +2243,19 @@ function renderWorkqueueItems() {
       }
     });
 
-    for (const it of colItems) {
+    for (const group of colItems) {
+      const it = group.canonical;
+      const siblings = Array.isArray(group.siblings) ? group.siblings : [];
+      const dupCount = siblings.length;
+      const isSelected = [it, ...siblings].some((x) => x?.id && x.id === workqueueState.selectedItemId);
+
+      const cardWrap = document.createElement('div');
+      cardWrap.className = 'wq-card-wrap';
+
       const card = document.createElement('button');
       card.type = 'button';
       card.className = 'wq-card';
-      if (it.id && it.id === workqueueState.selectedItemId) card.classList.add('selected');
+      if (isSelected) card.classList.add('selected');
       if (it.id) card.setAttribute('data-wq-item', it.id);
 
       // Allow dragging the whole card.
@@ -1727,6 +2278,9 @@ function renderWorkqueueItems() {
           <span class="wq-badge wq-badge-${escapeHtml(status)}">${escapeHtml(status)}</span>
           ${age ? `<span class="wq-card-chip mono">age ${escapeHtml(age)}</span>` : ''}
           ${leaseLabel ? `<span class="wq-card-chip mono">lease ${escapeHtml(leaseLabel)}</span>` : ''}
+          ${dupCount > 0 ? `<span class="wq-card-chip mono">×${escapeHtml(String(group.count || (dupCount + 1)))}</span>` : ''}
+          ${group.hasClaimed ? `<span class="wq-card-chip mono">claimed</span>` : ''}
+          ${group.hasExpiredLease ? `<span class="wq-card-chip mono">expired lease</span>` : ''}
         </div>
         <div class="wq-card-fields">
           <div class="wq-card-field"><span class="k">prio</span> <span class="v mono">${escapeHtml(String(it.priority ?? ''))}</span></div>
@@ -1742,7 +2296,38 @@ function renderWorkqueueItems() {
         renderWorkqueueInspect(it);
       });
 
-      lane.appendChild(card);
+      cardWrap.appendChild(card);
+
+      if (dupCount > 0) {
+        const details = document.createElement('details');
+        details.className = 'wq-duplicates';
+
+        const summary = document.createElement('summary');
+        summary.className = 'wq-duplicates-summary mono';
+        summary.textContent = `Show ${dupCount} duplicate${dupCount === 1 ? '' : 's'}`;
+
+        const list = document.createElement('div');
+        list.className = 'wq-duplicates-list';
+
+        for (const dup of siblings) {
+          const btn = document.createElement('button');
+          btn.type = 'button';
+          btn.className = 'wq-duplicate-btn';
+          btn.textContent = `${dup.id || ''} · prio ${dup.priority ?? ''} · ${dup.status || ''}`;
+          btn.addEventListener('click', () => {
+            workqueueState.selectedItemId = dup.id || null;
+            renderWorkqueueItems();
+            renderWorkqueueInspect(dup);
+          });
+          list.appendChild(btn);
+        }
+
+        details.appendChild(summary);
+        details.appendChild(list);
+        cardWrap.appendChild(details);
+      }
+
+      lane.appendChild(cardWrap);
     }
 
     col.appendChild(head);
@@ -1989,6 +2574,68 @@ async function renderWorkqueuePane(rootEl, { queue = '' } = {}) {
 window.__debug = window.__debug || {};
 window.__debug.renderWorkqueuePane = renderWorkqueuePane;
 
+function getWorkqueueItemRepo(item) {
+  const repo = String(item?.meta?.repo || '').trim();
+  if (repo) return repo;
+
+  const candidates = [String(item?.meta?.url || ''), String(item?.meta?.issueUrl || ''), String(item?.instructions || '')];
+  for (const text of candidates) {
+    const match = text.match(/github\.com\/([^\s/]+\/[^\s/#?]+)/i);
+    if (match?.[1]) return String(match[1]).trim();
+  }
+  return '';
+}
+
+function getWorkqueueItemSource(item) {
+  if (!item || typeof item !== 'object') return 'manual';
+  const repo = getWorkqueueItemRepo(item);
+  if (repo) return 'github';
+
+  const kind = String(item?.meta?.kind || '').toLowerCase();
+  if (kind.includes('pr-review')) return 'automation';
+  return 'manual';
+}
+
+function isWorkqueueActionableNoise(item) {
+  const title = String(item?.title || '').trim().toLowerCase();
+  const dedupeKey = String(item?.meta?.dedupeKey || '').trim().toLowerCase();
+  const kind = String(item?.meta?.kind || '').trim().toLowerCase();
+
+  if (!title && !dedupeKey && !kind) return false;
+
+  if (title.includes('[routine]') || title.includes('[coverage]')) return true;
+  if (title.startsWith('issue coverage:') || title.startsWith('triager:')) return true;
+  if (dedupeKey.startsWith('issue-coverage:') || dedupeKey.startsWith('triager:')) return true;
+  if (kind.includes('pr-review') || kind.includes('coverage') || kind.includes('triager')) return true;
+
+  return false;
+}
+
+function applyWorkqueueQuickFilters(items, quickFilters) {
+  const sourceFilter = String(quickFilters?.source || '').trim();
+  const repoFilter = String(quickFilters?.repo || '').trim();
+  const actionableOnly = !!quickFilters?.actionableOnly;
+
+  return (Array.isArray(items) ? items : []).filter((it) => {
+    if (sourceFilter && getWorkqueueItemSource(it) !== sourceFilter) return false;
+    if (repoFilter && getWorkqueueItemRepo(it) !== repoFilter) return false;
+    if (actionableOnly && isWorkqueueActionableNoise(it)) return false;
+    return true;
+  });
+}
+
+function applyWorkqueueScopeFilter(items, pane) {
+  const scope = String(pane?.workqueue?.scope || 'all').trim().toLowerCase();
+  if (scope === 'all') return Array.isArray(items) ? items : [];
+
+  const activeTarget = normalizeAgentId(String(pane?.agentId || 'main').trim() || 'main');
+  return (Array.isArray(items) ? items : []).filter((it) => {
+    const claimedBy = normalizeAgentId(String(it?.claimedBy || '').trim());
+    if (scope === 'unassigned') return !claimedBy;
+    if (scope === 'assigned') return claimedBy === activeTarget;
+    return true;
+  });
+}
 
 async function fetchAndRenderWorkqueueItemsForPane(pane) {
   if (!pane || pane.kind !== 'workqueue') return;
@@ -2010,7 +2657,16 @@ async function fetchAndRenderWorkqueueItemsForPane(pane) {
     if (!res.ok) throw new Error(String(res.status));
     const data = await res.json();
     const items = Array.isArray(data.items) ? data.items : [];
+    const previousSig = String(pane.workqueue?.lastItemsSignature || '');
+    const nextSig = items
+      .map((it) => `${String(it?.id || '')}:${String(it?.status || '')}:${String(it?.updatedAt || '')}`)
+      .sort()
+      .join('|');
     pane.workqueue.items = items;
+    pane.workqueue.lastItemsSignature = nextSig;
+    if (previousSig && nextSig && previousSig !== nextSig) {
+      paneMarkUnread(pane, 'workqueue');
+    }
     if (statusLine) statusLine.textContent = `${items.length} item(s)`;
     renderWorkqueuePaneItems(pane);
   } catch (err) {
@@ -2025,10 +2681,14 @@ function renderWorkqueuePaneItems(pane) {
   body.innerHTML = '';
 
   const itemsRaw = Array.isArray(pane.workqueue?.items) ? pane.workqueue.items : [];
-  const items = sortWorkqueueItems(itemsRaw, { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
+  const scopedItems = applyWorkqueueScopeFilter(itemsRaw, pane);
+  const filteredItems = applyWorkqueueQuickFilters(scopedItems, pane.workqueue?.quickFilters);
+  const items = sortWorkqueueItems(filteredItems, { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
+  const groups = groupWorkqueueItemsByDedupe(items, { groupingMode: pane.workqueue?.groupingMode });
+  const visibleItems = groups.map((g) => g.canonical);
 
   if (empty) {
-    const hasItems = items.length > 0;
+    const hasItems = visibleItems.length > 0;
     empty.hidden = hasItems;
     if (!hasItems) {
       const queue = String(pane.workqueue?.queue || '').trim() || 'dev-team';
@@ -2060,18 +2720,26 @@ function renderWorkqueuePaneItems(pane) {
   }
 
   const now = Date.now();
-  for (const it of items) {
+  for (const group of groups) {
+    const it = group.canonical;
+    const siblings = Array.isArray(group.siblings) ? group.siblings : [];
+    const dupCount = siblings.length;
+    const isSelected = [it, ...siblings].some((x) => x?.id && x.id === pane.workqueue.selectedItemId);
+
+    const groupWrap = document.createElement('div');
+    groupWrap.className = 'wq-row-group';
+
     const row = document.createElement('button');
     row.type = 'button';
     row.className = 'wq-row';
-    if (it.id && it.id === pane.workqueue.selectedItemId) row.classList.add('selected');
+    if (isSelected) row.classList.add('selected');
 
     const leaseMs = it.leaseUntil ? Number(it.leaseUntil) - now : NaN;
     const leaseLabel = it.leaseUntil ? fmtRemaining(leaseMs) : '';
     const status = String(it.status || '');
 
     row.innerHTML = `
-      <div class="wq-col title">${escapeHtml(String(it.title || ''))}</div>
+      <div class="wq-col title">${escapeHtml(String(it.title || ''))}${dupCount > 0 ? ` <span class="wq-card-chip mono">×${escapeHtml(String(group.count || (dupCount + 1)))}</span>` : ''}${group.hasClaimed ? ' <span class="wq-card-chip mono">claimed</span>' : ''}${group.hasExpiredLease ? ' <span class="wq-card-chip mono">expired lease</span>' : ''}</div>
       <div class="wq-col status"><span class="wq-badge wq-badge-${escapeHtml(status)}">${escapeHtml(status)}</span></div>
       <div class="wq-col prio mono">${escapeHtml(String(it.priority ?? ''))}</div>
       <div class="wq-col attempts mono">${escapeHtml(String(it.attempts ?? ''))}</div>
@@ -2085,7 +2753,38 @@ function renderWorkqueuePaneItems(pane) {
       renderWorkqueuePaneInspect(pane, it);
     });
 
-    body.appendChild(row);
+    groupWrap.appendChild(row);
+
+    if (dupCount > 0) {
+      const details = document.createElement('details');
+      details.className = 'wq-duplicates';
+
+      const summary = document.createElement('summary');
+      summary.className = 'wq-duplicates-summary mono';
+      summary.textContent = `+${dupCount} duplicate${dupCount === 1 ? '' : 's'}`;
+
+      const list = document.createElement('div');
+      list.className = 'wq-duplicates-list';
+
+      for (const dup of siblings) {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'wq-duplicate-btn';
+        btn.textContent = `${dup.id || ''} · prio ${dup.priority ?? ''} · ${dup.status || ''}`;
+        btn.addEventListener('click', () => {
+          pane.workqueue.selectedItemId = dup.id || null;
+          renderWorkqueuePaneItems(pane);
+          renderWorkqueuePaneInspect(pane, dup);
+        });
+        list.appendChild(btn);
+      }
+
+      details.appendChild(summary);
+      details.appendChild(list);
+      groupWrap.appendChild(details);
+    }
+
+    body.appendChild(groupWrap);
   }
 
   // Keep inspect in sync if selection vanished.
@@ -3379,6 +4078,87 @@ function panePumpOutbox(pane) {
 }
 
 
+function paneDraftCurrentOrigin(pane) {
+  return {
+    paneId: String(pane?.key || ''),
+    paneType: String(pane?.kind || 'chat'),
+    targetAgent: String((pane?.agentId || 'main') || 'main')
+  };
+}
+
+function paneDraftOriginLabel(origin) {
+  if (!origin) return 'unknown';
+  const paneType = String(origin.paneType || 'chat');
+  const target = String(origin.targetAgent || 'main');
+  return `${paneType}:${target}`;
+}
+
+function paneDismissSendGuard(pane) {
+  if (!pane?.sendGuard?.open) {
+    paneSetDestinationWarning(pane, false);
+    return;
+  }
+  pane.sendGuard.open = false;
+  pane.sendGuard.onConfirm = null;
+  const row = pane.elements?.root?.querySelector('[data-pane-send-guard]');
+  if (row) row.hidden = true;
+  paneSetDestinationWarning(pane, false);
+}
+
+function paneShowSendGuard(pane, { origin, current, onConfirm } = {}) {
+  const row = pane.elements?.root?.querySelector('[data-pane-send-guard]');
+  if (!row) return;
+  const msg = row.querySelector('[data-pane-send-guard-msg]');
+  if (msg) {
+    msg.textContent = `You started this draft in ${paneDraftOriginLabel(origin)}, now sending to ${paneDraftOriginLabel(current)}.`;
+  }
+  if (pane.sendGuard) {
+    pane.sendGuard.open = true;
+    pane.sendGuard.onConfirm = typeof onConfirm === 'function' ? onConfirm : null;
+  }
+  row.hidden = false;
+  paneSetDestinationWarning(pane, true);
+}
+
+function paneSyncDraftOrigin(pane) {
+  const value = String(pane?.elements?.input?.value || '');
+  if (!value.trim()) {
+    pane.draftOrigin = null;
+    paneDismissSendGuard(pane);
+    paneSetDestinationWarning(pane, false);
+    return;
+  }
+  if (!pane.draftOrigin) {
+    pane.draftOrigin = paneDraftCurrentOrigin(pane);
+  }
+  const current = paneDraftCurrentOrigin(pane);
+  const origin = pane.draftOrigin;
+  const mismatch = Boolean(
+    origin && (
+      String(origin.paneId || '') !== String(current.paneId || '') ||
+      String(origin.paneType || '') !== String(current.paneType || '') ||
+      String(origin.targetAgent || '') !== String(current.targetAgent || '')
+    )
+  );
+  paneSetDestinationWarning(pane, mismatch);
+}
+
+function paneCloseGuardPrompt(pane) {
+  if (!pane || pane.kind !== 'chat') return true;
+  const hasDraft = Boolean(String(pane.elements?.input?.value || '').trim());
+  const hasActiveRun = Boolean(pane.thinking?.active || pane.pendingSend);
+  if (!hasDraft && !hasActiveRun) return true;
+
+  const warnings = [];
+  if (hasDraft) warnings.push('- unsent draft text');
+  if (hasActiveRun) warnings.push('- active run in progress');
+  const ok = window.confirm(
+    `Close this pane?\n\nYou may lose:\n${warnings.join('\n')}`
+  );
+  return Boolean(ok);
+}
+
+
 async function paneSendChat(pane) {
   const raw = pane.elements.input.value.trim();
   if (!raw) return;
@@ -3397,6 +4177,8 @@ async function paneSendChat(pane) {
   if (command === '/clear') {
     paneClearChatHistory(pane, { wipeStorage: true });
     pane.elements.input.value = '';
+    pane.draftOrigin = null;
+    paneDismissSendGuard(pane);
     paneUpdateCommandHints(pane);
     addFeed('event', 'chat', `cleared local history (${pane.sessionKey()})`);
     return;
@@ -3405,9 +4187,33 @@ async function paneSendChat(pane) {
     const key = pane.sessionKey();
     paneClearChatHistory(pane, { wipeStorage: true });
     pane.elements.input.value = '';
+    pane.draftOrigin = null;
+    paneDismissSendGuard(pane);
     paneUpdateCommandHints(pane);
     pane.client.request('sessions.reset', { key });
     addFeed('event', 'chat', `reset session (${key})`);
+    return;
+  }
+
+  const currentOrigin = paneDraftCurrentOrigin(pane);
+  const origin = pane.draftOrigin;
+  const draftMismatch = Boolean(
+    origin && (
+      String(origin.paneId || '') !== String(currentOrigin.paneId || '') ||
+      String(origin.paneType || '') !== String(currentOrigin.paneType || '') ||
+      String(origin.targetAgent || '') !== String(currentOrigin.targetAgent || '')
+    )
+  );
+  if (draftMismatch) {
+    paneShowSendGuard(pane, {
+      origin,
+      current: currentOrigin,
+      onConfirm: () => {
+        paneDismissSendGuard(pane);
+        pane.draftOrigin = paneDraftCurrentOrigin(pane);
+        paneSendChat(pane);
+      }
+    });
     return;
   }
 
@@ -3485,6 +4291,8 @@ async function paneSendChat(pane) {
   paneEnqueueOutbound(pane, { message: outbound, sessionKey, idempotencyKey, bubble });
   panePumpOutbox(pane);
 
+  pane.draftOrigin = null;
+  paneDismissSendGuard(pane);
   pane.elements.input.value = '';
   paneUpdateCommandHints(pane);
 }
@@ -3537,6 +4345,7 @@ function handleGatewayFrame(pane, data) {
       pane.pendingSend = null;
       pane.inFlight = null;
       panePumpOutbox(pane);
+      paneMarkUnread(pane, 'chat');
       triggerFiring(1.2, 2);
     } else if (payload.state === 'error') {
       const shouldMarkCanceled =
@@ -3559,6 +4368,7 @@ function handleGatewayFrame(pane, data) {
       pane.pendingSend = null;
       pane.inFlight = null;
       panePumpOutbox(pane);
+      paneMarkUnread(pane, 'chat');
       triggerFiring(0.8, 1);
     }
   }
@@ -3598,6 +4408,7 @@ function buildClientForPane(pane) {
       }
       updateGlobalStatus();
       updateConnectionControls();
+      refreshPaneManagerIfOpen();
       paneSetChatEnabled(pane);
     },
     onFrame: (data) => handleGatewayFrame(pane, data),
@@ -3607,6 +4418,7 @@ function buildClientForPane(pane) {
       paneSetChatEnabled(pane);
       updateGlobalStatus();
       updateConnectionControls();
+      refreshPaneManagerIfOpen();
       paneEnsureHiddenWelcome(pane);
       pane.client.request('sessions.resolve', { key: pane.sessionKey() });
 
@@ -3631,6 +4443,7 @@ function buildClientForPane(pane) {
       paneSetChatEnabled(pane);
       updateGlobalStatus();
       updateConnectionControls();
+      refreshPaneManagerIfOpen();
     },
     isAuthed: () => uiState.authed,
     checkAuth: async () => {
@@ -3652,6 +4465,7 @@ function agentIdExists(agentId) {
 
 function paneSetHeaderTarget(pane, { label, value, ariaLabel, onClick } = {}) {
   if (!pane?.elements) return;
+  paneRenderDestinationStrip(pane);
   const { targetLabel, agentButton, agentLabel, agentSelect, agentWarning } = pane.elements;
 
   if (targetLabel && typeof label === 'string') targetLabel.textContent = label;
@@ -3681,6 +4495,8 @@ function paneSetHeaderTarget(pane, { label, value, ariaLabel, onClick } = {}) {
       agentButton.addEventListener('click', handler);
     }
   }
+
+  paneRenderDestinationStrip(pane);
 }
 
 function renderPaneAgentIdentity(pane) {
@@ -3841,6 +4657,10 @@ function paneSetAgent(pane, nextAgentId) {
     if (pane.elements.agentSelect) pane.elements.agentSelect.value = next;
   } catch {}
   renderPaneAgentIdentity(pane);
+  paneRenderDestinationStrip(pane);
+  if (pane.kind === 'workqueue') {
+    renderWorkqueuePaneItems(pane);
+  }
 
   pane.attachments.files = [];
   paneRenderAttachments(pane);
@@ -3890,12 +4710,16 @@ function renderAgentOptions(selectEl, agentId) {
   selectEl.value = normalizeAgentId(agentId || 'main');
 }
 
-function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sortKey, sortDir, closable = true } = {}) {
+function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, quickFilters, scope, sortKey, sortDir, closable = true } = {}) {
   const template = globalElements.paneTemplate;
   const root = template.content.firstElementChild.cloneNode(true);
   const elements = {
     root,
     name: root.querySelector('[data-pane-name]'),
+    activityBadge: root.querySelector('[data-pane-activity-badge]'),
+    typePill: root.querySelector('[data-pane-type-pill]'),
+    typeIcon: root.querySelector('[data-pane-type-icon]'),
+    typeText: root.querySelector('[data-pane-type-text]'),
     agentSelect: root.querySelector('[data-pane-agent-select]'),
     agentWrap: root.querySelector('[data-pane-agent-wrap]') || root.querySelector('.pane-agent'),
     targetLabel: root.querySelector('[data-pane-target-label]') || root.querySelector('.agent-label'),
@@ -3911,6 +4735,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
     inputRow: root.querySelector('.chat-input-row'),
     input: root.querySelector('[data-pane-input]'),
     commandHints: root.querySelector('[data-pane-command-hints]'),
+    shortcutHints: root.querySelector('[data-pane-shortcut-hints]'),
     fileInput: root.querySelector('[data-pane-file-input]'),
     attachBtn: root.querySelector('[data-pane-attach]'),
     attachmentStatus: root.querySelector('[data-pane-attachment-status]'),
@@ -3931,13 +4756,21 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
     workqueue: {
       queue: (queue || 'dev-team').trim() || 'dev-team',
       statusFilter: Array.isArray(statusFilter) ? statusFilter : ['ready', 'pending', 'claimed', 'in_progress'],
+      quickFilters: {
+        source: typeof quickFilters?.source === 'string' ? quickFilters.source.trim() : '',
+        repo: typeof quickFilters?.repo === 'string' ? quickFilters.repo.trim() : '',
+        actionableOnly: !!quickFilters?.actionableOnly
+      },
+      scope: ['assigned', 'unassigned', 'all'].includes(String(scope || '').trim().toLowerCase()) ? String(scope).trim().toLowerCase() : 'all',
       items: [],
       selectedItemId: null,
       sortKey: typeof sortKey === 'string' && sortKey.trim() ? sortKey.trim() : 'default',
-      sortDir: sortDir === 'asc' ? 'asc' : 'desc'
+      sortDir: sortDir === 'asc' ? 'asc' : 'desc',
+      groupingMode: ['auto', 'on', 'off'].includes(String(workqueue?.groupingMode || '').toLowerCase()) ? String(workqueue.groupingMode).toLowerCase() : 'auto'
     },
     connected: false,
     statusState: 'disconnected',
+    activity: { unread: 0, kind: '' },
     statusMeta: '',
     elements,
     chat: { runs: new Map(), history: [] },
@@ -3950,6 +4783,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
     catchUp: { active: false, attemptsLeft: 0, timer: null },
     outbox: [],
     inFlight: null,
+    draftOrigin: null,
+    sendGuard: { open: false, onConfirm: null },
     chatKey: () => computeChatKey({ role: pane.role, agentId: pane.agentId }),
     legacySessionKey: () => computeLegacySessionKey({ role: pane.role, agentId: pane.agentId }),
     sessionKey: () => computeSessionKey({ role: pane.role, agentId: pane.agentId, paneKey: pane.key }),
@@ -3957,11 +4792,38 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
     client: null
   };
 
+  function getPaneShortcutHints(currentPane) {
+    const common = ['Cmd/Ctrl+Shift+K next', 'Cmd/Ctrl+Shift+J prev', 'Press ? for all shortcuts'];
+    if (currentPane.kind === 'workqueue') return ['g w Workqueue modal', 'Alt+1..9 focus pane', ...common];
+    if (currentPane.kind === 'cron') return ['Cmd/Ctrl+Shift+R add Cron pane', 'Alt+1..9 focus pane', ...common];
+    if (currentPane.kind === 'timeline') return ['Cmd/Ctrl+Shift+T add Timeline pane', 'Alt+1..9 focus pane', ...common];
+    return ['Cmd/Ctrl+K command palette', 'Alt+1..9 focus pane', ...common];
+  }
+
+  function renderPaneShortcutHints(currentPane) {
+    const el = currentPane?.elements?.shortcutHints;
+    if (!el) return;
+    const active = document.activeElement;
+    const inPane = !!(currentPane?.elements?.root && active && currentPane.elements.root.contains(active));
+    if (inPane && isTypingContext(active)) {
+      el.textContent = '';
+      el.hidden = true;
+      return;
+    }
+    const hints = getPaneShortcutHints(currentPane).slice(0, 5);
+    el.textContent = hints.join(' · ');
+    el.hidden = hints.length === 0;
+  }
+
   // Mark pane kind on root for CSS + debugging.
   try {
     elements.root.dataset.paneKind = pane.kind;
+    elements.root.dataset.paneAccentKind = pane.kind;
     elements.root.classList.add(`pane-kind-${pane.kind}`);
   } catch {}
+  if (elements.name) elements.name.textContent = paneLabel(pane);
+  paneRenderTypePill(pane);
+  renderPaneShortcutHints(pane);
 
   // Per-pane inline help popover ("What is this pane?")
   try {
@@ -3974,7 +4836,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
             lines: ['Shows queued work items, grouped by status.', 'Drag cards between columns to change status.', 'Use Refresh when another worker updates the queue.'],
             shortcuts: [
               ['g w', 'open Workqueue modal'],
-              ['Cmd/Ctrl+K', 'cycle focus between panes']
+              ['Cmd/Ctrl+Shift+K', 'focus next pane'],
+              ['Cmd/Ctrl+Shift+J', 'focus previous pane']
             ]
           };
         }
@@ -3984,7 +4847,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
             lines: ['Shows scheduled jobs in the Gateway cron scheduler.', 'Use filters to find failing/disabled jobs.', 'Use Run/Edit/Disable for quick ops.'],
             shortcuts: [
               ['?', 'keyboard shortcuts overlay'],
-              ['Cmd/Ctrl+K', 'cycle focus between panes']
+              ['Cmd/Ctrl+Shift+K', 'focus next pane'],
+              ['Cmd/Ctrl+Shift+J', 'focus previous pane']
             ]
           };
         }
@@ -3994,7 +4858,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
             lines: ['Shows recent cron run history (best-effort).', 'Adjust range/status/search to find events.', 'Click View to inspect the underlying job.'],
             shortcuts: [
               ['?', 'keyboard shortcuts overlay'],
-              ['Cmd/Ctrl+K', 'cycle focus between panes']
+              ['Cmd/Ctrl+Shift+K', 'focus next pane'],
+              ['Cmd/Ctrl+Shift+J', 'focus previous pane']
             ]
           };
         }
@@ -4002,8 +4867,10 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
           title: 'Chat',
           lines: ['Chat with an agent/session.', 'Pick an agent target, then send messages/files.', 'Use Stop to cancel a long response.'],
           shortcuts: [
-            ['Cmd/Ctrl+1..4', 'focus a pane'],
-            ['Cmd/Ctrl+K', 'cycle focus between panes']
+            ['Alt+1..9', 'focus visible pane by order'],
+            ['Cmd/Ctrl+1..4', 'focus a pane (legacy index)'],
+            ['Cmd/Ctrl+Shift+K', 'focus next pane'],
+            ['Cmd/Ctrl+Shift+J', 'focus previous pane']
           ]
         };
       })();
@@ -4047,6 +4914,17 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
       paneAbortRun(pane);
     });
   }
+
+  elements.root.addEventListener('focusin', () => {
+    paneClearUnread(pane);
+    renderPaneShortcutHints(pane);
+  });
+  elements.root.addEventListener('focusout', () => {
+    setTimeout(() => renderPaneShortcutHints(pane), 0);
+  });
+  elements.root.addEventListener('input', () => {
+    renderPaneShortcutHints(pane);
+  });
 
   // WORKQUEUE PANE
   if (pane.role === 'admin' && pane.kind === 'workqueue') {
@@ -4092,6 +4970,42 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
             </div>
           </div>
 
+          <div class="wq-field wq-scope-field">
+            <span class="wq-label">Scope</span>
+            <div class="wq-scope" role="group" aria-label="Filter by ownership scope">
+              <button type="button" class="wq-scope-btn" data-wq-scope="assigned">Assigned to active target</button>
+              <button type="button" class="wq-scope-btn" data-wq-scope="unassigned">Unassigned</button>
+              <button type="button" class="wq-scope-btn" data-wq-scope="all">All</button>
+            </div>
+          </div>
+
+          <label class="wq-field">
+            <span class="wq-label">Source</span>
+            <select data-wq-quick-source aria-label="Filter by source">
+              <option value="">All</option>
+              <option value="github">GitHub</option>
+              <option value="automation">Automation</option>
+              <option value="manual">Manual</option>
+            </select>
+          </label>
+
+          <label class="wq-field">
+            <span class="wq-label">Repo</span>
+            <select data-wq-quick-repo aria-label="Filter by repository">
+              <option value="">All</option>
+            </select>
+          </label>
+
+          <button data-wq-preset-clawnsole class="secondary" type="button">Clawnsole only</button>
+          <button data-wq-preset-actionable class="secondary" type="button" aria-pressed="false">Actionable only</button>
+          <label class="wq-field">
+            <span class="wq-label">Grouping</span>
+            <select data-wq-grouping-mode aria-label="Grouping mode">
+              <option value="auto">Auto (&gt;12 items)</option>
+              <option value="on">On</option>
+              <option value="off">Off</option>
+            </select>
+          </label>
           <button data-wq-refresh class="secondary" type="button">Refresh</button>
 
           <div class="wq-sort" role="group" aria-label="Sort workqueue items">
@@ -4186,6 +5100,12 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
     const statusOptionsEl = elements.thread.querySelector('[data-wq-status-options]');
     const statusDetailsEl = elements.thread.querySelector('[data-wq-status-details]');
     const statusClearBtn = elements.thread.querySelector('[data-wq-status-clear]');
+    const scopeBtns = Array.from(elements.thread.querySelectorAll('[data-wq-scope]'));
+    const quickSourceEl = elements.thread.querySelector('[data-wq-quick-source]');
+    const quickRepoEl = elements.thread.querySelector('[data-wq-quick-repo]');
+    const clawnsoleOnlyBtn = elements.thread.querySelector('[data-wq-preset-clawnsole]');
+    const actionableOnlyBtn = elements.thread.querySelector('[data-wq-preset-actionable]');
+    const groupingModeEl = elements.thread.querySelector('[data-wq-grouping-mode]');
     const refreshBtn = elements.thread.querySelector('[data-wq-refresh]');
 
     const DEFAULT_STATUSES = ['ready', 'pending', 'claimed', 'in_progress'];
@@ -4202,6 +5122,65 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
       return sel;
     };
 
+    const updateActionablePresetUi = () => {
+      if (!actionableOnlyBtn) return;
+      const active = !!pane.workqueue.quickFilters?.actionableOnly;
+      actionableOnlyBtn.classList.toggle('active', active);
+      actionableOnlyBtn.setAttribute('aria-pressed', active ? 'true' : 'false');
+    };
+
+    const setQuickFilters = ({ source, repo, actionableOnly } = {}) => {
+      pane.workqueue.quickFilters = {
+        source: typeof source === 'string' ? source.trim() : String(pane.workqueue.quickFilters?.source || '').trim(),
+        repo: typeof repo === 'string' ? repo.trim() : String(pane.workqueue.quickFilters?.repo || '').trim(),
+        actionableOnly: typeof actionableOnly === 'boolean' ? actionableOnly : !!pane.workqueue.quickFilters?.actionableOnly
+      };
+      if (quickSourceEl) quickSourceEl.value = pane.workqueue.quickFilters.source || '';
+      if (quickRepoEl) quickRepoEl.value = pane.workqueue.quickFilters.repo || '';
+      updateActionablePresetUi();
+    };
+
+    const refreshQuickRepoOptions = () => {
+      if (!quickRepoEl) return;
+      const current = String(pane.workqueue.quickFilters?.repo || '').trim();
+      const repos = Array.from(new Set((Array.isArray(pane.workqueue?.items) ? pane.workqueue.items : []).map(getWorkqueueItemRepo).filter(Boolean)));
+      if (current && !repos.includes(current)) repos.push(current);
+      repos.sort((a, b) => a.localeCompare(b));
+      quickRepoEl.innerHTML = '';
+      const allOpt = document.createElement('option');
+      allOpt.value = '';
+      allOpt.textContent = 'All';
+      quickRepoEl.appendChild(allOpt);
+      for (const r of repos) {
+        const opt = document.createElement('option');
+        opt.value = r;
+        opt.textContent = r;
+        quickRepoEl.appendChild(opt);
+      }
+      if (current && repos.includes(current)) quickRepoEl.value = current;
+      else quickRepoEl.value = '';
+    };
+
+    const updateScopeUi = () => {
+      const current = String(pane.workqueue?.scope || 'all').trim().toLowerCase() || 'all';
+      scopeBtns.forEach((btn) => {
+        const value = String(btn.getAttribute('data-wq-scope') || '').trim().toLowerCase();
+        const active = value === current;
+        btn.classList.toggle('active', active);
+        btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+      });
+    };
+
+    const setScope = (scopeValue) => {
+      const next = ['assigned', 'unassigned', 'all'].includes(String(scopeValue || '').trim().toLowerCase())
+        ? String(scopeValue).trim().toLowerCase()
+        : 'all';
+      pane.workqueue.scope = next;
+      updateScopeUi();
+      renderWorkqueuePaneItems(pane);
+      paneManager.persistAdminPanes();
+    };
+
     const applyStatuses = async (next, { closeMenu = false } = {}) => {
       statusSet.clear();
       for (const s of next) statusSet.add(s);
@@ -4209,6 +5188,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
       renderStatusMultiSelect();
       if (closeMenu) statusDetailsEl?.removeAttribute('open');
       await fetchAndRenderWorkqueueItemsForPane(pane);
+      refreshQuickRepoOptions();
       paneManager.persistAdminPanes();
     };
 
@@ -4232,6 +5212,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
         renderStatusMultiSelect();
       }
       await fetchAndRenderWorkqueueItemsForPane(pane);
+      refreshQuickRepoOptions();
       paneManager.persistAdminPanes();
     };
 
@@ -4330,7 +5311,49 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
     });
 
     renderStatusMultiSelect();
+    setQuickFilters({
+      source: String(pane.workqueue?.quickFilters?.source || '').trim(),
+      repo: String(pane.workqueue?.quickFilters?.repo || '').trim(),
+      actionableOnly: !!pane.workqueue?.quickFilters?.actionableOnly
+    });
+    if (groupingModeEl) groupingModeEl.value = pane.workqueue.groupingMode || 'auto';
     populateQueueSelect().then(() => doRefresh());
+
+    quickSourceEl?.addEventListener('change', () => {
+      setQuickFilters({ source: quickSourceEl.value, repo: quickRepoEl?.value || '' });
+      renderWorkqueuePaneItems(pane);
+      paneManager.persistAdminPanes();
+    });
+    quickRepoEl?.addEventListener('change', () => {
+      setQuickFilters({ source: quickSourceEl?.value || '', repo: quickRepoEl.value });
+      renderWorkqueuePaneItems(pane);
+      paneManager.persistAdminPanes();
+    });
+    clawnsoleOnlyBtn?.addEventListener('click', () => {
+      setQuickFilters({ source: 'github', repo: 'rmdmattingly/clawnsole' });
+      renderWorkqueuePaneItems(pane);
+      paneManager.persistAdminPanes();
+    });
+    actionableOnlyBtn?.addEventListener('click', async () => {
+      const next = !pane.workqueue.quickFilters?.actionableOnly;
+      setQuickFilters({ actionableOnly: next });
+      if (next) {
+        pane.workqueue.sortKey = 'priority';
+        pane.workqueue.sortDir = 'desc';
+        try { updateSortUi(); } catch {}
+        await applyStatuses(DEFAULT_STATUSES);
+      } else {
+        renderWorkqueuePaneItems(pane);
+      }
+      paneManager.persistAdminPanes();
+    });
+
+    groupingModeEl?.addEventListener('change', () => {
+      const mode = String(groupingModeEl.value || 'auto').toLowerCase();
+      pane.workqueue.groupingMode = ['auto', 'on', 'off'].includes(mode) ? mode : 'auto';
+      renderWorkqueuePaneItems(pane);
+      paneManager.persistAdminPanes();
+    });
 
     refreshBtn?.addEventListener('click', () => doRefresh());
     queueCustomEl?.addEventListener('keydown', (e) => {
@@ -4351,6 +5374,11 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
 
       statusClearBtn?.addEventListener('click', () => applyStatuses([]));
     }
+
+    scopeBtns.forEach((btn) => {
+      btn.addEventListener('click', () => setScope(btn.getAttribute('data-wq-scope')));
+    });
+    updateScopeUi();
 
     // Sort controls (client-side): stable sorting with a status-grouping default.
     const sortBtns = Array.from(elements.thread.querySelectorAll('[data-wq-sort]'));
@@ -4461,6 +5489,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
       }
     });
 
+    pane.statusState = 'connected';
+    pane.statusMeta = '';
     setStatusPill(elements.status, 'connected', '');
     // initial fetch is deferred until admin authed, but safe to load immediately too.
     setTimeout(() => {
@@ -4469,6 +5499,9 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
 
     pane.client = null;
     pane.connected = true;
+    updateGlobalStatus();
+    updateConnectionControls();
+    refreshPaneManagerIfOpen();
     return pane;
   }
 
@@ -5013,13 +6046,15 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
     };
 
     pane.client = buildClientForPane(pane);
+    pane.statusState = 'disconnected';
+    pane.statusMeta = '';
     setStatusPill(elements.status, 'disconnected', '');
     return pane;
   }
 
   // CHAT PANE (existing behavior)
 
-  if (pane.role === 'admin') {
+  if (pane.role === 'admin' && pane.kind === 'chat') {
     renderAgentOptions(elements.agentSelect, pane.agentId);
     renderPaneAgentIdentity(pane);
 
@@ -5030,9 +6065,55 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
     elements.agentSelect?.addEventListener('change', (event) => {
       paneSetAgent(pane, String(event.target.value || '').trim());
     });
-  } else {
+  } else if (pane.role !== 'admin') {
     if (elements.agentWrap) elements.agentWrap.hidden = true;
     if (elements.closeBtn) elements.closeBtn.hidden = true;
+  }
+
+  {
+    const stack = elements.root?.querySelector('.chat-input-stack');
+    if (stack && !stack.querySelector('[data-pane-destination-strip]')) {
+      const strip = document.createElement('button');
+      strip.type = 'button';
+      strip.className = 'destination-strip';
+      strip.setAttribute('data-pane-destination-strip', '1');
+      strip.setAttribute('data-testid', 'pane-destination-strip');
+      strip.innerHTML = `
+        <span class="destination-strip-label">Sending to:</span>
+        <span class="destination-strip-value" data-pane-destination-value></span>
+      `;
+      strip.addEventListener('click', () => paneOpenInManager(pane));
+      stack.insertBefore(strip, stack.firstChild || null);
+    }
+    paneRenderDestinationStrip(pane);
+  }
+
+  if (pane.kind === 'chat') {
+    const stack = elements.root?.querySelector('.chat-input-stack');
+    if (stack && !stack.querySelector('[data-pane-send-guard]')) {
+      const guard = document.createElement('div');
+      guard.className = 'send-guard';
+      guard.hidden = true;
+      guard.setAttribute('data-pane-send-guard', '1');
+      guard.setAttribute('data-testid', 'pane-send-guard');
+      guard.innerHTML = `
+        <div class="send-guard-msg" data-pane-send-guard-msg></div>
+        <div class="send-guard-actions">
+          <button type="button" class="secondary" data-pane-send-guard-confirm data-testid="pane-send-guard-confirm">Send anyway</button>
+          <button type="button" class="secondary" data-pane-send-guard-cancel data-testid="pane-send-guard-cancel">Cancel</button>
+        </div>
+      `;
+      stack.insertBefore(guard, elements.commandHints || null);
+
+      guard.querySelector('[data-pane-send-guard-confirm]')?.addEventListener('click', () => {
+        const fn = pane.sendGuard?.onConfirm;
+        if (typeof fn === 'function') fn();
+      });
+      guard.querySelector('[data-pane-send-guard-cancel]')?.addEventListener('click', () => {
+        paneDismissSendGuard(pane);
+        elements.input?.focus?.();
+      });
+    }
   }
 
   elements.sendBtn.addEventListener('click', () => {
@@ -5041,6 +6122,11 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
   });
 
   elements.input.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && pane.sendGuard?.open) {
+      event.preventDefault();
+      paneDismissSendGuard(pane);
+      return;
+    }
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault();
       if (elements.sendBtn.disabled) return;
@@ -5049,6 +6135,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
   });
 
   elements.input.addEventListener('input', () => {
+    paneSyncDraftOrigin(pane);
     paneUpdateCommandHints(pane);
   });
 
@@ -5111,6 +6198,8 @@ const paneManager = {
         agentId: cfg.agentId,
         queue: cfg.queue,
         statusFilter: cfg.statusFilter,
+        quickFilters: cfg.quickFilters,
+        scope: cfg.scope,
         sortKey: cfg.sortKey,
         sortDir: cfg.sortDir,
         closable: true
@@ -5120,6 +6209,20 @@ const paneManager = {
     this.updatePaneLabels();
     this.updateCloseButtons();
     this.applyInferredLayout();
+  },
+  buildDefaultAdminPanes(defaultAgent) {
+    const safeDefaultAgent = normalizeAgentId(defaultAgent || 'main');
+    const paneA = { key: `p${randomId().slice(0, 8)}`, kind: 'chat', agentId: safeDefaultAgent };
+    const paneB = {
+      key: `p${randomId().slice(0, 8)}`,
+      kind: 'workqueue',
+      queue: 'dev-team',
+      statusFilter: ['ready', 'pending', 'claimed', 'in_progress'],
+      quickFilters: { source: '', repo: '' },
+      sortKey: 'default',
+      sortDir: 'desc'
+    };
+    return [paneA, paneB].slice(0, this.maxPanes);
   },
   destroyAll() {
     this.panes.forEach((pane) => {
@@ -5137,18 +6240,27 @@ const paneManager = {
     const storedDefault = storage.get(ADMIN_DEFAULT_AGENT_KEY, 'main');
     const defaultAgent = normalizeAgentId(storedDefault || 'main');
 
+    const isKnownKind = (value) => value === 'chat' || value === 'workqueue' || value === 'cron' || value === 'timeline';
+    const coerceKind = (rawKind, rawMode) => {
+      const normalized = typeof rawKind === 'string' ? rawKind.trim().toLowerCase() : '';
+      if (isKnownKind(normalized)) return normalized;
+
+      const normalizedMode = typeof rawMode === 'string' ? rawMode.trim().toLowerCase() : '';
+      if (isKnownKind(normalizedMode)) return normalizedMode;
+
+      // Legacy super-compact entries (no kind/mode) default to chat.
+      if (!normalized && !normalizedMode) return 'chat';
+
+      return null;
+    };
+
     const coerce = (item) => {
       // Legacy format: { key, agentId }
       if (item && typeof item === 'object') {
         const key = typeof item.key === 'string' && item.key ? item.key : '';
-        const rawKind = typeof item.kind === 'string' ? item.kind.trim().toLowerCase() : '';
-        const rawMode = typeof item.mode === 'string' ? item.mode.trim().toLowerCase() : '';
-        const kind = rawKind === 'workqueue' || rawKind === 'cron' || rawKind === 'timeline'
-          ? rawKind
-          : rawMode === 'workqueue' || rawMode === 'cron' || rawMode === 'timeline'
-            ? rawMode
-            : 'chat';
-        if (!key) return null;
+        const kind = coerceKind(item.kind, item.mode);
+        if (!key || !kind) return null;
+
         if (kind === 'workqueue') {
           const queue = typeof item.queue === 'string' && item.queue.trim() ? item.queue.trim() : 'dev-team';
           const statusFilter = Array.isArray(item.statusFilter)
@@ -5156,18 +6268,32 @@ const paneManager = {
             : ['ready', 'pending', 'claimed', 'in_progress'];
           const sortKey = typeof item.sortKey === 'string' ? item.sortKey : 'default';
           const sortDir = item.sortDir === 'asc' ? 'asc' : 'desc';
-          return { key, kind, queue, statusFilter, sortKey, sortDir };
+          const scope = ['assigned', 'unassigned', 'all'].includes(String(item.scope || '').trim().toLowerCase())
+            ? String(item.scope).trim().toLowerCase()
+            : 'all';
+          const quickFilters = item.quickFilters && typeof item.quickFilters === 'object'
+            ? {
+                source: typeof item.quickFilters.source === 'string' ? item.quickFilters.source.trim() : '',
+                repo: typeof item.quickFilters.repo === 'string' ? item.quickFilters.repo.trim() : '',
+                actionableOnly: !!item.quickFilters.actionableOnly
+              }
+            : { source: '', repo: '', actionableOnly: false };
+          return { key, kind, queue, statusFilter, scope, sortKey, sortDir, quickFilters };
         }
+
         if (kind === 'cron' || kind === 'timeline') {
           return { key, kind };
         }
+
         const agentId = normalizeAgentId(typeof item.agentId === 'string' ? item.agentId : defaultAgent);
-        return { key, kind: 'chat', agentId };
+        return { key, kind, agentId };
       }
+
       // Super-legacy format: ['pabc','pdef'] (treat as chat panes)
       if (typeof item === 'string' && item) {
         return { key: item, kind: 'chat', agentId: defaultAgent };
       }
+
       return null;
     };
 
@@ -5176,25 +6302,28 @@ const paneManager = {
       if (!raw) throw new Error('empty');
       const parsed = JSON.parse(raw);
       if (!Array.isArray(parsed)) throw new Error('not array');
-      const list = parsed.map(coerce).filter(Boolean);
-      if (list.length > 0) {
-        return list.slice(0, this.maxPanes);
+
+      const list = [];
+      let changed = false;
+      for (const item of parsed) {
+        const normalized = coerce(item);
+        if (normalized) list.push(normalized);
+        else changed = true;
+      }
+
+      const panes = list.slice(0, this.maxPanes);
+      if (panes.length > 0) {
+        if (changed || parsed.length !== panes.length) {
+          storage.set(ADMIN_PANES_KEY, JSON.stringify(panes));
+        }
+        return panes;
       }
     } catch {}
 
     // Default: Chat + Workqueue.
-    const paneA = { key: `p${randomId().slice(0, 8)}`, kind: 'chat', agentId: defaultAgent };
-    const paneB = {
-      key: `p${randomId().slice(0, 8)}`,
-      kind: 'workqueue',
-      queue: 'dev-team',
-      statusFilter: ['ready', 'pending', 'claimed', 'in_progress'],
-      sortKey: 'default',
-      sortDir: 'desc'
-    };
-    const list = [paneA, paneB].slice(0, this.maxPanes);
-    storage.set(ADMIN_PANES_KEY, JSON.stringify(list));
-    return list;
+    const panes = this.buildDefaultAdminPanes(defaultAgent);
+    storage.set(ADMIN_PANES_KEY, JSON.stringify(panes));
+    return panes;
   },
   persistAdminPanes() {
     if (roleState.role !== 'admin') return;
@@ -5205,6 +6334,12 @@ const paneManager = {
           kind: 'workqueue',
           queue: pane.workqueue?.queue || 'dev-team',
           statusFilter: Array.isArray(pane.workqueue?.statusFilter) ? pane.workqueue.statusFilter : [],
+          quickFilters: {
+            source: String(pane.workqueue?.quickFilters?.source || '').trim(),
+            repo: String(pane.workqueue?.quickFilters?.repo || '').trim(),
+            actionableOnly: !!pane.workqueue?.quickFilters?.actionableOnly
+          },
+          scope: String(pane.workqueue?.scope || 'all').trim().toLowerCase() || 'all',
           sortKey: pane.workqueue?.sortKey || 'default',
           sortDir: pane.workqueue?.sortDir || 'desc'
         };
@@ -5225,16 +6360,8 @@ const paneManager = {
 
     const storedDefault = storage.get(ADMIN_DEFAULT_AGENT_KEY, 'main');
     const defaultAgent = normalizeAgentId(storedDefault || 'main');
-    const paneA = { key: `p${randomId().slice(0, 8)}`, kind: 'chat', agentId: defaultAgent };
-    const paneB = {
-      key: `p${randomId().slice(0, 8)}`,
-      kind: 'workqueue',
-      queue: 'dev-team',
-      statusFilter: ['ready', 'pending', 'claimed', 'in_progress'],
-      sortKey: 'default',
-      sortDir: 'desc'
-    };
-    storage.set(ADMIN_PANES_KEY, JSON.stringify([paneA, paneB]));
+    const payload = this.buildDefaultAdminPanes(defaultAgent);
+    storage.set(ADMIN_PANES_KEY, JSON.stringify(payload));
 
     this.init();
 
@@ -5246,19 +6373,41 @@ const paneManager = {
       firstPane?.elements?.input?.focus?.();
     } catch {}
   },
-  addPane(kind = 'chat') {
+
+  addPane(kind = 'chat', { forceNew = false, queue } = {}) {
     if (roleState.role !== 'admin') return;
-    if (this.panes.length >= this.maxPanes) return;
 
     const normalizedKind = normalizePaneKind(kind);
 
+    if (normalizedKind === 'workqueue' || normalizedKind === 'cron' || normalizedKind === 'timeline') {
+      const targetQueue = String(queue || 'dev-team').trim() || 'dev-team';
+      const existing = this.panes.find((pane) => {
+        if (!pane || pane.kind !== normalizedKind) return false;
+        if (normalizedKind === 'workqueue') {
+          return String(pane.workqueue?.queue || 'dev-team').trim() === targetQueue;
+        }
+        return true;
+      });
+
+      if (existing && !forceNew) {
+        this.focusPanePrimary(existing);
+        const noun = normalizedKind === 'workqueue' ? `workqueue (${targetQueue})` : normalizedKind;
+        showToast(`Reusing existing ${noun} pane.`, { kind: 'info', timeoutMs: 1800 });
+        return existing;
+      }
+    }
+
+    if (this.panes.length >= this.maxPanes) return;
+
     if (normalizedKind === 'workqueue') {
+      const targetQueue = String(queue || 'dev-team').trim() || 'dev-team';
       const pane = createPane({
         key: `p${randomId().slice(0, 8)}`,
         role: 'admin',
         kind: 'workqueue',
-        queue: 'dev-team',
+        queue: targetQueue,
         statusFilter: ['ready', 'pending', 'claimed', 'in_progress'],
+        quickFilters: { source: '', repo: '' },
         closable: true
       });
       this.panes.push(pane);
@@ -5371,12 +6520,26 @@ const paneManager = {
       wqBtn.dataset.testid = 'pane-add-menu-workqueue';
       wqBtn.title = 'Shortcut: Ctrl/Cmd+Shift+W';
 
+      const wqForceBtn = document.createElement('button');
+      wqForceBtn.type = 'button';
+      wqForceBtn.className = 'pane-add-menu__item';
+      wqForceBtn.textContent = 'Open anyway: New Workqueue pane';
+      wqForceBtn.dataset.testid = 'pane-add-menu-workqueue-open-anyway';
+      wqForceBtn.hidden = true;
+
       const cronBtn = document.createElement('button');
       cronBtn.type = 'button';
       cronBtn.className = 'pane-add-menu__item';
       cronBtn.textContent = 'New Cron pane';
       cronBtn.dataset.testid = 'pane-add-menu-cron';
       cronBtn.title = 'Shortcut: Ctrl/Cmd+Shift+R';
+
+      const cronForceBtn = document.createElement('button');
+      cronForceBtn.type = 'button';
+      cronForceBtn.className = 'pane-add-menu__item';
+      cronForceBtn.textContent = 'Open anyway: New Cron pane';
+      cronForceBtn.dataset.testid = 'pane-add-menu-cron-open-anyway';
+      cronForceBtn.hidden = true;
 
       const timelineBtn = document.createElement('button');
       timelineBtn.type = 'button';
@@ -5385,38 +6548,50 @@ const paneManager = {
       timelineBtn.dataset.testid = 'pane-add-menu-timeline';
       timelineBtn.title = 'Shortcut: Ctrl/Cmd+Shift+T';
 
+      const timelineForceBtn = document.createElement('button');
+      timelineForceBtn.type = 'button';
+      timelineForceBtn.className = 'pane-add-menu__item';
+      timelineForceBtn.textContent = 'Open anyway: New Timeline pane';
+      timelineForceBtn.dataset.testid = 'pane-add-menu-timeline-open-anyway';
+      timelineForceBtn.hidden = true;
+
       menu.appendChild(chatBtn);
       menu.appendChild(wqBtn);
+      menu.appendChild(wqForceBtn);
       menu.appendChild(cronBtn);
+      menu.appendChild(cronForceBtn);
       menu.appendChild(timelineBtn);
+      menu.appendChild(timelineForceBtn);
 
-      const onMenuAdd = (kind) => (event) => {
-        if (state.menuActionInFlight) return;
-        state.menuActionInFlight = true;
+      const onMenuAdd = (kind, options = {}) => (event) => {
+        if (state.menuActionTaken) return;
+        state.menuActionTaken = true;
         if (event?.preventDefault) event.preventDefault();
         if (event?.stopPropagation) event.stopPropagation();
 
         this.closeAddPaneMenu();
-        this.addPane(kind);
-
-        queueMicrotask(() => {
-          state.menuActionInFlight = false;
-        });
+        this.addPane(kind, options);
       };
 
       chatBtn.addEventListener('click', onMenuAdd('chat'));
 
       wqBtn.addEventListener('click', onMenuAdd('workqueue'));
+      wqForceBtn.addEventListener('click', onMenuAdd('workqueue', { forceNew: true }));
 
       cronBtn.addEventListener('click', onMenuAdd('cron'));
+      cronForceBtn.addEventListener('click', onMenuAdd('cron', { forceNew: true }));
 
       timelineBtn.addEventListener('click', onMenuAdd('timeline'));
+      timelineForceBtn.addEventListener('click', onMenuAdd('timeline', { forceNew: true }));
 
       state.menuEl = menu;
       state.chatBtn = chatBtn;
       state.wqBtn = wqBtn;
+      state.wqForceBtn = wqForceBtn;
       state.cronBtn = cronBtn;
+      state.cronForceBtn = cronForceBtn;
       state.timelineBtn = timelineBtn;
+      state.timelineForceBtn = timelineForceBtn;
     }
 
     const positionMenu = () => {
@@ -5442,6 +6617,7 @@ const paneManager = {
     document.body.appendChild(state.menuEl);
     state.menuEl.style.display = 'block';
     state.open = true;
+    state.menuActionTaken = false;
 
     try {
       anchorEl.setAttribute('aria-expanded', 'true');
@@ -5459,10 +6635,30 @@ const paneManager = {
     window.addEventListener('scroll', positionMenu, true);
 
     const atMax = this.panes.length >= this.maxPanes;
+    const hasWorkqueue = this.panes.some((pane) => pane.kind === 'workqueue' && String(pane.workqueue?.queue || 'dev-team').trim() === 'dev-team');
+    const hasCron = this.panes.some((pane) => pane.kind === 'cron');
+    const hasTimeline = this.panes.some((pane) => pane.kind === 'timeline');
+
     state.chatBtn.disabled = atMax;
-    state.wqBtn.disabled = atMax;
-    state.cronBtn.disabled = atMax;
-    state.timelineBtn.disabled = atMax;
+    state.wqBtn.disabled = false;
+    state.cronBtn.disabled = false;
+    state.timelineBtn.disabled = false;
+
+    if (state.wqForceBtn) {
+      state.wqForceBtn.hidden = !hasWorkqueue;
+      state.wqForceBtn.disabled = atMax;
+      state.wqBtn.textContent = hasWorkqueue ? 'Open existing Workqueue pane' : 'New Workqueue pane';
+    }
+    if (state.cronForceBtn) {
+      state.cronForceBtn.hidden = !hasCron;
+      state.cronForceBtn.disabled = atMax;
+      state.cronBtn.textContent = hasCron ? 'Open existing Cron pane' : 'New Cron pane';
+    }
+    if (state.timelineForceBtn) {
+      state.timelineForceBtn.hidden = !hasTimeline;
+      state.timelineForceBtn.disabled = atMax;
+      state.timelineBtn.textContent = hasTimeline ? 'Open existing Timeline pane' : 'New Timeline pane';
+    }
 
     this._addPaneMenuState = state;
   },
@@ -5471,6 +6667,7 @@ const paneManager = {
     if (!state?.open) return;
 
     state.open = false;
+    state.menuActionTaken = false;
 
     try {
       state.anchorEl?.setAttribute?.('aria-expanded', 'false');
@@ -5495,7 +6692,9 @@ const paneManager = {
     if (this.panes.length <= 1) return;
     const idx = this.panes.findIndex((pane) => pane.key === key);
     if (idx < 0) return;
-    const [pane] = this.panes.splice(idx, 1);
+    const pane = this.panes[idx];
+    if (!paneCloseGuardPrompt(pane)) return;
+    this.panes.splice(idx, 1);
     try {
       pane.client?.disconnect(true);
     } catch {}
@@ -5537,7 +6736,13 @@ const paneManager = {
     this.panes.forEach((pane, index) => {
       const letter = String.fromCharCode(65 + (index % 26));
       if (pane.elements.name) pane.elements.name.textContent = letter;
+      paneRenderDestinationStrip(pane);
+      paneRenderActivityBadge(pane);
     });
+
+    if (globalElements.paneGrid) {
+      globalElements.paneGrid.setAttribute('aria-label', 'Panes');
+    }
   },
   updateCloseButtons() {
     const allowClose = roleState.role === 'admin' && this.panes.length > 1;
@@ -5588,6 +6793,21 @@ const paneManager = {
   }
 };
 
+try {
+  window.__clawnsoleTest = window.__clawnsoleTest || {};
+  window.__clawnsoleTest.forcePaneAgent = (index = 0, agentId = 'main') => {
+    const pane = paneManager.panes?.[Number(index) || 0];
+    if (!pane || pane.kind !== 'chat') return false;
+    pane.agentId = String(agentId || 'main').trim() || 'main';
+    try {
+      if (pane.elements?.agentSelect) pane.elements.agentSelect.value = pane.agentId;
+    } catch {}
+    renderPaneAgentIdentity(pane);
+    paneSetChatEnabled(pane);
+    return true;
+  };
+} catch {}
+
 // Global event wiring
 
 globalElements.settingsBtn?.addEventListener('click', () => openSettings());
@@ -5617,7 +6837,7 @@ globalElements.commandPaletteInput?.addEventListener('keydown', (event) => {
   }
   if (key === 'ArrowDown') {
     event.preventDefault();
-    commandPaletteState.selectedIndex = Math.min(commandPaletteState.filtered.length - 1, commandPaletteState.selectedIndex + 1);
+    commandPaletteState.selectedIndex = Math.min(commandPaletteState.visible.length - 1, commandPaletteState.selectedIndex + 1);
     renderCommandPalette();
     return;
   }
@@ -5629,7 +6849,15 @@ globalElements.commandPaletteInput?.addEventListener('keydown', (event) => {
   }
   if (key === 'Enter') {
     event.preventDefault();
-    const item = commandPaletteState.filtered[commandPaletteState.selectedIndex];
+    const entry = commandPaletteState.visible[commandPaletteState.selectedIndex];
+    if (!entry) return;
+    if (entry.kind === 'toggle' && entry.subgroupId) {
+      if (commandPaletteState.expandedSubgroups.has(entry.subgroupId)) commandPaletteState.expandedSubgroups.delete(entry.subgroupId);
+      else commandPaletteState.expandedSubgroups.add(entry.subgroupId);
+      renderCommandPalette();
+      return;
+    }
+    const item = entry.item;
     if (!item) return;
     try {
       item.run?.();
@@ -5656,9 +6884,27 @@ globalElements.agentsModal?.addEventListener('click', (event) => {
 });
 
 globalElements.agentsSearch?.addEventListener('input', () => renderAgentsModalList());
+globalElements.agentsSearch?.addEventListener('keydown', (event) => {
+  if (event.key !== 'Escape') return;
+  event.preventDefault();
+  if (globalElements.agentsSearch.value) {
+    globalElements.agentsSearch.value = '';
+    renderAgentsModalList();
+  }
+  globalElements.agentsSearch.focus();
+});
 
-globalElements.agentsActiveOnly?.addEventListener('change', () => {
-  storage.set(ADMIN_AGENT_ACTIVE_ONLY_KEY, !!globalElements.agentsActiveOnly.checked);
+globalElements.agentsFilterGroup?.addEventListener('click', (event) => {
+  const btn = event.target instanceof Element ? event.target.closest('[data-agents-filter]') : null;
+  if (!btn) return;
+  const value = String(btn.getAttribute('data-agents-filter') || 'all');
+  storage.set(ADMIN_AGENT_FILTER_KEY, value);
+  renderAgentsModalList();
+});
+
+globalElements.agentsSortMode?.addEventListener('change', () => {
+  const mode = String(globalElements.agentsSortMode.value || 'attention');
+  storage.set(ADMIN_AGENT_SORT_KEY, ['attention', 'recent', 'oldest'].includes(mode) ? mode : 'attention');
   renderAgentsModalList();
 });
 
@@ -5692,6 +6938,13 @@ globalElements.wqAutoRefreshInterval?.addEventListener('change', () => {
   startWorkqueueAutoRefresh();
 });
 
+globalElements.wqGroupingMode?.addEventListener('change', () => {
+  const mode = String(globalElements.wqGroupingMode.value || 'auto').toLowerCase();
+  workqueueState.groupingMode = ['auto', 'on', 'off'].includes(mode) ? mode : 'auto';
+  storage.set('clawnsole.wq.grouping.mode', workqueueState.groupingMode);
+  renderWorkqueueItems();
+});
+
 globalElements.wqRefreshBtn?.addEventListener('click', () => {
   fetchWorkqueueQueues().then(() => fetchAndRenderWorkqueueItems());
 });
@@ -5702,17 +6955,39 @@ globalElements.wqClaimBtn?.addEventListener('click', () => workqueueClaimNextFro
 let shortcutState = { lastGAtMs: 0 };
 
 function isTypingContext(target) {
-  const el = target || document.activeElement;
-  if (!el) return false;
-  const tag = String(el.tagName || '').toUpperCase();
-  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
-  if (el.isContentEditable) return true;
+  let el = target || document.activeElement;
+  while (el) {
+    if (!(el instanceof HTMLElement)) break;
+
+    const tag = String(el.tagName || '').toUpperCase();
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+    if (el.isContentEditable || String(el.contentEditable).toLowerCase() === 'true') return true;
+
+    el = el.parentElement;
+  }
+
+  return false;
+}
+
+function isTypingShortcutExempt(event) {
+  const key = String(event.key || '').toLowerCase();
+  if (!event.metaKey && !event.ctrlKey) return false;
+  if (event.altKey) return false;
+
+  // Explicitly exempt shifted pane shortcuts (existing intended behavior).
+  if (event.shiftKey && ['c', 'w', 'r', 't', 'n'].includes(key)) return true;
+
+  // Global admin launchers should work even when typing.
+  if (!event.shiftKey && ['k', 'p'].includes(key)) return true;
+
   return false;
 }
 
 function focusPaneIndex(idx) {
   const pane = paneManager.panes[idx];
   if (!pane) return;
+
+  paneClearUnread(pane);
 
   try {
     pane.elements?.root?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
@@ -5748,6 +7023,34 @@ function focusPaneIndex(idx) {
   }
 }
 
+function isPaneElementVisible(el) {
+  if (!(el instanceof HTMLElement)) return false;
+  try {
+    if (el.hidden) return false;
+    if (el.getClientRects && el.getClientRects().length === 0) return false;
+    return true;
+  } catch {
+    return true;
+  }
+}
+
+function focusVisiblePaneByShortcutPosition(position) {
+  if (!Number.isFinite(position) || position < 1) return;
+
+  const visibleRoots = Array.from(document.querySelectorAll('[data-pane]')).filter((el) => isPaneElementVisible(el));
+  if (visibleRoots.length === 0) return;
+
+  const targetRoot = visibleRoots[position - 1];
+  if (!targetRoot) return;
+
+  const pane = paneManager.panes.find((candidate) => candidate?.elements?.root === targetRoot);
+  if (!pane) return;
+
+  const idx = paneManager.panes.indexOf(pane);
+  if (idx < 0) return;
+  focusPaneIndex(idx);
+}
+
 function cyclePaneFocus() {
   const panes = paneManager.panes;
   if (!panes || panes.length === 0) return;
@@ -5756,6 +7059,31 @@ function cyclePaneFocus() {
   const idx = panes.findIndex((p) => p.elements?.root && (p.elements.root === active || p.elements.root.contains(active)));
   const next = idx >= 0 ? (idx + 1) % panes.length : 0;
   focusPaneIndex(next);
+}
+
+function cyclePaneFocusBackward() {
+  const panes = paneManager.panes;
+  if (!panes || panes.length === 0) return;
+
+  const active = document.activeElement;
+  const idx = panes.findIndex((p) => p.elements?.root && (p.elements.root === active || p.elements.root.contains(active)));
+  const prev = idx >= 0 ? (idx - 1 + panes.length) % panes.length : panes.length - 1;
+  focusPaneIndex(prev);
+}
+
+function isBlockingOverlayOpenForPaneShortcuts() {
+  // Scope pane-add keyboard accelerators to the main workspace only.
+  // If any overlay/modal is open, ignore pane-add shortcuts to avoid accidental pane creation.
+  const blockers = [
+    globalElements.loginOverlay,
+    globalElements.settingsModal,
+    globalElements.shortcutsModal,
+    globalElements.commandPaletteModal,
+    globalElements.paneManagerModal,
+    globalElements.workqueueModal,
+    globalElements.agentsModal
+  ];
+  return blockers.some((el) => !!el?.classList?.contains('open'));
 }
 
 window.addEventListener('keydown', (event) => {
@@ -5770,19 +7098,32 @@ window.addEventListener('keydown', (event) => {
   // If Pane Manager is open, it gets first dibs on keys.
   if (paneManagerHandleKeydown(event)) return;
 
+  // Agents modal fleet triage loop keys.
+  if (agentsModalHandleKeydown(event)) return;
+
+  // Never fire admin shortcuts while typing unless explicitly exempted.
+  if (isTypingContext(event.target) && !isTypingShortcutExempt(event)) return;
+
   // Add-pane shortcuts (admin-only)
   // Ctrl/Cmd+Shift+C → new chat
   // Ctrl/Cmd+Shift+W → new workqueue
   // Ctrl/Cmd+Shift+R → new cron
   // Ctrl/Cmd+Shift+T → new timeline
+  // Ctrl/Cmd+Shift+G → Workqueue for active chat agent
   const isAccel = (event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey;
   if (isAccel && roleState.role === 'admin') {
     const key = String(event.key || '').toLowerCase();
+    if (key === 'g') {
+      if (isBlockingOverlayOpenForPaneShortcuts()) return;
+      event.preventDefault();
+      paneManager.closeAddPaneMenu();
+      openWorkqueueForActiveChatAgent();
+      return;
+    }
     const map = { c: 'chat', w: 'workqueue', r: 'cron', t: 'timeline' };
     const kind = map[key];
     if (kind) {
-      // Don't hijack while typing unless it's a true accelerator.
-      // (We still allow it when focused in an input, but only with Ctrl/Cmd+Shift.)
+      if (isBlockingOverlayOpenForPaneShortcuts()) return;
       event.preventDefault();
       paneManager.closeAddPaneMenu();
       paneManager.addPane(kind);
@@ -5790,14 +7131,14 @@ window.addEventListener('keydown', (event) => {
     }
   }
 
-  // Cmd/Ctrl+P opens Pane Manager (even while typing).
+  // Cmd/Ctrl+P opens Pane Manager.
   if ((event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey && String(event.key || '').toLowerCase() === 'p') {
     event.preventDefault();
     openPaneManager();
     return;
   }
 
-  // Cmd/Ctrl+K opens command palette (even while typing).
+  // Cmd/Ctrl+K opens command palette.
   if ((event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey && String(event.key || '').toLowerCase() === 'k') {
     event.preventDefault();
     openCommandPalette();
@@ -5817,9 +7158,6 @@ window.addEventListener('keydown', (event) => {
     return;
   }
 
-  // Never steal focus / override browser shortcuts while typing.
-  if (isTypingContext(event.target)) return;
-
   const key = String(event.key || '');
 
   const isQuestion = key === '?' || (key === '/' && event.shiftKey);
@@ -5829,7 +7167,20 @@ window.addEventListener('keydown', (event) => {
     return;
   }
 
-  // Cmd/Ctrl+1..4 focuses a pane.
+  // Alt+1..9 focuses panes by visible on-screen order.
+  if (event.altKey && !event.metaKey && !event.ctrlKey && !event.shiftKey) {
+    const code = String(event.code || '');
+    if (code.startsWith('Digit')) {
+      const n = Number.parseInt(code.slice(5), 10);
+      if (Number.isFinite(n) && n >= 1 && n <= 9) {
+        event.preventDefault();
+        focusVisiblePaneByShortcutPosition(n);
+        return;
+      }
+    }
+  }
+
+  // Cmd/Ctrl+1..4 focuses a pane by layout index (legacy shortcut).
   if ((event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey) {
     const n = Number.parseInt(key, 10);
     if (Number.isFinite(n) && n >= 1 && n <= 4) {
@@ -5839,10 +7190,17 @@ window.addEventListener('keydown', (event) => {
     }
   }
 
-  // Cmd/Ctrl+Shift+K cycles focus across panes.
+  // Cmd/Ctrl+Shift+K focuses next pane.
   if ((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey && key.toLowerCase() === 'k') {
     event.preventDefault();
     cyclePaneFocus();
+    return;
+  }
+
+  // Cmd/Ctrl+Shift+J focuses previous pane.
+  if ((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey && key.toLowerCase() === 'j') {
+    event.preventDefault();
+    cyclePaneFocusBackward();
     return;
   }
 
@@ -5893,6 +7251,11 @@ globalElements.disconnectBtn?.addEventListener('click', () => {
 
 globalElements.resetLayoutBtn?.addEventListener('click', () => {
   paneManager.resetAdminLayoutToDefault({ confirm: true });
+});
+
+globalElements.resetLayoutQuickBtn?.addEventListener('click', () => {
+  paneManager.resetAdminLayoutToDefault({ confirm: false });
+  showToast('Layout reset to recommended: Chat + Workqueue.', { kind: 'success', timeoutMs: 1800 });
 });
 
 globalElements.paneManagerBtn?.addEventListener('click', (event) => {

--- a/app.js
+++ b/app.js
@@ -104,6 +104,11 @@ const fmtRemaining = __appCore.fmtRemaining || ((msUntil) => {
   return `${sec}s`;
 });
 const sortWorkqueueItems = __appCore.sortWorkqueueItems || ((items, opts) => (Array.isArray(items) ? items.slice() : []));
+const deriveWorkqueueDisplayTitle = __appCore.deriveWorkqueueDisplayTitle || ((item) => ({
+  title: String(item?.title || ''),
+  rawTitle: String(item?.title || ''),
+  canonicalized: false
+}));
 const detectShortcutConflict = __appCore.detectShortcutConflict || (() => null);
 const inferPaneCols = __appCore.inferPaneCols || ((count) => {
   const n = Number(count);
@@ -1265,6 +1270,8 @@ function paneIdentityOrdinal(pane) {
 
 function paneTargetLabel(pane, opts = {}) {
   const base = paneTargetBaseLabel(pane);
+  const nick = String(pane?.nickname || '').trim();
+  if (nick) return `${nick} (${base})`;
   const disambiguate = !!opts?.disambiguate;
   if (!disambiguate) return base;
   const ord = paneIdentityOrdinal(pane);
@@ -1362,6 +1369,45 @@ function paneRenderActivityBadge(pane) {
   badge.dataset.kind = String(pane?.activity?.kind || 'chat');
   badge.textContent = unread > 99 ? '99+' : String(unread);
   badge.setAttribute('aria-label', paneActivityLabel(pane));
+}
+
+const paneShortcutBadgeState = {
+  revealActive: false
+};
+
+function visiblePaneRoots() {
+  return Array.from(document.querySelectorAll('[data-pane]')).filter((el) => isPaneElementVisible(el));
+}
+
+function renderPaneShortcutIndexBadges() {
+  const visibleRoots = visiblePaneRoots();
+  const indexByRoot = new Map();
+  for (let i = 0; i < visibleRoots.length; i++) indexByRoot.set(visibleRoots[i], i + 1);
+
+  paneManager.panes.forEach((pane) => {
+    const badge = pane?.elements?.shortcutIndexBadge;
+    const root = pane?.elements?.root;
+    if (!badge || !root) return;
+    const index = Number(indexByRoot.get(root) || 0);
+    if (paneShortcutBadgeState.revealActive && index >= 1 && index <= 9) {
+      badge.hidden = false;
+      badge.textContent = String(index);
+      badge.setAttribute('title', `Direct focus shortcut: Alt/Option+${index}`);
+      badge.setAttribute('aria-hidden', 'false');
+      return;
+    }
+    badge.hidden = true;
+    badge.textContent = '';
+    badge.setAttribute('aria-hidden', 'true');
+    badge.removeAttribute('title');
+  });
+}
+
+function setPaneShortcutRevealActive(active) {
+  const next = !!active;
+  if (paneShortcutBadgeState.revealActive === next) return;
+  paneShortcutBadgeState.revealActive = next;
+  renderPaneShortcutIndexBadges();
 }
 
 function paneMarkUnread(pane, kind = 'chat') {
@@ -2231,6 +2277,16 @@ function renderAgentsModalList({ fallbackToFirst = true } = {}) {
 
   root.innerHTML = '';
   root.classList.toggle('agents-density-compact', density === 'compact');
+  const header = document.createElement('div');
+  header.className = 'agents-grid-header';
+  header.innerHTML = `
+    <div class="agents-grid-cell agents-grid-cell-pin" aria-hidden="true">Pin</div>
+    <div class="agents-grid-cell agents-grid-cell-identity">Agent</div>
+    <div class="agents-grid-cell agents-grid-cell-id">ID</div>
+    <div class="agents-grid-cell agents-grid-cell-health">Health</div>
+    <div class="agents-grid-cell agents-grid-cell-reason">Reason</div>
+  `;
+  root.appendChild(header);
   root.classList.toggle('agents-density-cozy', density !== 'compact');
   root.classList.toggle('agents-hide-id', !columns.id);
   root.classList.toggle('agents-hide-health', !columns.health);
@@ -2266,10 +2322,10 @@ function renderAgentsModalList({ fallbackToFirst = true } = {}) {
       row.innerHTML = `
         <button type="button" class="agents-pin" aria-label="${pinnedNow ? 'Unpin agent' : 'Pin agent'}" aria-pressed="${pinnedNow ? 'true' : 'false'}" data-agent-pin="${escapeHtml(id)}">${pinnedNow ? '★' : '☆'}</button>
         <div class="agents-row-main">
-          <div class="agents-row-title-wrap"><div class="agents-row-title">${escapeHtml(label)}</div></div>
-          <div class="agents-row-meta">${escapeHtml(id)}</div>
-          <div class="agents-row-chips"><span class="agents-health-chip">${escapeHtml(formatHealthChip(triage))}</span><span class="agents-age-chip">${escapeHtml(formatAgeChip(lastSeenAtMs))}</span></div>
-          <div class="agents-row-reason"><span class="agents-reason-chip">${escapeHtml(triage.attentionReason)}</span></div>
+          <div class="agents-row-title-wrap agents-col-identity"><div class="agents-row-title">${escapeHtml(label)}</div></div>
+          <div class="agents-row-meta agents-col-id">${escapeHtml(id)}</div>
+          <div class="agents-row-chips agents-col-health"><span class="agents-health-chip">${escapeHtml(formatHealthChip(triage))}</span><span class="agents-age-chip">${escapeHtml(formatAgeChip(lastSeenAtMs))}</span></div>
+          <div class="agents-row-reason agents-col-reason"><span class="agents-reason-chip">${escapeHtml(triage.attentionReason)}</span></div>
         </div>
       `;
 
@@ -2757,9 +2813,10 @@ function renderWorkqueueItems() {
       const status = String(it.status || '');
       const age = fmtAge(it.createdAt || it.updatedAt);
       const next = String(it.lastNote || '').trim();
+      const titleMeta = deriveWorkqueueDisplayTitle(it);
 
       card.innerHTML = `
-        <div class="wq-card-title">${escapeHtml(String(it.title || ''))}</div>
+        <div class="wq-card-title" title="${escapeHtml(titleMeta.rawTitle || titleMeta.title || '')}">${escapeHtml(String(titleMeta.title || ''))}</div>
         <div class="wq-card-meta">
           <span class="wq-badge wq-badge-${escapeHtml(status)}">${escapeHtml(status)}</span>
           ${age ? `<span class="wq-card-chip mono">age ${escapeHtml(age)}</span>` : ''}
@@ -2830,6 +2887,7 @@ function renderWorkqueueInspect(item) {
     return;
   }
   const kv = (k, v) => `<div class="wq-kv"><div class="k">${escapeHtml(k)}</div><div class="v">${escapeHtml(String(v ?? ''))}</div></div>`;
+  const titleMeta = deriveWorkqueueDisplayTitle(item);
   root.innerHTML = `
     <div class="wq-inspect-meta">
       ${kv('id', item.id)}
@@ -2843,8 +2901,9 @@ function renderWorkqueueInspect(item) {
     </div>
     <div class="wq-inspect-block">
       <div class="wq-inspect-label">Title</div>
-      <div class="wq-inspect-pre">${escapeHtml(String(item.title || ''))}</div>
+      <div class="wq-inspect-pre">${escapeHtml(String(titleMeta.title || ''))}</div>
     </div>
+    ${titleMeta.canonicalized ? `<div class="wq-inspect-block"><div class="wq-inspect-label">Raw title</div><div class="wq-inspect-pre">${escapeHtml(String(titleMeta.rawTitle || ''))}</div></div>` : ''}
     <div class="wq-inspect-block">
       <div class="wq-inspect-label">Instructions</div>
       <pre class="wq-inspect-pre">${escapeHtml(String(item.instructions || ''))}</pre>
@@ -2998,7 +3057,8 @@ function renderWorkqueueSimpleList(rootEl, items, { emptyText }) {
   for (const it of items) {
     const li = document.createElement('li');
     const lease = it.leaseUntil ? new Date(Number(it.leaseUntil)).toISOString() : '';
-    li.innerHTML = `<div><strong>${escapeHtml(String(it.title || ''))}</strong></div>
+    const titleMeta = deriveWorkqueueDisplayTitle(it);
+    li.innerHTML = `<div><strong title="${escapeHtml(String(titleMeta.rawTitle || titleMeta.title || ''))}">${escapeHtml(String(titleMeta.title || ''))}</strong></div>
 <div class="meta">${escapeHtml(String(it.status || ''))}${it.claimedBy ? ` • ${escapeHtml(String(it.claimedBy))}` : ''}${lease ? ` • lease ${escapeHtml(lease)}` : ''}</div>`;
     ul.appendChild(li);
   }
@@ -3324,9 +3384,10 @@ function renderWorkqueuePaneItems(pane) {
     const leaseMs = it.leaseUntil ? Number(it.leaseUntil) - now : NaN;
     const leaseLabel = it.leaseUntil ? fmtRemaining(leaseMs) : '';
     const status = String(it.status || '');
+    const titleMeta = deriveWorkqueueDisplayTitle(it);
 
     row.innerHTML = `
-      <div class="wq-col title">${escapeHtml(String(it.title || ''))}${dupCount > 0 ? ` <span class="wq-card-chip mono">×${escapeHtml(String(group.count || (dupCount + 1)))}</span>` : ''}${group.hasClaimed ? ' <span class="wq-card-chip mono">claimed</span>' : ''}${group.hasExpiredLease ? ' <span class="wq-card-chip mono">expired lease</span>' : ''}</div>
+      <div class="wq-col title" title="${escapeHtml(String(titleMeta.rawTitle || titleMeta.title || ''))}">${escapeHtml(String(titleMeta.title || ''))}${dupCount > 0 ? ` <span class="wq-card-chip mono">×${escapeHtml(String(group.count || (dupCount + 1)))}</span>` : ''}${group.hasClaimed ? ' <span class="wq-card-chip mono">claimed</span>' : ''}${group.hasExpiredLease ? ' <span class="wq-card-chip mono">expired lease</span>' : ''}</div>
       <div class="wq-col status"><span class="wq-badge wq-badge-${escapeHtml(status)}">${escapeHtml(status)}</span></div>
       <div class="wq-col prio mono">${escapeHtml(String(it.priority ?? ''))}</div>
       <div class="wq-col attempts mono">${escapeHtml(String(it.attempts ?? ''))}</div>
@@ -3389,6 +3450,7 @@ function renderWorkqueuePaneInspect(pane, item) {
     return;
   }
   const kv = (k, v) => `<div class="wq-kv"><div class="k">${escapeHtml(k)}</div><div class="v">${escapeHtml(String(v ?? ''))}</div></div>`;
+  const titleMeta = deriveWorkqueueDisplayTitle(item);
   root.innerHTML = `
     <div class="wq-inspect-meta">
       ${kv('id', item.id)}
@@ -3402,8 +3464,9 @@ function renderWorkqueuePaneInspect(pane, item) {
     </div>
     <div class="wq-inspect-block">
       <div class="wq-inspect-label">Title</div>
-      <div class="wq-inspect-pre">${escapeHtml(String(item.title || ''))}</div>
+      <div class="wq-inspect-pre">${escapeHtml(String(titleMeta.title || ''))}</div>
     </div>
+    ${titleMeta.canonicalized ? `<div class="wq-inspect-block"><div class="wq-inspect-label">Raw title</div><div class="wq-inspect-pre">${escapeHtml(String(titleMeta.rawTitle || ''))}</div></div>` : ''}
     <div class="wq-inspect-block">
       <div class="wq-inspect-label">Instructions</div>
       <pre class="wq-inspect-pre">${escapeHtml(String(item.instructions || ''))}</pre>
@@ -5029,7 +5092,13 @@ function buildClientForPane(pane) {
     onFrame: (data) => handleGatewayFrame(pane, data),
     onConnected: () => {
       pane.connected = true;
-      if (pane.elements.root) pane.elements.root.dataset.connected = 'true';
+      pane.statusState = 'connected';
+      pane.statusMeta = '';
+      setStatusPill(pane.elements.status, 'connected', '');
+      if (pane.elements.root) {
+        pane.elements.root.dataset.connected = 'true';
+        pane.elements.root.dataset.wsState = 'connected';
+      }
       paneSetChatEnabled(pane);
       updateGlobalStatus();
       updateConnectionControls();
@@ -5054,7 +5123,13 @@ function buildClientForPane(pane) {
     onDisconnected: () => {
       paneStopThinking(pane);
       pane.connected = false;
-      if (pane.elements.root) pane.elements.root.dataset.connected = 'false';
+      pane.statusState = 'disconnected';
+      pane.statusMeta = '';
+      setStatusPill(pane.elements.status, 'disconnected', '');
+      if (pane.elements.root) {
+        pane.elements.root.dataset.connected = 'false';
+        pane.elements.root.dataset.wsState = 'disconnected';
+      }
       paneSetChatEnabled(pane);
       updateGlobalStatus();
       updateConnectionControls();
@@ -5325,7 +5400,7 @@ function renderAgentOptions(selectEl, agentId) {
   selectEl.value = normalizeAgentId(agentId || 'main');
 }
 
-function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, quickFilters, scope, sortKey, sortDir, closable = true, pinned = false } = {}) {
+function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, quickFilters, scope, sortKey, sortDir, nickname = '', closable = true, pinned = false } = {}) {
   const template = globalElements.paneTemplate;
   const root = template.content.firstElementChild.cloneNode(true);
   const elements = {
@@ -5353,6 +5428,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
     input: root.querySelector('[data-pane-input]'),
     commandHints: root.querySelector('[data-pane-command-hints]'),
     shortcutHints: root.querySelector('[data-pane-shortcut-hints]'),
+    shortcutIndexBadge: root.querySelector('[data-pane-shortcut-index-badge]'),
     fileInput: root.querySelector('[data-pane-file-input]'),
     attachBtn: root.querySelector('[data-pane-attach]'),
     attachmentStatus: root.querySelector('[data-pane-attachment-status]'),
@@ -5369,6 +5445,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
       const k = String(kind || 'chat').trim().toLowerCase();
       return allowed.has(k) ? k : k.startsWith('w') ? 'workqueue' : 'chat';
     })(),
+    nickname: String(nickname || '').trim(),
     agentId: role === 'admin' ? normalizeAgentId(agentId || 'main') : null,
     workqueue: {
       queue: (queue || 'dev-team').trim() || 'dev-team',
@@ -5436,6 +5513,23 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
     el.hidden = hints.length === 0;
   }
 
+  try {
+    if (elements.name) {
+      elements.name.title = 'Double-click to set pane nickname';
+      elements.name.addEventListener('dblclick', () => {
+        if (roleState.role !== 'admin') return;
+        const current = String(pane.nickname || '').trim();
+        const input = window.prompt('Pane nickname (leave blank to clear):', current);
+        if (input == null) return;
+        const next = String(input || '').trim();
+        if (next === current) return;
+        pane.nickname = next;
+        paneManager.updatePaneLabels();
+        paneManager.persistAdminPanes();
+      });
+    }
+  } catch {}
+
   // Mark pane kind on root for CSS + debugging.
   try {
     elements.root.dataset.paneKind = pane.kind;
@@ -5445,6 +5539,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
   if (elements.name) elements.name.textContent = paneLabel(pane);
   paneRenderTypePill(pane);
   renderPaneShortcutHints(pane);
+  renderPaneShortcutIndexBadges();
 
   // Per-pane inline help popover ("What is this pane?")
   try {
@@ -7051,6 +7146,7 @@ const paneManager = {
         scope: cfg.scope,
         sortKey: cfg.sortKey,
         sortDir: cfg.sortDir,
+        nickname: cfg.nickname,
         closable: true
       })
     );
@@ -7128,15 +7224,18 @@ const paneManager = {
                 actionableOnly: !!item.quickFilters.actionableOnly
               }
             : { source: '', repo: '', actionableOnly: false };
-          return { key, kind, pinned: !!item.pinned, queue, statusFilter, scope, sortKey, sortDir, quickFilters };
+          const nickname = typeof item.nickname === 'string' ? item.nickname.trim() : '';
+          return { key, kind, pinned: !!item.pinned, queue, statusFilter, scope, sortKey, sortDir, quickFilters, nickname };
         }
 
         if (kind === 'cron' || kind === 'timeline') {
-          return { key, kind, pinned: !!item.pinned };
+          const nickname = typeof item.nickname === 'string' ? item.nickname.trim() : '';
+          return { key, kind, pinned: !!item.pinned, nickname };
         }
 
         const agentId = normalizeAgentId(typeof item.agentId === 'string' ? item.agentId : defaultAgent);
-        return { key, kind, pinned: !!item.pinned, agentId };
+        const nickname = typeof item.nickname === 'string' ? item.nickname.trim() : '';
+        return { key, kind, pinned: !!item.pinned, agentId, nickname };
       }
 
       // Super-legacy format: ['pabc','pdef'] (treat as chat panes)
@@ -7192,13 +7291,14 @@ const paneManager = {
           },
           scope: String(pane.workqueue?.scope || 'all').trim().toLowerCase() || 'all',
           sortKey: pane.workqueue?.sortKey || 'default',
-          sortDir: pane.workqueue?.sortDir || 'desc'
+          sortDir: pane.workqueue?.sortDir || 'desc',
+          nickname: String(pane.nickname || '').trim()
         };
       }
       if (pane.kind === 'cron' || pane.kind === 'timeline') {
-        return { key: pane.key, kind: pane.kind, pinned: !!pane.pinned };
+        return { key: pane.key, kind: pane.kind, pinned: !!pane.pinned, nickname: String(pane.nickname || '').trim() };
       }
-      return { key: pane.key, kind: 'chat', pinned: !!pane.pinned, agentId: pane.agentId || 'main' };
+      return { key: pane.key, kind: 'chat', pinned: !!pane.pinned, agentId: pane.agentId || 'main', nickname: String(pane.nickname || '').trim() };
     });
     storage.set(ADMIN_PANES_KEY, JSON.stringify(payload));
   },
@@ -7617,6 +7717,8 @@ const paneManager = {
       paneRenderDraftBadge(pane);
     });
 
+    renderPaneShortcutIndexBadges();
+
     if (globalElements.paneGrid) {
       globalElements.paneGrid.setAttribute('aria-label', 'Panes');
     }
@@ -7966,7 +8068,7 @@ function isPaneElementVisible(el) {
 function focusVisiblePaneByShortcutPosition(position) {
   if (!Number.isFinite(position) || position < 1) return;
 
-  const visibleRoots = Array.from(document.querySelectorAll('[data-pane]')).filter((el) => isPaneElementVisible(el));
+  const visibleRoots = visiblePaneRoots();
   if (visibleRoots.length === 0) return;
 
   const targetRoot = visibleRoots[position - 1];
@@ -8142,6 +8244,10 @@ window.addEventListener('keydown', (event) => {
 
   const key = String(event.key || '');
 
+  if (key === 'Alt' && !event.metaKey && !event.ctrlKey && !event.shiftKey) {
+    setPaneShortcutRevealActive(true);
+  }
+
   const isQuestion = key === '?' || (key === '/' && event.shiftKey);
   if (isQuestion && !event.metaKey && !event.ctrlKey && !event.altKey) {
     event.preventDefault();
@@ -8263,6 +8369,14 @@ window.addEventListener('keydown', (event) => {
       return;
     }
   }
+});
+
+window.addEventListener('keyup', (event) => {
+  if (String(event.key || '') === 'Alt') setPaneShortcutRevealActive(false);
+});
+
+window.addEventListener('blur', () => {
+  setPaneShortcutRevealActive(false);
 });
 
 globalElements.disconnectBtn?.addEventListener('click', () => {

--- a/app.js
+++ b/app.js
@@ -16,6 +16,7 @@ const globalElements = {
   agentsActiveMinutes: document.getElementById('agentsActiveMinutes'),
   agentsFilterGroup: document.getElementById('agentsFilterGroup'),
   agentsSortMode: document.getElementById('agentsSortMode'),
+  agentsResetTriageBtn: document.getElementById('agentsResetTriageBtn'),
   agentsList: document.getElementById('agentsList'),
   agentsEmpty: document.getElementById('agentsEmpty'),
   toastHost: document.getElementById('toastHost'),
@@ -55,7 +56,10 @@ const globalElements = {
   settingsCloseBtn: document.getElementById('settingsCloseBtn'),
   rolePill: document.getElementById('rolePill'),
   loginOverlay: document.getElementById('loginOverlay'),
+  instanceIdentity: document.getElementById('instanceIdentity'),
+  loginInstanceIdentity: document.getElementById('loginInstanceIdentity'),
   loginPassword: document.getElementById('loginPassword'),
+  loginCapsLockHint: document.getElementById('loginCapsLockHint'),
   loginBtn: document.getElementById('loginBtn'),
   loginError: document.getElementById('loginError'),
   logoutBtn: document.getElementById('logoutBtn'),
@@ -132,6 +136,18 @@ function getRouteRole() {
   return null;
 }
 
+function getPostLoginDestination() {
+  try {
+    const path = String(window.location.pathname || '/admin');
+    const search = String(window.location.search || '');
+    const hash = String(window.location.hash || '');
+    if (path === '/admin' || path.startsWith('/admin/')) {
+      return `${path}${search}${hash}`;
+    }
+  } catch {}
+  return '/admin';
+}
+
 const routeRole = getRouteRole();
 
 function installViewportVhVar() {
@@ -170,6 +186,7 @@ const ADMIN_AGENT_PINS_KEY = 'clawnsole.admin.agentPins';
 const ADMIN_AGENT_LAST_SEEN_KEY = 'clawnsole.admin.agentLastSeenAtMs';
 const ADMIN_AGENT_ACTIVE_MINUTES_KEY = 'clawnsole.admin.agents.activeMinutes';
 const ADMIN_AGENT_FILTER_KEY = 'clawnsole.admin.agents.filter';
+const ADMIN_AGENT_QUERY_KEY = 'clawnsole.admin.agents.query';
 const ADMIN_AGENT_SORT_KEY = 'clawnsole.admin.agents.sort';
 
 function readJsonFromStorage(key, fallback) {
@@ -325,6 +342,8 @@ const uiState = {
   agents: []
 };
 
+let loginInFlight = false;
+
 let toastSeq = 0;
 function showToast(message, { kind = 'info', timeoutMs = 2600 } = {}) {
   if (!globalElements.toastHost) return;
@@ -450,10 +469,12 @@ async function refreshAgents({ reason = 'manual', showSuccessToast = false } = {
     // Refresh workqueue agent claim selectors (modal + item cards) if present.
     refreshWorkqueueAgentSelects();
 
-    // If the Agents modal is open, refresh its list.
+    // If the Agents modal is open, refresh its list while preserving viewport context.
     try {
       if (globalElements.agentsModal?.classList?.contains('open')) {
-        renderAgentsModalList();
+        const viewportContext = captureAgentsModalViewportContext();
+        renderAgentsModalList({ fallbackToFirst: false });
+        restoreAgentsModalViewportContext(viewportContext, { showMissingSelectionToast: reason !== 'initial' });
       }
     } catch {}
 
@@ -654,6 +675,7 @@ async function fetchMeta() {
     if (data?.wsUrl) {
       globalElements.wsUrl.value = data.wsUrl;
       uiState.meta = data;
+      renderInstanceIdentity();
       return data;
     }
     return null;
@@ -726,6 +748,34 @@ function resolveWsUrl(raw) {
     return `${proto}://${window.location.host}${raw}`;
   }
   return raw;
+}
+
+function deriveInstanceIdentityText() {
+  const meta = uiState.meta || {};
+  const instance = String(meta.instance || '').trim();
+  let host = String(meta.host || '').trim();
+
+  if (!host) {
+    try {
+      const wsUrl = resolveWsUrl(String(meta.wsUrl || ''));
+      if (wsUrl) {
+        const parsed = new URL(wsUrl);
+        host = parsed.host || '';
+      }
+    } catch {}
+  }
+
+  if (!host) host = window.location.host || '';
+  if (!host) host = 'unknown-host';
+
+  if (instance) return `${instance} · ${host}`;
+  return `instance · ${host}`;
+}
+
+function renderInstanceIdentity() {
+  const text = deriveInstanceIdentityText();
+  if (globalElements.instanceIdentity) globalElements.instanceIdentity.textContent = text;
+  if (globalElements.loginInstanceIdentity) globalElements.loginInstanceIdentity.textContent = text;
 }
 
 function computeGatewayTarget(_kind) {
@@ -869,11 +919,25 @@ function setRole(role) {
   }
 }
 
-function showLogin(message = '') {
+function setLoginSubmitting(submitting) {
+  loginInFlight = !!submitting;
+  if (globalElements.loginBtn) {
+    globalElements.loginBtn.disabled = loginInFlight;
+    globalElements.loginBtn.textContent = loginInFlight ? 'Unlocking…' : 'Unlock';
+    globalElements.loginBtn.setAttribute('aria-busy', loginInFlight ? 'true' : 'false');
+  }
+  if (globalElements.loginPassword) {
+    globalElements.loginPassword.disabled = loginInFlight;
+  }
+}
+
+function showLogin(message = '', { clearPassword = true } = {}) {
+  setLoginSubmitting(false);
   globalElements.loginOverlay.classList.add('open');
   globalElements.loginOverlay.setAttribute('aria-hidden', 'false');
   globalElements.loginError.textContent = message;
-  globalElements.loginPassword.value = '';
+  if (globalElements.loginCapsLockHint) globalElements.loginCapsLockHint.textContent = '';
+  if (clearPassword) globalElements.loginPassword.value = '';
 
   // Guest role selection removed.
 
@@ -885,25 +949,40 @@ function showLogin(message = '') {
   globalElements.settingsBtn?.setAttribute('disabled', 'disabled');
   if (globalElements.settingsBtn) globalElements.settingsBtn.style.opacity = '0.5';
 
-  const isTouch = window.matchMedia && window.matchMedia('(hover: none) and (pointer: coarse)').matches;
-  if (!isTouch) {
-    globalElements.loginPassword.focus();
-  }
+  focusLoginPassword();
 }
 
 function hideLogin() {
   globalElements.loginOverlay.classList.remove('open');
   globalElements.loginOverlay.setAttribute('aria-hidden', 'true');
   globalElements.loginError.textContent = '';
+  if (globalElements.loginCapsLockHint) globalElements.loginCapsLockHint.textContent = '';
   setAuthState(true);
 }
 
+function setLoginCapsLockHint(event) {
+  if (!globalElements.loginCapsLockHint) return;
+  const capsLockOn = !!event?.getModifierState?.('CapsLock');
+  globalElements.loginCapsLockHint.textContent = capsLockOn ? 'Caps Lock is on.' : '';
+}
+
+function focusLoginPassword() {
+  try {
+    globalElements.loginPassword?.focus();
+    requestAnimationFrame(() => {
+      try { globalElements.loginPassword?.focus(); } catch {}
+    });
+  } catch {}
+}
+
 async function attemptLogin() {
+  if (loginInFlight) return;
   const password = globalElements.loginPassword.value.trim();
   if (!password) {
     showLogin('Password required.');
     return;
   }
+  setLoginSubmitting(true);
   try {
     const res = await fetch('/auth/login', {
       method: 'POST',
@@ -912,13 +991,15 @@ async function attemptLogin() {
       credentials: 'include'
     });
     if (!res.ok) {
-      showLogin('Invalid password. Try again.');
+      showLogin('Invalid password. Try again.', { clearPassword: false });
       return;
     }
     await res.json();
-    window.location.replace('/admin');
+    window.location.replace(getPostLoginDestination());
   } catch {
-    showLogin('Login failed. Please retry.');
+    showLogin('Login failed. Please retry.', { clearPassword: false });
+  } finally {
+    setLoginSubmitting(false);
   }
 }
 
@@ -975,9 +1056,9 @@ function paneLabel(pane) {
 function paneIcon(pane) {
   const kind = pane?.kind || 'chat';
   if (kind === 'workqueue') return 'WQ';
-  if (kind === 'cron') return '⏰';
+  if (kind === 'cron') return '⏱';
   if (kind === 'timeline') return '🕒';
-  if (kind === 'fleet') return '🛰️';
+  if (kind === 'fleet') return 'FL';
   return '💬';
 }
 
@@ -999,6 +1080,10 @@ function paneRenderTypePill(pane) {
   for (const name of knownKinds) pill.classList.remove(`pane-type-${name}`);
   pill.classList.add(`pane-type-${knownKinds.includes(kind) ? kind : 'chat'}`);
   pill.setAttribute('aria-label', `Pane type ${paneLabel(pane)}`);
+
+  const summary = paneDestinationSummary(pane);
+  const tooltip = `${summary.letter} ${summary.kind} · ${summary.target}`;
+  pill.setAttribute('title', tooltip);
 
   if (pane?.elements?.typeText) pane.elements.typeText.textContent = text;
   if (pane?.elements?.typeIcon) pane.elements.typeIcon.textContent = icon;
@@ -1067,6 +1152,22 @@ function paneActivityLabel(pane) {
   return `${unread} unread chat message${unread === 1 ? '' : 's'}`;
 }
 
+function paneHasUnsentDraft(pane) {
+  return Boolean(String(pane?.elements?.input?.value || '').trim());
+}
+
+function paneRenderDraftBadge(pane) {
+  const badge = pane?.elements?.draftBadge;
+  if (!badge) return;
+  const hasDraft = paneHasUnsentDraft(pane);
+  badge.hidden = !hasDraft;
+  if (!hasDraft) {
+    badge.removeAttribute('aria-label');
+    return;
+  }
+  badge.setAttribute('aria-label', 'Has unsent draft');
+}
+
 function paneRenderActivityBadge(pane) {
   const badge = pane?.elements?.activityBadge;
   if (!badge) return;
@@ -1122,20 +1223,27 @@ function renderPaneManager() {
     row.setAttribute('aria-selected', idx === selected ? 'true' : 'false');
 
     const state = String(pane.statusState || (pane.connected ? 'connected' : 'disconnected'));
+    const isDisconnected = state === 'disconnected';
     const letter = paneLetterLabel(pane);
     const unread = Math.max(0, Number(pane?.activity?.unread || 0));
     const unreadLabel = paneActivityLabel(pane);
+    const hasDraft = paneHasUnsentDraft(pane);
 
     row.innerHTML = `
       <div class="pane-manager-main">
         <div class="pane-manager-kind" title="${escapeHtml(paneLabel(pane))}">
           <span class="pane-manager-letter" aria-label="Pane ${escapeHtml(letter)}">${escapeHtml(letter)}</span>
-          <span class="pane-manager-icon" aria-hidden="true">${escapeHtml(paneIcon(pane))}</span>
-          <span class="pane-manager-kind-label">${escapeHtml(paneLabel(pane))}</span>
+          <span class="pane-manager-type-badge pane-type-${escapeHtml(String(pane?.kind || 'chat'))}" aria-label="Pane type ${escapeHtml(paneLabel(pane))}">
+            <span class="pane-manager-icon" aria-hidden="true">${escapeHtml(paneIcon(pane))}</span>
+            <span class="pane-manager-kind-label">${escapeHtml(paneLabel(pane))}</span>
+          </span>
         </div>
         <div class="pane-manager-target" title="${escapeHtml(paneTargetLabel(pane))}">${escapeHtml(paneTargetLabel(pane))}</div>
-        <div class="pane-manager-state" data-state="${escapeHtml(state)}">${escapeHtml(state)}</div>
-        ${unread ? `<div class="pane-activity-badge" data-kind="${escapeHtml(String(pane?.activity?.kind || 'chat'))}" aria-label="${escapeHtml(unreadLabel)}">${escapeHtml(unread > 99 ? '99+' : String(unread))}</div>` : ''}
+        <div class="pane-manager-state-chips">
+          ${isDisconnected ? '<div class="pane-manager-state pane-manager-state--disconnected" data-state="disconnected" aria-label="Disconnected">Disconnected</div>' : ''}
+          ${hasDraft ? '<div class="pane-draft-badge" aria-label="Has unsent draft">Draft</div>' : ''}
+          ${unread ? `<div class="pane-activity-badge" data-kind="${escapeHtml(String(pane?.activity?.kind || 'chat'))}" aria-label="${escapeHtml(unreadLabel)}">${escapeHtml(unread > 99 ? '99+' : String(unread))}</div>` : ''}
+        </div>
       </div>
       <div class="pane-manager-actions">
         <button class="secondary pane-manager-up" type="button" data-action="move-up" data-testid="pane-manager-move-up" title="Move pane up" aria-label="Move pane up" ${idx === 0 ? 'disabled' : ''}>↑</button>
@@ -1319,14 +1427,8 @@ function getFocusedPane() {
   return (paneManager?.panes || []).find((pane) => pane?.elements?.root && (pane.elements.root === active || pane.elements.root.contains(active))) || null;
 }
 
-function openWorkqueueForActiveChatAgent() {
-  const focused = getFocusedPane();
-  if (!focused || focused.kind !== 'chat') {
-    showToast('No active chat agent selected', { kind: 'error', timeoutMs: 2200 });
-    return null;
-  }
-
-  const agentId = normalizeAgentId(focused.agentId || 'main');
+function openWorkqueueForAgent(agentIdInput) {
+  const agentId = normalizeAgentId(agentIdInput || 'main');
   const existing = (paneManager?.panes || []).find((pane) => {
     if (!pane || pane.kind !== 'workqueue') return false;
     return normalizeAgentId(pane.agentId || 'main') === agentId;
@@ -1346,6 +1448,73 @@ function openWorkqueueForActiveChatAgent() {
   }
 
   return pane;
+}
+
+function openWorkqueueForActiveChatAgent() {
+  const focused = getFocusedPane();
+  if (!focused || focused.kind !== 'chat') {
+    showToast('No active chat agent selected', { kind: 'error', timeoutMs: 2200 });
+    return null;
+  }
+
+  return openWorkqueueForAgent(focused.agentId || 'main');
+}
+
+function togglePairedPaneForActiveTarget() {
+  const focused = getFocusedPane();
+  if (!focused) {
+    showToast('No valid Chat/Workqueue pair for this pane.', { kind: 'error', timeoutMs: 2200 });
+    return false;
+  }
+
+  if (focused.kind === 'chat') {
+    return !!openWorkqueueForAgent(focused.agentId || 'main');
+  }
+
+  if (focused.kind === 'workqueue') {
+    const agentId = normalizeAgentId(focused.agentId || '');
+    if (!agentId) {
+      showToast('No valid Chat/Workqueue pair for this pane.', { kind: 'error', timeoutMs: 2200 });
+      return false;
+    }
+    return !!focusOrCreateAgentChatPane(agentId);
+  }
+
+  showToast('No valid Chat/Workqueue pair for this pane.', { kind: 'error', timeoutMs: 2200 });
+  return false;
+}
+
+function focusFleetFirstNeedsAttention() {
+  if (roleState.role !== 'admin') return false;
+
+  // Force a full, attention-ranked fleet view for this action.
+  storage.set(ADMIN_AGENT_FILTER_KEY, 'all');
+  if (globalElements.agentsSortMode) globalElements.agentsSortMode.value = 'attention';
+  storage.set(ADMIN_AGENT_SORT_KEY, 'attention');
+
+  if (!globalElements.agentsModal?.classList.contains('open')) {
+    openAgentsModal();
+  } else {
+    renderAgentsModalList({ fallbackToFirst: true });
+  }
+
+  const rows = getAgentsModalRows();
+  if (!rows.length) return false;
+
+  const needsAttentionRow = rows.find((row) => String(row.dataset.needsAttention || 'false') === 'true') || null;
+  if (needsAttentionRow) {
+    selectAgentsModalRowByAgentId(needsAttentionRow.dataset.agentId, { fallbackToFirst: true, scroll: true });
+    return true;
+  }
+
+  const fallbackRow = rows[0] || null;
+  if (fallbackRow) {
+    selectAgentsModalRowByAgentId(fallbackRow.dataset.agentId, { fallbackToFirst: true, scroll: true });
+    showToast('No attention-needed agents right now.', { kind: 'info', timeoutMs: 1800 });
+    return true;
+  }
+
+  return false;
 }
 
 function buildCommandPaletteItems() {
@@ -1374,6 +1543,8 @@ function buildCommandPaletteItems() {
   });
   pushItem({ id: 'cmd:open-workqueue', group: 'workqueue', rank: 90, label: 'Workqueue: Open modal', detail: 'Open the Workqueue modal (g w)', run: () => openWorkqueue() });
   pushItem({ id: 'cmd:open-workqueue-active-agent', group: 'workqueue', rank: 89, label: 'Workqueue for active chat agent', detail: 'Open/focus Workqueue pane scoped to assigned items for active chat agent', run: () => openWorkqueueForActiveChatAgent() });
+  pushItem({ id: 'cmd:toggle-paired-pane', group: 'navigation', rank: 89, label: 'Toggle paired pane (Chat ↔ Workqueue)', detail: 'Switch between paired Chat/Workqueue panes for the active target (Cmd/Ctrl+Shift+Y)', run: () => togglePairedPaneForActiveTarget() });
+  pushItem({ id: 'cmd:fleet-first-needs-attention', group: 'agents', rank: 90, label: 'Fleet: Focus first needs attention', detail: 'Open/focus Fleet and preselect the first needs-attention agent', run: () => focusFleetFirstNeedsAttention() });
   pushItem({ id: 'cmd:refresh-agents', group: 'agents', rank: 88, label: 'Agents: Refresh', detail: 'Refresh agent list', run: () => globalElements.refreshAgentsBtn?.click?.() });
 
   for (const pane of (paneManager?.panes || [])) {
@@ -1586,6 +1757,62 @@ function getAgentsModalRows() {
   return Array.from(globalElements.agentsList?.querySelectorAll?.('.agents-row[data-agent-id]') || []);
 }
 
+function captureAgentsModalViewportContext() {
+  const container = globalElements.agentsList;
+  const rows = getAgentsModalRows();
+  const currentSelectedId = String(agentsModalState.selectedAgentId || '').trim();
+  const selectedFromDom = rows.find((row) => row.getAttribute('aria-selected') === 'true');
+  const selectedId = currentSelectedId || String(selectedFromDom?.dataset?.agentId || '').trim();
+  const selectedIndex = rows.findIndex((row) => String(row.dataset.agentId || '').trim() === selectedId);
+  const scrollTop = Number(container?.scrollTop || 0);
+  const anchorRow = rows.find((row) => {
+    const top = Number(row.offsetTop || 0);
+    const height = Number(row.offsetHeight || 0);
+    return (top + height) >= scrollTop;
+  }) || rows[0] || null;
+  const anchorTop = Number(anchorRow?.offsetTop || 0);
+
+  return {
+    selectedId,
+    selectedIndex,
+    scrollTop,
+    anchorId: String(anchorRow?.dataset?.agentId || '').trim(),
+    anchorDelta: scrollTop - anchorTop
+  };
+}
+
+function restoreAgentsModalViewportContext(context, { showMissingSelectionToast = false } = {}) {
+  const container = globalElements.agentsList;
+  if (!container || !context) return;
+
+  const hadSelectedId = !!String(context.selectedId || '').trim();
+  let selectedRow = null;
+  if (hadSelectedId) {
+    selectedRow = selectAgentsModalRowByAgentId(context.selectedId, { fallbackToFirst: false, scroll: false });
+  }
+  if (!selectedRow && Number.isFinite(context.selectedIndex) && context.selectedIndex >= 0) {
+    selectedRow = selectAgentsModalRowByIndex(context.selectedIndex, { scroll: false });
+    if (showMissingSelectionToast && hadSelectedId) {
+      showToast('Selected agent no longer in current list; kept nearby context.', { kind: 'info', timeoutMs: 2200 });
+    }
+  }
+  if (!selectedRow) {
+    selectAgentsModalRowByAgentId(agentsModalState.selectedAgentId, { fallbackToFirst: true, scroll: false });
+  }
+
+  const anchorId = String(context.anchorId || '').trim();
+  const rows = getAgentsModalRows();
+  const anchorRow = rows.find((row) => String(row.dataset.agentId || '').trim() === anchorId) || null;
+  if (anchorRow) {
+    const delta = Number.isFinite(context.anchorDelta) ? context.anchorDelta : 0;
+    container.scrollTop = Math.max(0, Number(anchorRow.offsetTop || 0) + delta);
+    return;
+  }
+  if (Number.isFinite(context.scrollTop)) {
+    container.scrollTop = Math.max(0, Number(context.scrollTop || 0));
+  }
+}
+
 function selectAgentsModalRowByIndex(index, { scroll = true } = {}) {
   const rows = getAgentsModalRows();
   if (!rows.length) {
@@ -1647,13 +1874,7 @@ function runAgentsModalTriageAction({ openWorkqueue = false, openTimeline = fals
   if (!focusOrCreateAgentChatPane(agentId)) return false;
 
   if (openWorkqueue) {
-    openWorkqueue();
-    if (globalElements.wqClaimAgentId) {
-      globalElements.wqClaimAgentId.value = agentId;
-      try {
-        globalElements.wqClaimAgentId.dispatchEvent(new Event('input', { bubbles: true }));
-      } catch {}
-    }
+    openWorkqueueForAgent(agentId);
   }
 
   if (openTimeline) {
@@ -1673,6 +1894,13 @@ function agentsModalHandleKeydown(event) {
 
   if (key === 'Escape') {
     event.preventDefault();
+    if (event.target === globalElements.agentsSearch && globalElements.agentsSearch.value) {
+      globalElements.agentsSearch.value = '';
+      storage.remove(ADMIN_AGENT_QUERY_KEY);
+      renderAgentsModalList();
+      globalElements.agentsSearch.focus();
+      return true;
+    }
     closeAgentsModal();
     return true;
   }
@@ -1722,6 +1950,9 @@ function openAgentsModal() {
     const sortMode = String(storage.get(ADMIN_AGENT_SORT_KEY, 'attention') || 'attention');
     globalElements.agentsSortMode.value = ['attention', 'recent', 'oldest'].includes(sortMode) ? sortMode : 'attention';
   }
+  if (globalElements.agentsSearch) {
+    globalElements.agentsSearch.value = String(storage.get(ADMIN_AGENT_QUERY_KEY, '') || '');
+  }
 
   agentsModalState.selectedAgentId = '';
   renderAgentsModalList();
@@ -1743,7 +1974,7 @@ function closeAgentsModal({ restoreFocus = true } = {}) {
   }
 }
 
-function renderAgentsModalList() {
+function renderAgentsModalList({ fallbackToFirst = true } = {}) {
   const root = globalElements.agentsList;
   if (!root) return;
 
@@ -1823,6 +2054,7 @@ function renderAgentsModalList() {
       const lastSeenAtMs = Number(lastSeenMap[id]) || 0;
       row.className = `agents-row ${triage.health === 'active' ? 'is-active' : triage.health === 'stale' ? 'is-stale' : 'is-offline'}`;
       row.dataset.agentId = id;
+      row.dataset.needsAttention = triage.needsAttention ? 'true' : 'false';
       row.setAttribute('role', 'option');
       row.setAttribute('tabindex', '-1');
       row.setAttribute('aria-selected', 'false');
@@ -1868,19 +2100,30 @@ function renderAgentsModalList() {
   const empty = pinned.length === 0 && rest.length === 0;
   if (globalElements.agentsEmpty) globalElements.agentsEmpty.hidden = !empty;
 
-  if (!empty) selectAgentsModalRowByAgentId(agentsModalState.selectedAgentId, { fallbackToFirst: true, scroll: false });
+  if (!empty) selectAgentsModalRowByAgentId(agentsModalState.selectedAgentId, { fallbackToFirst, scroll: false });
   else agentsModalState.selectedAgentId = '';
 }
 
 // Workqueue (admin-only)
 
 const WORKQUEUE_STATUSES = ['ready', 'pending', 'claimed', 'in_progress', 'done', 'failed'];
+const WORKQUEUE_STATUS_LABELS = {
+  ready: 'Ready',
+  pending: 'Pending',
+  claimed: 'Claimed',
+  in_progress: 'In progress',
+  done: 'Done',
+  failed: 'Failed'
+};
 const WORKQUEUE_GROUPING_AUTO_THRESHOLD = 12;
+const WORKQUEUE_SORT_KEY_STORAGE_KEY = 'clawnsole.wq.sort.key';
+const WORKQUEUE_SORT_DIR_STORAGE_KEY = 'clawnsole.wq.sort.dir';
 
 const workqueueState = {
   queues: [],
   selectedQueue: '',
   statusFilter: new Set(['ready', 'pending', 'claimed', 'in_progress']),
+  statusCounts: {},
   items: [],
   selectedItemId: null,
   sortKey: 'default',
@@ -1914,10 +2157,12 @@ function renderWorkqueueStatusFilters() {
   if (!root) return;
   root.innerHTML = '';
   for (const s of WORKQUEUE_STATUSES) {
+    const count = Number(workqueueState.statusCounts?.[s] || 0);
+    const human = WORKQUEUE_STATUS_LABELS[s] || String(s || '').replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
     const id = `wq-status-${s}`;
     const label = document.createElement('label');
     label.className = 'wq-status-chip';
-    label.innerHTML = `<input type="checkbox" id="${id}" ${workqueueState.statusFilter.has(s) ? 'checked' : ''} /> <span>${escapeHtml(s)}</span>`;
+    label.innerHTML = `<input type="checkbox" id="${id}" ${workqueueState.statusFilter.has(s) ? 'checked' : ''} /> <span>${escapeHtml(human)} (${escapeHtml(String(count))})</span>`;
     const checkbox = label.querySelector('input');
     checkbox.addEventListener('change', () => {
       if (checkbox.checked) workqueueState.statusFilter.add(s);
@@ -1933,6 +2178,16 @@ function ensureWorkqueueModalSorting() {
 
   const btns = Array.from(document.querySelectorAll('[data-wq-modal-sort]'));
   if (!btns.length) return;
+
+  const allowedKeys = new Set(['default', ...btns.map((btn) => String(btn.getAttribute('data-wq-modal-sort') || '').trim()).filter(Boolean)]);
+  try {
+    const persistedKey = String(storage.get(WORKQUEUE_SORT_KEY_STORAGE_KEY, 'default') || 'default').trim() || 'default';
+    const persistedDir = String(storage.get(WORKQUEUE_SORT_DIR_STORAGE_KEY, 'desc') || 'desc').trim().toLowerCase();
+    if (allowedKeys.has(persistedKey)) workqueueState.sortKey = persistedKey;
+    if (persistedDir === 'asc' || persistedDir === 'desc') workqueueState.sortDir = persistedDir;
+  } catch {
+    // ignore storage failures
+  }
 
   workqueueState.sortingBootstrapped = true;
 
@@ -1955,6 +2210,12 @@ function ensureWorkqueueModalSorting() {
       // sensible initial directions
       if (nextKey === 'title' || nextKey === 'claimedBy' || nextKey === 'status') workqueueState.sortDir = 'asc';
       else workqueueState.sortDir = 'desc';
+    }
+    try {
+      storage.set(WORKQUEUE_SORT_KEY_STORAGE_KEY, workqueueState.sortKey);
+      storage.set(WORKQUEUE_SORT_DIR_STORAGE_KEY, workqueueState.sortDir);
+    } catch {
+      // ignore storage failures
     }
     updateUi();
     renderWorkqueueItems();
@@ -2045,11 +2306,16 @@ async function fetchAndRenderWorkqueueItems() {
   const url = `/api/workqueue/items${params.toString() ? `?${params.toString()}` : ''}`;
 
   try {
-    const res = await fetch(url, { credentials: 'include', cache: 'no-store' });
+    const [res, summary] = await Promise.all([
+      fetch(url, { credentials: 'include', cache: 'no-store' }),
+      fetchWorkqueueSummary(queue).catch(() => null)
+    ]);
     if (!res.ok) throw new Error(String(res.status));
     const data = await res.json();
     const items = Array.isArray(data.items) ? data.items : [];
     workqueueState.items = items;
+    workqueueState.statusCounts = summary?.counts && typeof summary.counts === 'object' ? summary.counts : {};
+    renderWorkqueueStatusFilters();
     renderWorkqueueItems();
   } catch (err) {
     addFeed('err', 'workqueue', `failed to load items: ${String(err)}`);
@@ -2637,23 +2903,46 @@ function applyWorkqueueScopeFilter(items, pane) {
   });
 }
 
+function applyWorkqueueStatusFilter(items, statuses) {
+  const active = new Set((Array.isArray(statuses) ? statuses : []).map((s) => String(s || '').trim()).filter(Boolean));
+  if (!active.size) return Array.isArray(items) ? items : [];
+  return (Array.isArray(items) ? items : []).filter((it) => active.has(String(it?.status || '').trim()));
+}
+
+function applyWorkqueueItemSearch(items, query) {
+  const q = String(query || '').trim().toLowerCase();
+  if (!q) return Array.isArray(items) ? items : [];
+  return (Array.isArray(items) ? items : []).filter((it) => {
+    const haystack = [
+      String(it?.title || ''),
+      String(it?.instructions || ''),
+      String(it?.queue || ''),
+      String(it?.status || ''),
+      String(it?.claimedBy || ''),
+      JSON.stringify(it?.meta || {})
+    ].join('\n').toLowerCase();
+    return haystack.includes(q);
+  });
+}
+
 async function fetchAndRenderWorkqueueItemsForPane(pane) {
   if (!pane || pane.kind !== 'workqueue') return;
   const body = pane.elements?.thread?.querySelector('[data-wq-list-body]');
   if (!body) return;
 
   const queue = (pane.workqueue?.queue || '').trim();
-  const statuses = Array.isArray(pane.workqueue?.statusFilter) ? pane.workqueue.statusFilter : [];
   const params = new URLSearchParams();
   if (queue) params.set('queue', queue);
-  if (statuses.length) params.set('status', statuses.join(','));
   const url = `/api/workqueue/items${params.toString() ? `?${params.toString()}` : ''}`;
 
   const statusLine = pane.elements.thread.querySelector('[data-wq-statusline]');
   if (statusLine) statusLine.textContent = 'Loading...';
 
   try {
-    const res = await fetch(url, { credentials: 'include', cache: 'no-store' });
+    const [res, summary] = await Promise.all([
+      fetch(url, { credentials: 'include', cache: 'no-store' }),
+      fetchWorkqueueSummary(queue).catch(() => null)
+    ]);
     if (!res.ok) throw new Error(String(res.status));
     const data = await res.json();
     const items = Array.isArray(data.items) ? data.items : [];
@@ -2663,15 +2952,80 @@ async function fetchAndRenderWorkqueueItemsForPane(pane) {
       .sort()
       .join('|');
     pane.workqueue.items = items;
+    pane.workqueue.totalCount = summary?.counts && typeof summary.counts === 'object'
+      ? Object.values(summary.counts).reduce((acc, n) => acc + (Number(n) || 0), 0)
+      : items.length;
     pane.workqueue.lastItemsSignature = nextSig;
     if (previousSig && nextSig && previousSig !== nextSig) {
       paneMarkUnread(pane, 'workqueue');
     }
-    if (statusLine) statusLine.textContent = `${items.length} item(s)`;
     renderWorkqueuePaneItems(pane);
   } catch (err) {
     if (statusLine) statusLine.textContent = `Failed to load: ${String(err)}`;
   }
+}
+
+function renderWorkqueueActiveFilters(pane, { visibleCount = 0, totalCount = 0 } = {}) {
+  const thread = pane?.elements?.thread;
+  if (!thread) return;
+  const root = thread.querySelector('[data-wq-filter-summary]');
+  const chipsEl = thread.querySelector('[data-wq-filter-chips]');
+  const clearAllBtn = thread.querySelector('[data-wq-clear-all-filters]');
+  const statusLine = thread.querySelector('[data-wq-statusline]');
+  if (!root || !chipsEl || !clearAllBtn || !statusLine) return;
+
+  const queue = String(pane.workqueue?.queue || 'dev-team').trim() || 'dev-team';
+  const scope = String(pane.workqueue?.scope || 'all').trim().toLowerCase();
+  const statuses = Array.isArray(pane.workqueue?.statusFilter) ? pane.workqueue.statusFilter : [];
+  const source = String(pane.workqueue?.quickFilters?.source || '').trim();
+  const repo = String(pane.workqueue?.quickFilters?.repo || '').trim();
+  const actionableOnly = !!pane.workqueue?.quickFilters?.actionableOnly;
+  const search = String(pane.workqueue?.searchQuery || '').trim();
+
+  const clearAndRefresh = async (mutate) => {
+    mutate();
+    await fetchAndRenderWorkqueueItemsForPane(pane);
+    paneManager.persistAdminPanes();
+  };
+
+  const chips = [];
+  chips.push({ key: 'queue', label: `Queue: ${queue}`, onClear: () => { pane.workqueue.queue = 'dev-team'; } });
+  if (scope !== 'all') chips.push({ key: 'scope', label: `Scope: ${scope}`, onClear: () => { pane.workqueue.scope = 'all'; } });
+  for (const s of statuses) {
+    chips.push({ key: `status-${s}`, label: `Status: ${s}`, onClear: () => {
+      pane.workqueue.statusFilter = (Array.isArray(pane.workqueue.statusFilter) ? pane.workqueue.statusFilter : []).filter((x) => x !== s);
+    } });
+  }
+  if (search) chips.push({ key: 'search', label: `Search: ${search}`, onClear: () => { pane.workqueue.searchQuery = ''; } });
+  if (source) chips.push({ key: 'source', label: `Source: ${source}`, onClear: () => { pane.workqueue.quickFilters = { ...pane.workqueue.quickFilters, source: '' }; } });
+  if (repo) chips.push({ key: 'repo', label: `Repo: ${repo}`, onClear: () => { pane.workqueue.quickFilters = { ...pane.workqueue.quickFilters, repo: '' }; } });
+  if (actionableOnly) chips.push({ key: 'actionable', label: 'Actionable only', onClear: () => { pane.workqueue.quickFilters = { ...pane.workqueue.quickFilters, actionableOnly: false }; } });
+
+  const hasActive = chips.length > 1;
+  root.hidden = !hasActive;
+  chipsEl.innerHTML = '';
+  if (hasActive) {
+    for (const chip of chips) {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'wq-filter-chip';
+      btn.setAttribute('data-testid', `wq-filter-chip-${chip.key}`);
+      btn.textContent = `${chip.label} ×`;
+      btn.addEventListener('click', () => clearAndRefresh(chip.onClear));
+      chipsEl.appendChild(btn);
+    }
+  }
+
+  clearAllBtn.hidden = !hasActive;
+  clearAllBtn.onclick = () => clearAndRefresh(() => {
+    pane.workqueue.scope = 'all';
+    pane.workqueue.searchQuery = '';
+    pane.workqueue.quickFilters = { source: '', repo: '', actionableOnly: false };
+    pane.workqueue.statusFilter = Array.from(WORKQUEUE_STATUSES);
+  });
+
+  const total = Number.isFinite(Number(totalCount)) ? Number(totalCount) : visibleCount;
+  statusLine.textContent = hasActive ? `Showing ${visibleCount} of ${total} items` : `${visibleCount} item(s)`;
 }
 
 function renderWorkqueuePaneItems(pane) {
@@ -2682,10 +3036,13 @@ function renderWorkqueuePaneItems(pane) {
 
   const itemsRaw = Array.isArray(pane.workqueue?.items) ? pane.workqueue.items : [];
   const scopedItems = applyWorkqueueScopeFilter(itemsRaw, pane);
-  const filteredItems = applyWorkqueueQuickFilters(scopedItems, pane.workqueue?.quickFilters);
-  const items = sortWorkqueueItems(filteredItems, { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
+  const quickFilteredItems = applyWorkqueueQuickFilters(scopedItems, pane.workqueue?.quickFilters);
+  const statusFilteredItems = applyWorkqueueStatusFilter(quickFilteredItems, pane.workqueue?.statusFilter);
+  const searchedItems = applyWorkqueueItemSearch(statusFilteredItems, pane.workqueue?.searchQuery);
+  const items = sortWorkqueueItems(searchedItems, { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
   const groups = groupWorkqueueItemsByDedupe(items, { groupingMode: pane.workqueue?.groupingMode });
   const visibleItems = groups.map((g) => g.canonical);
+  renderWorkqueueActiveFilters(pane, { visibleCount: visibleItems.length, totalCount: pane.workqueue?.totalCount });
 
   if (empty) {
     const hasItems = visibleItems.length > 0;
@@ -2694,11 +3051,14 @@ function renderWorkqueuePaneItems(pane) {
       const queue = String(pane.workqueue?.queue || '').trim() || 'dev-team';
       const statuses = Array.isArray(pane.workqueue?.statusFilter) ? pane.workqueue.statusFilter : [];
       const statusLabel = statuses.length ? statuses.join(', ') : 'default';
+      const query = String(pane.workqueue?.searchQuery || '').trim();
       empty.innerHTML = `
         <div class="empty-state">
-          <div style="font-weight:700; margin-bottom:6px;">No items in this queue.</div>
+          <div style="font-weight:700; margin-bottom:6px;">${query ? 'No items match this search.' : 'No items in this queue.'}</div>
           <div class="hint">Queue: <span class="mono">${escapeHtml(queue)}</span> · Status: <span class="mono">${escapeHtml(statusLabel)}</span></div>
+          ${query ? `<div class="hint" style="margin-top:8px;">Search: <span class="mono">${escapeHtml(query)}</span></div>` : ''}
           <div style="display:flex; gap:8px; margin-top:10px; flex-wrap:wrap;">
+            ${query ? '<button type="button" class="secondary" data-wq-empty-clear-search>Clear search</button>' : ''}
             <button type="button" class="secondary" data-wq-empty-enqueue>Enqueue item</button>
             <button type="button" class="secondary" data-wq-empty-refresh>Refresh</button>
           </div>
@@ -2709,6 +3069,13 @@ function renderWorkqueuePaneItems(pane) {
       const refreshBtn = pane.elements?.thread?.querySelector('[data-wq-refresh]');
       const enqueueDetails = pane.elements?.thread?.querySelector('details.wq-enqueue');
       empty.querySelector('[data-wq-empty-refresh]')?.addEventListener('click', () => refreshBtn?.click());
+      empty.querySelector('[data-wq-empty-clear-search]')?.addEventListener('click', () => {
+        pane.workqueue.searchQuery = '';
+        const input = pane.elements?.thread?.querySelector('[data-wq-item-search]');
+        if (input) input.value = '';
+        renderWorkqueuePaneItems(pane);
+        paneManager.persistAdminPanes();
+      });
       empty.querySelector('[data-wq-empty-enqueue]')?.addEventListener('click', () => {
         try {
           enqueueDetails?.setAttribute('open', '');
@@ -4121,6 +4488,8 @@ function paneShowSendGuard(pane, { origin, current, onConfirm } = {}) {
 }
 
 function paneSyncDraftOrigin(pane) {
+  paneRenderDraftBadge(pane);
+  refreshPaneManagerIfOpen();
   const value = String(pane?.elements?.input?.value || '');
   if (!value.trim()) {
     pane.draftOrigin = null;
@@ -4179,6 +4548,7 @@ async function paneSendChat(pane) {
     pane.elements.input.value = '';
     pane.draftOrigin = null;
     paneDismissSendGuard(pane);
+    paneSyncDraftOrigin(pane);
     paneUpdateCommandHints(pane);
     addFeed('event', 'chat', `cleared local history (${pane.sessionKey()})`);
     return;
@@ -4189,6 +4559,7 @@ async function paneSendChat(pane) {
     pane.elements.input.value = '';
     pane.draftOrigin = null;
     paneDismissSendGuard(pane);
+    paneSyncDraftOrigin(pane);
     paneUpdateCommandHints(pane);
     pane.client.request('sessions.reset', { key });
     addFeed('event', 'chat', `reset session (${key})`);
@@ -4294,6 +4665,7 @@ async function paneSendChat(pane) {
   pane.draftOrigin = null;
   paneDismissSendGuard(pane);
   pane.elements.input.value = '';
+  paneSyncDraftOrigin(pane);
   paneUpdateCommandHints(pane);
 }
 
@@ -4717,6 +5089,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
     root,
     name: root.querySelector('[data-pane-name]'),
     activityBadge: root.querySelector('[data-pane-activity-badge]'),
+    draftBadge: root.querySelector('[data-pane-draft-badge]'),
     typePill: root.querySelector('[data-pane-type-pill]'),
     typeIcon: root.querySelector('[data-pane-type-icon]'),
     typeText: root.querySelector('[data-pane-type-text]'),
@@ -4794,10 +5167,10 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
 
   function getPaneShortcutHints(currentPane) {
     const common = ['Cmd/Ctrl+Shift+K next', 'Cmd/Ctrl+Shift+J prev', 'Press ? for all shortcuts'];
-    if (currentPane.kind === 'workqueue') return ['g w Workqueue modal', 'Alt+1..9 focus pane', ...common];
-    if (currentPane.kind === 'cron') return ['Cmd/Ctrl+Shift+R add Cron pane', 'Alt+1..9 focus pane', ...common];
-    if (currentPane.kind === 'timeline') return ['Cmd/Ctrl+Shift+T add Timeline pane', 'Alt+1..9 focus pane', ...common];
-    return ['Cmd/Ctrl+K command palette', 'Alt+1..9 focus pane', ...common];
+    if (currentPane.kind === 'workqueue') return ['g w Workqueue modal', 'Alt+1..9 or Cmd/Ctrl+Shift+1..9 focus pane', ...common];
+    if (currentPane.kind === 'cron') return ['Cmd/Ctrl+Shift+R add Cron pane', 'Alt+1..9 or Cmd/Ctrl+Shift+1..9 focus pane', ...common];
+    if (currentPane.kind === 'timeline') return ['Cmd/Ctrl+Shift+T add Timeline pane', 'Alt+1..9 or Cmd/Ctrl+Shift+1..9 focus pane', ...common];
+    return ['Cmd/Ctrl+K command palette', 'Alt+1..9 or Cmd/Ctrl+Shift+1..9 focus pane', ...common];
   }
 
   function renderPaneShortcutHints(currentPane) {
@@ -4867,7 +5240,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
           title: 'Chat',
           lines: ['Chat with an agent/session.', 'Pick an agent target, then send messages/files.', 'Use Stop to cancel a long response.'],
           shortcuts: [
-            ['Alt+1..9', 'focus visible pane by order'],
+            ['Alt/Option+1..9 or Cmd/Ctrl+Shift+1..9', 'focus visible pane by order'],
             ['Cmd/Ctrl+1..4', 'focus a pane (legacy index)'],
             ['Cmd/Ctrl+Shift+K', 'focus next pane'],
             ['Cmd/Ctrl+Shift+J', 'focus previous pane']
@@ -4944,11 +5317,14 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
     elements.thread.innerHTML = `
       <div class="wq-toolbar">
         <div class="wq-toolbar-row">
+          <div class="wq-control-group" role="group" aria-label="Viewing queue controls">
           <label class="wq-field">
-            <span class="wq-label">Queue</span>
-            <select data-wq-queue-select aria-label="Select workqueue"></select>
-            <input data-wq-queue-custom type="text" value="${escapeHtml(pane.workqueue.queue)}" placeholder="Custom queue" hidden />
+            <span class="wq-label">Viewing queue</span>
+            <select data-wq-queue-select aria-label="Viewing queue selector"></select>
+            <input data-wq-queue-custom type="text" value="${escapeHtml(pane.workqueue.queue)}" placeholder="Custom viewing queue" hidden />
+            <span class="hint">Affects which queue items are shown in this pane.</span>
           </label>
+          </div>
 
           <div class="wq-field wq-status-field">
             <span class="wq-label">Status filter</span>
@@ -4996,8 +5372,15 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
             </select>
           </label>
 
+          <label class="wq-field">
+            <span class="wq-label">Search items</span>
+            <input data-wq-item-search type="search" placeholder="Search items…" aria-label="Search items in current queue" />
+          </label>
+
           <button data-wq-preset-clawnsole class="secondary" type="button">Clawnsole only</button>
+          <button data-wq-preset-triage class="secondary" type="button">Triage mode</button>
           <button data-wq-preset-actionable class="secondary" type="button" aria-pressed="false">Actionable only</button>
+          <span class="wq-pill" data-wq-triage-chip data-testid="wq-triage-chip" hidden>Triage mode active</span>
           <label class="wq-field">
             <span class="wq-label">Grouping</span>
             <select data-wq-grouping-mode aria-label="Grouping mode">
@@ -5020,6 +5403,15 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
         <details class="wq-enqueue">
           <summary>Enqueue new item</summary>
           <form data-wq-enqueue-form class="wq-enqueue-form">
+            <div class="wq-control-group wq-field-wide" role="group" aria-label="Enqueue destination controls">
+              <label class="wq-field">
+                <span class="wq-label">Enqueue to</span>
+                <select data-wq-enqueue-queue-select aria-label="Enqueue destination selector"></select>
+                <input data-wq-enqueue-queue-custom type="text" placeholder="Custom enqueue destination" hidden />
+                <span class="hint">Only affects where this new item is created.</span>
+              </label>
+            </div>
+
             <label class="wq-field">
               <span class="wq-label">Title</span>
               <input data-wq-enqueue-title type="text" required placeholder="Short title" />
@@ -5057,6 +5449,10 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
         </details>
 
         <div class="hint" data-wq-statusline></div>
+        <div class="wq-filter-summary" data-wq-filter-summary hidden>
+          <div class="wq-filter-chips" data-wq-filter-chips></div>
+          <button type="button" class="secondary" data-wq-clear-all-filters>Clear all filters</button>
+        </div>
       </div>
 
       <div class="wq-layout">
@@ -5082,6 +5478,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
 
     const queueSelectEl = elements.thread.querySelector('[data-wq-queue-select]');
     const queueCustomEl = elements.thread.querySelector('[data-wq-queue-custom]');
+    const enqueueQueueSelectEl = elements.thread.querySelector('[data-wq-enqueue-queue-select]');
+    const enqueueQueueCustomEl = elements.thread.querySelector('[data-wq-enqueue-queue-custom]');
 
     // Make header pill focus the queue selector in the body (no duplicated selector state).
     paneSetHeaderTarget(pane, {
@@ -5103,12 +5501,41 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
     const scopeBtns = Array.from(elements.thread.querySelectorAll('[data-wq-scope]'));
     const quickSourceEl = elements.thread.querySelector('[data-wq-quick-source]');
     const quickRepoEl = elements.thread.querySelector('[data-wq-quick-repo]');
+    const itemSearchEl = elements.thread.querySelector('[data-wq-item-search]');
     const clawnsoleOnlyBtn = elements.thread.querySelector('[data-wq-preset-clawnsole]');
+    const triageModeBtn = elements.thread.querySelector('[data-wq-preset-triage]');
     const actionableOnlyBtn = elements.thread.querySelector('[data-wq-preset-actionable]');
+    const triageModeChip = elements.thread.querySelector('[data-wq-triage-chip]');
     const groupingModeEl = elements.thread.querySelector('[data-wq-grouping-mode]');
     const refreshBtn = elements.thread.querySelector('[data-wq-refresh]');
 
     const DEFAULT_STATUSES = ['ready', 'pending', 'claimed', 'in_progress'];
+    const TRIAGE_STATUSES = ['ready', 'pending'];
+
+    const isTriageModeActive = () => {
+      const queue = String(pane.workqueue?.queue || '').trim();
+      const scope = String(pane.workqueue?.scope || '').trim().toLowerCase();
+      const statuses = Array.isArray(pane.workqueue?.statusFilter) ? pane.workqueue.statusFilter.map((s) => String(s || '').trim()).filter(Boolean) : [];
+      const sortKey = String(pane.workqueue?.sortKey || 'default').trim();
+      const sortDir = String(pane.workqueue?.sortDir || '').trim().toLowerCase();
+      return queue === 'dev-team'
+        && scope === 'unassigned'
+        && statuses.length === TRIAGE_STATUSES.length
+        && TRIAGE_STATUSES.every((s) => statuses.includes(s))
+        && sortKey === 'priority'
+        && sortDir === 'desc';
+    };
+
+    const updateTriagePresetUi = () => {
+      const active = isTriageModeActive();
+      if (triageModeBtn) {
+        triageModeBtn.classList.toggle('active', active);
+        triageModeBtn.setAttribute('aria-pressed', active ? 'true' : 'false');
+      }
+      if (triageModeChip) {
+        triageModeChip.hidden = !active;
+      }
+    };
 
     const statusSet = new Set(
       (Array.isArray(pane.workqueue?.statusFilter) && pane.workqueue.statusFilter.length ? pane.workqueue.statusFilter : DEFAULT_STATUSES)
@@ -5178,6 +5605,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
       pane.workqueue.scope = next;
       updateScopeUi();
       renderWorkqueuePaneItems(pane);
+      updateTriagePresetUi();
       paneManager.persistAdminPanes();
     };
 
@@ -5189,6 +5617,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
       if (closeMenu) statusDetailsEl?.removeAttribute('open');
       await fetchAndRenderWorkqueueItemsForPane(pane);
       refreshQuickRepoOptions();
+      updateTriagePresetUi();
       paneManager.persistAdminPanes();
     };
 
@@ -5213,6 +5642,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
       }
       await fetchAndRenderWorkqueueItemsForPane(pane);
       refreshQuickRepoOptions();
+      updateTriagePresetUi();
       paneManager.persistAdminPanes();
     };
 
@@ -5225,7 +5655,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
         for (const s of selected) {
           const chip = document.createElement('span');
           chip.className = 'wq-pill';
-          chip.textContent = s;
+          chip.textContent = WORKQUEUE_STATUS_LABELS[s] || s;
           statusSelectedEl.appendChild(chip);
         }
       } else {
@@ -5236,11 +5666,21 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
       }
 
       statusOptionsEl.innerHTML = '';
+      const filteredForCounts = applyWorkqueueQuickFilters(
+        applyWorkqueueScopeFilter(Array.isArray(pane.workqueue?.items) ? pane.workqueue.items : [], pane),
+        pane.workqueue?.quickFilters
+      );
+      const counts = Object.fromEntries(WORKQUEUE_STATUSES.map((s) => [s, 0]));
+      for (const it of filteredForCounts) {
+        const status = String(it?.status || '').trim();
+        if (status in counts) counts[status] += 1;
+      }
       for (const s of WORKQUEUE_STATUSES) {
         const id = `wq-pane-status-${pane.id}-${s}`;
         const label = document.createElement('label');
         label.className = 'wq-status-chip';
-        label.innerHTML = `<input type="checkbox" id="${id}" ${statusSet.has(s) ? 'checked' : ''} /> <span>${escapeHtml(s)}</span>`;
+        const human = WORKQUEUE_STATUS_LABELS[s] || s;
+        label.innerHTML = `<input type="checkbox" id="${id}" ${statusSet.has(s) ? 'checked' : ''} /> <span>${escapeHtml(human)} (${escapeHtml(String(counts[s] || 0))})</span>`;
         const checkbox = label.querySelector('input');
         checkbox.addEventListener('change', () => {
           if (checkbox.checked) statusSet.add(s);
@@ -5264,40 +5704,74 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
         unique.sort((a, b) => a.localeCompare(b));
 
         queueSelectEl.innerHTML = '';
+        if (enqueueQueueSelectEl) enqueueQueueSelectEl.innerHTML = '';
         for (const q of unique) {
           const opt = document.createElement('option');
           opt.value = q;
           opt.textContent = q;
           queueSelectEl.appendChild(opt);
+          if (enqueueQueueSelectEl) {
+            const enqueueOpt = document.createElement('option');
+            enqueueOpt.value = q;
+            enqueueOpt.textContent = q;
+            enqueueQueueSelectEl.appendChild(enqueueOpt);
+          }
         }
 
         const customOpt = document.createElement('option');
         customOpt.value = '__custom__';
         customOpt.textContent = 'Custom…';
         queueSelectEl.appendChild(customOpt);
+        if (enqueueQueueSelectEl) {
+          const enqueueCustomOpt = document.createElement('option');
+          enqueueCustomOpt.value = '__custom__';
+          enqueueCustomOpt.textContent = 'Custom…';
+          enqueueQueueSelectEl.appendChild(enqueueCustomOpt);
+        }
 
         if (unique.includes(current)) {
           queueSelectEl.value = current;
           if (queueCustomEl) queueCustomEl.hidden = true;
+          if (enqueueQueueSelectEl) enqueueQueueSelectEl.value = current;
+          if (enqueueQueueCustomEl) enqueueQueueCustomEl.hidden = true;
         } else {
           queueSelectEl.value = '__custom__';
           if (queueCustomEl) {
             queueCustomEl.hidden = false;
             queueCustomEl.value = current;
           }
+          if (enqueueQueueSelectEl) enqueueQueueSelectEl.value = '__custom__';
+          if (enqueueQueueCustomEl) {
+            enqueueQueueCustomEl.hidden = false;
+            enqueueQueueCustomEl.value = current;
+          }
         }
       } catch {
         // fallback: keep current queue editable
         queueSelectEl.innerHTML = '';
+        if (enqueueQueueSelectEl) enqueueQueueSelectEl.innerHTML = '';
         const opt = document.createElement('option');
         opt.value = pane.workqueue.queue || 'dev-team';
         opt.textContent = pane.workqueue.queue || 'dev-team';
         queueSelectEl.appendChild(opt);
+        if (enqueueQueueSelectEl) {
+          const enqueueOpt = document.createElement('option');
+          enqueueOpt.value = opt.value;
+          enqueueOpt.textContent = opt.textContent;
+          enqueueQueueSelectEl.appendChild(enqueueOpt);
+        }
         const customOpt = document.createElement('option');
         customOpt.value = '__custom__';
         customOpt.textContent = 'Custom…';
         queueSelectEl.appendChild(customOpt);
+        if (enqueueQueueSelectEl) {
+          const enqueueCustomOpt = document.createElement('option');
+          enqueueCustomOpt.value = '__custom__';
+          enqueueCustomOpt.textContent = 'Custom…';
+          enqueueQueueSelectEl.appendChild(enqueueCustomOpt);
+        }
         queueSelectEl.value = opt.value;
+        if (enqueueQueueSelectEl) enqueueQueueSelectEl.value = opt.value;
       }
     };
 
@@ -5310,14 +5784,29 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
       doRefresh();
     });
 
+    enqueueQueueSelectEl?.addEventListener('change', () => {
+      const isCustom = String(enqueueQueueSelectEl.value) === '__custom__';
+      if (enqueueQueueCustomEl) {
+        enqueueQueueCustomEl.hidden = !isCustom;
+        if (isCustom) enqueueQueueCustomEl.focus();
+      }
+    });
+
     renderStatusMultiSelect();
     setQuickFilters({
       source: String(pane.workqueue?.quickFilters?.source || '').trim(),
       repo: String(pane.workqueue?.quickFilters?.repo || '').trim(),
       actionableOnly: !!pane.workqueue?.quickFilters?.actionableOnly
     });
+    if (itemSearchEl) itemSearchEl.value = String(pane.workqueue?.searchQuery || '').trim();
     if (groupingModeEl) groupingModeEl.value = pane.workqueue.groupingMode || 'auto';
     populateQueueSelect().then(() => doRefresh());
+
+    itemSearchEl?.addEventListener('input', () => {
+      pane.workqueue.searchQuery = String(itemSearchEl.value || '').trim();
+      renderWorkqueuePaneItems(pane);
+      paneManager.persistAdminPanes();
+    });
 
     quickSourceEl?.addEventListener('change', () => {
       setQuickFilters({ source: quickSourceEl.value, repo: quickRepoEl?.value || '' });
@@ -5332,6 +5821,36 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
     clawnsoleOnlyBtn?.addEventListener('click', () => {
       setQuickFilters({ source: 'github', repo: 'rmdmattingly/clawnsole' });
       renderWorkqueuePaneItems(pane);
+      updateTriagePresetUi();
+      paneManager.persistAdminPanes();
+    });
+    triageModeBtn?.addEventListener('click', async () => {
+      pane.workqueue.queue = 'dev-team';
+      pane.workqueue.scope = 'unassigned';
+      pane.workqueue.sortKey = 'priority';
+      pane.workqueue.sortDir = 'desc';
+      statusSet.clear();
+      for (const s of TRIAGE_STATUSES) statusSet.add(s);
+      pane.workqueue.statusFilter = Array.from(statusSet);
+
+      await populateQueueSelect();
+      paneSetHeaderTarget(pane, {
+        label: 'Queue',
+        value: 'dev-team',
+        ariaLabel: 'Change queue (current: dev-team)',
+        onClick: () => {
+          try {
+            queueSelectEl?.focus?.();
+            queueSelectEl?.click?.();
+          } catch {}
+        }
+      });
+      renderStatusMultiSelect();
+      updateScopeUi();
+      try { updateSortUi(); } catch {}
+      updateTriagePresetUi();
+      await fetchAndRenderWorkqueueItemsForPane(pane);
+      refreshQuickRepoOptions();
       paneManager.persistAdminPanes();
     });
     actionableOnlyBtn?.addEventListener('click', async () => {
@@ -5345,6 +5864,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
       } else {
         renderWorkqueuePaneItems(pane);
       }
+      updateTriagePresetUi();
       paneManager.persistAdminPanes();
     });
 
@@ -5352,6 +5872,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
       const mode = String(groupingModeEl.value || 'auto').toLowerCase();
       pane.workqueue.groupingMode = ['auto', 'on', 'off'].includes(mode) ? mode : 'auto';
       renderWorkqueuePaneItems(pane);
+      updateTriagePresetUi();
       paneManager.persistAdminPanes();
     });
 
@@ -5402,6 +5923,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
       }
       updateSortUi();
       renderWorkqueuePaneItems(pane);
+      updateTriagePresetUi();
       paneManager.persistAdminPanes();
     };
 
@@ -5409,6 +5931,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
       btn.addEventListener('click', () => setSort(btn.getAttribute('data-wq-sort')));
     });
     updateSortUi();
+    updateTriagePresetUi();
 
     // Agent dropdown (prefer select over free-text).
     const claimAgentSelect = elements.thread.querySelector('[data-wq-claim-agent]');
@@ -5442,7 +5965,10 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
 
     enqueueForm?.addEventListener('submit', async (e) => {
       e.preventDefault();
-      const queue = (getQueueValue() || pane.workqueue.queue || '').trim();
+      const enqueueQueue = String(enqueueQueueSelectEl?.value || '').trim() === '__custom__'
+        ? String(enqueueQueueCustomEl?.value || '').trim()
+        : String(enqueueQueueSelectEl?.value || '').trim();
+      const queue = (enqueueQueue || getQueueValue() || pane.workqueue.queue || '').trim();
       const title = (enqueueTitle?.value || '').trim();
       const instructions = (enqueueInstructions?.value || '').trim();
       const priority = Number(enqueuePriority?.value || 0) || 0;
@@ -5473,7 +5999,10 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
         }
 
         const item = data.item || null;
-        setEnqueueStatus(item && item._deduped ? 'Deduped: ' + item.id : 'Enqueued: ' + String(item?.id || ''));
+        setEnqueueStatus(item && item._deduped
+          ? `Deduped in ${queue}: ${item.id}`
+          : `Enqueued to ${queue}: ${String(item?.id || '')}`);
+        showToast(`Enqueue submitted to ${queue}`, { kind: 'success', timeoutMs: 1800 });
         if (enqueueTitle) enqueueTitle.value = '';
         if (enqueueInstructions) enqueueInstructions.value = '';
         if (enqueueDedupe) enqueueDedupe.value = '';
@@ -6163,6 +6692,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, qu
   }
 
   paneRestoreChatHistory(pane);
+  paneSyncDraftOrigin(pane);
 
   // Ensure initial disabled state before auth/connection comes up.
   paneSetChatEnabled(pane);
@@ -6687,12 +7217,31 @@ const paneManager = {
       } catch {}
     }
   },
+  canRemovePane(pane, { silent = false } = {}) {
+    if (roleState.role !== 'admin') return false;
+    if (!pane) return false;
+    if (this.panes.length <= 1) return false;
+
+    const kind = normalizePaneKind(pane.kind);
+    if (kind === 'chat' || kind === 'workqueue') {
+      const kindCount = this.panes.filter((p) => normalizePaneKind(p.kind) === kind).length;
+      if (kindCount <= 1) {
+        if (!silent) {
+          const label = kind === 'chat' ? 'Chat' : 'Workqueue';
+          showToast(`Can’t close the last ${label} pane. Use + Add pane to replace it.`, { kind: 'info', timeoutMs: 2600 });
+        }
+        return false;
+      }
+    }
+
+    return true;
+  },
   removePane(key) {
     if (roleState.role !== 'admin') return;
-    if (this.panes.length <= 1) return;
     const idx = this.panes.findIndex((pane) => pane.key === key);
     if (idx < 0) return;
     const pane = this.panes[idx];
+    if (!this.canRemovePane(pane)) return;
     if (!paneCloseGuardPrompt(pane)) return;
     this.panes.splice(idx, 1);
     try {
@@ -6737,7 +7286,9 @@ const paneManager = {
       const letter = String.fromCharCode(65 + (index % 26));
       if (pane.elements.name) pane.elements.name.textContent = letter;
       paneRenderDestinationStrip(pane);
+      paneRenderTypePill(pane);
       paneRenderActivityBadge(pane);
+      paneRenderDraftBadge(pane);
     });
 
     if (globalElements.paneGrid) {
@@ -6745,10 +7296,10 @@ const paneManager = {
     }
   },
   updateCloseButtons() {
-    const allowClose = roleState.role === 'admin' && this.panes.length > 1;
     this.panes.forEach((pane) => {
       if (!pane.elements.closeBtn) return;
-      pane.elements.closeBtn.hidden = !(allowClose && pane.role === 'admin');
+      const allowClose = pane.role === 'admin' && this.canRemovePane(pane, { silent: true });
+      pane.elements.closeBtn.hidden = !allowClose;
     });
   },
   applyLayout(cols) {
@@ -6883,15 +7434,22 @@ globalElements.agentsModal?.addEventListener('click', (event) => {
   if (event.target === globalElements.agentsModal) closeAgentsModal();
 });
 
-globalElements.agentsSearch?.addEventListener('input', () => renderAgentsModalList());
+globalElements.agentsSearch?.addEventListener('input', () => {
+  const query = String(globalElements.agentsSearch.value || '');
+  if (query) storage.set(ADMIN_AGENT_QUERY_KEY, query);
+  else storage.remove(ADMIN_AGENT_QUERY_KEY);
+  renderAgentsModalList();
+});
 globalElements.agentsSearch?.addEventListener('keydown', (event) => {
   if (event.key !== 'Escape') return;
   event.preventDefault();
   if (globalElements.agentsSearch.value) {
     globalElements.agentsSearch.value = '';
+    storage.remove(ADMIN_AGENT_QUERY_KEY);
     renderAgentsModalList();
+    return;
   }
-  globalElements.agentsSearch.focus();
+  closeAgentsModal();
 });
 
 globalElements.agentsFilterGroup?.addEventListener('click', (event) => {
@@ -6906,6 +7464,18 @@ globalElements.agentsSortMode?.addEventListener('change', () => {
   const mode = String(globalElements.agentsSortMode.value || 'attention');
   storage.set(ADMIN_AGENT_SORT_KEY, ['attention', 'recent', 'oldest'].includes(mode) ? mode : 'attention');
   renderAgentsModalList();
+});
+
+globalElements.agentsResetTriageBtn?.addEventListener('click', () => {
+  if (globalElements.agentsSearch) globalElements.agentsSearch.value = '';
+  if (globalElements.agentsSortMode) globalElements.agentsSortMode.value = 'attention';
+  storage.remove(ADMIN_AGENT_QUERY_KEY);
+  storage.remove(ADMIN_AGENT_SORT_KEY);
+  storage.remove(ADMIN_AGENT_FILTER_KEY);
+  renderAgentsModalList();
+  try {
+    globalElements.agentsSearch?.focus?.();
+  } catch {}
 });
 
 globalElements.agentsActiveMinutes?.addEventListener('change', () => {
@@ -7071,6 +7641,27 @@ function cyclePaneFocusBackward() {
   focusPaneIndex(prev);
 }
 
+function cyclePaneFocusByKind(kind, direction = 'next') {
+  const panes = Array.isArray(paneManager.panes) ? paneManager.panes : [];
+  if (!panes.length) return;
+
+  const normalized = String(kind || '').trim().toLowerCase();
+  const matches = panes
+    .map((pane, idx) => ({ pane, idx }))
+    .filter(({ pane }) => String(pane?.kind || 'chat').toLowerCase() === normalized);
+  if (!matches.length) return;
+
+  const active = document.activeElement;
+  const activeIdx = panes.findIndex((p) => p.elements?.root && (p.elements.root === active || p.elements.root.contains(active)));
+  const activeMatchPos = matches.findIndex(({ idx }) => idx === activeIdx);
+  const delta = direction === 'prev' ? -1 : 1;
+  const nextPos = activeMatchPos >= 0
+    ? (activeMatchPos + delta + matches.length) % matches.length
+    : (direction === 'prev' ? matches.length - 1 : 0);
+
+  focusPaneIndex(matches[nextPos].idx);
+}
+
 function isBlockingOverlayOpenForPaneShortcuts() {
   // Scope pane-add keyboard accelerators to the main workspace only.
   // If any overlay/modal is open, ignore pane-add shortcuts to avoid accidental pane creation.
@@ -7109,15 +7700,31 @@ window.addEventListener('keydown', (event) => {
   // Ctrl/Cmd+Shift+W → new workqueue
   // Ctrl/Cmd+Shift+R → new cron
   // Ctrl/Cmd+Shift+T → new timeline
+  // Ctrl/Cmd+Shift+F → Fleet first needs-attention row
   // Ctrl/Cmd+Shift+G → Workqueue for active chat agent
+  // Ctrl/Cmd+Shift+Y → Toggle paired pane (Chat ↔ Workqueue)
   const isAccel = (event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey;
   if (isAccel && roleState.role === 'admin') {
     const key = String(event.key || '').toLowerCase();
+    if (key === 'f') {
+      if (isBlockingOverlayOpenForPaneShortcuts()) return;
+      event.preventDefault();
+      paneManager.closeAddPaneMenu();
+      focusFleetFirstNeedsAttention();
+      return;
+    }
     if (key === 'g') {
       if (isBlockingOverlayOpenForPaneShortcuts()) return;
       event.preventDefault();
       paneManager.closeAddPaneMenu();
       openWorkqueueForActiveChatAgent();
+      return;
+    }
+    if (key === 'y') {
+      if (isBlockingOverlayOpenForPaneShortcuts()) return;
+      event.preventDefault();
+      paneManager.closeAddPaneMenu();
+      togglePairedPaneForActiveTarget();
       return;
     }
     const map = { c: 'chat', w: 'workqueue', r: 'cron', t: 'timeline' };
@@ -7167,8 +7774,35 @@ window.addEventListener('keydown', (event) => {
     return;
   }
 
+  if (key === '/' && !event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey) {
+    const activePane = paneManager.getActivePane();
+    if (activePane?.kind === 'workqueue') {
+      const searchInput = activePane.elements?.thread?.querySelector?.('[data-wq-item-search]');
+      if (searchInput) {
+        event.preventDefault();
+        searchInput.focus();
+        try { searchInput.select?.(); } catch {}
+        return;
+      }
+    }
+  }
+
   // Alt+1..9 focuses panes by visible on-screen order.
   if (event.altKey && !event.metaKey && !event.ctrlKey && !event.shiftKey) {
+    const code = String(event.code || '');
+    if (code.startsWith('Digit')) {
+      const n = Number.parseInt(code.slice(5), 10);
+      if (Number.isFinite(n) && n >= 1 && n <= 9) {
+        event.preventDefault();
+        focusVisiblePaneByShortcutPosition(n);
+        return;
+      }
+    }
+  }
+
+  // Cmd/Ctrl+Shift+1..9 also focuses panes by visible on-screen order
+  // (layout-safe alternative to Alt/Option+1..9 on non-US keyboards).
+  if ((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey) {
     const code = String(event.code || '');
     if (code.startsWith('Digit')) {
       const n = Number.parseInt(code.slice(5), 10);
@@ -7201,6 +7835,20 @@ window.addEventListener('keydown', (event) => {
   if ((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey && key.toLowerCase() === 'j') {
     event.preventDefault();
     cyclePaneFocusBackward();
+    return;
+  }
+
+  // Cmd/Ctrl+Alt+K cycles to next chat pane only.
+  if ((event.metaKey || event.ctrlKey) && !event.shiftKey && event.altKey && key.toLowerCase() === 'k') {
+    event.preventDefault();
+    cyclePaneFocusByKind('chat', 'next');
+    return;
+  }
+
+  // Cmd/Ctrl+Alt+J cycles to previous chat pane only.
+  if ((event.metaKey || event.ctrlKey) && !event.shiftKey && event.altKey && key.toLowerCase() === 'j') {
+    event.preventDefault();
+    cyclePaneFocusByKind('chat', 'prev');
     return;
   }
 
@@ -7282,10 +7930,15 @@ globalElements.status?.addEventListener('click', () => {
 
 globalElements.loginBtn?.addEventListener('click', () => attemptLogin());
 globalElements.loginPassword?.addEventListener('keydown', (event) => {
+  setLoginCapsLockHint(event);
   if (event.key === 'Enter') {
     event.preventDefault();
     attemptLogin();
   }
+});
+globalElements.loginPassword?.addEventListener('keyup', setLoginCapsLockHint);
+globalElements.loginPassword?.addEventListener('blur', () => {
+  if (globalElements.loginCapsLockHint) globalElements.loginCapsLockHint.textContent = '';
 });
 
 globalElements.logoutBtn?.addEventListener('click', async () => {
@@ -7325,6 +7978,8 @@ document.addEventListener('visibilitychange', () => {
 });
 
 window.addEventListener('load', () => {
+  renderInstanceIdentity();
+
   const loginGuard = setTimeout(() => {
     if (!uiState.authed) {
       roleState.role = null;

--- a/clawnsole-server.js
+++ b/clawnsole-server.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const WebSocket = require('ws');
 const { createProxyHandlers, assertSecureWsUrl } = require('./proxy');
+const { createAdminPromptsStore } = require('./lib/admin-prompts-store');
 
 function createClawnsoleServer(options = {}) {
   const root = options.root || __dirname;
@@ -31,6 +32,15 @@ function createClawnsoleServer(options = {}) {
     process.env.CLAWNSOLE_RECURRING_PROMPTS_PATH ??
     path.join(openclawHome, `clawnsole-recurring-prompts${cookieSuffix}.json`);
 
+  const adminPromptsDbPath =
+    options.adminPromptsDbPath ??
+    process.env.CLAWNSOLE_ADMIN_PROMPTS_DB_PATH ??
+    path.join(openclawHome, `clawnsole-admin-prompts${cookieSuffix}.sqlite`);
+
+  const adminPromptsStore = createAdminPromptsStore({
+    dbPath: adminPromptsDbPath,
+    legacyPromptsPath: recurringPromptsPath
+  });
 
   const WebSocketImpl = options.WebSocketImpl || WebSocket;
 
@@ -147,23 +157,29 @@ function createClawnsoleServer(options = {}) {
 
 
   function readRecurringPrompts() {
-    try {
-      const raw = fs.readFileSync(recurringPromptsPath, 'utf8');
-      const data = JSON.parse(raw);
-      const prompts = Array.isArray(data?.prompts) ? data.prompts : [];
-      return { prompts };
-    } catch {
-      return { prompts: [] };
-    }
+    return { prompts: adminPromptsStore.listPrompts() };
   }
 
   function writeRecurringPrompts(state) {
     const prompts = Array.isArray(state?.prompts) ? state.prompts : [];
-    const dir = path.dirname(recurringPromptsPath);
-    fs.mkdirSync(dir, { recursive: true });
-    const tmp = recurringPromptsPath + '.tmp';
-    fs.writeFileSync(tmp, JSON.stringify({ prompts }, null, 2) + '\n', 'utf8');
-    fs.renameSync(tmp, recurringPromptsPath);
+    const existingById = new Map(adminPromptsStore.listPrompts().map((p) => [p.id, p]));
+    const incomingIds = new Set();
+
+    for (const prompt of prompts) {
+      if (!prompt || !prompt.id) continue;
+      incomingIds.add(prompt.id);
+      if (existingById.has(prompt.id)) {
+        adminPromptsStore.updatePrompt(prompt.id, prompt);
+      } else {
+        adminPromptsStore.createPrompt(prompt);
+      }
+    }
+
+    for (const existing of existingById.values()) {
+      if (!incomingIds.has(existing.id)) {
+        adminPromptsStore.deletePrompt(existing.id);
+      }
+    }
   }
 
   function randomId() {

--- a/index.html
+++ b/index.html
@@ -85,9 +85,9 @@
                   <span class="pane-type-text" data-pane-type-text>CHAT</span>
                 </div>
                 <div class="pane-agent" data-pane-agent-wrap>
-                  <span class="agent-label">Agent</span>
+                  <span class="agent-label" data-pane-target-label data-testid="pane-target-label">Agent</span>
                   <button class="agent-pill-btn" type="button" data-pane-agent-button aria-label="Change agent" data-testid="pane-agent-button">
-                    <span class="agent-pill-label" data-pane-agent-label>main</span>
+                    <span class="agent-pill-label" data-pane-agent-label data-testid="pane-target-value">main</span>
                   </button>
                   <select data-pane-agent-select aria-label="Select agent" data-testid="pane-agent-select"></select>
                   <div class="agent-warning" data-pane-agent-warning role="status" aria-live="polite" hidden></div>

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
           <div class="brand-mark"></div>
           <div>
             <h1>Clawnsole</h1>
+            <p id="instanceIdentity" class="instance-identity" data-testid="instance-identity"></p>
           </div>
         </div>
         <div class="topbar-actions">
@@ -42,10 +43,22 @@
           </div>
           <div id="paneControls" class="pane-controls" hidden>
             <div class="pane-add-wrap">
-              <button id="addPaneBtn" class="icon-btn" type="button" aria-haspopup="menu" aria-expanded="false" aria-label="Add pane" data-testid="add-pane-btn">
-                +
+              <button id="addPaneBtn" class="icon-btn action-btn" type="button" aria-haspopup="menu" aria-expanded="false" aria-label="Add pane" title="Add Pane (Ctrl/Cmd+Shift+N)" data-testid="add-pane-btn">
+                <span class="btn-icon" aria-hidden="true">+</span>
+                <span class="btn-label">Add Pane</span>
               </button>
             </div>
+            <button
+              id="resetLayoutQuickBtn"
+              class="icon-btn action-btn"
+              type="button"
+              aria-label="Reset panes to recommended layout"
+              title="Reset to recommended layout: Chat + Workqueue"
+              data-testid="reset-layout-quick-btn"
+            >
+              <span class="btn-icon" aria-hidden="true">↺</span>
+              <span class="btn-label">Reset Layout</span>
+            </button>
             <select id="layoutSelect" aria-label="Pane layout">
               <option value="1">1-up</option>
               <option value="2" selected>2-up</option>
@@ -53,33 +66,40 @@
             </select>
           </div>
           <div class="role-pill" id="rolePill" data-testid="role-pill">signed out</div>
-          <button id="refreshAgentsBtn" class="icon-btn" type="button" aria-label="Refresh agent list" hidden>
-            ⟳
+          <button id="refreshAgentsBtn" class="icon-btn action-btn" type="button" aria-label="Refresh agent list" title="Refresh (Ctrl/Cmd+R)" hidden>
+            <span class="btn-icon" aria-hidden="true">⟳</span>
+            <span class="btn-label">Refresh</span>
           </button>
-          <button id="agentsBtn" class="icon-btn" type="button" aria-label="Open agents" hidden>
-            ★
+          <button id="agentsBtn" class="icon-btn action-btn" type="button" aria-label="Open agents" title="Agents" hidden>
+            <span class="btn-icon" aria-hidden="true">★</span>
+            <span class="btn-label">Agents</span>
           </button>
-          <button id="workqueueBtn" class="icon-btn" type="button" aria-label="Open workqueue" hidden>
-            WQ
+          <button id="workqueueBtn" class="icon-btn action-btn" type="button" aria-label="Open workqueue" title="Workqueue (g w)" hidden>
+            <span class="btn-icon" aria-hidden="true">WQ</span>
+            <span class="btn-label">Workqueue</span>
           </button>
-          <button id="settingsBtn" class="icon-btn" type="button" aria-label="Open settings">
-            ⚙︎
+          <button id="settingsBtn" class="icon-btn action-btn" type="button" aria-label="Open settings" title="Settings">
+            <span class="btn-icon" aria-hidden="true">⚙︎</span>
+            <span class="btn-label">Settings</span>
           </button>
-          <button id="logoutBtn" class="icon-btn" type="button" aria-label="Log out">
-            ⎋
+          <button id="logoutBtn" class="icon-btn action-btn" type="button" aria-label="Log out" title="Logout">
+            <span class="btn-icon" aria-hidden="true">⎋</span>
+            <span class="btn-label">Logout</span>
           </button>
         </div>
       </header>
 
       <main class="chat-page">
         <canvas id="pulseCanvas" class="flux-canvas"></canvas>
-        <div id="paneGrid" class="pane-grid" aria-label="Chat panes" data-testid="pane-grid"></div>
+        <div id="paneGrid" class="pane-grid" aria-label="Panes" data-testid="pane-grid"></div>
 
         <template id="paneTemplate">
           <section class="chat-panel pane" data-pane data-testid="pane">
             <div class="pane-header">
               <div class="pane-header-left">
                 <div class="pane-name" data-pane-name data-testid="pane-type-label">Pane</div>
+                <span class="pane-activity-badge" data-pane-activity-badge hidden aria-live="polite"></span>
+                <span class="pane-draft-badge" data-pane-draft-badge hidden aria-live="polite">Draft</span>
                 <div class="pane-type-pill" data-pane-type-pill data-testid="pane-type-pill" aria-label="Pane type">
                   <span class="pane-type-icon" data-pane-type-icon aria-hidden="true">💬</span>
                   <span class="pane-type-text" data-pane-type-text>CHAT</span>
@@ -92,6 +112,7 @@
                   <select data-pane-agent-select aria-label="Select agent" data-testid="pane-agent-select"></select>
                   <div class="agent-warning" data-pane-agent-warning role="status" aria-live="polite" hidden></div>
                 </div>
+                <div class="pane-shortcut-hints" data-pane-shortcut-hints role="note" aria-live="polite"></div>
               </div>
               <div class="pane-header-right">
                 <div class="pane-agent-pill" data-pane-agent-pill data-testid="pane-agent-pill" hidden></div>
@@ -103,6 +124,9 @@
                 </details>
 
                 <div class="status-pill pane-status" data-pane-status data-testid="pane-connection-status">disconnected</div>
+                <button class="icon-btn pane-pin" data-pane-pin type="button" aria-label="Pin pane" aria-pressed="false" title="Pin pane to prevent accidental close">
+                  📌
+                </button>
                 <button class="icon-btn pane-close" data-pane-close type="button" aria-label="Close pane" data-testid="pane-close">
                   ✕
                 </button>
@@ -177,10 +201,12 @@
           </div>
         </div>
         <p class="login-copy">Enter the admin password to continue.</p>
+        <p id="loginInstanceIdentity" class="login-identity" data-testid="login-instance-identity"></p>
         <label>
           Password
           <input id="loginPassword" type="password" placeholder="Enter password" data-testid="login-password" />
         </label>
+        <div id="loginCapsLockHint" class="login-capslock-hint" role="status" aria-live="polite" data-testid="login-capslock-hint"></div>
         <div id="loginError" class="login-error" role="alert" data-testid="login-error"></div>
         <button id="loginBtn" class="primary" data-testid="login-button">Unlock</button>
       </div>
@@ -219,8 +245,26 @@
         </div>
         <div class="modal-body">
           <div class="hint" style="margin-bottom: 10px;">
-            Shortcuts work when youre not typing in a text field.
+            Shortcuts work when you’re not typing in a text field.
           </div>
+          <div class="shortcuts-controls" role="search" aria-label="Search keyboard shortcuts">
+            <input
+              id="shortcutsSearchInput"
+              class="shortcuts-search-input"
+              type="text"
+              placeholder="Search keys, actions, or categories…"
+              autocomplete="off"
+              spellcheck="false"
+            />
+            <div id="shortcutsFilterChips" class="shortcuts-filter-chips" role="toolbar" aria-label="Shortcut category filters">
+              <button class="shortcuts-chip is-active" type="button" data-shortcuts-filter="all" aria-pressed="true">All</button>
+              <button class="shortcuts-chip" type="button" data-shortcuts-filter="global" aria-pressed="false">Global</button>
+              <button class="shortcuts-chip" type="button" data-shortcuts-filter="chat" aria-pressed="false">Chat</button>
+              <button class="shortcuts-chip" type="button" data-shortcuts-filter="workqueue" aria-pressed="false">Workqueue</button>
+              <button class="shortcuts-chip" type="button" data-shortcuts-filter="fleet" aria-pressed="false">Fleet</button>
+            </div>
+          </div>
+          <div id="shortcutsEmpty" class="hint" hidden>No shortcuts match your filters.</div>
 
           <div class="shortcut-group">
             <h3 class="shortcut-group-title">Help</h3>
@@ -230,11 +274,21 @@
 
           <div class="shortcut-group">
             <h3 class="shortcut-group-title">Panes</h3>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>1</kbd>..<kbd>4</kbd></div><div class="shortcut-desc">Focus pane 14</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>1</kbd>..<kbd>4</kbd></div><div class="shortcut-desc">Focus pane 1-4</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>P</kbd></div><div class="shortcut-desc">Open Pane Manager</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Open command palette</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Pane switcher (cycle focus)</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Alt</kbd>/<kbd>Option</kbd>+<kbd>1</kbd>..<kbd>9</kbd> or <kbd>Cmd/Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>1</kbd>..<kbd>9</kbd></div><div class="shortcut-desc">Focus visible pane by order</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Ctrl</kbd>+<kbd>Tab</kbd> / <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Tab</kbd></div><div class="shortcut-desc">Quick switch panes by recent focus (MRU)</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Focus next pane</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd></div><div class="shortcut-desc">Focus previous pane</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Y</kbd></div><div class="shortcut-desc">Toggle paired pane (Chat ↔ Workqueue)</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Focus next chat pane</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>J</kbd></div><div class="shortcut-desc">Focus previous chat pane</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd></div><div class="shortcut-desc">Add pane</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>C</kbd></div><div class="shortcut-desc">Add Chat pane</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>W</kbd></div><div class="shortcut-desc">Add Workqueue pane</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd></div><div class="shortcut-desc">Add Cron pane</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd></div><div class="shortcut-desc">Add Timeline pane</div></div>
           </div>
 
           <div class="shortcut-group">
@@ -244,7 +298,13 @@
 
           <div class="shortcut-group">
             <h3 class="shortcut-group-title">Agents</h3>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd></div><div class="shortcut-desc">Focus Fleet: first needs attention</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>G</kbd></div><div class="shortcut-desc">Open/focus Workqueue for active chat agent</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>R</kbd></div><div class="shortcut-desc">Refresh agent list</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>j</kbd> / <kbd>k</kbd></div><div class="shortcut-desc">Move fleet selection down/up</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Enter</kbd></div><div class="shortcut-desc">Open selected agent chat pane</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Shift</kbd>+<kbd>Enter</kbd></div><div class="shortcut-desc">Open selected agent + Workqueue modal</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>.</kbd></div><div class="shortcut-desc">Open selected agent + Timeline pane</div></div>
           </div>
         </div>
       </div>
@@ -275,75 +335,85 @@
           </button>
         </div>
         <div class="modal-body">
-          <div class="wq-toolbar">
-            <label class="wq-field">
-              Queue
-              <select id="wqQueueSelect" aria-label="Select workqueue"></select>
-            </label>
-            <div class="wq-field">
-              Status
-              <div id="wqStatusFilters" class="wq-status-filters" aria-label="Status filters"></div>
-            </div>
-            <label class="wq-field">
-              Auto-refresh
-              <div class="wq-autorefresh">
-                <label class="wq-toggle"><input id="wqAutoRefreshEnabled" type="checkbox" /> <span>On</span></label>
-                <select id="wqAutoRefreshInterval" aria-label="Auto-refresh interval">
-                  <option value="5000">5s</option>
-                  <option value="15000" selected>15s</option>
-                  <option value="30000">30s</option>
-                  <option value="60000">60s</option>
+          <div class="wq-modal-controls">
+            <div class="wq-toolbar">
+              <label class="wq-field">
+                Queue
+                <select id="wqQueueSelect" aria-label="Select workqueue"></select>
+              </label>
+              <div class="wq-field">
+                Status
+                <div id="wqStatusFilters" class="wq-status-filters" aria-label="Status filters"></div>
+              </div>
+              <label class="wq-field">
+                Auto-refresh
+                <div class="wq-autorefresh">
+                  <label class="wq-toggle"><input id="wqAutoRefreshEnabled" type="checkbox" /> <span>On</span></label>
+                  <select id="wqAutoRefreshInterval" aria-label="Auto-refresh interval">
+                    <option value="5000">5s</option>
+                    <option value="15000" selected>15s</option>
+                    <option value="30000">30s</option>
+                    <option value="60000">60s</option>
+                  </select>
+                </div>
+              </label>
+              <label class="wq-field">
+                Grouping
+                <select id="wqGroupingMode" aria-label="Grouping mode">
+                  <option value="auto" selected>Auto (&gt;12 items)</option>
+                  <option value="on">On</option>
+                  <option value="off">Off</option>
                 </select>
-              </div>
-            </label>
-            <button id="wqRefreshBtn" class="secondary" type="button">Refresh</button>
-          </div>
-
-          <div class="wq-actions" aria-label="Workqueue actions">
-            <div class="wq-actions-row">
-              <div class="wq-action-card">
-                <div class="wq-action-title">Enqueue</div>
-                <div class="wq-action-grid">
-                  <label class="wq-action-field">
-                    Title
-                    <input id="wqEnqueueTitle" type="text" placeholder="Short title" />
-                  </label>
-                  <label class="wq-action-field">
-                    Priority
-                    <input id="wqEnqueuePriority" type="number" value="50" min="0" max="999" />
-                  </label>
-                  <label class="wq-action-field" style="grid-column: 1 / -1;">
-                    Instructions
-                    <textarea id="wqEnqueueInstructions" rows="4" placeholder="What should the worker do?"></textarea>
-                  </label>
-                  <label class="wq-action-field" style="grid-column: 1 / -1;">
-                    Dedupe Key (optional)
-                    <input id="wqEnqueueDedupeKey" type="text" placeholder="e.g. issue22:actions" />
-                  </label>
-                </div>
-                <div class="wq-action-buttons">
-                  <button id="wqEnqueueBtn" class="primary" type="button">Enqueue</button>
-                </div>
-              </div>
-
-              <div class="wq-action-card">
-                <div class="wq-action-title">Claim next</div>
-                <div class="wq-action-grid">
-                  <label class="wq-action-field">
-                    Agent ID
-                    <input id="wqClaimAgentId" type="text" value="dev" />
-                  </label>
-                  <label class="wq-action-field">
-                    Lease (ms)
-                    <input id="wqClaimLeaseMs" type="number" value="900000" min="1000" step="1000" />
-                  </label>
-                </div>
-                <div class="wq-action-buttons">
-                  <button id="wqClaimBtn" class="secondary" type="button">Claim next</button>
-                </div>
-              </div>
+              </label>
+              <button id="wqRefreshBtn" class="secondary" type="button">Refresh</button>
             </div>
-            <div id="wqActionStatus" class="wq-action-status" role="status" aria-live="polite"></div>
+
+            <div class="wq-actions" aria-label="Workqueue actions">
+              <div class="wq-actions-row">
+                <div class="wq-action-card">
+                  <div class="wq-action-title">Enqueue</div>
+                  <div class="wq-action-grid">
+                    <label class="wq-action-field">
+                      Title
+                      <input id="wqEnqueueTitle" type="text" placeholder="Short title" />
+                    </label>
+                    <label class="wq-action-field">
+                      Priority
+                      <input id="wqEnqueuePriority" type="number" value="50" min="0" max="999" />
+                    </label>
+                    <label class="wq-action-field" style="grid-column: 1 / -1;">
+                      Instructions
+                      <textarea id="wqEnqueueInstructions" rows="4" placeholder="What should the worker do?"></textarea>
+                    </label>
+                    <label class="wq-action-field" style="grid-column: 1 / -1;">
+                      Dedupe Key (optional)
+                      <input id="wqEnqueueDedupeKey" type="text" placeholder="e.g. issue22:actions" />
+                    </label>
+                  </div>
+                  <div class="wq-action-buttons">
+                    <button id="wqEnqueueBtn" class="primary" type="button">Enqueue</button>
+                  </div>
+                </div>
+
+                <div class="wq-action-card">
+                  <div class="wq-action-title">Claim next</div>
+                  <div class="wq-action-grid">
+                    <label class="wq-action-field">
+                      Agent ID
+                      <input id="wqClaimAgentId" type="text" value="dev" />
+                    </label>
+                    <label class="wq-action-field">
+                      Lease (ms)
+                      <input id="wqClaimLeaseMs" type="number" value="900000" min="1000" step="1000" />
+                    </label>
+                  </div>
+                  <div class="wq-action-buttons">
+                    <button id="wqClaimBtn" class="secondary" type="button">Claim next</button>
+                  </div>
+                </div>
+              </div>
+              <div id="wqActionStatus" class="wq-action-status" role="status" aria-live="polite"></div>
+            </div>
           </div>
 
           <div class="wq-layout">
@@ -386,12 +456,48 @@
               <input id="agentsSearch" type="text" placeholder="Filter agents…" />
             </label>
             <label class="agents-field agents-active-only">
-              <span class="agents-label">Active only</span>
+              <span class="agents-label">Fresh window</span>
               <div class="agents-active-controls">
-                <label class="agents-toggle"><input id="agentsActiveOnly" type="checkbox" /> <span>On</span></label>
                 <input id="agentsActiveMinutes" type="number" min="1" step="1" value="10" aria-label="Active within minutes" />
                 <span class="hint">min</span>
               </div>
+            </label>
+            <label class="agents-field">
+              <span class="agents-label">Filter</span>
+              <div id="agentsFilterGroup" class="agents-filter-group" role="group" aria-label="Fleet triage filter">
+                <button id="agentsFilterAll" type="button" class="agents-filter-btn" data-agents-filter="all">All</button>
+                <button id="agentsFilterNeedsAttention" type="button" class="agents-filter-btn" data-agents-filter="needs_attention">Needs attention</button>
+                <button id="agentsFilterConnected" type="button" class="agents-filter-btn" data-agents-filter="connected">Connected</button>
+                <button id="agentsFilterDisconnected" type="button" class="agents-filter-btn" data-agents-filter="disconnected">Disconnected</button>
+                <button id="agentsFilterBusy" type="button" class="agents-filter-btn" data-agents-filter="busy">Busy</button>
+              </div>
+            </label>
+            <label class="agents-field">
+              <span class="agents-label">Sort</span>
+              <select id="agentsSortMode" aria-label="Sort agents">
+                <option value="attention">Attention first (default)</option>
+                <option value="recent">Last heartbeat (newest first)</option>
+                <option value="oldest">Last heartbeat age (oldest first)</option>
+              </select>
+            </label>
+            <label class="agents-field">
+              <span class="agents-label">Density</span>
+              <select id="agentsDensityMode" aria-label="Fleet density">
+                <option value="cozy">Cozy</option>
+                <option value="compact">Compact</option>
+              </select>
+            </label>
+            <label class="agents-field">
+              <span class="agents-label">Columns</span>
+              <div id="agentsColumns" class="agents-columns" role="group" aria-label="Fleet column visibility">
+                <label class="agents-toggle"><input id="agentsColId" type="checkbox" checked /> ID</label>
+                <label class="agents-toggle"><input id="agentsColHealth" type="checkbox" checked /> Health</label>
+                <label class="agents-toggle"><input id="agentsColReason" type="checkbox" checked /> Reason</label>
+              </div>
+            </label>
+            <label class="agents-field agents-reset-field">
+              <span class="agents-label">View</span>
+              <button id="agentsResetTriageBtn" type="button" class="secondary" aria-label="Reset agents triage view">Reset agents triage view</button>
             </label>
           </div>
 
@@ -429,6 +535,11 @@
           <div class="hint">
             Auto-connecting with the gateway token from your local OpenClaw config.
           </div>
+
+          <label style="display:flex; align-items:center; gap:8px; margin-top:10px;">
+            <input id="sendGuardRecentFocusEnabled" type="checkbox" checked />
+            Confirm send when pane focus changed recently
+          </label>
 
           <div class="hint" style="margin-top: 12px;">
             <div style="font-weight: 600; margin-bottom: 6px;">Keyboard shortcuts (admin)</div>

--- a/lib/admin-prompts-store.js
+++ b/lib/admin-prompts-store.js
@@ -1,0 +1,293 @@
+const fs = require('fs')
+const path = require('path')
+const { DatabaseSync } = require('node:sqlite')
+
+function randomId() {
+  try {
+    return require('crypto').randomUUID()
+  } catch {
+    return String(Date.now()) + '-' + Math.random().toString(16).slice(2) + '-' + Math.random().toString(16).slice(2)
+  }
+}
+
+function coercePromptRow(row) {
+  if (!row) return null
+  return {
+    id: String(row.id || ''),
+    title: String(row.title || ''),
+    agentId: String(row.agent_id || 'main'),
+    message: String(row.message || ''),
+    intervalMinutes: Number(row.interval_minutes || 60),
+    enabled: Number(row.enabled || 0) !== 0,
+    createdAt: Number(row.created_at || 0) || Date.now(),
+    updatedAt: Number(row.updated_at || 0) || Date.now(),
+    lastRunAt: row.last_run_at == null ? null : Number(row.last_run_at),
+    nextRunAt: row.next_run_at == null ? null : Number(row.next_run_at),
+    lastStatus: String(row.last_status || 'never'),
+    lastError: String(row.last_error || '')
+  }
+}
+
+function coerceRunRow(row) {
+  if (!row) return null
+  return {
+    id: String(row.id || ''),
+    promptId: String(row.prompt_id || ''),
+    idempotencyKey: String(row.idempotency_key || ''),
+    sessionKey: String(row.session_key || ''),
+    status: String(row.status || 'pending'),
+    error: String(row.error || ''),
+    createdAt: Number(row.created_at || 0) || Date.now(),
+    deliveredAt: row.delivered_at == null ? null : Number(row.delivered_at)
+  }
+}
+
+function createAdminPromptsStore({ dbPath, legacyPromptsPath } = {}) {
+  const resolvedPath = typeof dbPath === 'string' && dbPath.trim() ? dbPath.trim() : path.join(process.cwd(), 'clawnsole.db')
+  fs.mkdirSync(path.dirname(resolvedPath), { recursive: true })
+
+  const db = new DatabaseSync(resolvedPath)
+  db.exec('PRAGMA journal_mode = WAL;')
+  db.exec('PRAGMA busy_timeout = 5000;')
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS admin_prompts (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      agent_id TEXT NOT NULL,
+      message TEXT NOT NULL,
+      interval_minutes INTEGER NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      last_run_at INTEGER,
+      next_run_at INTEGER,
+      last_status TEXT NOT NULL DEFAULT 'never',
+      last_error TEXT NOT NULL DEFAULT ''
+    );
+
+    CREATE TABLE IF NOT EXISTS admin_prompt_runs (
+      id TEXT PRIMARY KEY,
+      prompt_id TEXT NOT NULL,
+      idempotency_key TEXT NOT NULL,
+      session_key TEXT NOT NULL,
+      status TEXT NOT NULL,
+      error TEXT NOT NULL DEFAULT '',
+      created_at INTEGER NOT NULL,
+      delivered_at INTEGER,
+      FOREIGN KEY (prompt_id) REFERENCES admin_prompts(id) ON DELETE CASCADE,
+      UNIQUE (idempotency_key)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_admin_prompts_next_run
+      ON admin_prompts (enabled, next_run_at);
+
+    CREATE INDEX IF NOT EXISTS idx_admin_prompt_runs_prompt_created
+      ON admin_prompt_runs (prompt_id, created_at DESC);
+  `)
+
+  const countStmt = db.prepare('SELECT COUNT(*) AS c FROM admin_prompts')
+  const promptCount = Number(countStmt.get()?.c || 0)
+
+  if (promptCount === 0 && legacyPromptsPath) {
+    try {
+      const raw = fs.readFileSync(legacyPromptsPath, 'utf8')
+      const data = JSON.parse(raw)
+      const prompts = Array.isArray(data?.prompts) ? data.prompts : []
+      const insert = db.prepare(`
+        INSERT INTO admin_prompts (
+          id, title, agent_id, message, interval_minutes, enabled,
+          created_at, updated_at, last_run_at, next_run_at, last_status, last_error
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `)
+      const tx = db.transaction((rows) => {
+        for (const p of rows) {
+          if (!p || typeof p !== 'object') continue
+          const now = Date.now()
+          insert.run(
+            String(p.id || randomId()),
+            String(p.title || 'Recurring prompt'),
+            String(p.agentId || 'main'),
+            String(p.message || ''),
+            Math.max(1, Number(p.intervalMinutes) || 60),
+            p.enabled === false ? 0 : 1,
+            Number(p.createdAt || now),
+            Number(p.updatedAt || now),
+            p.lastRunAt == null ? null : Number(p.lastRunAt),
+            p.nextRunAt == null ? null : Number(p.nextRunAt),
+            String(p.lastStatus || 'never'),
+            String(p.lastError || '')
+          )
+        }
+      })
+      tx(prompts)
+    } catch {}
+  }
+
+  const stmtListPrompts = db.prepare('SELECT * FROM admin_prompts ORDER BY created_at ASC, id ASC')
+  const stmtGetPrompt = db.prepare('SELECT * FROM admin_prompts WHERE id = ? LIMIT 1')
+  const stmtDeletePrompt = db.prepare('DELETE FROM admin_prompts WHERE id = ?')
+  const stmtInsertPrompt = db.prepare(`
+    INSERT INTO admin_prompts (
+      id, title, agent_id, message, interval_minutes, enabled,
+      created_at, updated_at, last_run_at, next_run_at, last_status, last_error
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `)
+  const stmtUpdatePrompt = db.prepare(`
+    UPDATE admin_prompts
+    SET title=?, agent_id=?, message=?, interval_minutes=?, enabled=?,
+        updated_at=?, last_run_at=?, next_run_at=?, last_status=?, last_error=?
+    WHERE id=?
+  `)
+
+  const stmtFindRunByIdempotency = db.prepare('SELECT * FROM admin_prompt_runs WHERE idempotency_key = ? LIMIT 1')
+  const stmtInsertRun = db.prepare(`
+    INSERT INTO admin_prompt_runs (
+      id, prompt_id, idempotency_key, session_key, status, error, created_at, delivered_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `)
+  const stmtUpdateRun = db.prepare(`
+    UPDATE admin_prompt_runs
+    SET status = ?, error = ?, delivered_at = ?
+    WHERE id = ?
+  `)
+  const stmtListRunsByPrompt = db.prepare(`
+    SELECT * FROM admin_prompt_runs
+    WHERE prompt_id = ?
+    ORDER BY created_at DESC, id DESC
+    LIMIT ?
+  `)
+
+  return {
+    dbPath: resolvedPath,
+
+    listPrompts() {
+      return stmtListPrompts.all().map(coercePromptRow)
+    },
+
+    getPrompt(id) {
+      return coercePromptRow(stmtGetPrompt.get(String(id || '')))
+    },
+
+    createPrompt(input) {
+      const now = Date.now()
+      const prompt = {
+        id: String(input?.id || randomId()),
+        title: String(input?.title || 'Recurring prompt'),
+        agentId: String(input?.agentId || 'main'),
+        message: String(input?.message || ''),
+        intervalMinutes: Math.max(1, Number(input?.intervalMinutes) || 60),
+        enabled: input?.enabled === false ? false : true,
+        createdAt: Number(input?.createdAt || now),
+        updatedAt: Number(input?.updatedAt || now),
+        lastRunAt: input?.lastRunAt == null ? null : Number(input.lastRunAt),
+        nextRunAt: input?.nextRunAt == null ? null : Number(input.nextRunAt),
+        lastStatus: String(input?.lastStatus || 'never'),
+        lastError: String(input?.lastError || '')
+      }
+      stmtInsertPrompt.run(
+        prompt.id,
+        prompt.title,
+        prompt.agentId,
+        prompt.message,
+        prompt.intervalMinutes,
+        prompt.enabled ? 1 : 0,
+        prompt.createdAt,
+        prompt.updatedAt,
+        prompt.lastRunAt,
+        prompt.nextRunAt,
+        prompt.lastStatus,
+        prompt.lastError
+      )
+      return prompt
+    },
+
+    updatePrompt(id, input) {
+      const existing = this.getPrompt(id)
+      if (!existing) return null
+      const now = Date.now()
+      const next = {
+        ...existing,
+        ...input,
+        id: existing.id,
+        updatedAt: Number(input?.updatedAt || now)
+      }
+      stmtUpdatePrompt.run(
+        String(next.title || 'Recurring prompt'),
+        String(next.agentId || 'main'),
+        String(next.message || ''),
+        Math.max(1, Number(next.intervalMinutes) || 60),
+        next.enabled === false ? 0 : 1,
+        Number(next.updatedAt || now),
+        next.lastRunAt == null ? null : Number(next.lastRunAt),
+        next.nextRunAt == null ? null : Number(next.nextRunAt),
+        String(next.lastStatus || 'never'),
+        String(next.lastError || ''),
+        existing.id
+      )
+      return this.getPrompt(existing.id)
+    },
+
+    deletePrompt(id) {
+      const info = stmtDeletePrompt.run(String(id || ''))
+      return Number(info?.changes || 0) > 0
+    },
+
+    findRunByIdempotencyKey(idempotencyKey) {
+      return coerceRunRow(stmtFindRunByIdempotency.get(String(idempotencyKey || '')))
+    },
+
+    insertRun(input) {
+      const existing = this.findRunByIdempotencyKey(input?.idempotencyKey)
+      if (existing) return { run: existing, deduped: true }
+      const run = {
+        id: String(input?.id || randomId()),
+        promptId: String(input?.promptId || ''),
+        idempotencyKey: String(input?.idempotencyKey || randomId()),
+        sessionKey: String(input?.sessionKey || ''),
+        status: String(input?.status || 'pending'),
+        error: String(input?.error || ''),
+        createdAt: Number(input?.createdAt || Date.now()),
+        deliveredAt: input?.deliveredAt == null ? null : Number(input.deliveredAt)
+      }
+      stmtInsertRun.run(
+        run.id,
+        run.promptId,
+        run.idempotencyKey,
+        run.sessionKey,
+        run.status,
+        run.error,
+        run.createdAt,
+        run.deliveredAt
+      )
+      return { run, deduped: false }
+    },
+
+    updateRun(id, patch) {
+      const existing = db.prepare('SELECT * FROM admin_prompt_runs WHERE id = ? LIMIT 1').get(String(id || ''))
+      if (!existing) return null
+      const status = patch?.status != null ? String(patch.status) : String(existing.status || 'pending')
+      const error = patch?.error != null ? String(patch.error) : String(existing.error || '')
+      const deliveredAt = patch?.deliveredAt === undefined
+        ? (existing.delivered_at == null ? null : Number(existing.delivered_at))
+        : (patch.deliveredAt == null ? null : Number(patch.deliveredAt))
+      stmtUpdateRun.run(status, error, deliveredAt, String(id))
+      return coerceRunRow(db.prepare('SELECT * FROM admin_prompt_runs WHERE id = ? LIMIT 1').get(String(id || '')))
+    },
+
+    listRunsByPrompt(promptId, { limit = 50 } = {}) {
+      const max = Math.max(1, Math.min(500, Number(limit) || 50))
+      return stmtListRunsByPrompt.all(String(promptId || ''), max).map(coerceRunRow)
+    },
+
+    close() {
+      try {
+        db.close()
+      } catch {}
+    }
+  }
+}
+
+module.exports = {
+  createAdminPromptsStore
+}

--- a/lib/app-core.js
+++ b/lib/app-core.js
@@ -115,7 +115,171 @@
       .map((x) => x.it);
   }
 
-  const AppCore = { escapeHtml, fmtRemaining, sortWorkqueueItems };
+  function inferPaneCols(count) {
+    const n = Number(count);
+    if (!Number.isFinite(n) || n <= 1) return 1;
+    if (n === 2) return 2;
+    if (n === 3) return 3;
+    if (n === 4) return 2;
+    // 5-6 panes: pack into 3 columns.
+    return 3;
+  }
+
+  function normalizePaneKind(rawKind) {
+    const k = String(rawKind || 'chat').trim().toLowerCase();
+    return k === 'chat'
+      ? 'chat'
+      : k === 'workqueue' || k === 'cron' || k === 'timeline'
+        ? k
+        : k.startsWith('w')
+          ? 'workqueue'
+          : k === 'c' || k.startsWith('cr')
+            ? 'cron'
+            : k === 't' || k.startsWith('ti')
+              ? 'timeline'
+              : 'chat';
+  }
+
+  function deriveAuthOverlayState({ authed, role = null } = {}) {
+    const isAdmin = role === 'admin';
+    return {
+      isAdmin,
+      startAgentAutoRefresh: isAdmin && !!authed,
+      stopAgentAutoRefresh: !isAdmin || !authed,
+      rolePillText: isAdmin ? 'signed in' : (role || 'signed out'),
+      rolePillAdmin: isAdmin,
+      showAdminControls: isAdmin,
+      logoutEnabled: !!authed,
+      logoutOpacity: authed ? '1' : '0.5'
+    };
+  }
+
+  function extractChatText(message) {
+    if (!message) return '';
+    if (typeof message === 'string') return message;
+    if (Array.isArray(message)) {
+      return message
+        .map((part) => {
+          if (!part) return '';
+          if (typeof part.text === 'string') return part.text;
+          const type = typeof part.type === 'string' ? part.type : '';
+          if (type === 'image_url' && typeof part.image_url?.url === 'string') {
+            return `\n\n![](${part.image_url.url})\n\n`;
+          }
+          if (type === 'image' && typeof part.url === 'string') {
+            return `\n\n![](${part.url})\n\n`;
+          }
+          if ((type === 'file' || type === 'attachment') && typeof part.url === 'string') {
+            const name = typeof part.name === 'string' ? part.name : 'attachment';
+            return `\n\n[${name}](${part.url})\n\n`;
+          }
+          if (typeof part.url === 'string') {
+            return `\n\n${part.url}\n\n`;
+          }
+          return '';
+        })
+        .filter(Boolean)
+        .join('');
+    }
+    if (typeof message.text === 'string') return message.text;
+    if (Array.isArray(message.content)) {
+      return message.content
+        .map((part) => {
+          if (!part) return '';
+          if (typeof part.text === 'string') return part.text;
+
+          const type = typeof part.type === 'string' ? part.type : '';
+          if (type === 'image_url' && typeof part.image_url?.url === 'string') {
+            return `\n\n![](${part.image_url.url})\n\n`;
+          }
+          if (type === 'image' && typeof part.url === 'string') {
+            return `\n\n![](${part.url})\n\n`;
+          }
+          if ((type === 'file' || type === 'attachment') && typeof part.url === 'string') {
+            const name = typeof part.name === 'string' ? part.name : 'attachment';
+            return `\n\n[${name}](${part.url})\n\n`;
+          }
+
+          if (typeof part.url === 'string') {
+            return `\n\n${part.url}\n\n`;
+          }
+          return '';
+        })
+        .filter(Boolean)
+        .join('');
+    }
+    return '';
+  }
+
+  function normalizeHistoryEntries(payload) {
+    // Support multiple possible gateway shapes.
+    // Expected output: [{ role: 'user'|'assistant'|'system', text: string }]
+    if (!payload) return [];
+
+    const candidates =
+      payload.messages ||
+      payload.history ||
+      payload.items ||
+      payload.entries ||
+      payload.chat ||
+      payload;
+
+    if (!Array.isArray(candidates)) return [];
+
+    return candidates
+      .map((item) => {
+        const roleRaw =
+          item?.role ||
+          item?.author ||
+          item?.speaker ||
+          item?.type ||
+          (item?.isAssistant ? 'assistant' : item?.isUser ? 'user' : null);
+        const role = String(roleRaw || '').toLowerCase();
+        const normalizedRole = role.includes('assistant') ? 'assistant' : role.includes('user') ? 'user' : role || 'assistant';
+        const text = extractChatText(item?.message ?? item?.content ?? item?.text ?? item);
+        return { role: normalizedRole, text: String(text || '') };
+      })
+      .filter((entry) => entry.text);
+  }
+
+  function renderMarkdown(text) {
+    if (!text) return '';
+    let html = escapeHtml(text);
+
+    html = html.replace(/```([\s\S]*?)```/g, (match, code) => {
+      return `<pre><code>${code.replace(/^\n+|\n+$/g, '')}</code></pre>`;
+    });
+    html = html.replace(/`([^`]+)`/g, '<code>$1</code>');
+    html = html.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+    html = html.replace(/\*([^*]+)\*/g, '<em>$1</em>');
+    html = html.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '<img alt="$1" src="$2" />');
+    html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
+
+    html = html.replace(
+      /(^|[\s(\[])(https?:\/\/[^\s<)\]]+)/g,
+      (match, prefix, url) => `${prefix}<a href="${url}" target="_blank" rel="noopener">${url}</a>`
+    );
+
+    html = html.replace(/\n- (.+)/g, '<ul><li>$1</li></ul>');
+    html = html.replace(/<\/ul>\n<ul>/g, '');
+    html = html.replace(/\n\d+\. (.+)/g, '<ol><li>$1</li></ol>');
+    html = html.replace(/<\/ol>\n<ol>/g, '');
+    html = html.replace(/\n/g, '<br />');
+
+    return html;
+  }
+
+  const AppCore = {
+    escapeHtml,
+    fmtRemaining,
+    sortWorkqueueItems,
+    inferPaneCols,
+    normalizePaneKind,
+    deriveAuthOverlayState,
+    extractChatText,
+    normalizeHistoryEntries,
+    renderMarkdown
+  };
 
   try {
     if (typeof module !== 'undefined' && module.exports) module.exports = AppCore;

--- a/lib/app-core.js
+++ b/lib/app-core.js
@@ -52,16 +52,16 @@
         const A = a.it || {};
         const B = b.it || {};
 
-        // Default: status grouping (active first), then priority desc, then updatedAt desc, then createdAt desc.
+        // Default: priority-first (desc), then recency, then status rank as a stable tie-breaker.
         if (sortKey === 'default') {
-          const sr = statusRank(A.status) - statusRank(B.status);
-          if (sr) return sr;
           const pr = numOr0(B.priority) - numOr0(A.priority);
           if (pr) return pr;
           const ur = timeOr0(B.updatedAt) - timeOr0(A.updatedAt);
           if (ur) return ur;
           const cr = timeOr0(B.createdAt) - timeOr0(A.createdAt);
           if (cr) return cr;
+          const sr = statusRank(A.status) - statusRank(B.status);
+          if (sr) return sr;
           return a.idx - b.idx;
         }
 
@@ -138,6 +138,55 @@
             : k === 't' || k.startsWith('ti')
               ? 'timeline'
               : 'chat';
+  }
+
+  function deriveWorkqueueDisplayTitle(item) {
+    const rawTitle = String(item?.title || '').trim();
+    const kind = String(item?.meta?.kind || '').trim().toLowerCase();
+    const issueUrl = String(item?.meta?.issueUrl || item?.meta?.url || '').trim();
+
+    const looksIssue = kind === 'issue' || rawTitle.toLowerCase().startsWith('[issue]') || /\/issues\/\d+$/i.test(issueUrl);
+    if (!looksIssue) return { title: rawTitle, rawTitle, canonicalized: false };
+
+    const repoFromMeta = String(item?.meta?.repo || '').trim();
+    const repoFromUrl = (() => {
+      const m = issueUrl.match(/github\.com\/([^\s/]+\/[^\s/#?]+)\/issues\/\d+/i);
+      return m?.[1] ? String(m[1]).trim() : '';
+    })();
+    const repoFromTitle = (() => {
+      const m = rawTitle.match(/([a-z0-9_.-]+\/[a-z0-9_.-]+)#\d+/i);
+      return m?.[1] ? String(m[1]).trim() : '';
+    })();
+    const repo = repoFromMeta || repoFromUrl || repoFromTitle;
+
+    const issueNumber = (() => {
+      const n = Number(item?.meta?.issueNumber);
+      if (Number.isFinite(n) && n > 0) return String(Math.trunc(n));
+      const fromUrl = issueUrl.match(/\/issues\/(\d+)/i)?.[1] || '';
+      if (fromUrl) return fromUrl;
+      const fromTitle = rawTitle.match(/#(\d+)/)?.[1] || '';
+      return fromTitle;
+    })();
+
+    let cleaned = rawTitle
+      .replace(/^\s*\[[^\]]+\]\s*/i, '')
+      .replace(/^\s*(?:open issue|triager|issue coverage)\s*:\s*/i, '')
+      .trim();
+    if (repo && issueNumber) {
+      const locatorRe = new RegExp(`^${repo.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}#${issueNumber}(?:\s*[\-–—:]\s*)?`, 'i');
+      cleaned = cleaned.replace(locatorRe, '').trim();
+    }
+    cleaned = cleaned.replace(/^#\d+(?:\s*[\-–—:]\s*)?/, '').trim();
+
+    const canonical = repo && issueNumber
+      ? (cleaned ? `${repo}#${issueNumber} — ${cleaned}` : `${repo}#${issueNumber}`)
+      : cleaned || rawTitle;
+
+    return {
+      title: canonical,
+      rawTitle,
+      canonicalized: canonical !== rawTitle
+    };
   }
 
   function deriveAuthOverlayState({ authed, role = null } = {}) {
@@ -242,6 +291,31 @@
       .filter((entry) => entry.text);
   }
 
+  function detectShortcutConflict(keysText, { platform = '' } = {}) {
+    const normalized = String(keysText || '').toLowerCase().replace(/\s+/g, '');
+    if (!normalized) return null;
+
+    const isMac = String(platform || '').toLowerCase().includes('mac');
+
+    if (normalized.includes('cmd/ctrl+r') || normalized.includes('cmd+ctrl+r') || normalized.includes('cmd+rr') || normalized.includes('ctrl+r')) {
+      return {
+        level: 'warn',
+        reason: 'Often intercepted by browser refresh before web apps can handle it.',
+        suggestion: isMac ? 'Use Cmd+Shift+G, or click Refresh in Agents.' : 'Use Ctrl+Shift+G, or click Refresh in Agents.'
+      };
+    }
+
+    if (normalized.includes('ctrl+tab')) {
+      return {
+        level: 'warn',
+        reason: 'Usually reserved by browsers for tab switching.',
+        suggestion: isMac ? 'Use Cmd+Shift+K / Cmd+Shift+J for pane navigation.' : 'Use Ctrl+Shift+K / Ctrl+Shift+J for pane navigation.'
+      };
+    }
+
+    return null;
+  }
+
   function renderMarkdown(text) {
     if (!text) return '';
     let html = escapeHtml(text);
@@ -278,7 +352,9 @@
     deriveAuthOverlayState,
     extractChatText,
     normalizeHistoryEntries,
-    renderMarkdown
+    detectShortcutConflict,
+    renderMarkdown,
+    deriveWorkqueueDisplayTitle
   };
 
   try {

--- a/scripts/recurring-prompts-scheduler.js
+++ b/scripts/recurring-prompts-scheduler.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 const WebSocket = require('ws');
+const { createAdminPromptsStore } = require('../lib/admin-prompts-store');
 
 function parseArgs(argv) {
   const args = { _: [] };
@@ -141,9 +142,7 @@ async function connectGateway({ wsUrl, token }) {
   };
 }
 
-async function deliverPrompt(gateway, { agentId, message, deviceLabel }) {
-  const sessionKey = computeSessionKey(agentId, deviceLabel);
-  const idempotencyKey = randomId();
+async function deliverPrompt(gateway, { message, sessionKey, idempotencyKey }) {
   const res = await gateway.sendReq('chat.send', {
     sessionKey,
     message,
@@ -164,13 +163,14 @@ function findDuePrompts(prompts, now) {
   });
 }
 
-async function runOnce({ promptsPath, openclawConfigPath, deviceLabel, dryRun = false }) {
-  const state = readJsonFile(promptsPath, { prompts: [] });
-  const prompts = Array.isArray(state?.prompts) ? state.prompts : [];
+async function runOnce({ dbPath, legacyPromptsPath, openclawConfigPath, deviceLabel, dryRun = false }) {
+  const store = createAdminPromptsStore({ dbPath, legacyPromptsPath });
+  const prompts = store.listPrompts();
   const now = Date.now();
 
   const due = findDuePrompts(prompts, now);
   if (due.length === 0) {
+    store.close();
     return { ok: true, delivered: 0, due: 0 };
   }
 
@@ -183,17 +183,18 @@ async function runOnce({ promptsPath, openclawConfigPath, deviceLabel, dryRun = 
   try {
     gateway = await connectGateway({ wsUrl, token });
   } catch (err) {
-    // mark all due as failed
     const message = String(err || 'gateway connect failed');
     due.forEach((p) => {
-      p.lastStatus = 'error';
-      p.lastError = message;
-      p.lastRunAt = now;
-      p.updatedAt = now;
-      const minutes = Number(p.intervalMinutes) || 60;
-      p.nextRunAt = now + Math.max(1, minutes) * 60 * 1000;
+      const minutes = Math.max(1, Number(p.intervalMinutes) || 60);
+      store.updatePrompt(p.id, {
+        lastStatus: 'error',
+        lastError: message,
+        lastRunAt: now,
+        nextRunAt: now + minutes * 60 * 1000,
+        updatedAt: now
+      });
     });
-    writeJsonAtomic(promptsPath, { prompts });
+    store.close();
     return { ok: false, delivered: 0, due: due.length, error: message };
   }
 
@@ -201,27 +202,53 @@ async function runOnce({ promptsPath, openclawConfigPath, deviceLabel, dryRun = 
   for (const prompt of due) {
     const minutes = Math.max(1, Number(prompt.intervalMinutes) || 60);
     const nextRunAt = now + minutes * 60 * 1000;
+    const sessionKey = computeSessionKey(prompt.agentId || 'main', deviceLabel);
+    const idempotencyKey = `admin-prompt:${prompt.id}:${now}`;
+
+    const runInsert = store.insertRun({
+      promptId: prompt.id,
+      idempotencyKey,
+      sessionKey,
+      status: 'pending',
+      createdAt: now
+    });
 
     try {
       if (!dryRun) {
-        await deliverPrompt(gateway, { agentId: prompt.agentId || 'main', message: prompt.message || '', deviceLabel });
+        await deliverPrompt(gateway, {
+          message: prompt.message || '',
+          sessionKey,
+          idempotencyKey
+        });
       }
-      prompt.lastStatus = dryRun ? 'dry_run' : 'ok';
-      prompt.lastError = '';
+      store.updateRun(runInsert.run.id, {
+        status: dryRun ? 'dry_run' : 'ok',
+        error: '',
+        deliveredAt: now
+      });
+      store.updatePrompt(prompt.id, {
+        lastStatus: dryRun ? 'dry_run' : 'ok',
+        lastError: '',
+        lastRunAt: now,
+        nextRunAt,
+        updatedAt: now
+      });
       delivered += 1;
     } catch (err) {
-      prompt.lastStatus = 'error';
-      prompt.lastError = String(err || 'delivery failed');
+      const message = String(err || 'delivery failed');
+      store.updateRun(runInsert.run.id, { status: 'error', error: message });
+      store.updatePrompt(prompt.id, {
+        lastStatus: 'error',
+        lastError: message,
+        lastRunAt: now,
+        nextRunAt,
+        updatedAt: now
+      });
     }
-
-    prompt.lastRunAt = now;
-    prompt.nextRunAt = nextRunAt;
-    prompt.updatedAt = now;
   }
 
-  writeJsonAtomic(promptsPath, { prompts });
   gateway.close();
-
+  store.close();
   return { ok: true, delivered, due: due.length };
 }
 
@@ -230,7 +257,8 @@ async function main() {
 
   const homeDir = process.env.HOME || '';
   const openclawHome = process.env.OPENCLAW_HOME || path.join(homeDir, '.openclaw');
-  const promptsPath = args.promptsPath || args.prompts || process.env.CLAWNSOLE_RECURRING_PROMPTS_PATH || path.join(openclawHome, 'clawnsole-recurring-prompts.json');
+  const legacyPromptsPath = args.promptsPath || args.prompts || process.env.CLAWNSOLE_RECURRING_PROMPTS_PATH || path.join(openclawHome, 'clawnsole-recurring-prompts.json');
+  const dbPath = args.dbPath || process.env.CLAWNSOLE_ADMIN_PROMPTS_DB_PATH || path.join(openclawHome, 'clawnsole-admin-prompts.sqlite');
   const openclawConfigPath = args.openclawConfig || process.env.OPENCLAW_CONFIG || path.join(openclawHome, 'openclaw.json');
   const deviceLabel = args.deviceLabel || 'scheduler';
   const loopSeconds = Number(args.loopSeconds || 60) || 60;
@@ -238,7 +266,7 @@ async function main() {
   const dryRun = Boolean(args.dryRun);
 
   const tick = async () => {
-    const result = await runOnce({ promptsPath, openclawConfigPath, deviceLabel, dryRun });
+    const result = await runOnce({ dbPath, legacyPromptsPath, openclawConfigPath, deviceLabel, dryRun });
     const summary = `[recurring-prompts] ok=${result.ok} due=${result.due} delivered=${result.delivered}${result.error ? ' err=' + result.error : ''}`;
     console.log(summary);
   };

--- a/styles.css
+++ b/styles.css
@@ -11,7 +11,15 @@
   --warning: #ff6b6b;
   --glow: rgba(255, 179, 71, 0.35);
   --shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
+
+  /* Pane accent tokens (AA-safe in dark UI). */
+  --pane-accent-chat: rgba(127, 209, 185, 0.78);
+  --pane-accent-workqueue: rgba(255, 179, 71, 0.84);
+  --pane-accent-cron: rgba(162, 155, 254, 0.84);
+  --pane-accent-timeline: rgba(86, 204, 242, 0.82);
+  --pane-accent-fleet: rgba(244, 114, 182, 0.84);
 }
+
 
 html {
   height: 100%;
@@ -135,6 +143,13 @@ body::before {
   font-size: 14px;
 }
 
+.instance-identity {
+  margin: 2px 0 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.3;
+}
+
 .status {
   display: flex;
   flex-direction: column;
@@ -188,7 +203,7 @@ body::before {
   font-size: 12px;
 }
 
-/* addPaneBtn uses default .icon-btn styling */
+/* addPaneBtn uses default .icon-btn styling unless promoted to action-btn. */
 .pane-controls .icon-btn {
   width: 36px;
   height: 36px;
@@ -196,6 +211,12 @@ body::before {
   font-size: 18px;
   min-height: 0;
   padding: 0;
+}
+
+.pane-controls .action-btn {
+  width: auto;
+  min-width: 36px;
+  padding: 0 12px;
 }
 
 .role-pill {
@@ -266,6 +287,38 @@ body::before {
 .icon-btn:hover {
   transform: translateY(-1px);
   box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+}
+
+.action-btn {
+  width: auto;
+  min-width: 40px;
+  height: 40px;
+  gap: 8px;
+  padding: 0 12px;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.action-btn .btn-icon {
+  font-size: 14px;
+  line-height: 1;
+}
+
+.action-btn .btn-label {
+  white-space: nowrap;
+}
+
+@media (max-width: 920px) {
+  .action-btn {
+    width: 36px;
+    min-width: 36px;
+    padding: 0;
+    gap: 0;
+  }
+
+  .action-btn .btn-label {
+    display: none;
+  }
 }
 
 .status-pill {
@@ -422,6 +475,17 @@ body::before {
   align-items: center;
   gap: 12px;
   min-width: 0;
+  flex-wrap: wrap;
+}
+
+.pane-shortcut-hints {
+  font-size: 11px;
+  color: var(--muted);
+  opacity: 0.92;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: min(62vw, 760px);
 }
 
 .pane-name {
@@ -432,11 +496,51 @@ body::before {
   white-space: nowrap;
 }
 
+.pane-activity-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 6px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  color: #0a0d11;
+  background: rgba(127, 209, 185, 0.95);
+}
+
+.pane-activity-badge[data-kind="workqueue"] {
+  background: rgba(255, 179, 71, 0.95);
+}
+
+.pane-draft-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 6px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #ffd468;
+  border: 1px solid rgba(255, 212, 104, 0.45);
+  background: rgba(255, 212, 104, 0.14);
+}
+
 .pane-type-pill {
   display: inline-flex;
   align-items: center;
   gap: 8px;
   padding: 6px 10px;
+  min-width: 0;
+  max-width: min(40vw, 220px);
+  flex: 0 0 auto;
   border-radius: 999px;
   border: 1px solid rgba(255, 255, 255, 0.12);
   background: rgba(255, 255, 255, 0.06);
@@ -451,31 +555,41 @@ body::before {
 .pane-type-icon {
   font-size: 12px;
   opacity: 0.95;
+  flex: 0 0 auto;
 }
 
 .pane-type-text {
   font-weight: 650;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Per-pane subtle treatment */
 .pane-kind-chat {
-  --pane-accent: rgba(127, 209, 185, 0.75);
+  --pane-accent: var(--pane-accent-chat);
   --pane-header-tint: rgba(127, 209, 185, 0.08);
 }
 
 .pane-kind-workqueue {
-  --pane-accent: rgba(255, 179, 71, 0.8);
+  --pane-accent: var(--pane-accent-workqueue);
   --pane-header-tint: rgba(255, 179, 71, 0.09);
 }
 
 .pane-kind-cron {
-  --pane-accent: rgba(162, 155, 254, 0.8);
+  --pane-accent: var(--pane-accent-cron);
   --pane-header-tint: rgba(162, 155, 254, 0.09);
 }
 
 .pane-kind-timeline {
-  --pane-accent: rgba(86, 204, 242, 0.78);
+  --pane-accent: var(--pane-accent-timeline);
   --pane-header-tint: rgba(86, 204, 242, 0.08);
+}
+
+.pane-kind-fleet {
+  --pane-accent: var(--pane-accent-fleet);
+  --pane-header-tint: rgba(244, 114, 182, 0.08);
 }
 
 .pane-type-chat {
@@ -496,6 +610,11 @@ body::before {
 .pane-type-timeline {
   border-color: rgba(86, 204, 242, 0.55);
   background: rgba(86, 204, 242, 0.12);
+}
+
+.pane-type-fleet {
+  border-color: rgba(244, 114, 182, 0.55);
+  background: rgba(244, 114, 182, 0.12);
 }
 
 .pane-agent {
@@ -974,12 +1093,24 @@ button.send-btn .btn-icon {
   line-height: 1.45;
 }
 
+.login-identity {
+  font-size: 12px;
+  color: var(--text);
+  opacity: 0.9;
+}
+
 .login-card label {
   display: flex;
   flex-direction: column;
   gap: 6px;
   font-size: 12px;
   color: var(--muted);
+}
+
+.login-capslock-hint {
+  min-height: 16px;
+  color: color-mix(in srgb, var(--warning) 86%, #fff 14%);
+  font-size: 12px;
 }
 
 .login-error {
@@ -1093,6 +1224,14 @@ button.send-btn .btn-icon {
   padding-right: 2px;
 }
 
+.command-palette-group-title {
+  margin-top: 8px;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
 .command-palette-item {
   display: grid;
   grid-template-columns: 1fr auto;
@@ -1126,6 +1265,14 @@ button.send-btn .btn-icon {
   color: var(--muted);
 }
 
+.command-palette-subgroup {
+  border-style: dashed;
+}
+
+.command-palette-subitem {
+  margin-left: 12px;
+}
+
 /* Pane Manager */
 
 .status-meta-btn {
@@ -1149,6 +1296,7 @@ button.send-btn .btn-icon {
 }
 
 .pane-manager-row {
+  --pane-row-accent: rgba(255, 255, 255, 0.2);
   display: grid;
   grid-template-columns: 1fr auto;
   gap: 10px;
@@ -1156,8 +1304,15 @@ button.send-btn .btn-icon {
   padding: 10px 12px;
   border-radius: 12px;
   border: 1px solid rgba(255, 255, 255, 0.08);
+  border-left: 4px solid var(--pane-row-accent);
   background: rgba(255, 255, 255, 0.02);
 }
+
+.pane-manager-row[data-pane-accent-kind="chat"] { --pane-row-accent: var(--pane-accent-chat); }
+.pane-manager-row[data-pane-accent-kind="workqueue"] { --pane-row-accent: var(--pane-accent-workqueue); }
+.pane-manager-row[data-pane-accent-kind="cron"] { --pane-row-accent: var(--pane-accent-cron); }
+.pane-manager-row[data-pane-accent-kind="timeline"] { --pane-row-accent: var(--pane-accent-timeline); }
+.pane-manager-row[data-pane-accent-kind="fleet"] { --pane-row-accent: var(--pane-accent-fleet); }
 
 .pane-manager-row[aria-selected="true"] {
   border-color: rgba(110, 231, 183, 0.5);
@@ -1172,12 +1327,60 @@ button.send-btn .btn-icon {
   min-width: 0;
 }
 
+.pane-manager-type-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.04);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.pane-manager-state-chips {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  justify-self: end;
+}
+
+.pane-manager-main .pane-activity-badge {
+  min-width: 16px;
+  height: 16px;
+  padding: 0 5px;
+  font-size: 10px;
+}
+
+.pane-manager-main .pane-draft-badge {
+  min-width: 16px;
+  height: 16px;
+  padding: 0 5px;
+  font-size: 9px;
+}
+
 .pane-manager-kind {
   display: inline-flex;
   gap: 8px;
   align-items: center;
   font-weight: 600;
   white-space: nowrap;
+}
+
+.pane-manager-letter {
+  width: 20px;
+  height: 20px;
+  border-radius: 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.12);
 }
 
 .pane-manager-target {
@@ -1188,10 +1391,25 @@ button.send-btn .btn-icon {
 }
 
 .pane-manager-state {
+  display: inline-flex;
+  align-items: center;
+  height: 18px;
+  padding: 0 7px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.04);
   font-size: 12px;
   color: var(--muted);
-  text-transform: lowercase;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 600;
   white-space: nowrap;
+}
+
+.pane-manager-state--disconnected {
+  color: #ffb4b4;
+  border-color: rgba(255, 130, 130, 0.4);
+  background: rgba(255, 130, 130, 0.12);
 }
 
 .pane-manager-actions {
@@ -1226,6 +1444,28 @@ button.send-btn .btn-icon {
   display: inline-flex;
   gap: 10px;
   align-items: center;
+}
+
+.agents-filter-group {
+  display: inline-flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.agents-filter-btn {
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text);
+  padding: 5px 10px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.agents-filter-btn.is-active,
+.agents-filter-btn[aria-pressed="true"] {
+  border-color: rgba(122, 162, 255, 0.7);
+  background: rgba(122, 162, 255, 0.2);
 }
 
 .agents-toggle {
@@ -1271,6 +1511,12 @@ button.send-btn .btn-icon {
   background: rgba(255, 255, 255, 0.02);
 }
 
+.agents-row.is-selected {
+  border-color: rgba(120, 188, 255, 0.62);
+  box-shadow: 0 0 0 2px rgba(66, 153, 225, 0.2);
+  background: rgba(56, 132, 255, 0.1);
+}
+
 .agents-pin {
   width: 36px;
   height: 36px;
@@ -1286,16 +1532,66 @@ button.send-btn .btn-icon {
   background: rgba(255, 179, 71, 0.12);
 }
 
+.agents-row-title-wrap {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: space-between;
+}
+
 .agents-row-title {
   font-size: 14px;
   font-weight: 600;
   color: var(--text);
 }
 
+.agents-age-chip {
+  font-size: 11px;
+  color: var(--muted);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  padding: 2px 8px;
+}
+
+.agents-row.is-active .agents-age-chip {
+  border-color: rgba(114, 220, 130, 0.45);
+}
+
+.agents-row.is-stale .agents-age-chip {
+  border-color: rgba(255, 188, 89, 0.5);
+}
+
+.agents-row.is-offline .agents-age-chip {
+  border-color: rgba(255, 99, 99, 0.5);
+}
+
 .agents-row-meta {
   margin-top: 2px;
   font-size: 12px;
   color: var(--muted);
+}
+
+.agents-row-reason {
+  margin-top: 6px;
+}
+
+.agents-reason-chip {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 11px;
+  color: var(--text);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.agents-row.is-offline .agents-reason-chip {
+  border-color: rgba(255, 99, 99, 0.5);
+}
+
+.agents-row.is-stale .agents-reason-chip {
+  border-color: rgba(255, 188, 89, 0.5);
 }
 
 /* Shortcuts modal */
@@ -1349,6 +1645,26 @@ kbd {
 }
 
 /* Workqueue modal */
+
+.wq-modal-controls {
+  position: sticky;
+  top: 0;
+  z-index: 4;
+  background: linear-gradient(to bottom, rgba(12, 15, 20, 0.97), rgba(12, 15, 20, 0.93));
+  backdrop-filter: blur(8px);
+  padding-top: 2px;
+  margin-bottom: 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.wq-modal-controls .wq-toolbar,
+.wq-modal-controls .wq-actions {
+  margin-bottom: 10px;
+}
+
+.wq-modal-controls .wq-actions {
+  margin-bottom: 2px;
+}
 
 .wq-toolbar {
   display: flex;
@@ -1514,6 +1830,16 @@ kbd {
   flex-wrap: wrap;
 }
 
+.wq-control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
 .wq-field {
   display: flex;
   flex-direction: column;
@@ -1578,6 +1904,32 @@ kbd {
   color: var(--muted);
 }
 
+.wq-scope-field {
+  min-width: min(420px, 100%);
+}
+
+.wq-scope {
+  display: inline-flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.wq-scope-btn {
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  border-radius: 999px;
+  padding: 6px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.wq-scope-btn.active {
+  border-color: rgba(127, 209, 185, 0.5);
+  background: rgba(127, 209, 185, 0.12);
+}
+
 .wq-sort {
   display: flex;
   gap: 6px;
@@ -1607,6 +1959,30 @@ kbd {
 .wq-list-sort.active {
   border-color: rgba(127, 209, 185, 0.5);
   background: rgba(127, 209, 185, 0.12);
+}
+
+.wq-filter-summary {
+  margin-top: 8px;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.wq-filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.wq-filter-chip {
+  font-size: 11px;
+  border-radius: 999px;
+  padding: 4px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+  cursor: pointer;
 }
 
 .wq-enqueue {
@@ -1863,6 +2239,39 @@ kbd {
 
 .wq-row.selected {
   background: rgba(127, 209, 185, 0.12);
+}
+
+.wq-row-group,
+.wq-card-wrap {
+  display: grid;
+  gap: 6px;
+}
+
+.wq-duplicates {
+  margin: 0 0 8px;
+}
+
+.wq-duplicates-summary {
+  font-size: 11px;
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.wq-duplicates-list {
+  display: grid;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.wq-duplicate-btn {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text);
+  border-radius: 8px;
+  padding: 6px 8px;
+  text-align: left;
+  font-size: 12px;
+  cursor: pointer;
 }
 
 .wq-col {
@@ -2238,6 +2647,59 @@ kbd {
   display: flex;
 }
 
+.destination-strip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid rgba(120, 184, 255, 0.35);
+  background: rgba(81, 155, 255, 0.08);
+  color: var(--text);
+  font-size: 12px;
+  padding: 8px 10px;
+  cursor: pointer;
+  text-align: left;
+}
+
+.destination-strip-label {
+  color: var(--muted);
+}
+
+.destination-strip-value {
+  font-weight: 600;
+}
+
+.destination-strip[data-warning="true"] {
+  border-color: rgba(244, 184, 38, 0.6);
+  background: rgba(244, 184, 38, 0.12);
+}
+
+.send-guard {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(244, 184, 38, 0.08);
+  border: 1px solid rgba(244, 184, 38, 0.35);
+  color: #f8e4a4;
+  font-size: 12px;
+}
+
+.send-guard[hidden] {
+  display: none !important;
+}
+
+.send-guard-msg {
+  line-height: 1.35;
+}
+
+.send-guard-actions {
+  display: flex;
+  gap: 8px;
+}
+
 .command-hint {
   display: flex;
   justify-content: space-between;
@@ -2549,6 +3011,11 @@ kbd {
     width: 34px;
     height: 34px;
     border-radius: 10px;
+  }
+
+  .action-btn {
+    width: 34px;
+    min-width: 34px;
   }
 
   .chat-panel {

--- a/styles.css
+++ b/styles.css
@@ -1468,6 +1468,12 @@ button.send-btn .btn-icon {
   background: rgba(122, 162, 255, 0.2);
 }
 
+.agents-columns {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 .agents-toggle {
   display: inline-flex;
   align-items: center;
@@ -1511,6 +1517,17 @@ button.send-btn .btn-icon {
   background: rgba(255, 255, 255, 0.02);
 }
 
+.agents-list.agents-density-compact .agents-row {
+  padding: 7px 10px;
+  border-radius: 10px;
+}
+
+.agents-list.agents-density-compact .agents-row-meta,
+.agents-list.agents-density-compact .agents-row-reason,
+.agents-list.agents-density-compact .agents-row-chips {
+  margin-top: 4px;
+}
+
 .agents-row.is-selected {
   border-color: rgba(120, 188, 255, 0.62);
   box-shadow: 0 0 0 2px rgba(66, 153, 225, 0.2);
@@ -1545,7 +1562,17 @@ button.send-btn .btn-icon {
   color: var(--text);
 }
 
-.agents-age-chip {
+.agents-row-chips {
+  margin-top: 6px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.agents-age-chip,
+.agents-health-chip {
+  display: inline-flex;
+  align-items: center;
   font-size: 11px;
   color: var(--muted);
   border: 1px solid rgba(255, 255, 255, 0.12);
@@ -1553,15 +1580,18 @@ button.send-btn .btn-icon {
   padding: 2px 8px;
 }
 
-.agents-row.is-active .agents-age-chip {
+.agents-row.is-active .agents-age-chip,
+.agents-row.is-active .agents-health-chip {
   border-color: rgba(114, 220, 130, 0.45);
 }
 
-.agents-row.is-stale .agents-age-chip {
+.agents-row.is-stale .agents-age-chip,
+.agents-row.is-stale .agents-health-chip {
   border-color: rgba(255, 188, 89, 0.5);
 }
 
-.agents-row.is-offline .agents-age-chip {
+.agents-row.is-offline .agents-age-chip,
+.agents-row.is-offline .agents-health-chip {
   border-color: rgba(255, 99, 99, 0.5);
 }
 
@@ -1573,6 +1603,18 @@ button.send-btn .btn-icon {
 
 .agents-row-reason {
   margin-top: 6px;
+}
+
+.agents-list.agents-hide-id .agents-row-meta {
+  display: none;
+}
+
+.agents-list.agents-hide-health .agents-row-chips {
+  display: none;
+}
+
+.agents-list.agents-hide-reason .agents-row-reason {
+  display: none;
 }
 
 .agents-reason-chip {
@@ -1595,6 +1637,42 @@ button.send-btn .btn-icon {
 }
 
 /* Shortcuts modal */
+
+.shortcuts-controls {
+  display: grid;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.shortcuts-search-input {
+  width: 100%;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text);
+  padding: 10px 12px;
+}
+
+.shortcuts-filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.shortcuts-chip {
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text);
+  padding: 6px 10px;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.shortcuts-chip.is-active {
+  border-color: rgba(94, 173, 255, 0.85);
+  background: rgba(94, 173, 255, 0.16);
+}
 
 .shortcut-group {
   border: 1px solid rgba(255, 255, 255, 0.08);
@@ -1627,6 +1705,24 @@ button.send-btn .btn-icon {
 
 .shortcut-desc {
   opacity: 0.9;
+}
+
+.shortcut-row-conflict {
+  border-left: 3px solid rgba(245, 158, 11, 0.75);
+  padding-left: 9px;
+}
+
+.shortcut-conflict-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  color: #f59e0b;
+  background: rgba(245, 158, 11, 0.14);
+  border: 1px solid rgba(245, 158, 11, 0.4);
 }
 
 kbd {

--- a/tests/pane.layout.e2e.spec.js
+++ b/tests/pane.layout.e2e.spec.js
@@ -4,6 +4,26 @@ const { startClawnsoleTestApp } = require('./helpers/pw-app');
 
 let app;
 
+async function loginAdmin(page, serverPort) {
+  await page.goto(`http://127.0.0.1:${serverPort}/`);
+
+  const loginPassword = page.locator('#loginPassword');
+  const loginBtn = page.locator('#loginBtn');
+  const loginOverlay = page.locator('#loginOverlay');
+
+  await loginPassword.waitFor({ state: 'visible', timeout: 10000 });
+  for (let i = 0; i < 3; i += 1) {
+    await loginPassword.fill('admin');
+    await loginBtn.click();
+    try {
+      await loginOverlay.waitFor({ state: 'hidden', timeout: 4000 });
+      return;
+    } catch {
+      if (i === 2) throw new Error('login did not complete after retries');
+    }
+  }
+}
+
 test.beforeAll(async () => {
   app = await startClawnsoleTestApp();
 });
@@ -18,13 +38,14 @@ test('layout: default admin layout is 2 panes (Chat + Workqueue)', async ({ page
 
   installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
 
-  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
-  await page.fill('#loginPassword', 'admin');
-  await page.click('#loginBtn');
-  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+  await loginAdmin(page, app.serverPort);
 
   const panes = page.locator('[data-pane]');
   await expect(panes).toHaveCount(2);
+
+  // Mixed default layout (chat + non-chat) should use a neutral pane-grid heading.
+  await expect(page.getByTestId('pane-grid')).toHaveAttribute('aria-label', 'Panes');
+  await expect(page.getByTestId('pane-grid')).not.toHaveAttribute('aria-label', 'Chat panes');
 
   const chatPane = panes.first();
   await expect(chatPane.locator('[data-pane-input]')).toBeVisible();
@@ -41,10 +62,7 @@ test('layout: reset layout restores default (Chat + Workqueue)', async ({ page }
 
   installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
 
-  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
-  await page.fill('#loginPassword', 'admin');
-  await page.click('#loginBtn');
-  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+  await loginAdmin(page, app.serverPort);
 
   // Add a third pane so we can prove reset clears the saved layout.
   await page.getByRole('button', { name: 'Add pane' }).click();

--- a/tests/pane.manager.e2e.spec.js
+++ b/tests/pane.manager.e2e.spec.js
@@ -49,3 +49,33 @@ test('pane manager: lists panes + focuses via keyboard', async ({ page }) => {
   });
   expect(focusedPaneIndex).toBe(1);
 });
+
+test('pane header: target label matches pane kind (agent vs queue vs jobs vs timeline)', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const chatPane = page.locator('[data-pane][data-pane-kind="chat"]').first();
+  const wqPane = page.locator('[data-pane][data-pane-kind="workqueue"]').first();
+
+  await expect(chatPane.getByTestId('pane-target-label')).toHaveText('Agent');
+  await expect(wqPane.getByTestId('pane-target-label')).toHaveText('Queue');
+
+  await page.getByTestId('add-pane-btn').click();
+  await page.getByTestId('pane-add-menu-cron').click();
+
+  const cronPane = page.locator('[data-pane][data-pane-kind="cron"]').last();
+  await expect(cronPane.getByTestId('pane-target-label')).toHaveText('Jobs');
+
+  await page.getByTestId('add-pane-btn').click();
+  await page.getByTestId('pane-add-menu-timeline').click();
+
+  const timelinePane = page.locator('[data-pane][data-pane-kind="timeline"]').last();
+  await expect(timelinePane.getByTestId('pane-target-label')).toHaveText('Timeline');
+});

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -34,7 +34,247 @@ test('shortcuts overlay: ? opens, Esc closes, content renders', async ({ page })
   await expect(modal).toHaveAttribute('aria-hidden', 'false');
   await expect(modal).toContainText('Keyboard shortcuts');
   await expect(modal).toContainText('Workqueue');
+  await expect(modal).toContainText('Focus visible pane by order');
+  await expect(modal).toContainText('Focus previous pane');
 
   await page.keyboard.press('Escape');
   await expect(modal).toHaveAttribute('aria-hidden', 'true');
+});
+
+test('admin shortcuts do not fire while typing in chat input', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const input = page.locator('[data-pane-input]').first();
+  const modal = page.locator('#shortcutsModal');
+  const palette = page.locator('[data-testid="command-palette-modal"]');
+  const workqueueModal = page.locator('#workqueueModal');
+
+  await input.click();
+  await expect(input).toBeFocused();
+
+  await page.keyboard.press('Shift+/');
+  await expect(modal).toHaveAttribute('aria-hidden', 'true');
+  await expect(palette).toHaveAttribute('aria-hidden', 'true');
+  await expect(workqueueModal).toHaveAttribute('aria-hidden', 'true');
+
+  await page.keyboard.press('ControlOrMeta+K');
+  await expect(palette).toHaveAttribute('aria-hidden', 'true');
+
+  await page.keyboard.press('g');
+  await page.keyboard.press('w');
+  await expect(workqueueModal).toHaveAttribute('aria-hidden', 'true');
+
+  let agentRequests = 0;
+  const onRequest = (req) => {
+    const url = req.url();
+    if (url.includes('/agents')) agentRequests += 1;
+  };
+  page.on('request', onRequest);
+  await page.keyboard.press('ControlOrMeta+R');
+  await page.waitForTimeout(300);
+  page.off('request', onRequest);
+  expect(agentRequests).toBe(0);
+});
+
+test('admin shortcuts do not fire while typing in contenteditable', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const modal = page.locator('#shortcutsModal');
+  const palette = page.locator('[data-testid="command-palette-modal"]');
+  const workqueueModal = page.locator('#workqueueModal');
+
+  await page.evaluate(() => {
+    const el = document.createElement('div');
+    el.id = 'typingSandbox';
+    el.contentEditable = 'true';
+    el.tabIndex = 0;
+    el.style.cssText = 'position: fixed; right: 16px; top: 16px; width: 260px; height: 48px; border: 1px solid #888; padding: 6px; background: white; z-index: 9999;';
+    el.setAttribute('aria-label', 'contenteditable typing sandbox');
+    document.body.appendChild(el);
+    el.focus();
+  });
+
+  const sandbox = page.locator('#typingSandbox');
+  await sandbox.focus();
+  await expect(sandbox).toBeFocused();
+
+  await page.keyboard.type('?:gw');
+  await expect(modal).toHaveAttribute('aria-hidden', 'true');
+  await expect(palette).toHaveAttribute('aria-hidden', 'true');
+  await expect(workqueueModal).toHaveAttribute('aria-hidden', 'true');
+
+  let agentRequests = 0;
+  const onRequest = (req) => {
+    const url = req.url();
+    if (url.includes('/agents')) agentRequests += 1;
+  };
+  page.on('request', onRequest);
+  await page.keyboard.press('ControlOrMeta+R');
+  await page.keyboard.press('ControlOrMeta+K');
+  await page.waitForTimeout(250);
+  page.off('request', onRequest);
+
+  expect(agentRequests).toBe(0);
+  await expect(workqueueModal).toHaveAttribute('aria-hidden', 'true');
+  await expect(palette).toHaveAttribute('aria-hidden', 'true');
+
+  await page.evaluate(() => {
+    const el = document.getElementById('typingSandbox');
+    if (el) el.remove();
+  });
+});
+
+test('admin shortcuts: Shift+K moves forward, Shift+J moves backward through panes', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const firstPaneInput = page.locator('[data-pane]').first().locator('[data-pane-input]');
+
+  const activePaneIndex = async () =>
+    page.evaluate(() => {
+      const panes = Array.from(document.querySelectorAll('[data-pane]'));
+      const active = document.activeElement;
+      if (!active) return -1;
+      return panes.findIndex((pane) => pane === active || pane.contains(active));
+    });
+
+  await expect(firstPaneInput).toBeVisible();
+  await expect(firstPaneInput).toBeFocused();
+
+  await page.locator('#addPaneBtn').click();
+  const menu = page.locator('[data-testid="pane-add-menu"]');
+  await expect(menu).toBeVisible();
+  await menu.locator('[data-testid="pane-add-menu-workqueue"]').click();
+
+  await page.locator('[data-pane]').first().locator('[data-pane-send]').click();
+
+  await page.keyboard.press('ControlOrMeta+Shift+K');
+  expect(await activePaneIndex()).toBe(1);
+
+  await page.keyboard.press('ControlOrMeta+Shift+J');
+  expect(await activePaneIndex()).toBe(0);
+});
+
+test('pane-add shortcuts are blocked while an overlay modal is open', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  await expect(page.locator('[data-pane]')).toHaveCount(2);
+
+  // Blur away from input so global shortcuts are eligible.
+  await page.click('#connectionStatus');
+
+  await page.keyboard.press('Shift+/');
+  await expect(page.locator('#shortcutsModal')).toHaveAttribute('aria-hidden', 'false');
+
+  await page.keyboard.press('ControlOrMeta+Shift+W');
+  await page.keyboard.press('ControlOrMeta+Shift+R');
+  await page.keyboard.press('ControlOrMeta+Shift+T');
+  await page.keyboard.press('ControlOrMeta+Shift+C');
+
+  await expect(page.locator('[data-pane]')).toHaveCount(2);
+
+  await page.keyboard.press('Escape');
+  await expect(page.locator('#shortcutsModal')).toHaveAttribute('aria-hidden', 'true');
+
+  // Once overlay is closed, shortcut should work again.
+  await page.keyboard.press('ControlOrMeta+Shift+W');
+  await expect(page.locator('[data-pane]')).toHaveCount(3);
+});
+
+test('admin shortcut: Ctrl/Cmd+Shift+G opens/focuses workqueue for active chat agent', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  await page.locator('[data-pane-kind="workqueue"] [data-pane-close]').first().click();
+  await expect(page.locator('[data-pane-kind="workqueue"]')).toHaveCount(0);
+
+  await page.locator('[data-pane-kind="chat"]').first().locator('[data-pane-input]').click();
+  await page.keyboard.press('ControlOrMeta+Shift+G');
+
+  const wqPane = page.locator('[data-pane-kind="workqueue"]');
+  await expect(wqPane).toHaveCount(1);
+
+  await expect(wqPane.first().locator('[data-wq-scope="assigned"]')).toHaveAttribute('aria-pressed', 'true');
+  await expect(wqPane.first().locator('[data-wq-claim-agent]')).toHaveValue('main');
+
+  await page.keyboard.press('ControlOrMeta+Shift+G');
+  await expect(wqPane).toHaveCount(1);
+});
+
+test('admin shortcuts: Alt+1..9 focuses panes by visible order', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const activePaneIndex = async () =>
+    page.evaluate(() => {
+      const panes = Array.from(document.querySelectorAll('[data-pane]')).filter((pane) => {
+        if (!(pane instanceof HTMLElement)) return false;
+        if (pane.hidden) return false;
+        return pane.getClientRects().length > 0;
+      });
+      const active = document.activeElement;
+      if (!active) return -1;
+      return panes.findIndex((pane) => pane === active || pane.contains(active));
+    });
+
+  await page.locator('#addPaneBtn').click();
+  await page.locator('[data-testid="pane-add-menu-workqueue"]').click();
+  await page.locator('#addPaneBtn').click();
+  await page.locator('[data-testid="pane-add-menu-cron"]').click();
+
+  await expect(page.locator('[data-pane]')).toHaveCount(4);
+
+  await page.keyboard.press('Alt+3');
+  expect(await activePaneIndex()).toBe(2);
+
+  await page.keyboard.press('Alt+1');
+  expect(await activePaneIndex()).toBe(0);
+
+  await page.keyboard.press('Alt+9');
+  expect(await activePaneIndex()).toBe(0);
 });

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -23,3 +23,155 @@ test('agents modal supports pinning agents and persists to localStorage', async 
   const firstPinAfter = page.locator('#agentsList .agents-pin').first();
   await expect(firstPinAfter).toHaveAttribute('aria-pressed', 'true');
 });
+
+test('agents modal search filter reduces list and Escape clears it', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  await clawnsole.gotoAndLoginAdmin(page);
+
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsModal')).toHaveClass(/open/);
+
+  const rows = page.locator('#agentsList .agents-row');
+  const before = await rows.count();
+  expect(before).toBeGreaterThan(0);
+
+  const search = page.locator('#agentsSearch');
+  await search.fill('zzzz-no-match');
+  await expect(rows).toHaveCount(0);
+  await expect(page.locator('#agentsEmpty')).toBeVisible();
+
+  await search.press('Escape');
+  await expect(search).toHaveValue('');
+  await expect(rows).toHaveCount(before);
+  await expect(page.locator('#agentsEmpty')).toBeHidden();
+});
+
+test('agents modal triage controls persist filter/query/sort and support reset', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  await clawnsole.gotoAndLoginAdmin(page);
+
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsModal')).toHaveClass(/open/);
+
+  const attentionBtn = page.getByRole('button', { name: 'Needs attention' });
+  await attentionBtn.focus();
+  await page.keyboard.press('Space');
+  await expect(attentionBtn).toHaveAttribute('aria-pressed', 'true');
+
+  const sort = page.locator('#agentsSortMode');
+  await expect(sort).toHaveValue('attention');
+  await sort.selectOption('oldest');
+  await expect(sort).toHaveValue('oldest');
+
+  const search = page.locator('#agentsSearch');
+  await search.fill('main');
+  await expect(search).toHaveValue('main');
+
+  // Close/reopen should preserve triage filter + query + sort.
+  await page.getByRole('button', { name: 'Close agents' }).click();
+  await expect(page.locator('#agentsModal')).not.toHaveClass(/open/);
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsSearch')).toHaveValue('main');
+  await expect(page.locator('#agentsSortMode')).toHaveValue('oldest');
+  await expect(page.getByRole('button', { name: 'Needs attention' })).toHaveAttribute('aria-pressed', 'true');
+
+  // Reload should also preserve triage filter + query + sort.
+  await page.reload();
+  await page.waitForSelector('[data-pane] [data-pane-input]', { timeout: 90000 });
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsSearch')).toHaveValue('main');
+  await expect(page.locator('#agentsSortMode')).toHaveValue('oldest');
+  await expect(page.getByRole('button', { name: 'Needs attention' })).toHaveAttribute('aria-pressed', 'true');
+
+  // Reset action clears persisted filter/query/sort.
+  await page.getByRole('button', { name: 'Reset agents triage view' }).click();
+  await expect(page.locator('#agentsSearch')).toHaveValue('');
+  await expect(page.locator('#agentsSortMode')).toHaveValue('attention');
+  await expect(page.getByRole('button', { name: 'All agents' })).toHaveAttribute('aria-pressed', 'true');
+
+  await page.getByRole('button', { name: 'Close agents' }).click();
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsSearch')).toHaveValue('');
+  await expect(page.locator('#agentsSortMode')).toHaveValue('attention');
+  await expect(page.getByRole('button', { name: 'All agents' })).toHaveAttribute('aria-pressed', 'true');
+});
+
+test('agents modal shows explicit health + heartbeat chips on rows', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  await clawnsole.gotoAndLoginAdmin(page);
+
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsModal')).toHaveClass(/open/);
+
+  const firstRow = page.locator('#agentsList .agents-row').first();
+  await expect(firstRow.locator('.agents-health-chip')).toBeVisible();
+  await expect(firstRow.locator('.agents-health-chip')).toContainText('health:');
+  await expect(firstRow.locator('.agents-age-chip')).toBeVisible();
+  await expect(firstRow.locator('.agents-age-chip')).toContainText('heartbeat:');
+});
+
+test('fleet density + column visibility persist and reset', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  await clawnsole.gotoAndLoginAdmin(page);
+  await page.getByRole('button', { name: 'Open agents' }).click();
+
+  const density = page.locator('#agentsDensityMode');
+  await density.selectOption('compact');
+  await expect(density).toHaveValue('compact');
+
+  await page.locator('#agentsColReason').uncheck();
+  const firstRow = page.locator('#agentsList .agents-row').first();
+  await expect(firstRow.locator('.agents-row-reason')).toBeHidden();
+
+  await page.getByRole('button', { name: 'Close agents' }).click();
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsDensityMode')).toHaveValue('compact');
+  await expect(page.locator('#agentsColReason')).not.toBeChecked();
+
+  await page.getByRole('button', { name: 'Reset agents triage view' }).click();
+  await expect(page.locator('#agentsDensityMode')).toHaveValue('cozy');
+  await expect(page.locator('#agentsColReason')).toBeChecked();
+});
+
+test('agents modal keyboard triage loop: j/k select, Enter open, Shift+Enter workqueue, dot timeline', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  await clawnsole.gotoAndLoginAdmin(page);
+
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsModal')).toHaveClass(/open/);
+
+  const selectedRow = page.locator('#agentsList .agents-row[aria-selected="true"]').first();
+  await expect(selectedRow).toBeVisible();
+  const selectedAgentId = (await selectedRow.getAttribute('data-agent-id')) || 'main';
+
+  // j/k should keep a concrete selection in the fleet list.
+  await page.keyboard.press('j');
+  await expect(page.locator('#agentsList .agents-row[aria-selected="true"]').first()).toBeVisible();
+  await page.keyboard.press('k');
+  await expect(page.locator('#agentsList .agents-row[aria-selected="true"]').first()).toBeVisible();
+
+  // Shift+Enter opens/focuses a workqueue pane scoped to the selected agent.
+  await page.keyboard.press('Shift+Enter');
+  await expect(page.locator('#agentsModal')).not.toHaveClass(/open/);
+  const triageWqPane = page.locator('[data-pane][data-pane-kind="workqueue"]').first();
+  await expect(triageWqPane).toBeVisible();
+  await expect(triageWqPane.locator('[data-pane-agent-select]')).toHaveValue(selectedAgentId);
+
+  // Dot opens timeline pane and closes agents modal.
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsModal')).toHaveClass(/open/);
+  await page.keyboard.press('.');
+  await expect(page.locator('#agentsModal')).not.toHaveClass(/open/);
+  await expect(page.locator('[data-pane][data-pane-kind="timeline"]')).toHaveCount(1);
+
+  // Enter opens selected agent chat and closes agents modal.
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsModal')).toHaveClass(/open/);
+  await page.keyboard.press('Enter');
+  await expect(page.locator('#agentsModal')).not.toHaveClass(/open/);
+});

--- a/tests/ui/command-palette.spec.js
+++ b/tests/ui/command-palette.spec.js
@@ -45,3 +45,82 @@ test('command palette: Ctrl/Cmd+K opens and can add a pane', async ({ page }) =>
   const countAfter = await page.locator('[data-pane]').count();
   expect(countAfter).toBeGreaterThan(countBefore);
 });
+
+test('command palette: generated agent actions are collapsed and auto-expand on search', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await page.keyboard.press('ControlOrMeta+K');
+
+  const modal = page.locator('[data-testid="command-palette-modal"]');
+  await expect(modal).toBeVisible();
+
+  const input = page.locator('#commandPaletteInput');
+  await expect(input).toBeFocused();
+
+  await expect(page.locator('.command-palette-item', { hasText: 'Agent targets (1)' })).toBeVisible();
+  await expect(page.locator('.command-palette-item-label', { hasText: 'Agent: main' })).toHaveCount(0);
+
+  await input.fill('agent: main');
+  await expect(page.locator('.command-palette-item-label', { hasText: 'Agent: main' })).toBeVisible();
+  await expect(page.locator('.command-palette-item-detail', { hasText: 'CHAT · main' })).toBeVisible();
+});
+
+test('command palette: agent target prefers focusing existing pane for that target', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+
+  const chatMain = page.locator('[data-pane-kind="chat"][data-pane-target="main"]');
+  await expect(chatMain).toHaveCount(1);
+
+  await page.keyboard.press('ControlOrMeta+K');
+  const input = page.locator('#commandPaletteInput');
+  await input.fill('agent: main');
+  await page.keyboard.press('Enter');
+
+  await expect(chatMain).toHaveCount(1);
+});
+
+test('command palette: workqueue for active chat agent covers create, focus-existing, and no-agent paths', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+
+  const runCommand = async (text) => {
+    await page.keyboard.press('ControlOrMeta+K');
+    const input = page.locator('#commandPaletteInput');
+    await expect(input).toBeFocused();
+    await input.fill(text);
+    await page.keyboard.press('Enter');
+  };
+
+  await page.locator('[data-pane-kind="workqueue"] [data-pane-close]').first().click();
+  await expect(page.locator('[data-pane-kind="workqueue"]')).toHaveCount(0);
+
+  await page.locator('[data-pane-kind="chat"]').first().locator('[data-pane-input]').click();
+  await runCommand('workqueue for active chat agent');
+
+  const wqPane = page.locator('[data-pane-kind="workqueue"]');
+  await expect(wqPane).toHaveCount(1);
+
+  await expect(wqPane.first().locator('[data-wq-scope="assigned"]')).toHaveAttribute('aria-pressed', 'true');
+  await expect(wqPane.first().locator('[data-wq-claim-agent]')).toHaveValue('main');
+
+  await runCommand('workqueue for active chat agent');
+  await expect(wqPane).toHaveCount(1);
+
+  await wqPane.first().click();
+  await runCommand('workqueue for active chat agent');
+
+  await expect(page.locator('[data-testid="toast"], .toast')).toContainText('No active chat agent selected');
+});

--- a/tests/ui/pane-add-menu.spec.js
+++ b/tests/ui/pane-add-menu.spec.js
@@ -49,6 +49,27 @@ test('pane add menu: opens + adds explicit pane kinds + focuses sane defaults', 
   await expect(queueSelect).toBeFocused();
 });
 
+test('pane add menu: single click on item adds exactly one pane', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+
+  const addBtn = page.locator('#addPaneBtn');
+  await expect(addBtn).toBeVisible();
+
+  const countBefore = await page.locator('[data-pane]').count();
+  await addBtn.click();
+  const menu = page.locator('[data-testid="pane-add-menu"]');
+  await expect(menu).toBeVisible();
+
+  await menu.locator('[data-testid="pane-add-menu-workqueue"]').click();
+  const countAfter = await page.locator('[data-pane]').count();
+  expect(countAfter).toBe(countBefore + 1);
+});
+
 test('pane add shortcuts: Ctrl/Cmd+Shift+T adds a timeline pane', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -38,3 +38,198 @@ test('workqueue pane: renders + has queue dropdown + does not show chat composer
   await expect(wqPane.locator('.chat-input-row')).toBeHidden();
   await expect(wqPane.locator('[data-pane-input]')).toBeHidden();
 });
+
+test('workqueue pane: item search filters rows and / focuses search', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  const panes = page.locator('[data-pane]');
+  const wqPane = panes.last();
+  const search = wqPane.locator('[data-wq-item-search]');
+  await expect(search).toBeVisible();
+
+  const stamp = Date.now();
+  const keepTitle = `pw-pane-search-keep-${stamp}`;
+  const hideTitle = `pw-pane-search-hide-${stamp}`;
+
+  const postItem = async (title) => {
+    const res = await page.request.post(`http://127.0.0.1:${env.serverPort}/api/workqueue/enqueue`, {
+      data: { queue: 'dev-team', title, instructions: `test-${title}`, priority: 1 }
+    });
+    expect(res.ok()).toBeTruthy();
+    const body = await res.json();
+    expect(body?.item?.id).toBeTruthy();
+    return body.item.id;
+  };
+
+  const keepId = await postItem(keepTitle);
+  const hideId = await postItem(hideTitle);
+
+  await wqPane.locator('[data-wq-refresh]').click();
+  await expect(wqPane.locator(`[data-wq-item="${keepId}"]`)).toBeVisible();
+  await expect(wqPane.locator(`[data-wq-item="${hideId}"]`)).toBeVisible();
+
+  await wqPane.focus();
+  await page.keyboard.press('/');
+  await expect(search).toBeFocused();
+
+  await search.fill(`keep-${stamp}`);
+  await expect(wqPane.locator(`[data-wq-item="${keepId}"]`)).toBeVisible();
+  await expect(wqPane.locator(`[data-wq-item="${hideId}"]`)).toHaveCount(0);
+});
+
+test('workqueue pane: queue search filters queue dropdown options (separate from item search)', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  const panes = page.locator('[data-pane]');
+  const wqPane = panes.last();
+  const queueSearch = wqPane.locator('[data-wq-queue-search]');
+  const queueSelect = wqPane.locator('[data-wq-queue-select]');
+  await expect(queueSearch).toBeVisible();
+  await expect(queueSelect).toBeVisible();
+
+  const stamp = Date.now();
+  const alphaQueue = `pw-alpha-${stamp}`;
+  const betaQueue = `pw-beta-${stamp}`;
+
+  const postItem = async (queue, title) => {
+    const res = await page.request.post(`http://127.0.0.1:${env.serverPort}/api/workqueue/enqueue`, {
+      data: { queue, title, instructions: `test-${title}`, priority: 1 }
+    });
+    expect(res.ok()).toBeTruthy();
+  };
+
+  await postItem(alphaQueue, `seed-alpha-${stamp}`);
+  await postItem(betaQueue, `seed-beta-${stamp}`);
+
+  await wqPane.locator('[data-wq-refresh]').click();
+
+  await queueSearch.fill('alpha');
+  const optionValues = await queueSelect.locator('option').allTextContents();
+  expect(optionValues.some((v) => v.includes(alphaQueue))).toBeTruthy();
+  expect(optionValues.some((v) => v.includes(betaQueue))).toBeFalsy();
+  expect(optionValues.some((v) => v === 'Custom…')).toBeTruthy();
+});
+
+test('workqueue modal: sort preference persists across reopen + reload', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+
+  await page.locator('#workqueueBtn').click();
+  const modal = page.locator('#workqueueModal');
+  await expect(modal).toHaveClass(/open/);
+
+  const titleSort = page.locator('[data-wq-modal-sort="title"]');
+  await titleSort.click(); // default -> title asc
+  await expect(titleSort).toHaveClass(/active/);
+  await expect(titleSort).toHaveAttribute('title', 'Sorted ascending');
+
+  await page.locator('#workqueueCloseBtn').click();
+  await expect(modal).not.toHaveClass(/open/);
+
+  await page.locator('#workqueueBtn').click();
+  await expect(modal).toHaveClass(/open/);
+  await expect(titleSort).toHaveClass(/active/);
+  await expect(titleSort).toHaveAttribute('title', 'Sorted ascending');
+
+  await page.reload();
+  const loginPassword = page.locator('#loginPassword');
+  const loginBtn = page.locator('#loginBtn');
+  const loginOverlay = page.locator('#loginOverlay');
+  if (await loginPassword.isVisible()) {
+    await loginPassword.fill('admin');
+    await loginBtn.click();
+    await loginOverlay.waitFor({ state: 'hidden', timeout: 10000 });
+  }
+  await page.locator('#workqueueBtn').click();
+  await expect(modal).toHaveClass(/open/);
+  await expect(page.locator('[data-wq-modal-sort="title"]')).toHaveClass(/active/);
+  await expect(page.locator('[data-wq-modal-sort="title"]')).toHaveAttribute('title', 'Sorted ascending');
+});
+
+test('workqueue modal: enqueue + status transition + edit + delete', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+
+  await page.locator('#workqueueBtn').click();
+  const modal = page.locator('#workqueueModal');
+  await expect(modal).toHaveClass(/open/);
+
+  await expect(page.locator('#wqQueueSelect')).toBeVisible();
+  await expect(page.locator('#wqStatusFilters')).toBeVisible();
+
+  const stamp = Date.now();
+  const title = `pw-modal-${stamp}`;
+  const instructions = `pw-modal-instructions-${stamp}`;
+
+  await page.locator('#wqEnqueueTitle').fill(title);
+  await page.locator('#wqEnqueueInstructions').fill(instructions);
+
+  const enqueueResP = page.waitForResponse((res) => res.url().includes('/api/workqueue/enqueue') && res.request().method() === 'POST');
+  await page.locator('#wqEnqueueBtn').click();
+  const enqueueRes = await enqueueResP;
+  expect(enqueueRes.ok()).toBeTruthy();
+  const enqueueBody = await enqueueRes.json();
+  const itemId = enqueueBody?.item?.id;
+  expect(itemId).toBeTruthy();
+
+  const itemCard = page.locator(`[data-wq-item="${itemId}"]`);
+  await expect(itemCard).toBeVisible();
+
+  const inProgressCol = page.locator('[data-wq-col="in_progress"]');
+  await itemCard.dragTo(inProgressCol);
+  await page.waitForResponse((res) => res.url().includes('/api/workqueue/update') && res.request().method() === 'POST' && res.ok());
+  await expect(inProgressCol.locator(`[data-wq-item="${itemId}"]`)).toBeVisible();
+
+  await inProgressCol.locator(`[data-wq-item="${itemId}"]`).click();
+
+  const editedTitle = `${title}-edited`;
+  const editedInstructions = `${instructions}-edited`;
+  page.once('dialog', async (dialog) => {
+    await dialog.accept(editedTitle);
+  });
+  page.once('dialog', async (dialog) => {
+    await dialog.accept(editedInstructions);
+  });
+
+  const updateResP = page.waitForResponse((res) => res.url().includes('/api/workqueue/update') && res.request().method() === 'POST');
+  await page.locator('[data-wq-action="edit"]').click();
+  const updateRes = await updateResP;
+  expect(updateRes.ok()).toBeTruthy();
+
+  const inspect = page.locator('#wqInspectBody');
+  await expect(inspect).toContainText(editedTitle);
+  await expect(inspect).toContainText(editedInstructions);
+
+  page.once('dialog', async (dialog) => {
+    await dialog.accept();
+  });
+  const deleteResP = page.waitForResponse((res) => res.url().includes('/api/workqueue/delete') && res.request().method() === 'POST');
+  await page.locator('[data-wq-action="delete"]').click();
+  const deleteRes = await deleteResP;
+  expect(deleteRes.ok()).toBeTruthy();
+
+  await expect(page.locator(`[data-wq-item="${itemId}"]`)).toHaveCount(0);
+
+  await page.locator('#workqueueCloseBtn').click();
+  await expect(modal).not.toHaveClass(/open/);
+});

--- a/tests/unit/admin-prompts-store.test.js
+++ b/tests/unit/admin-prompts-store.test.js
@@ -1,0 +1,89 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const { createAdminPromptsStore } = require('../../lib/admin-prompts-store')
+
+function tempRoot() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'clawnsole-admin-prompts-'))
+}
+
+test('admin-prompts-store: initializes schema on fresh db', () => {
+  const root = tempRoot()
+  const dbPath = path.join(root, 'admin-prompts.sqlite')
+  const store = createAdminPromptsStore({ dbPath })
+
+  const prompts = store.listPrompts()
+  assert.deepEqual(prompts, [])
+
+  // smoke: create + read proves table exists and is writable
+  const created = store.createPrompt({ title: 'A', agentId: 'main', message: 'hello', intervalMinutes: 5 })
+  assert.ok(created.id)
+  assert.equal(store.getPrompt(created.id)?.message, 'hello')
+
+  store.close()
+})
+
+test('admin-prompts-store: prompt CRUD persists across reopen', () => {
+  const root = tempRoot()
+  const dbPath = path.join(root, 'admin-prompts.sqlite')
+
+  let store = createAdminPromptsStore({ dbPath })
+  const created = store.createPrompt({
+    title: 'Daily check-in',
+    agentId: 'main',
+    message: 'Ping me',
+    intervalMinutes: 60,
+    enabled: true,
+    nextRunAt: Date.now() + 60_000
+  })
+  store.updatePrompt(created.id, { enabled: false, title: 'Updated title' })
+  store.close()
+
+  store = createAdminPromptsStore({ dbPath })
+  const fetched = store.getPrompt(created.id)
+  assert.ok(fetched)
+  assert.equal(fetched.title, 'Updated title')
+  assert.equal(fetched.enabled, false)
+
+  const deleted = store.deletePrompt(created.id)
+  assert.equal(deleted, true)
+  assert.equal(store.getPrompt(created.id), null)
+  store.close()
+})
+
+test('admin-prompts-store: run insert/list and idempotency lookup', () => {
+  const root = tempRoot()
+  const dbPath = path.join(root, 'admin-prompts.sqlite')
+  const store = createAdminPromptsStore({ dbPath })
+
+  const prompt = store.createPrompt({ title: 'x', agentId: 'main', message: 'm', intervalMinutes: 5 })
+  const first = store.insertRun({
+    promptId: prompt.id,
+    idempotencyKey: 'k1',
+    sessionKey: 'agent:main:admin:scheduler',
+    status: 'pending'
+  })
+  assert.equal(first.deduped, false)
+
+  const second = store.insertRun({
+    promptId: prompt.id,
+    idempotencyKey: 'k1',
+    sessionKey: 'agent:main:admin:scheduler',
+    status: 'pending'
+  })
+  assert.equal(second.deduped, true)
+  assert.equal(second.run.id, first.run.id)
+
+  const listed = store.listRunsByPrompt(prompt.id, { limit: 10 })
+  assert.equal(listed.length, 1)
+  assert.equal(listed[0].idempotencyKey, 'k1')
+
+  const found = store.findRunByIdempotencyKey('k1')
+  assert.ok(found)
+  assert.equal(found.promptId, prompt.id)
+
+  store.close()
+})

--- a/tests/unit/app-core.test.js
+++ b/tests/unit/app-core.test.js
@@ -9,7 +9,9 @@ const {
   normalizePaneKind,
   deriveAuthOverlayState,
   extractChatText,
-  normalizeHistoryEntries
+  normalizeHistoryEntries,
+  detectShortcutConflict,
+  deriveWorkqueueDisplayTitle
 } = require('../../lib/app-core.js');
 
 test('escapeHtml escapes html special chars', () => {
@@ -29,7 +31,7 @@ test('fmtRemaining formats remaining time', () => {
   assert.equal(fmtRemaining(3_660_000), '1h 1m');
 });
 
-test('sortWorkqueueItems default groups by status then priority then timestamps', () => {
+test('sortWorkqueueItems default is priority-first with stable tie-breakers', () => {
   const items = [
     { id: 'a', status: 'ready', priority: 1, updatedAt: '2026-01-01T00:00:00Z' },
     { id: 'b', status: 'in_progress', priority: 0, updatedAt: '2026-01-01T00:00:00Z' },
@@ -39,7 +41,7 @@ test('sortWorkqueueItems default groups by status then priority then timestamps'
   ];
 
   const sorted = sortWorkqueueItems(items);
-  assert.deepEqual(sorted.map((it) => it.id), ['b', 'c', 'd', 'e', 'a']);
+  assert.deepEqual(sorted.map((it) => it.id), ['c', 'e', 'd', 'a', 'b']);
 });
 
 test('sortWorkqueueItems supports explicit sort keys and stable ordering fallback', () => {
@@ -124,4 +126,30 @@ test('normalizeHistoryEntries supports gateway payload variants', () => {
     { role: 'assistant', text: 'hi' },
     { role: 'user', text: 'me' }
   ]);
+});
+
+test('deriveWorkqueueDisplayTitle canonicalizes issue-backed noise prefixes', () => {
+  const canonical = deriveWorkqueueDisplayTitle({
+    title: 'Open issue: rmdmattingly/clawnsole#316: UX/Auth: Unlock form polish',
+    meta: { kind: 'issue', repo: 'rmdmattingly/clawnsole', issueNumber: 316 }
+  });
+  assert.equal(canonical.title, 'rmdmattingly/clawnsole#316 — UX/Auth: Unlock form polish');
+  assert.equal(canonical.canonicalized, true);
+
+  const untouched = deriveWorkqueueDisplayTitle({ title: 'Review open PRs', meta: { kind: 'routine' } });
+  assert.equal(untouched.title, 'Review open PRs');
+  assert.equal(untouched.canonicalized, false);
+});
+
+test('detectShortcutConflict flags browser-reserved combos and suggests alternatives', () => {
+  const refreshConflict = detectShortcutConflict('Cmd/Ctrl+R', { platform: 'MacIntel' });
+  assert.equal(!!refreshConflict, true);
+  assert.match(refreshConflict.reason, /browser refresh/i);
+
+  const tabConflict = detectShortcutConflict('Ctrl+Tab / Ctrl+Shift+Tab', { platform: 'Win32' });
+  assert.equal(!!tabConflict, true);
+  assert.match(tabConflict.reason, /tab switching/i);
+
+  const safe = detectShortcutConflict('Cmd/Ctrl+Shift+K', { platform: 'MacIntel' });
+  assert.equal(safe, null);
 });


### PR DESCRIPTION
## Summary
- canonicalize issue-backed workqueue display titles to `owner/repo#num — title`
- strip noisy source prefixes like `[issue]`, `Open issue:`, `Triager:`, and `Issue coverage:` from primary row/card titles
- keep raw title available via title tooltip and inspect panel `Raw title` section
- add unit coverage for canonical title derivation in `app-core`

## Testing
- npm test -- tests/unit/app-core.test.js

Closes #370
