### PR TITLE
Humanize Workqueue status filters with labels + counts

### DIFF
--- a/app.js
+++ b/app.js
@@ -2239,6 +2239,32 @@ function renderAgentsModalList() {
 // Workqueue (admin-only)
 
 const WORKQUEUE_STATUSES = ['ready', 'pending', 'claimed', 'in_progress', 'done', 'failed'];
+const WORKQUEUE_STATUS_LABELS = {
+  ready: 'Ready',
+  pending: 'Pending',
+  claimed: 'Claimed',
+  in_progress: 'In progress',
+  done: 'Done',
+  failed: 'Failed'
+};
+
+function workqueueStatusLabel(status) {
+  const key = String(status || '').trim();
+  return WORKQUEUE_STATUS_LABELS[key] || key || 'Unknown';
+}
+
+function countWorkqueueItemsByStatus(items) {
+  const counts = Object.create(null);
+  WORKQUEUE_STATUSES.forEach((status) => {
+    counts[status] = 0;
+  });
+  (Array.isArray(items) ? items : []).forEach((item) => {
+    const status = String(item?.status || '').trim();
+    if (!status) return;
+    counts[status] = Number(counts[status] || 0) + 1;
+  });
+  return counts;
+}
 
 const workqueueState = {
   queues: [],
@@ -2274,12 +2300,13 @@ function closeWorkqueue() {
 function renderWorkqueueStatusFilters() {
   const root = globalElements.wqStatusFilters;
   if (!root) return;
+  const counts = countWorkqueueItemsByStatus(workqueueState.items);
   root.innerHTML = '';
   for (const s of WORKQUEUE_STATUSES) {
     const id = `wq-status-${s}`;
     const label = document.createElement('label');
     label.className = 'wq-status-chip';
-    label.innerHTML = `<input type="checkbox" id="${id}" ${workqueueState.statusFilter.has(s) ? 'checked' : ''} /> <span>${escapeHtml(s)}</span>`;
+    label.innerHTML = `<input type="checkbox" id="${id}" ${workqueueState.statusFilter.has(s) ? 'checked' : ''} /> <span>${escapeHtml(workqueueStatusLabel(s))} (${Number(counts[s] || 0)})</span>`;
     const checkbox = label.querySelector('input');
     checkbox.addEventListener('change', () => {
       if (checkbox.checked) workqueueState.statusFilter.add(s);
@@ -2407,6 +2434,7 @@ async function fetchAndRenderWorkqueueItems() {
     const data = await res.json();
     const items = Array.isArray(data.items) ? data.items : [];
     workqueueState.items = items;
+    renderWorkqueueStatusFilters();
     renderWorkqueueItems();
   } catch (err) {
     addFeed('err', 'workqueue', `failed to load items: ${String(err)}`);
@@ -2835,6 +2863,9 @@ async function fetchAndRenderWorkqueueItemsForPane(pane) {
     const items = Array.isArray(data.items) ? data.items : [];
     pane.workqueue.items = items;
     if (statusLine) statusLine.textContent = `${items.length} item(s)`;
+    if (typeof pane.workqueue?.renderStatusMultiSelect === 'function') {
+      pane.workqueue.renderStatusMultiSelect();
+    }
     renderWorkqueuePaneItems(pane);
   } catch (err) {
     if (statusLine) statusLine.textContent = `Failed to load: ${String(err)}`;
@@ -5181,6 +5212,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
 
     const renderStatusMultiSelect = () => {
       if (!statusRootEl || !statusSelectedEl || !statusOptionsEl) return;
+      const counts = countWorkqueueItemsByStatus(pane.workqueue?.items);
 
       statusSelectedEl.innerHTML = '';
       const selected = Array.from(statusSet);
@@ -5188,7 +5220,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         for (const s of selected) {
           const chip = document.createElement('span');
           chip.className = 'wq-pill';
-          chip.textContent = s;
+          chip.textContent = `${workqueueStatusLabel(s)} (${Number(counts[s] || 0)})`;
           statusSelectedEl.appendChild(chip);
         }
       } else {
@@ -5203,7 +5235,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         const id = `wq-pane-status-${pane.id}-${s}`;
         const label = document.createElement('label');
         label.className = 'wq-status-chip';
-        label.innerHTML = `<input type="checkbox" id="${id}" ${statusSet.has(s) ? 'checked' : ''} /> <span>${escapeHtml(s)}</span>`;
+        label.innerHTML = `<input type="checkbox" id="${id}" ${statusSet.has(s) ? 'checked' : ''} /> <span>${escapeHtml(workqueueStatusLabel(s))} (${Number(counts[s] || 0)})</span>`;
         const checkbox = label.querySelector('input');
         checkbox.addEventListener('change', () => {
           if (checkbox.checked) statusSet.add(s);
@@ -5213,6 +5245,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         statusOptionsEl.appendChild(label);
       }
     };
+    pane.workqueue.renderStatusMultiSelect = renderStatusMultiSelect;
 
     const applyQueueSearchFilter = () => {
       if (!queueSelectEl) return;


### PR DESCRIPTION
Closes #324

## Summary
- humanize Workqueue status filter labels (`in_progress` → `In progress`)
- show per-status item counts in both Workqueue modal filters and Workqueue pane multi-select
- refresh modal filter counts after each item fetch
- refresh pane status controls after each pane fetch so counts stay in sync

## Validation
- `npm test -- tests/ui/workqueue-pane.spec.js`
