### PR TITLE
Fix #382: keep Workqueue column header sticky while scrolling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1922,12 +1922,16 @@ kbd {
 }
 
 .wq-list-header {
+  position: sticky;
+  top: 0;
+  z-index: 3;
   padding: 10px 12px;
   font-size: 11px;
   letter-spacing: 0.04em;
   text-transform: uppercase;
   color: var(--muted);
-  background: rgba(0, 0, 0, 0.2);
+  background: rgba(12, 15, 20, 0.94);
+  backdrop-filter: blur(6px);
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -116,3 +116,49 @@ test('workqueue pane: controls toolbar is sticky and list scrolls independently'
   });
   expect(['auto', 'scroll']).toContain(listStyles.overflowY);
 });
+
+test('workqueue pane: list column header remains sticky while list body scrolls', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  const wqPane = page.locator('[data-pane]').last();
+  const listHeader = wqPane.locator('.wq-pane .wq-list-header').first();
+  const listBody = wqPane.locator('.wq-pane [data-wq-list-body]').first();
+
+  await expect(listHeader).toBeVisible();
+  await expect(listBody).toHaveCount(1);
+
+  const headerStyles = await listHeader.evaluate((el) => {
+    const cs = window.getComputedStyle(el);
+    return {
+      position: cs.position,
+      top: cs.top,
+      zIndex: cs.zIndex,
+      backgroundColor: cs.backgroundColor
+    };
+  });
+
+  expect(headerStyles.position).toBe('sticky');
+  expect(headerStyles.top).toBe('0px');
+  expect(Number(headerStyles.zIndex)).toBeGreaterThanOrEqual(3);
+  expect(headerStyles.backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
+
+  await listBody.evaluate((el) => {
+    el.scrollTop = 200;
+  });
+
+  const pinned = await listHeader.evaluate((el) => {
+    const parent = el.closest('.wq-list');
+    if (!parent) return false;
+    const parentTop = parent.getBoundingClientRect().top;
+    const headerTop = el.getBoundingClientRect().top;
+    return Math.abs(headerTop - parentTop) < 2;
+  });
+
+  expect(pinned).toBe(true);
+});


### PR DESCRIPTION
## Summary
- make the Workqueue list column header row sticky within the list container
- give the sticky header an opaque/blurred background so rows do not bleed through while scrolling
- add a UI test that asserts sticky positioning and verifies the header stays pinned when list body scrolls

## Testing
- `node --check app.js`
- `npm test -- tests/ui/workqueue-pane.spec.js` *(fails in this local env before UI tests due to missing optional deps: `ws`, `@playwright/test`)*

Closes #382.
