### PR TITLE
fix: canonicalize issue dedupe keys across hash/colon variants

### DIFF
--- a/lib/workqueue.js
+++ b/lib/workqueue.js
@@ -156,16 +156,42 @@ function createItem({ queue, title, instructions, priority }) {
   };
 }
 
+function normalizeIssueDedupeKey(value) {
+  const raw = String(value || '').trim();
+  if (!raw) return '';
+
+  // Accept both legacy and canonical issue shapes, then normalize to:
+  //   owner/repo#<issueNumber>
+  // Supported inputs:
+  //   issue:owner/repo#123
+  //   issue:owner/repo:123
+  //   owner/repo#123
+  //   owner/repo:123
+  const m = raw.match(/^(?:issue:)?([^\s/:#]+\/[^\s/:#]+)[#:](\d+)$/i);
+  if (!m) return raw;
+  const repo = m[1].toLowerCase();
+  const num = String(Number.parseInt(m[2], 10));
+  if (!num || num === 'NaN') return raw;
+  return `${repo}#${num}`;
+}
+
+function normalizeDedupeKey(value) {
+  const raw = String(value || '').trim();
+  if (!raw) return '';
+  return normalizeIssueDedupeKey(raw);
+}
+
 
 
 function findItemByDedupeKey(state, { queue, dedupeKey }) {
   const q = String(queue || '').trim();
-  const key = String(dedupeKey || '').trim();
+  const key = normalizeDedupeKey(dedupeKey);
   if (!q || !key) return null;
   // Search newest-first so if there are multiple (e.g. old data), we return the most recent.
   for (let i = state.items.length - 1; i >= 0; i--) {
     const it = state.items[i];
-    if (it && it.queue === q && it.dedupeKey === key) return it;
+    const existingKey = normalizeDedupeKey(it?.dedupeKey);
+    if (it && it.queue === q && existingKey === key) return it;
   }
   return null;
 }
@@ -176,7 +202,7 @@ function enqueueItem(rootDir, { queue, title, instructions, priority, dedupeKey 
     const state = loadState(rootDir);
     ensureQueue(state, queue);
 
-    const key = String(dedupeKey || '').trim();
+    const key = normalizeDedupeKey(dedupeKey);
     if (key) {
       const existing = findItemByDedupeKey(state, { queue, dedupeKey: key });
       if (existing) {
@@ -474,5 +500,7 @@ module.exports = {
   setAssignments,
   resolveClaimQueues,
   // exported for tests
-  findItemByDedupeKey
+  findItemByDedupeKey,
+  normalizeIssueDedupeKey,
+  normalizeDedupeKey
 };

--- a/tests/unit/workqueue.test.js
+++ b/tests/unit/workqueue.test.js
@@ -256,3 +256,30 @@ test('workqueue: enqueue supports dedupeKey idempotency', () => {
   const state = loadState(root);
   assert.equal(state.items.length, 1);
 });
+
+test('workqueue: issue dedupe keys are canonicalized across hash/colon + issue prefix variants', () => {
+  const root = tempRoot();
+
+  const first = enqueueItem(root, {
+    queue: 'dev-team',
+    title: 'Issue follow-up',
+    instructions: 'do it',
+    priority: 1,
+    dedupeKey: 'issue:rmdmattingly/clawnsole:398'
+  });
+
+  const second = enqueueItem(root, {
+    queue: 'dev-team',
+    title: 'Issue follow-up duplicate',
+    instructions: 'do it',
+    priority: 1,
+    dedupeKey: 'rmdmattingly/clawnsole#398'
+  });
+
+  assert.equal(second.id, first.id);
+  assert.equal(second._deduped, true);
+
+  const state = loadState(root);
+  assert.equal(state.items.length, 1);
+  assert.equal(state.items[0].dedupeKey, 'rmdmattingly/clawnsole#398');
+});


### PR DESCRIPTION
## Summary
Normalize issue-backed workqueue dedupe keys to a single canonical form (`owner/repo#number`) so mixed producer formats (`issue:owner/repo:number`, `owner/repo:number`, etc.) dedupe correctly.

## Changes
- Added `normalizeIssueDedupeKey` + `normalizeDedupeKey` in `lib/workqueue.js`.
- Canonicalized dedupe keys during enqueue and dedupe lookup.
- Dedupe lookup now compares normalized forms for existing historical rows.
- Added regression test covering colon/hash + `issue:` prefix variants.

## Test
- `node --test tests/unit/workqueue.test.js`

Closes #398
