### PR TITLE
Workqueue: bulk archive terminal items older than threshold

### DIFF
--- a/app.js
+++ b/app.js
@@ -68,6 +68,9 @@ const globalElements = {
   wqClaimAgentId: document.getElementById('wqClaimAgentId'),
   wqClaimLeaseMs: document.getElementById('wqClaimLeaseMs'),
   wqClaimBtn: document.getElementById('wqClaimBtn'),
+  wqArchiveDays: document.getElementById('wqArchiveDays'),
+  wqArchivePreviewBtn: document.getElementById('wqArchivePreviewBtn'),
+  wqArchiveApplyBtn: document.getElementById('wqArchiveApplyBtn'),
   wqActionStatus: document.getElementById('wqActionStatus'),
   settingsBtn: document.getElementById('settingsBtn'),
   settingsModal: document.getElementById('settingsModal'),
@@ -3078,6 +3081,51 @@ async function workqueueClaimNextFromUi() {
     renderWorkqueueInspect(item);
   } catch (err) {
     setWorkqueueActionStatus(`Claim failed: ${String(err)}`, 'err');
+  }
+}
+
+async function workqueueArchiveTerminal({ dryRun }) {
+  if (roleState.role !== 'admin') return null;
+  const queue = (workqueueState.selectedQueue || '').trim();
+  const olderThanDays = Number(globalElements.wqArchiveDays?.value || 14);
+  const res = await fetch('/api/workqueue/archive-terminal', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ queue, olderThanDays, dryRun: !!dryRun })
+  });
+  const data = await res.json().catch(() => null);
+  if (!res.ok || !data?.ok) {
+    throw new Error(String(data?.error || res.status));
+  }
+  return data;
+}
+
+async function workqueueArchivePreviewFromUi() {
+  try {
+    const data = await workqueueArchiveTerminal({ dryRun: true });
+    setWorkqueueActionStatus(`Preview: ${data?.count || 0} terminal items eligible for archive.`);
+  } catch (err) {
+    setWorkqueueActionStatus(`Archive preview failed: ${String(err)}`, 'err');
+  }
+}
+
+async function workqueueArchiveApplyFromUi() {
+  try {
+    const preview = await workqueueArchiveTerminal({ dryRun: true });
+    const count = Number(preview?.count || 0);
+    if (count <= 0) {
+      setWorkqueueActionStatus('No terminal items match the selected age threshold.');
+      return;
+    }
+    const days = Number(globalElements.wqArchiveDays?.value || 14);
+    const ok = window.confirm(`Archive ${count} terminal items (done/failed) older than ${days} days?`);
+    if (!ok) return;
+    const applied = await workqueueArchiveTerminal({ dryRun: false });
+    setWorkqueueActionStatus(`Archived ${applied?.count || 0} terminal items.`);
+    await fetchAndRenderWorkqueueItems();
+  } catch (err) {
+    setWorkqueueActionStatus(`Archive failed: ${String(err)}`, 'err');
   }
 }
 
@@ -6836,6 +6884,8 @@ globalElements.wqRefreshBtn?.addEventListener('click', () => {
 
 globalElements.wqEnqueueBtn?.addEventListener('click', () => workqueueEnqueueFromUi());
 globalElements.wqClaimBtn?.addEventListener('click', () => workqueueClaimNextFromUi());
+globalElements.wqArchivePreviewBtn?.addEventListener('click', () => workqueueArchivePreviewFromUi());
+globalElements.wqArchiveApplyBtn?.addEventListener('click', () => workqueueArchiveApplyFromUi());
 
 let shortcutState = { lastGAtMs: 0 };
 

--- a/app.js
+++ b/app.js
@@ -68,6 +68,9 @@ const globalElements = {
   wqClaimAgentId: document.getElementById('wqClaimAgentId'),
   wqClaimLeaseMs: document.getElementById('wqClaimLeaseMs'),
   wqClaimBtn: document.getElementById('wqClaimBtn'),
+  wqArchiveDays: document.getElementById('wqArchiveDays'),
+  wqArchivePreviewBtn: document.getElementById('wqArchivePreviewBtn'),
+  wqArchiveApplyBtn: document.getElementById('wqArchiveApplyBtn'),
   wqActionStatus: document.getElementById('wqActionStatus'),
   settingsBtn: document.getElementById('settingsBtn'),
   settingsModal: document.getElementById('settingsModal'),
@@ -3821,6 +3824,51 @@ async function workqueueClaimNextFromUi() {
     renderWorkqueueInspect(item);
   } catch (err) {
     setWorkqueueActionStatus(`Claim failed: ${String(err)}`, 'err');
+  }
+}
+
+async function workqueueArchiveTerminal({ dryRun }) {
+  if (roleState.role !== 'admin') return null;
+  const queue = (workqueueState.selectedQueue || '').trim();
+  const olderThanDays = Number(globalElements.wqArchiveDays?.value || 14);
+  const res = await fetch('/api/workqueue/archive-terminal', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ queue, olderThanDays, dryRun: !!dryRun })
+  });
+  const data = await res.json().catch(() => null);
+  if (!res.ok || !data?.ok) {
+    throw new Error(String(data?.error || res.status));
+  }
+  return data;
+}
+
+async function workqueueArchivePreviewFromUi() {
+  try {
+    const data = await workqueueArchiveTerminal({ dryRun: true });
+    setWorkqueueActionStatus(`Preview: ${data?.count || 0} terminal items eligible for archive.`);
+  } catch (err) {
+    setWorkqueueActionStatus(`Archive preview failed: ${String(err)}`, 'err');
+  }
+}
+
+async function workqueueArchiveApplyFromUi() {
+  try {
+    const preview = await workqueueArchiveTerminal({ dryRun: true });
+    const count = Number(preview?.count || 0);
+    if (count <= 0) {
+      setWorkqueueActionStatus('No terminal items match the selected age threshold.');
+      return;
+    }
+    const days = Number(globalElements.wqArchiveDays?.value || 14);
+    const ok = window.confirm(`Archive ${count} terminal items (done/failed) older than ${days} days?`);
+    if (!ok) return;
+    const applied = await workqueueArchiveTerminal({ dryRun: false });
+    setWorkqueueActionStatus(`Archived ${applied?.count || 0} terminal items.`);
+    await fetchAndRenderWorkqueueItems();
+  } catch (err) {
+    setWorkqueueActionStatus(`Archive failed: ${String(err)}`, 'err');
   }
 }
 
@@ -7706,6 +7754,8 @@ globalElements.wqRefreshBtn?.addEventListener('click', () => {
 
 globalElements.wqEnqueueBtn?.addEventListener('click', () => workqueueEnqueueFromUi());
 globalElements.wqClaimBtn?.addEventListener('click', () => workqueueClaimNextFromUi());
+globalElements.wqArchivePreviewBtn?.addEventListener('click', () => workqueueArchivePreviewFromUi());
+globalElements.wqArchiveApplyBtn?.addEventListener('click', () => workqueueArchiveApplyFromUi());
 
 let shortcutState = { lastGAtMs: 0 };
 

--- a/clawnsole-server.js
+++ b/clawnsole-server.js
@@ -930,6 +930,40 @@ function createClawnsoleServer(options = {}) {
       return;
     }
 
+    if (req.url === '/api/workqueue/archive-terminal') {
+      if (!requireAuth(req, res)) return;
+      if (req.clawnsoleRole !== 'admin') {
+        sendJson(res, 403, { error: 'forbidden' });
+        return;
+      }
+      if (req.method !== 'POST') {
+        sendJson(res, 405, { error: 'method_not_allowed' });
+        return;
+      }
+
+      (async () => {
+        const payload = await readJsonBody(req, res);
+        if (!payload) return;
+        const queue = String(payload.queue || '').trim();
+        const olderThanDays = Number(payload.olderThanDays);
+        const dryRun = !!payload.dryRun;
+
+        try {
+          const { archiveTerminalItems } = require('./lib/workqueue');
+          const result = archiveTerminalItems(null, { queue, olderThanDays, dryRun });
+          sendJson(res, 200, { ok: true, ...result });
+        } catch (err) {
+          const code = err && err.code;
+          if (code === 'INVALID_THRESHOLD') {
+            sendJson(res, 400, { error: 'invalid_threshold' });
+            return;
+          }
+          sendJson(res, 500, { error: 'workqueue_error' });
+        }
+      })();
+      return;
+    }
+
     if (req.url === '/api/workqueue/assignments') {
       if (!requireAuth(req, res)) return;
       if (req.clawnsoleRole !== 'admin') {

--- a/clawnsole-server.js
+++ b/clawnsole-server.js
@@ -1137,6 +1137,40 @@ function createClawnsoleServer(options = {}) {
       return;
     }
 
+    if (req.url === '/api/workqueue/archive-terminal') {
+      if (!requireAuth(req, res)) return;
+      if (req.clawnsoleRole !== 'admin') {
+        sendJson(res, 403, { error: 'forbidden' });
+        return;
+      }
+      if (req.method !== 'POST') {
+        sendJson(res, 405, { error: 'method_not_allowed' });
+        return;
+      }
+
+      (async () => {
+        const payload = await readJsonBody(req, res);
+        if (!payload) return;
+        const queue = String(payload.queue || '').trim();
+        const olderThanDays = Number(payload.olderThanDays);
+        const dryRun = !!payload.dryRun;
+
+        try {
+          const { archiveTerminalItems } = require('./lib/workqueue');
+          const result = archiveTerminalItems(null, { queue, olderThanDays, dryRun });
+          sendJson(res, 200, { ok: true, ...result });
+        } catch (err) {
+          const code = err && err.code;
+          if (code === 'INVALID_THRESHOLD') {
+            sendJson(res, 400, { error: 'invalid_threshold' });
+            return;
+          }
+          sendJson(res, 500, { error: 'workqueue_error' });
+        }
+      })();
+      return;
+    }
+
     if (req.url === '/api/workqueue/assignments') {
       if (!requireAuth(req, res)) return;
       if (req.clawnsoleRole !== 'admin') {

--- a/index.html
+++ b/index.html
@@ -364,6 +364,25 @@
                   <button id="wqClaimBtn" class="secondary" type="button">Claim next</button>
                 </div>
               </div>
+
+              <div class="wq-action-card">
+                <div class="wq-action-title">Bulk archive terminal</div>
+                <div class="wq-action-grid">
+                  <label class="wq-action-field">
+                    Older than
+                    <select id="wqArchiveDays" aria-label="Archive threshold">
+                      <option value="7">7 days</option>
+                      <option value="14" selected>14 days</option>
+                      <option value="30">30 days</option>
+                      <option value="90">90 days</option>
+                    </select>
+                  </label>
+                </div>
+                <div class="wq-action-buttons">
+                  <button id="wqArchivePreviewBtn" class="secondary" type="button">Preview</button>
+                  <button id="wqArchiveApplyBtn" class="secondary" type="button">Archive…</button>
+                </div>
+              </div>
             </div>
             <div id="wqActionStatus" class="wq-action-status" role="status" aria-live="polite"></div>
           </div>

--- a/index.html
+++ b/index.html
@@ -374,6 +374,25 @@
                   <button id="wqClaimBtn" class="secondary" type="button">Claim next</button>
                 </div>
               </div>
+
+              <div class="wq-action-card">
+                <div class="wq-action-title">Bulk archive terminal</div>
+                <div class="wq-action-grid">
+                  <label class="wq-action-field">
+                    Older than
+                    <select id="wqArchiveDays" aria-label="Archive threshold">
+                      <option value="7">7 days</option>
+                      <option value="14" selected>14 days</option>
+                      <option value="30">30 days</option>
+                      <option value="90">90 days</option>
+                    </select>
+                  </label>
+                </div>
+                <div class="wq-action-buttons">
+                  <button id="wqArchivePreviewBtn" class="secondary" type="button">Preview</button>
+                  <button id="wqArchiveApplyBtn" class="secondary" type="button">Archive…</button>
+                </div>
+              </div>
             </div>
             <div id="wqActionStatus" class="wq-action-status" role="status" aria-live="polite"></div>
           </div>

--- a/lib/workqueue.js
+++ b/lib/workqueue.js
@@ -460,6 +460,45 @@ function deleteItem(rootDir, { itemId } = {}) {
   });
 }
 
+function archiveTerminalItems(rootDir, { queue, olderThanDays, dryRun } = {}) {
+  const { lockFile } = statePaths(rootDir);
+  const q = String(queue || '').trim();
+  const days = Number(olderThanDays);
+  if (!Number.isFinite(days) || days <= 0) {
+    const e = new Error('olderThanDays must be a positive number');
+    e.code = 'INVALID_THRESHOLD';
+    throw e;
+  }
+  const cutoffMs = nowMs() - Math.floor(days * 24 * 60 * 60 * 1000);
+  const terminal = new Set(['done', 'failed']);
+  const previewOnly = !!dryRun;
+
+  return withFileLock(lockFile, () => {
+    const state = loadState(rootDir);
+    const candidates = state.items.filter((it) => {
+      if (!it || !terminal.has(String(it.status || ''))) return false;
+      if (q && it.queue !== q) return false;
+      const updatedAtMs = Date.parse(String(it.updatedAt || it.createdAt || ''));
+      if (!Number.isFinite(updatedAtMs)) return false;
+      return updatedAtMs <= cutoffMs;
+    });
+
+    if (!previewOnly && candidates.length > 0) {
+      const removeIds = new Set(candidates.map((it) => it.id));
+      state.items = state.items.filter((it) => !removeIds.has(it.id));
+      saveState(rootDir, state);
+    }
+
+    return {
+      queue: q || null,
+      olderThanDays: days,
+      cutoffMs,
+      count: candidates.length,
+      dryRun: previewOnly
+    };
+  });
+}
+
 module.exports = {
   statePaths,
   loadState,
@@ -470,6 +509,7 @@ module.exports = {
   transitionItem,
   updateItem,
   deleteItem,
+  archiveTerminalItems,
   listAssignments,
   setAssignments,
   resolveClaimQueues,

--- a/lib/workqueue.js
+++ b/lib/workqueue.js
@@ -558,6 +558,45 @@ function deleteItem(rootDir, { itemId } = {}) {
   });
 }
 
+function archiveTerminalItems(rootDir, { queue, olderThanDays, dryRun } = {}) {
+  const { lockFile } = statePaths(rootDir);
+  const q = String(queue || '').trim();
+  const days = Number(olderThanDays);
+  if (!Number.isFinite(days) || days <= 0) {
+    const e = new Error('olderThanDays must be a positive number');
+    e.code = 'INVALID_THRESHOLD';
+    throw e;
+  }
+  const cutoffMs = nowMs() - Math.floor(days * 24 * 60 * 60 * 1000);
+  const terminal = new Set(['done', 'failed']);
+  const previewOnly = !!dryRun;
+
+  return withFileLock(lockFile, () => {
+    const state = loadState(rootDir);
+    const candidates = state.items.filter((it) => {
+      if (!it || !terminal.has(String(it.status || ''))) return false;
+      if (q && it.queue !== q) return false;
+      const updatedAtMs = Date.parse(String(it.updatedAt || it.createdAt || ''));
+      if (!Number.isFinite(updatedAtMs)) return false;
+      return updatedAtMs <= cutoffMs;
+    });
+
+    if (!previewOnly && candidates.length > 0) {
+      const removeIds = new Set(candidates.map((it) => it.id));
+      state.items = state.items.filter((it) => !removeIds.has(it.id));
+      saveState(rootDir, state);
+    }
+
+    return {
+      queue: q || null,
+      olderThanDays: days,
+      cutoffMs,
+      count: candidates.length,
+      dryRun: previewOnly
+    };
+  });
+}
+
 module.exports = {
   statePaths,
   loadState,
@@ -568,6 +607,7 @@ module.exports = {
   transitionItem,
   updateItem,
   deleteItem,
+  archiveTerminalItems,
   listAssignments,
   setAssignments,
   resolveClaimQueues,

--- a/tests/pane.workqueue.e2e.spec.js
+++ b/tests/pane.workqueue.e2e.spec.js
@@ -192,3 +192,24 @@ test('pane: workqueue scope filter toggles deterministic row counts', async ({ p
   await wqPane.locator('[data-wq-scope="assigned"]').click();
   await expect(rowsWithPrefix()).toHaveCount(0);
 });
+
+test('workqueue modal: bulk archive controls render and preview executes', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  await page.click('#workqueueBtn');
+  await expect(page.locator('#workqueueModal')).toHaveClass(/open/);
+  await expect(page.locator('#wqArchiveDays')).toBeVisible();
+  await expect(page.locator('#wqArchivePreviewBtn')).toBeVisible();
+  await expect(page.locator('#wqArchiveApplyBtn')).toBeVisible();
+
+  await page.click('#wqArchivePreviewBtn');
+  await expect(page.locator('#wqActionStatus')).toContainText('terminal items eligible', { timeout: 15000 });
+});

--- a/tests/pane.workqueue.e2e.spec.js
+++ b/tests/pane.workqueue.e2e.spec.js
@@ -198,3 +198,29 @@ test('pane: workqueue scope filter toggles deterministic row counts', async ({ p
   await wqPane.locator('[data-wq-scope="assigned"]').click();
   await expect(rowsWithPrefix()).toHaveCount(0);
 });
+
+test('workqueue modal: bulk archive controls render and preview executes', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  // With an active chat pane, the topbar Workqueue button focuses the paired pane.
+  // Remove chat first so the same visible control takes the modal fallback path.
+  await page.locator('[data-pane][data-pane-kind="chat"]').first().locator('[data-pane-close]').click();
+  await expect(page.locator('[data-pane][data-pane-kind="chat"]')).toHaveCount(0);
+
+  await page.click('#workqueueBtn');
+  await expect(page.locator('#workqueueModal')).toHaveClass(/open/);
+  await expect(page.locator('#wqArchiveDays')).toBeVisible();
+  await expect(page.locator('#wqArchivePreviewBtn')).toBeVisible();
+  await expect(page.locator('#wqArchiveApplyBtn')).toBeVisible();
+
+  await page.click('#wqArchivePreviewBtn');
+  await expect(page.locator('#wqActionStatus')).toContainText('terminal items eligible', { timeout: 15000 });
+});

--- a/tests/unit/workqueue.test.js
+++ b/tests/unit/workqueue.test.js
@@ -4,7 +4,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
-const { enqueueItem, claimNext, loadState, saveState, transitionItem } = require('../../lib/workqueue');
+const { enqueueItem, claimNext, loadState, saveState, transitionItem, archiveTerminalItems } = require('../../lib/workqueue');
 
 function withFakeNow(ms, fn) {
   const realNow = Date.now;
@@ -255,4 +255,44 @@ test('workqueue: enqueue supports dedupeKey idempotency', () => {
 
   const state = loadState(root);
   assert.equal(state.items.length, 1);
+});
+
+test('workqueue: archiveTerminalItems only removes terminal items older than threshold', () => {
+  withFakeNow(1_800_000_000_000, () => {
+    const root = tempRoot();
+
+    const doneOld = enqueueItem(root, { queue: 'dev', title: 'done-old', instructions: 'x', priority: 0 });
+    const doneRecent = enqueueItem(root, { queue: 'dev', title: 'done-recent', instructions: 'x', priority: 0 });
+    const failedOld = enqueueItem(root, { queue: 'dev', title: 'failed-old', instructions: 'x', priority: 0 });
+    const readyOld = enqueueItem(root, { queue: 'dev', title: 'ready-old', instructions: 'x', priority: 0 });
+
+    const state = loadState(root);
+    const set = (id, patch) => Object.assign(state.items.find((it) => it.id === id), patch);
+    set(doneOld.id, { status: 'done', updatedAt: new Date(1_800_000_000_000 - 20 * 24 * 60 * 60 * 1000).toISOString() });
+    set(doneRecent.id, { status: 'done', updatedAt: new Date(1_800_000_000_000 - 2 * 24 * 60 * 60 * 1000).toISOString() });
+    set(failedOld.id, { status: 'failed', updatedAt: new Date(1_800_000_000_000 - 30 * 24 * 60 * 60 * 1000).toISOString() });
+    set(readyOld.id, { status: 'ready', updatedAt: new Date(1_800_000_000_000 - 30 * 24 * 60 * 60 * 1000).toISOString() });
+    saveState(root, state);
+
+    const preview = archiveTerminalItems(root, { queue: 'dev', olderThanDays: 14, dryRun: true });
+    assert.equal(preview.count, 2);
+
+    const applied = archiveTerminalItems(root, { queue: 'dev', olderThanDays: 14, dryRun: false });
+    assert.equal(applied.count, 2);
+
+    const after = loadState(root);
+    const ids = new Set(after.items.map((it) => it.id));
+    assert.equal(ids.has(doneOld.id), false);
+    assert.equal(ids.has(failedOld.id), false);
+    assert.equal(ids.has(doneRecent.id), true);
+    assert.equal(ids.has(readyOld.id), true);
+  });
+});
+
+test('workqueue: archiveTerminalItems validates threshold', () => {
+  const root = tempRoot();
+  assert.throws(
+    () => archiveTerminalItems(root, { queue: 'dev', olderThanDays: 0, dryRun: true }),
+    (err) => err && err.code === 'INVALID_THRESHOLD'
+  );
 });

--- a/tests/unit/workqueue.test.js
+++ b/tests/unit/workqueue.test.js
@@ -4,7 +4,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
-const { enqueueItem, claimNext, loadState, saveState, transitionItem } = require('../../lib/workqueue');
+const { enqueueItem, claimNext, loadState, saveState, transitionItem, archiveTerminalItems } = require('../../lib/workqueue');
 
 function withFakeNow(ms, fn) {
   const realNow = Date.now;
@@ -368,4 +368,44 @@ test('workqueue: issue-backed enqueue creates new row when only terminal matches
   assert.equal(second._enqueueAction, 'created');
   assert.equal(second.dedupeKey, 'rmdmattingly/clawnsole#392');
   assert.equal(loadState(root).items.length, 2);
+});
+
+test('workqueue: archiveTerminalItems only removes terminal items older than threshold', () => {
+  withFakeNow(1_800_000_000_000, () => {
+    const root = tempRoot();
+
+    const doneOld = enqueueItem(root, { queue: 'dev', title: 'done-old', instructions: 'x', priority: 0 });
+    const doneRecent = enqueueItem(root, { queue: 'dev', title: 'done-recent', instructions: 'x', priority: 0 });
+    const failedOld = enqueueItem(root, { queue: 'dev', title: 'failed-old', instructions: 'x', priority: 0 });
+    const readyOld = enqueueItem(root, { queue: 'dev', title: 'ready-old', instructions: 'x', priority: 0 });
+
+    const state = loadState(root);
+    const set = (id, patch) => Object.assign(state.items.find((it) => it.id === id), patch);
+    set(doneOld.id, { status: 'done', updatedAt: new Date(1_800_000_000_000 - 20 * 24 * 60 * 60 * 1000).toISOString() });
+    set(doneRecent.id, { status: 'done', updatedAt: new Date(1_800_000_000_000 - 2 * 24 * 60 * 60 * 1000).toISOString() });
+    set(failedOld.id, { status: 'failed', updatedAt: new Date(1_800_000_000_000 - 30 * 24 * 60 * 60 * 1000).toISOString() });
+    set(readyOld.id, { status: 'ready', updatedAt: new Date(1_800_000_000_000 - 30 * 24 * 60 * 60 * 1000).toISOString() });
+    saveState(root, state);
+
+    const preview = archiveTerminalItems(root, { queue: 'dev', olderThanDays: 14, dryRun: true });
+    assert.equal(preview.count, 2);
+
+    const applied = archiveTerminalItems(root, { queue: 'dev', olderThanDays: 14, dryRun: false });
+    assert.equal(applied.count, 2);
+
+    const after = loadState(root);
+    const ids = new Set(after.items.map((it) => it.id));
+    assert.equal(ids.has(doneOld.id), false);
+    assert.equal(ids.has(failedOld.id), false);
+    assert.equal(ids.has(doneRecent.id), true);
+    assert.equal(ids.has(readyOld.id), true);
+  });
+});
+
+test('workqueue: archiveTerminalItems validates threshold', () => {
+  const root = tempRoot();
+  assert.throws(
+    () => archiveTerminalItems(root, { queue: 'dev', olderThanDays: 0, dryRun: true }),
+    (err) => err && err.code === 'INVALID_THRESHOLD'
+  );
 });


### PR DESCRIPTION
Closes #378

## Summary
- Add admin API endpoint `POST /api/workqueue/archive-terminal`
  - Supports `olderThanDays`, optional `queue`, and `dryRun` preview mode
  - Hard safety guard: only targets terminal statuses (`done`/`failed`)
- Add Workqueue modal UI action card:
  - Select age threshold (7/14/30/90 days)
  - Preview eligible count
  - Confirm-before-apply archive action
- Refresh list and show result toast after apply

## Coverage
- Unit: `tests/unit/workqueue.test.js`
  - threshold filtering
  - terminal-only guard
  - invalid threshold validation
- UI: `tests/pane.workqueue.e2e.spec.js`
  - bulk archive controls render + preview executes

## Local validation
- `node --test tests/unit/workqueue.test.js`
- `node --check app.js && node --check clawnsole-server.js`
- `npx playwright test tests/pane.workqueue.e2e.spec.js -g "bulk archive controls" --workers=1`
