### PR TITLE
Workqueue: show visible/total counts and hidden-by-filter context

### DIFF
--- a/app.js
+++ b/app.js
@@ -2829,12 +2829,18 @@ async function fetchAndRenderWorkqueueItemsForPane(pane) {
   if (statusLine) statusLine.textContent = 'Loading...';
 
   try {
-    const res = await fetch(url, { credentials: 'include', cache: 'no-store' });
+    const [res, summary] = await Promise.all([
+      fetch(url, { credentials: 'include', cache: 'no-store' }),
+      fetchWorkqueueSummary(queue).catch(() => null)
+    ]);
     if (!res.ok) throw new Error(String(res.status));
     const data = await res.json();
     const items = Array.isArray(data.items) ? data.items : [];
     pane.workqueue.items = items;
-    if (statusLine) statusLine.textContent = `${items.length} item(s)`;
+    const counts = (summary && summary.counts && typeof summary.counts === 'object') ? summary.counts : null;
+    pane.workqueue.totalCount = counts
+      ? WORKQUEUE_STATUSES.reduce((sum, key) => sum + Number(counts[key] || 0), 0)
+      : items.length;
     renderWorkqueuePaneItems(pane);
   } catch (err) {
     if (statusLine) statusLine.textContent = `Failed to load: ${String(err)}`;
@@ -2844,6 +2850,7 @@ async function fetchAndRenderWorkqueueItemsForPane(pane) {
 function renderWorkqueuePaneItems(pane) {
   const body = pane.elements?.thread?.querySelector('[data-wq-list-body]');
   const empty = pane.elements?.thread?.querySelector('[data-wq-empty]');
+  const statusLine = pane.elements?.thread?.querySelector('[data-wq-statusline]');
   if (!body) return;
   body.innerHTML = '';
 
@@ -2859,6 +2866,23 @@ function renderWorkqueuePaneItems(pane) {
   });
   const items = sortWorkqueueItems(scopedItems, { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
 
+  const selectedStatuses = Array.isArray(pane.workqueue?.statusFilter) ? pane.workqueue.statusFilter : [];
+  const statusFilteredCount = Math.max(0, Number(pane.workqueue?.totalCount ?? itemsRaw.length) - itemsRaw.length);
+  const scopeFilteredCount = Math.max(0, itemsRaw.length - scopedItems.length);
+  const totalCount = Math.max(items.length, Number(pane.workqueue?.totalCount ?? itemsRaw.length));
+  const anyFilterActive = selectedStatuses.length > 0 || scope !== 'all';
+  if (statusLine) {
+    if (anyFilterActive) {
+      const hiddenParts = [];
+      if (statusFilteredCount > 0) hiddenParts.push(`status ${statusFilteredCount}`);
+      if (scopeFilteredCount > 0) hiddenParts.push(`scope ${scopeFilteredCount}`);
+      const hiddenText = hiddenParts.length ? ` · hidden: ${hiddenParts.join(', ')}` : '';
+      statusLine.textContent = `Showing ${items.length} of ${totalCount} items${hiddenText}`;
+    } else {
+      statusLine.textContent = `${items.length} item(s)`;
+    }
+  }
+
   if (empty) {
     const hasItems = items.length > 0;
     empty.hidden = hasItems;
@@ -2867,10 +2891,13 @@ function renderWorkqueuePaneItems(pane) {
       const statuses = Array.isArray(pane.workqueue?.statusFilter) ? pane.workqueue.statusFilter : [];
       const statusLabel = statuses.length ? statuses.join(', ') : 'default';
       const scopeLabel = pane.workqueue?.scopeFilter || 'all';
+      const filtersHidingAll = totalCount > 0;
+      const title = filtersHidingAll ? 'No items match current filters.' : 'No items in this queue.';
       empty.innerHTML = `
         <div class="empty-state">
-          <div style="font-weight:700; margin-bottom:6px;">No items in this queue.</div>
+          <div style="font-weight:700; margin-bottom:6px;">${escapeHtml(title)}</div>
           <div class="hint">Queue: <span class="mono">${escapeHtml(queue)}</span> · Status: <span class="mono">${escapeHtml(statusLabel)}</span> · Scope: <span class="mono">${escapeHtml(scopeLabel)}</span></div>
+          ${filtersHidingAll ? `<div class="hint" style="margin-top:6px;">Showing 0 of <span class="mono">${escapeHtml(String(totalCount))}</span> items.</div>` : ''}
           <div style="display:flex; gap:8px; margin-top:10px; flex-wrap:wrap;">
             <button type="button" class="secondary" data-wq-empty-enqueue>Enqueue item</button>
             <button type="button" class="secondary" data-wq-empty-refresh>Refresh</button>

--- a/tests/pane.workqueue.e2e.spec.js
+++ b/tests/pane.workqueue.e2e.spec.js
@@ -183,12 +183,17 @@ test('pane: workqueue scope filter toggles deterministic row counts', async ({ p
 
   const rowsWithPrefix = () => wqPane.locator('.wq-row').filter({ hasText: `pw-e2e-${runId}-` });
 
+  const statusline = wqPane.locator('[data-wq-statusline]');
+
   await wqPane.locator('[data-wq-scope="all"]').click();
   await expect(rowsWithPrefix()).toHaveCount(2);
+  await expect(statusline).toContainText(/Showing\s+2\s+of\s+\d+\s+items/);
 
   await wqPane.locator('[data-wq-scope="unassigned"]').click();
   await expect(rowsWithPrefix()).toHaveCount(2);
 
   await wqPane.locator('[data-wq-scope="assigned"]').click();
   await expect(rowsWithPrefix()).toHaveCount(0);
+  await expect(statusline).toContainText(/Showing\s+0\s+of\s+\d+\s+items/);
+  await expect(wqPane.locator('[data-wq-empty]')).toContainText('No items match current filters.');
 });


### PR DESCRIPTION
## Summary
- update Workqueue pane status line to show `Showing visible of total items` when filters are active
- include hidden-by-filter breakdown for status and scope
- distinguish empty queue vs filtered-empty states with clearer empty copy
- add e2e assertions for the new status line and filtered-empty messaging

## Testing
- `npm test -- tests/pane.workqueue.e2e.spec.js` *(fails in this environment due to missing optional dependency `ws` in unit test bootstrap; syntax/unit subset still ran before failure)*

Closes #371
