### PR TITLE
feat: keyboard triage loop in Agents modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -397,6 +397,7 @@ let agentAutoRefreshInterval = null;
 let agentsModalAutoRefreshInterval = null;
 let agentsModalFreshnessTicker = null;
 let agentsLastRefreshedAtMs = 0;
+let agentsModalSelectedAgentId = '';
 
 function startAgentAutoRefresh() {
   if (roleState.role !== 'admin') return;
@@ -2028,8 +2029,36 @@ function openAgentsModal() {
 function closeAgentsModal() {
   globalElements.agentsModal?.classList.remove('open');
   globalElements.agentsModal?.setAttribute('aria-hidden', 'true');
+  agentsModalSelectedAgentId = '';
   stopAgentsModalAutoRefresh();
   stopAgentsModalFreshnessTicker();
+}
+
+function setAgentsModalSelectedAgent(agentId) {
+  agentsModalSelectedAgentId = String(agentId || '').trim();
+  const rows = Array.from(document.querySelectorAll('#agentsList .agents-row[data-agent-row-id]'));
+  rows.forEach((row) => {
+    const id = String(row.getAttribute('data-agent-row-id') || '').trim();
+    const active = !!id && id === agentsModalSelectedAgentId;
+    row.classList.toggle('agents-row-active', active);
+    row.setAttribute('aria-selected', active ? 'true' : 'false');
+  });
+}
+
+function moveAgentsModalSelection(delta) {
+  const rows = Array.from(document.querySelectorAll('#agentsList .agents-row[data-agent-row-id]'));
+  if (!rows.length) return;
+
+  let idx = rows.findIndex((row) => String(row.getAttribute('data-agent-row-id') || '') === agentsModalSelectedAgentId);
+  if (idx < 0) idx = 0;
+  const nextIdx = ((idx + Number(delta || 0)) % rows.length + rows.length) % rows.length;
+  const nextRow = rows[nextIdx];
+  const nextId = String(nextRow?.getAttribute('data-agent-row-id') || '').trim();
+  if (!nextId) return;
+  setAgentsModalSelectedAgent(nextId);
+  try {
+    nextRow.scrollIntoView({ block: 'nearest' });
+  } catch {}
 }
 
 function findExistingPane(kind, predicate = null) {
@@ -2169,6 +2198,9 @@ function renderAgentsModalList() {
       const id = String(agent?.id || '').trim();
       const row = document.createElement('div');
       row.className = 'agents-row';
+      row.setAttribute('data-agent-row-id', id);
+      row.setAttribute('role', 'option');
+      row.setAttribute('aria-selected', 'false');
 
       const label = formatAgentLabel(agent, { includeId: true });
       const pinnedNow = pins.has(id);
@@ -2222,6 +2254,8 @@ function renderAgentsModalList() {
         });
       });
 
+      row.addEventListener('click', () => setAgentsModalSelectedAgent(id));
+
       list.appendChild(row);
     }
 
@@ -2234,6 +2268,19 @@ function renderAgentsModalList() {
 
   const empty = pinned.length === 0 && rest.length === 0;
   if (globalElements.agentsEmpty) globalElements.agentsEmpty.hidden = !empty;
+
+  if (empty) {
+    agentsModalSelectedAgentId = '';
+    return;
+  }
+
+  const rows = Array.from(root.querySelectorAll('.agents-row[data-agent-row-id]'));
+  const hasCurrent = rows.some((row) => String(row.getAttribute('data-agent-row-id') || '').trim() === agentsModalSelectedAgentId);
+  if (!hasCurrent) {
+    const firstId = String(rows[0]?.getAttribute('data-agent-row-id') || '').trim();
+    agentsModalSelectedAgentId = firstId;
+  }
+  setAgentsModalSelectedAgent(agentsModalSelectedAgentId);
 }
 
 // Workqueue (admin-only)
@@ -6754,6 +6801,32 @@ globalElements.agentsBtn?.addEventListener('click', () => openAgentsModal());
 globalElements.agentsCloseBtn?.addEventListener('click', () => closeAgentsModal());
 globalElements.agentsModal?.addEventListener('click', (event) => {
   if (event.target === globalElements.agentsModal) closeAgentsModal();
+});
+globalElements.agentsModal?.addEventListener('keydown', (event) => {
+  if (!globalElements.agentsModal?.classList?.contains('open')) return;
+
+  const target = event.target;
+  const isEditable =
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    target instanceof HTMLSelectElement ||
+    (target instanceof HTMLElement && target.isContentEditable);
+
+  if (!isEditable && !event.metaKey && !event.ctrlKey && !event.altKey && (event.key === 'j' || event.key === 'k')) {
+    event.preventDefault();
+    event.stopPropagation();
+    moveAgentsModalSelection(event.key === 'j' ? 1 : -1);
+    return;
+  }
+
+  if (event.key === 'Enter' && !event.metaKey && !event.ctrlKey && !event.altKey) {
+    const selected = agentsModalSelectedAgentId;
+    if (!selected) return;
+    event.preventDefault();
+    event.stopPropagation();
+    if (event.shiftKey) openAgentWorkqueueFromFleet();
+    else openAgentChatFromFleet(selected);
+  }
 });
 
 globalElements.agentsSearch?.addEventListener('input', () => renderAgentsModalList());

--- a/app.js
+++ b/app.js
@@ -4283,10 +4283,11 @@ function moveFleetSelection(delta) {
   return true;
 }
 
-function runFleetSelectedAgent() {
+function runFleetSelectedAgent({ workqueue = false } = {}) {
   const id = String(fleetSelectionState.selectedAgentId || '').trim();
   if (!id) return false;
-  openAgentTriageFromFleet(id);
+  if (workqueue) openAgentWorkqueueFromFleet(id);
+  else openAgentChatFromFleet(id);
   return true;
 }
 
@@ -10273,7 +10274,7 @@ globalElements.agentsModal?.addEventListener('keydown', (event) => {
     }
     if (key === 'Enter') {
       event.preventDefault();
-      runFleetSelectedAgent();
+      runFleetSelectedAgent({ workqueue: event.shiftKey });
       return;
     }
   }

--- a/styles.css
+++ b/styles.css
@@ -1389,6 +1389,11 @@ button.send-btn .btn-icon {
   background: rgba(255, 255, 255, 0.02);
 }
 
+.agents-row.agents-row-active {
+  border-color: rgba(126, 168, 255, 0.65);
+  background: rgba(126, 168, 255, 0.08);
+}
+
 .agents-pin {
   width: 36px;
   height: 36px;

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -83,3 +83,26 @@ test('agents modal quick actions open/reuse chat, timeline, and workqueue contex
   await firstRow.locator('[data-agent-action="open-workqueue"]').first().click();
   await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
 });
+
+test('agents modal keyboard triage loop supports j/k + enter/shift+enter', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  await clawnsole.gotoAndLoginAdmin(page);
+
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsModal')).toHaveClass(/open/);
+
+  // Ensure key events hit modal container (not the search input).
+  await page.locator('#agentsModal').click();
+
+  await expect(page.locator('#agentsList .agents-row.agents-row-active')).toHaveCount(1);
+
+  await page.keyboard.press('j');
+  await expect(page.locator('#agentsList .agents-row.agents-row-active')).toHaveCount(1);
+
+  await page.keyboard.press('Enter');
+  await expect(page.locator('[data-pane][data-pane-kind="chat"]').first()).toBeVisible();
+
+  await page.keyboard.press('Shift+Enter');
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
+});

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -304,13 +304,16 @@ test('fleet refresh keeps scroll anchor and keyboard triage selection', async ({
   await expect(page.locator('#agentsList .agents-row[data-agent-id="agent-21"]')).toHaveAttribute('aria-selected', 'true');
   await page.keyboard.press('k');
   await expect(row20).toHaveAttribute('aria-selected', 'true');
+  await page.keyboard.press('Shift+Enter');
+  await expect.poll(async () => (
+    page.locator('[data-pane][data-pane-kind="workqueue"] [data-wq-claim-agent]')
+      .evaluateAll((els) => els.map((el) => el.value))
+  )).toContain('agent-20');
+
+  await row20.click();
   await page.keyboard.press('Enter');
   await expect.poll(async () => (
     page.locator('[data-pane][data-pane-kind="chat"] [data-pane-agent-select]')
-      .evaluateAll((els) => els.map((el) => el.value))
-  )).toContain('agent-20');
-  await expect.poll(async () => (
-    page.locator('[data-pane][data-pane-kind="workqueue"] [data-wq-claim-agent]')
       .evaluateAll((els) => els.map((el) => el.value))
   )).toContain('agent-20');
 });


### PR DESCRIPTION
## Summary
- keep Agents modal row selection navigation on j/k and arrow keys
- make Enter open/focus Chat for the selected agent
- make Shift+Enter open/focus Workqueue for the selected agent
- update UI coverage for the split keyboard actions

## Testing
- npm run test:syntax
- npx playwright test tests/ui/agents-modal.spec.js -g "keyboard triage" --workers=1

Closes #383