### PR TITLE
UX/Agents modal: keyboard triage loop (j/k, Enter, Shift+Enter)

### DIFF
--- a/app.js
+++ b/app.js
@@ -350,7 +350,8 @@ const roleState = {
 const uiState = {
   authed: false,
   meta: {},
-  agents: []
+  agents: [],
+  agentsModalSelectedAgentId: ''
 };
 
 let toastSeq = 0;
@@ -2032,6 +2033,82 @@ function closeAgentsModal() {
   stopAgentsModalFreshnessTicker();
 }
 
+function getAgentsModalRows() {
+  const root = globalElements.agentsList;
+  if (!root) return [];
+  return Array.from(root.querySelectorAll('.agents-row[data-agent-id]'));
+}
+
+function applyAgentsModalSelection(agentId, { scroll = false } = {}) {
+  const rows = getAgentsModalRows();
+  if (!rows.length) {
+    uiState.agentsModalSelectedAgentId = '';
+    return;
+  }
+
+  const desired = String(agentId || '').trim();
+  const selectedRow =
+    rows.find((row) => String(row.getAttribute('data-agent-id') || '') === desired) || rows[0];
+  const selectedId = String(selectedRow?.getAttribute('data-agent-id') || '').trim();
+  uiState.agentsModalSelectedAgentId = selectedId;
+
+  rows.forEach((row) => {
+    const active = row === selectedRow;
+    row.classList.toggle('agents-row-selected', active);
+    row.setAttribute('aria-selected', active ? 'true' : 'false');
+  });
+
+  if (scroll && selectedRow) {
+    try {
+      selectedRow.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+    } catch {}
+  }
+}
+
+function moveAgentsModalSelection(delta) {
+  const rows = getAgentsModalRows();
+  if (!rows.length) return;
+  const dir = delta >= 0 ? 1 : -1;
+  const currentId = String(uiState.agentsModalSelectedAgentId || '').trim();
+  const currentIdx = rows.findIndex((row) => String(row.getAttribute('data-agent-id') || '') === currentId);
+  const baseIdx = currentIdx >= 0 ? currentIdx : 0;
+  const nextIdx = Math.max(0, Math.min(rows.length - 1, baseIdx + dir));
+  const nextId = String(rows[nextIdx].getAttribute('data-agent-id') || '').trim();
+  applyAgentsModalSelection(nextId, { scroll: true });
+}
+
+function isAgentsModalOpen() {
+  return !!globalElements.agentsModal?.classList?.contains('open');
+}
+
+function handleAgentsModalKeydown(event) {
+  if (!isAgentsModalOpen()) return false;
+  if (event.metaKey || event.ctrlKey || event.altKey) return false;
+  if (isTypingContext(event.target)) return false;
+
+  const key = String(event.key || '');
+  if (key === 'j' || key === 'ArrowDown') {
+    event.preventDefault();
+    moveAgentsModalSelection(1);
+    return true;
+  }
+  if (key === 'k' || key === 'ArrowUp') {
+    event.preventDefault();
+    moveAgentsModalSelection(-1);
+    return true;
+  }
+  if (key === 'Enter') {
+    const selectedId = String(uiState.agentsModalSelectedAgentId || '').trim();
+    if (!selectedId) return false;
+    event.preventDefault();
+    if (event.shiftKey) openAgentWorkqueueFromFleet(selectedId);
+    else openAgentChatFromFleet(selectedId);
+    return true;
+  }
+
+  return false;
+}
+
 function findExistingPane(kind, predicate = null) {
   const list = Array.isArray(paneManager?.panes) ? paneManager.panes : [];
   for (const pane of list) {
@@ -2169,6 +2246,9 @@ function renderAgentsModalList() {
       const id = String(agent?.id || '').trim();
       const row = document.createElement('div');
       row.className = 'agents-row';
+      row.setAttribute('data-agent-id', id);
+      row.setAttribute('role', 'option');
+      row.setAttribute('aria-selected', 'false');
 
       const label = formatAgentLabel(agent, { includeId: true });
       const pinnedNow = pins.has(id);
@@ -2222,6 +2302,8 @@ function renderAgentsModalList() {
         });
       });
 
+      row.addEventListener('mousedown', () => applyAgentsModalSelection(id));
+
       list.appendChild(row);
     }
 
@@ -2231,6 +2313,8 @@ function renderAgentsModalList() {
 
   renderSection('Pinned', pinned);
   renderSection('Agents', rest);
+
+  applyAgentsModalSelection(uiState.agentsModalSelectedAgentId);
 
   const empty = pinned.length === 0 && rest.length === 0;
   if (globalElements.agentsEmpty) globalElements.agentsEmpty.hidden = !empty;
@@ -6977,6 +7061,8 @@ window.addEventListener('keydown', (event) => {
     }
     return;
   }
+
+  if (handleAgentsModalKeydown(event)) return;
 
   // Never steal focus / override browser shortcuts while typing.
   if (isTypingContext(event.target)) return;

--- a/styles.css
+++ b/styles.css
@@ -1389,6 +1389,13 @@ button.send-btn .btn-icon {
   background: rgba(255, 255, 255, 0.02);
 }
 
+
+.agents-row.agents-row-selected {
+  border-color: rgba(77, 196, 255, 0.7);
+  background: rgba(77, 196, 255, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(77, 196, 255, 0.25);
+}
+
 .agents-pin {
   width: 36px;
   height: 36px;

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -83,3 +83,42 @@ test('agents modal quick actions open/reuse chat, timeline, and workqueue contex
   await firstRow.locator('[data-agent-action="open-workqueue"]').first().click();
   await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
 });
+
+test('agents modal keyboard triage loop selects rows and opens chat/workqueue while suppressing input bleed', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  await clawnsole.gotoAndLoginAdmin(page);
+
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsModal')).toHaveClass(/open/);
+
+  const selectedRows = page.locator('#agentsList .agents-row.agents-row-selected');
+  await expect(selectedRows).toHaveCount(1);
+
+  // Keyboard movement should keep a visible selection.
+  await page.keyboard.press('j');
+  await expect(selectedRows).toHaveCount(1);
+
+  await page.keyboard.press('k');
+  await expect(selectedRows).toHaveCount(1);
+
+  // Enter opens chat for selected row.
+  await page.keyboard.press('Enter');
+  await expect(page.locator('[data-pane][data-pane-kind="chat"]').first()).toBeVisible();
+
+  // Shift+Enter opens/focuses workqueue.
+  await page.keyboard.press('Shift+Enter');
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
+
+  // Typing in search should suppress triage shortcuts.
+  const chatCountBefore = await page.locator('[data-pane][data-pane-kind="chat"]').count();
+  const workqueueCountBefore = await page.locator('[data-pane][data-pane-kind="workqueue"]').count();
+  const search = page.locator('#agentsSearch');
+  await search.focus();
+  await search.press('j');
+  await search.press('Enter');
+  await search.press('Shift+Enter');
+
+  await expect(page.locator('[data-pane][data-pane-kind="chat"]')).toHaveCount(chatCountBefore);
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(workqueueCountBefore);
+});


### PR DESCRIPTION
## Summary
- add a persistent selected-row state in the Agents modal (visible on open)
- add keyboard triage loop: `j/k` + `ArrowUp/ArrowDown` to move selection
- add `Enter` (open/focus selected agent chat) and `Shift+Enter` (open/focus workqueue)
- suppress modal triage shortcuts while typing in inputs (including the filter field)
- add UI coverage for keyboard behavior and shortcut suppression

Closes #383.

## Testing
- `node --check app.js && node --test tests/unit/*.test.js`
- `npx playwright test tests/ui/agents-modal.spec.js --workers=1`
