### PR TITLE
UX/Topbar: separate pane status chip from manage button

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,6 +19,7 @@ const globalElements = {
   recurringPromptHistoryRows: document.getElementById('recurringPromptHistoryRows'),
   recurringPromptHistoryEmpty: document.getElementById('recurringPromptHistoryEmpty'),
   status: document.getElementById('connectionStatus'),
+  panesStatusChip: document.getElementById('panesStatusChip'),
   paneManagerBtn: document.getElementById('paneManagerBtn'),
   pulseCanvas: document.getElementById('pulseCanvas'),
   workqueueBtn: document.getElementById('workqueueBtn'),
@@ -838,7 +839,11 @@ function setStatusPill(el, state, meta = '') {
 function updateGlobalStatus() {
   const status = deriveGlobalConnectionState({ authed: uiState.authed, panes: paneManager.panes });
   setStatusPill(globalElements.status, status.state, status.meta);
-  if (globalElements.paneManagerBtn) globalElements.paneManagerBtn.textContent = status.meta;
+  if (globalElements.panesStatusChip) {
+    globalElements.panesStatusChip.textContent = status.meta;
+    globalElements.panesStatusChip.title = status.meta ? `Pane status: ${status.meta}` : 'Pane status';
+    globalElements.panesStatusChip.setAttribute('aria-label', status.meta ? `Pane status: ${status.meta}` : 'Pane status');
+  }
 }
 
 function updateConnectionControls() {
@@ -7093,6 +7098,11 @@ globalElements.resetLayoutBtn?.addEventListener('click', () => {
 });
 
 globalElements.paneManagerBtn?.addEventListener('click', (event) => {
+  event?.preventDefault?.();
+  openPaneManager();
+});
+
+globalElements.panesStatusChip?.addEventListener('click', (event) => {
   event?.preventDefault?.();
   openPaneManager();
 });

--- a/app.js
+++ b/app.js
@@ -19,6 +19,7 @@ const globalElements = {
   recurringPromptHistoryRows: document.getElementById('recurringPromptHistoryRows'),
   recurringPromptHistoryEmpty: document.getElementById('recurringPromptHistoryEmpty'),
   status: document.getElementById('connectionStatus'),
+  panesStatusChip: document.getElementById('panesStatusChip'),
   paneManagerBtn: document.getElementById('paneManagerBtn'),
   pulseCanvas: document.getElementById('pulseCanvas'),
   workqueueBtn: document.getElementById('workqueueBtn'),
@@ -1206,7 +1207,11 @@ function setStatusPill(el, state, meta = '') {
 function updateGlobalStatus() {
   const status = deriveGlobalConnectionState({ authed: uiState.authed, panes: paneManager.panes });
   setStatusPill(globalElements.status, status.state, status.meta);
-  if (globalElements.paneManagerBtn) globalElements.paneManagerBtn.textContent = status.meta;
+  if (globalElements.panesStatusChip) {
+    globalElements.panesStatusChip.textContent = status.meta;
+    globalElements.panesStatusChip.title = status.meta ? `Pane status: ${status.meta}` : 'Pane status';
+    globalElements.panesStatusChip.setAttribute('aria-label', status.meta ? `Pane status: ${status.meta}` : 'Pane status');
+  }
 }
 
 function updateConnectionControls() {
@@ -8479,6 +8484,11 @@ globalElements.resetLayoutBtn?.addEventListener('click', () => {
 });
 
 globalElements.paneManagerBtn?.addEventListener('click', (event) => {
+  event?.preventDefault?.();
+  openPaneManager();
+});
+
+globalElements.panesStatusChip?.addEventListener('click', (event) => {
   event?.preventDefault?.();
   openPaneManager();
 });

--- a/index.html
+++ b/index.html
@@ -32,13 +32,17 @@
         <div class="topbar-actions">
           <div class="status compact">
             <div class="status-pill" id="connectionStatus" data-testid="connection-status">disconnected</div>
+            <button class="status-meta status-meta-btn" id="panesStatusChip" type="button" aria-label="Pane status" title="Pane status"></button>
             <button
-              class="status-meta status-meta-btn"
+              class="status-meta-btn icon-btn icon-btn-label"
               id="paneManagerBtn"
               type="button"
-              aria-label="Open pane manager"
-              data-testid="panes-indicator"
-            ></button>
+              aria-label="Manage panes"
+              title="Manage panes (Ctrl+P)"
+              data-testid="manage-panes-btn"
+            >
+              Manage panes
+            </button>
           </div>
           <div id="paneControls" class="pane-controls" hidden>
             <div class="pane-add-wrap">

--- a/index.html
+++ b/index.html
@@ -34,11 +34,22 @@
             <div class="status-pill" id="connectionStatus" data-testid="connection-status">disconnected</div>
             <button
               class="status-meta status-meta-btn"
-              id="paneManagerBtn"
+              id="panesStatusChip"
               type="button"
-              aria-label="Open pane manager"
+              aria-label="Pane status"
+              title="Pane status"
               data-testid="panes-indicator"
             ></button>
+            <button
+              class="status-meta-btn icon-btn icon-btn-label"
+              id="paneManagerBtn"
+              type="button"
+              aria-label="Manage panes"
+              title="Manage panes (Ctrl+P)"
+              data-testid="manage-panes-btn"
+            >
+              Manage panes
+            </button>
           </div>
           <div id="paneControls" class="pane-controls" hidden>
             <div class="pane-add-wrap">

--- a/styles.css
+++ b/styles.css
@@ -1130,13 +1130,28 @@ button.send-btn .btn-icon {
 
 .status-meta-btn {
   background: transparent;
-  border: none;
-  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  padding: 4px 8px;
   cursor: pointer;
 }
 
 .status-meta-btn:hover {
   color: var(--text);
+}
+
+.status-meta-btn:focus-visible {
+  outline: none;
+  border-color: color-mix(in srgb, var(--accent) 70%, white 30%);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.icon-btn-label {
+  width: auto;
+  min-width: 40px;
+  padding: 0 12px;
+  font-size: 12px;
+  letter-spacing: 0.01em;
 }
 
 .pane-manager-search-wrap {

--- a/styles.css
+++ b/styles.css
@@ -1253,13 +1253,28 @@ button.send-btn .btn-icon {
 
 .status-meta-btn {
   background: transparent;
-  border: none;
-  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  padding: 4px 8px;
   cursor: pointer;
 }
 
 .status-meta-btn:hover {
   color: var(--text);
+}
+
+.status-meta-btn:focus-visible {
+  outline: none;
+  border-color: color-mix(in srgb, var(--accent) 70%, white 30%);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.icon-btn-label {
+  width: auto;
+  min-width: 40px;
+  padding: 0 12px;
+  font-size: 12px;
+  letter-spacing: 0.01em;
 }
 
 .pane-manager-search-wrap {

--- a/tests/pane.manager.e2e.spec.js
+++ b/tests/pane.manager.e2e.spec.js
@@ -50,6 +50,32 @@ test('pane manager: lists panes + focuses via keyboard', async ({ page }) => {
   expect(focusedPaneIndex).toBe(1);
 });
 
+test('topbar: pane status chip and manage action are distinct + labeled', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const statusChip = page.locator('#panesStatusChip');
+  const manageBtn = page.getByTestId('manage-panes-btn');
+
+  await expect(statusChip).toBeVisible();
+  await expect(statusChip).toHaveAttribute('aria-label', /Pane status:/);
+  await expect(statusChip).toHaveText(/panes: \d+\/\d+ connected|sign in required/i);
+
+  await expect(manageBtn).toBeVisible();
+  await expect(manageBtn).toHaveText('Manage panes');
+  await expect(manageBtn).toHaveAttribute('title', /Manage panes/);
+
+  await manageBtn.focus();
+  await expect(manageBtn).toBeFocused();
+});
+
 test('pane header: identity line uses "[Letter] [Type] · [Target]" across pane kinds', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!app?.skipReason, app?.skipReason);


### PR DESCRIPTION
## Summary\n- split topbar pane affordances into a dedicated status chip and a separate explicit **Manage panes** button\n- keep status chip as informational shortcut target and update accessible name/title with current pane connection meta\n- give manage button clear text + tooltip and focus-visible styling\n- add Playwright coverage asserting both controls are present and role-distinct\n\n## Validation\n- ✅ npm run test:syntax\n- ⚠️  (blocked in this runner: missing local  module)\n\nCloses #376