### PR TITLE
feat: paired Chat↔Workqueue pane toggle

### DIFF
--- a/app.js
+++ b/app.js
@@ -1854,6 +1854,15 @@ function buildCommandPaletteItems() {
       '⌘/Ctrl+Shift+K'
     ),
     withShortcut(
+      {
+        id: 'cmd:pane-toggle-paired',
+        label: 'Panes: Toggle paired pane (Chat ↔ Workqueue)',
+        detail: 'Switch to existing paired pane or open it for the same target',
+        run: () => togglePairedPane()
+      },
+      '⌘/Ctrl+Shift+Y'
+    ),
+    withShortcut(
       { id: 'cmd:pane-cycle-backward', label: 'Panes: Cycle focus backward', detail: 'Move focus to previous pane', run: () => cyclePaneFocusBackward() },
       '⌘/Ctrl+Shift+J'
     ),
@@ -2102,6 +2111,60 @@ function openAgentWorkqueueFromFleet() {
   if (!pane) return;
 
   paneManager.focusPanePrimary(pane);
+}
+
+function getActivePane() {
+  const panes = Array.isArray(paneManager?.panes) ? paneManager.panes : [];
+  if (!panes.length) return null;
+  const active = document.activeElement;
+  if (!active) return null;
+  return panes.find((p) => p?.elements?.root && (p.elements.root === active || p.elements.root.contains(active))) || null;
+}
+
+function togglePairedPane() {
+  const activePane = getActivePane();
+  if (!activePane) {
+    toast('Focus a Chat or Workqueue pane first.', 'info');
+    return;
+  }
+
+  if (activePane.kind === 'chat') {
+    const target = normalizeAgentId(activePane.agentId || 'main');
+    const existing = findExistingPane('workqueue', (p) => normalizeAgentId(p.agentId || 'main') === target);
+    if (existing) {
+      paneManager.focusPanePrimary(existing);
+      return;
+    }
+    const created = paneManager.addPane('workqueue');
+    if (!created) {
+      toast('Unable to open paired Workqueue pane.', 'info');
+      return;
+    }
+    created.agentId = target;
+    paneManager.persistAdminPanes();
+    renderWorkqueuePaneItems(created);
+    paneManager.focusPanePrimary(created);
+    return;
+  }
+
+  if (activePane.kind === 'workqueue') {
+    const target = normalizeAgentId(activePane.agentId || 'main');
+    const existing = findExistingPane('chat', (p) => normalizeAgentId(p.agentId || 'main') === target);
+    if (existing) {
+      paneManager.focusPanePrimary(existing);
+      return;
+    }
+    const created = paneManager.addPane('chat');
+    if (!created) {
+      toast('Unable to open paired Chat pane.', 'info');
+      return;
+    }
+    paneSetAgent(created, target, { requireDraftConfirm: false });
+    paneManager.focusPanePrimary(created);
+    return;
+  }
+
+  toast('Paired toggle supports Chat and Workqueue panes only.', 'info');
 }
 
 function renderAgentsModalList() {
@@ -4932,7 +4995,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
             ['Alt/Option+1..9', 'focus panes 1-9 by visible order'],
             ['Cmd/Ctrl+1..4', 'focus pane 1-4'],
             ['Cmd/Ctrl+Shift+K', 'focus next pane'],
-            ['Cmd/Ctrl+Shift+J', 'focus previous pane']
+            ['Cmd/Ctrl+Shift+J', 'focus previous pane'],
+            ['Cmd/Ctrl+Shift+Y', 'toggle paired Chat ↔ Workqueue pane']
           ]
         };
       })();
@@ -6838,6 +6902,10 @@ globalElements.wqEnqueueBtn?.addEventListener('click', () => workqueueEnqueueFro
 globalElements.wqClaimBtn?.addEventListener('click', () => workqueueClaimNextFromUi());
 
 let shortcutState = { lastGAtMs: 0 };
+const ADMIN_SHORTCUTS = {
+  addPane: { c: 'chat', w: 'workqueue', r: 'cron', t: 'timeline' },
+  togglePairedPane: 'y'
+};
 
 function isTypingContext(target) {
   const el = target || document.activeElement;
@@ -6940,8 +7008,7 @@ window.addEventListener('keydown', (event) => {
   const isAccel = (event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey;
   if (isAccel && roleState.role === 'admin' && !isTypingContext(event.target)) {
     const key = String(event.key || '').toLowerCase();
-    const map = { c: 'chat', w: 'workqueue', r: 'cron', t: 'timeline' };
-    const kind = map[key];
+    const kind = ADMIN_SHORTCUTS.addPane[key];
     if (kind) {
       // Don't hijack add-pane shortcuts while typing in inputs/editors.
       event.preventDefault();
@@ -7047,6 +7114,13 @@ window.addEventListener('keydown', (event) => {
   if ((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey && key.toLowerCase() === 'f') {
     event.preventDefault();
     openFleetPane();
+    return;
+  }
+
+  // Cmd/Ctrl+Shift+Y toggles paired pane (Chat ↔ Workqueue) for active target.
+  if ((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey && key.toLowerCase() === ADMIN_SHORTCUTS.togglePairedPane) {
+    event.preventDefault();
+    togglePairedPane();
     return;
   }
 

--- a/app.js
+++ b/app.js
@@ -2684,7 +2684,7 @@ function buildCommandPaletteItems() {
     const label = String(item.label || '');
     const enriched = { ...item, group: 'Advanced', subgroup: '', priority: 20, kind: 'action' };
 
-    if (id.startsWith('cmd:focus-pane-') || id === 'cmd:pane-cycle' || id === 'cmd:pane-cycle-backward' || id === 'cmd:pane-return-last-chat' || id === 'cmd:pane-mru-next' || id === 'cmd:pane-mru-prev' || id === 'cmd:pane-next-unread' || id === 'cmd:pane-prev-unread') {
+    if (id.startsWith('cmd:focus-pane-') || id === 'cmd:pane-cycle' || id === 'cmd:pane-cycle-backward' || id === 'cmd:pane-return-last-chat' || id === 'cmd:pane-mru-next' || id === 'cmd:pane-mru-prev' || id === 'cmd:pane-next-unread' || id === 'cmd:pane-prev-unread' || id === 'cmd:pane-toggle-paired') {
       enriched.group = 'Panes';
       enriched.priority = id.startsWith('cmd:focus-pane-') ? 130 : 110;
       return enriched;
@@ -9049,10 +9049,19 @@ window.addEventListener('keydown', (event) => {
     return;
   }
 
+  const key = String(event.key || '');
+
+  // Cmd/Ctrl+Shift+Y toggles paired pane (Chat ↔ Workqueue) for active target.
+  // This intentionally works while the chat composer is focused because that is
+  // the common case where the active Chat pane target is unambiguous.
+  if ((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey && key.toLowerCase() === ADMIN_SHORTCUTS.togglePairedPane) {
+    event.preventDefault();
+    togglePairedPane();
+    return;
+  }
+
   // Never steal focus / override browser shortcuts while typing.
   if (isTypingContext(event.target)) return;
-
-  const key = String(event.key || '');
 
   // Ctrl+Tab walks panes in most-recently-used order; Shift reverses the traversal.
   if (event.ctrlKey && !event.metaKey && !event.altKey && key === 'Tab') {
@@ -9138,13 +9147,6 @@ window.addEventListener('keydown', (event) => {
   if ((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey && key.toLowerCase() === 'f') {
     event.preventDefault();
     openFleetPane();
-    return;
-  }
-
-  // Cmd/Ctrl+Shift+Y toggles paired pane (Chat ↔ Workqueue) for active target.
-  if ((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey && key.toLowerCase() === ADMIN_SHORTCUTS.togglePairedPane) {
-    event.preventDefault();
-    togglePairedPane();
     return;
   }
 

--- a/app.js
+++ b/app.js
@@ -2614,6 +2614,15 @@ function buildCommandPaletteItems() {
       '⌘/Ctrl+Shift+K'
     ),
     withShortcut(
+      {
+        id: 'cmd:pane-toggle-paired',
+        label: 'Panes: Toggle paired pane (Chat ↔ Workqueue)',
+        detail: 'Switch to existing paired pane or open it for the same target',
+        run: () => togglePairedPane()
+      },
+      '⌘/Ctrl+Shift+Y'
+    ),
+    withShortcut(
       { id: 'cmd:pane-cycle-backward', label: 'Panes: Cycle focus backward', detail: 'Move focus to previous pane', run: () => cyclePaneFocusBackward() },
       '⌘/Ctrl+Shift+J'
     ),
@@ -3181,6 +3190,46 @@ function openTopbarWorkqueueAction() {
   const activeChatTarget = getActiveChatTargetForWorkqueuePairing();
   if (activeChatTarget && openOrFocusPairedWorkqueuePaneForTarget(activeChatTarget)) return;
   openWorkqueue();
+}
+
+function togglePairedPane() {
+  const activePane = findActivePaneFromFocus();
+  if (!activePane) {
+    toast('Focus a Chat or Workqueue pane first.', 'info');
+    return;
+  }
+
+  if (activePane.kind === 'chat') {
+    const target = normalizeAgentId(activePane.agentId || 'main');
+    const existing = findExistingPane('workqueue', (p) => normalizeAgentId(p.agentId || 'main') === target);
+    if (existing) {
+      paneManager.focusPanePrimary(existing);
+      return;
+    }
+    const created = paneManager.addPane('workqueue', { agentId: target, scopeFilter: 'assigned' });
+    if (!created) {
+      toast('Unable to open paired Workqueue pane.', 'info');
+      return;
+    }
+    return;
+  }
+
+  if (activePane.kind === 'workqueue') {
+    const target = normalizeAgentId(activePane.agentId || 'main');
+    const existing = findExistingPane('chat', (p) => normalizeAgentId(p.agentId || 'main') === target);
+    if (existing) {
+      paneManager.focusPanePrimary(existing);
+      return;
+    }
+    const created = paneManager.addPane('chat', { agentId: target });
+    if (!created) {
+      toast('Unable to open paired Chat pane.', 'info');
+      return;
+    }
+    return;
+  }
+
+  toast('Paired toggle supports Chat and Workqueue panes only.', 'info');
 }
 
 function renderAgentsModalList() {
@@ -6464,7 +6513,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
             ['Cmd/Ctrl+1..9', 'focus panes 1-9 by visible order'],
             ['Cmd/Ctrl+L', 'focus Chat composer'],
             ['Cmd/Ctrl+Shift+K', 'focus next pane'],
-            ['Cmd/Ctrl+Shift+J', 'focus previous pane']
+            ['Cmd/Ctrl+Shift+J', 'focus previous pane'],
+            ['Cmd/Ctrl+Shift+Y', 'toggle paired Chat ↔ Workqueue pane']
           ]
         };
       })();
@@ -8589,6 +8639,10 @@ const SHORTCUT_BLOCK_MESSAGES = {
   modal: 'Close modal to use this shortcut',
   layout: 'Use Cmd/Ctrl+1..9 on this keyboard layout'
 };
+const ADMIN_SHORTCUTS = {
+  addPane: { c: 'chat', w: 'workqueue', r: 'cron', t: 'timeline' },
+  togglePairedPane: 'y'
+};
 
 function reportBlockedShortcut(reason) {
   const key = String(reason || '').trim();
@@ -8649,7 +8703,9 @@ function hasPaneNumberLayoutMismatch(event) {
 
 function isTypingShortcutExempt(event) {
   const key = String(event?.key || '').toLowerCase();
-  return (event?.metaKey || event?.ctrlKey) && !event.shiftKey && !event.altKey && (key === 'p' || key === 'k' || key === 'l');
+  if (!(event?.metaKey || event?.ctrlKey) || event.altKey) return false;
+  if (!event.shiftKey && (key === 'p' || key === 'k' || key === 'l')) return true;
+  return event.shiftKey && key === ADMIN_SHORTCUTS.togglePairedPane;
 }
 
 function isNonTrivialGlobalShortcut(event) {
@@ -8658,7 +8714,7 @@ function isNonTrivialGlobalShortcut(event) {
   const lower = key.toLowerCase();
   const hasMetaCtrl = !!(event.metaKey || event.ctrlKey);
   const isAccel = hasMetaCtrl && event.shiftKey;
-  if (isAccel && ['c', 'w', 'r', 't', 'k', 'j', 'n', 'f', 'h'].includes(lower)) return true;
+  if (isAccel && ['c', 'w', 'r', 't', 'k', 'j', 'n', 'f', 'h', ADMIN_SHORTCUTS.togglePairedPane].includes(lower)) return true;
   if (hasMetaCtrl && event.altKey && !event.shiftKey && ['k', 'j'].includes(lower)) return true;
   if (isAccel && (key === ']' || key === '}' || key === '[' || key === '{')) return true;
   if (hasMetaCtrl && !event.shiftKey && !event.altKey && ['p', 'k', 'r'].includes(lower)) return true;
@@ -8955,8 +9011,7 @@ window.addEventListener('keydown', (event) => {
   const isAccel = (event.metaKey || event.ctrlKey) && event.shiftKey;
   if (isAccel && roleState.role === 'admin' && !isTypingContext(event.target) && !isAnyOverlayOpen()) {
     const key = String(event.key || '').toLowerCase();
-    const map = { c: 'chat', w: 'workqueue', r: 'cron', t: 'timeline' };
-    const kind = map[key];
+    const kind = ADMIN_SHORTCUTS.addPane[key];
     if (kind) {
       // Don't hijack add-pane shortcuts while typing or while overlays are active.
       event.preventDefault();
@@ -9083,6 +9138,13 @@ window.addEventListener('keydown', (event) => {
   if ((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey && key.toLowerCase() === 'f') {
     event.preventDefault();
     openFleetPane();
+    return;
+  }
+
+  // Cmd/Ctrl+Shift+Y toggles paired pane (Chat ↔ Workqueue) for active target.
+  if ((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey && key.toLowerCase() === ADMIN_SHORTCUTS.togglePairedPane) {
+    event.preventDefault();
+    togglePairedPane();
     return;
   }
 

--- a/app.js
+++ b/app.js
@@ -624,6 +624,10 @@ function showToast(
   });
 }
 
+function toast(message, kind = 'info') {
+  showToast(message, { kind, timeoutMs: 2600 });
+}
+
 let agentRefreshTimer = null;
 let agentRefreshInFlight = null;
 let agentAutoRefreshInterval = null;
@@ -3201,12 +3205,17 @@ function togglePairedPane() {
 
   if (activePane.kind === 'chat') {
     const target = normalizeAgentId(activePane.agentId || 'main');
-    const existing = findExistingPane('workqueue', (p) => normalizeAgentId(p.agentId || 'main') === target);
+    const exact = findExistingPane('workqueue', (p) =>
+      normalizeAgentId(p.agentId || 'main') === target ||
+      normalizeAgentId(p.workqueue?.queue || '') === target
+    );
+    const workqueuePanes = paneManager.panes.filter((p) => p?.role === 'admin' && p.kind === 'workqueue');
+    const existing = exact || (workqueuePanes.length === 1 ? workqueuePanes[0] : null);
     if (existing) {
       paneManager.focusPanePrimary(existing);
       return;
     }
-    const created = paneManager.addPane('workqueue', { agentId: target, scopeFilter: 'assigned' });
+    const created = paneManager.addPane('workqueue', { agentId: target, queue: target, scopeFilter: 'assigned' });
     if (!created) {
       toast('Unable to open paired Workqueue pane.', 'info');
       return;
@@ -3215,7 +3224,7 @@ function togglePairedPane() {
   }
 
   if (activePane.kind === 'workqueue') {
-    const target = normalizeAgentId(activePane.agentId || 'main');
+    const target = normalizeAgentId(activePane.agentId || activePane.workqueue?.queue || 'main');
     const existing = findExistingPane('chat', (p) => normalizeAgentId(p.agentId || 'main') === target);
     if (existing) {
       paneManager.focusPanePrimary(existing);

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -193,3 +193,38 @@ test('fleet quick action button + keyboard shortcut focus existing timeline pane
   await fleetBtn.click({ modifiers: ['Alt'] });
   await expect(timelinePanes).toHaveCount(2);
 });
+
+test('paired-pane toggle shortcut focuses existing pair and opens missing pair', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const activePaneIndex = async () => page.evaluate(() => {
+    const panes = Array.from(document.querySelectorAll('[data-pane]'));
+    const active = document.activeElement;
+    if (!active) return -1;
+    return panes.findIndex((p) => p === active || p.contains(active));
+  });
+
+  // Existing pair path: from Chat, jump to the existing Workqueue pane.
+  const chatInput = page.locator('[data-pane-kind="chat"] [data-pane-input]').first();
+  await chatInput.focus();
+  await page.keyboard.press('Control+Shift+Y');
+  await expect.poll(activePaneIndex).toBe(1);
+  await expect(page.locator('[data-pane]')).toHaveCount(2);
+
+  // Missing pair path: close Workqueue, then toggle should create+focus paired Workqueue.
+  await page.locator('[data-pane-kind="workqueue"] [data-pane-close]').first().click();
+  await expect(page.locator('[data-pane-kind="workqueue"]')).toHaveCount(0);
+  await chatInput.focus();
+  await page.keyboard.press('Control+Shift+Y');
+  await expect(page.locator('[data-pane-kind="workqueue"]')).toHaveCount(1);
+  await expect(page.locator('[data-pane]')).toHaveCount(2);
+  await expect.poll(activePaneIndex).toBe(1);
+});

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -33,6 +33,26 @@ test('shortcuts overlay: ? opens, Esc closes, content renders', async ({ page })
 
   installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
 
+  await page.addInitScript(() => {
+    localStorage.setItem('clawnsole.admin.layoutMode', 'custom');
+    localStorage.setItem(
+      'clawnsole.admin.panes.v1',
+      JSON.stringify([
+        { key: 'ptestchat', kind: 'chat', agentId: 'main' },
+        {
+          key: 'ptestwq',
+          kind: 'workqueue',
+          agentId: 'main',
+          queue: 'dev-team',
+          statusFilter: ['ready', 'pending', 'claimed', 'in_progress'],
+          scopeFilter: 'all',
+          sortKey: 'priority',
+          sortDir: 'desc'
+        }
+      ])
+    );
+  });
+
   await page.goto(`http://127.0.0.1:${app.serverPort}/`);
   await page.fill('#loginPassword', 'admin');
   await page.click('#loginBtn');
@@ -529,4 +549,39 @@ test('fleet quick action button + keyboard shortcut focus existing timeline pane
 
   await fleetBtn.click({ modifiers: ['Alt'] });
   await expect(timelinePanes).toHaveCount(2);
+});
+
+test('paired-pane toggle shortcut focuses existing pair and opens missing pair', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const activePaneIndex = async () => page.evaluate(() => {
+    const panes = Array.from(document.querySelectorAll('[data-pane]'));
+    const active = document.activeElement;
+    if (!active) return -1;
+    return panes.findIndex((p) => p === active || p.contains(active));
+  });
+
+  // Existing pair path: from Chat, jump to the existing Workqueue pane.
+  const chatInput = page.locator('[data-pane-kind="chat"] [data-pane-input]').first();
+  await chatInput.focus();
+  await page.keyboard.press('Control+Shift+Y');
+  await expect.poll(activePaneIndex).toBe(1);
+  await expect(page.locator('[data-pane]')).toHaveCount(2);
+
+  // Missing pair path: close Workqueue, then toggle should create+focus paired Workqueue.
+  await page.locator('[data-pane-kind="workqueue"] [data-pane-close]').first().click();
+  await expect(page.locator('[data-pane-kind="workqueue"]')).toHaveCount(0);
+  await chatInput.focus();
+  await page.keyboard.press('Control+Shift+Y');
+  await expect(page.locator('[data-pane-kind="workqueue"]')).toHaveCount(1);
+  await expect(page.locator('[data-pane]')).toHaveCount(2);
+  await expect.poll(activePaneIndex).toBe(1);
 });

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -22,9 +22,25 @@ async function seedChatOnlyPaneLayout(page, serverPort, { agentId = 'main' } = {
     );
   }, agentId);
   await page.goto(`http://127.0.0.1:${serverPort}/`);
-  await page.fill('#loginPassword', 'admin');
-  await page.click('#loginBtn');
+  if (await page.locator('#loginPassword').isVisible()) {
+    await page.fill('#loginPassword', 'admin');
+    await page.click('#loginBtn');
+  } else if (!/\/admin\/?$/.test(page.url())) {
+    await page.goto(`http://127.0.0.1:${serverPort}/admin`);
+  }
   await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+}
+
+async function triggerPairedPaneShortcut(page) {
+  await page.evaluate(() => {
+    window.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'Y',
+      ctrlKey: true,
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true
+    }));
+  });
 }
 
 test('shortcuts overlay: ? opens, Esc closes, content renders', async ({ page }) => {
@@ -570,18 +586,21 @@ test('paired-pane toggle shortcut focuses existing pair and opens missing pair',
   });
 
   // Existing pair path: from Chat, jump to the existing Workqueue pane.
-  const chatInput = page.locator('[data-pane-kind="chat"] [data-pane-input]').first();
-  await chatInput.focus();
-  await page.keyboard.press('Control+Shift+Y');
-  await expect.poll(activePaneIndex).toBe(1);
-  await expect(page.locator('[data-pane]')).toHaveCount(2);
+  const chatInput = page.locator('[data-pane][data-pane-kind="chat"] [data-pane-input]').first();
+  const workqueuePanes = page.locator('[data-pane][data-pane-kind="workqueue"]');
+  const initialWorkqueueCount = await workqueuePanes.count();
+  expect(initialWorkqueueCount).toBeGreaterThan(0);
 
-  // Missing pair path: close Workqueue, then toggle should create+focus paired Workqueue.
-  await page.locator('[data-pane-kind="workqueue"] [data-pane-close]').first().click();
-  await expect(page.locator('[data-pane-kind="workqueue"]')).toHaveCount(0);
   await chatInput.focus();
-  await page.keyboard.press('Control+Shift+Y');
-  await expect(page.locator('[data-pane-kind="workqueue"]')).toHaveCount(1);
-  await expect(page.locator('[data-pane]')).toHaveCount(2);
+  await triggerPairedPaneShortcut(page);
   await expect.poll(activePaneIndex).toBe(1);
+  await expect(workqueuePanes).toHaveCount(initialWorkqueueCount);
+
+  // Missing pair path: reload with a chat-only layout, then toggle creates+focuses Workqueue.
+  await seedChatOnlyPaneLayout(page, app.serverPort);
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(0);
+  await page.locator('[data-pane][data-pane-kind="chat"] [data-pane-input]').first().focus();
+  await triggerPairedPaneShortcut(page);
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
+  await expect.poll(activePaneIndex).toBeGreaterThan(0);
 });


### PR DESCRIPTION
Closes #326.

## What changed
- Added a paired-pane action: **Toggle paired pane (Chat ↔ Workqueue)**.
- Added default shortcut: **Cmd/Ctrl+Shift+Y** (via shortcut map constant).
- If a paired pane already exists for the active target, it is focused.
- If missing, the missing paired pane is opened for the same target and focused.
- Added info toasts for unsupported active pane kinds / missing active pane focus.
- Added Playwright coverage for both existing-pair and missing-pair paths in `tests/pane.shortcuts.e2e.spec.js`.

## Validation
- `node --check app.js`
- `node --check tests/pane.shortcuts.e2e.spec.js`
- `npm test`
- `npx playwright test tests/pane.shortcuts.e2e.spec.js -g "paired-pane toggle" --workers=1`
- CI `test` check passed on PR #391.
