### PR TITLE
Fix #397: topbar Workqueue opens/focuses paired target pane

### DIFF
--- a/app.js
+++ b/app.js
@@ -2104,6 +2104,45 @@ function openAgentWorkqueueFromFleet() {
   paneManager.focusPanePrimary(pane);
 }
 
+function findActivePaneFromFocus() {
+  const active = document.activeElement;
+  if (!active) return null;
+  return paneManager.panes.find((pane) => {
+    const root = pane?.elements?.root;
+    return !!(root && (root === active || root.contains(active)));
+  }) || null;
+}
+
+function getActiveChatTargetForWorkqueuePairing() {
+  const activePane = findActivePaneFromFocus();
+  if (activePane?.kind === 'chat') {
+    return normalizeAgentId(activePane.agentId || 'main');
+  }
+  return '';
+}
+
+function openOrFocusPairedWorkqueuePaneForTarget(target) {
+  const nextTarget = normalizeAgentId(target || '');
+  if (!nextTarget) return false;
+
+  const pane =
+    findExistingPane('workqueue', (p) => normalizeAgentId(p?.workqueue?.queue || '') === nextTarget) ||
+    paneManager.addPane('workqueue', { queue: nextTarget });
+  if (!pane) return false;
+
+  pane.workqueue = pane.workqueue || {};
+  pane.workqueue.queue = nextTarget;
+  paneManager.persistAdminPanes();
+  paneManager.focusPanePrimary(pane);
+  return true;
+}
+
+function openTopbarWorkqueueAction() {
+  const activeChatTarget = getActiveChatTargetForWorkqueuePairing();
+  if (activeChatTarget && openOrFocusPairedWorkqueuePaneForTarget(activeChatTarget)) return;
+  openWorkqueue();
+}
+
 function renderAgentsModalList() {
   const root = globalElements.agentsList;
   if (!root) return;
@@ -6803,7 +6842,7 @@ window.addEventListener('focus', () => {
   refreshAgents({ reason: 'fleet_focus_resume' }).catch(() => {});
 });
 
-globalElements.workqueueBtn?.addEventListener('click', () => openWorkqueue());
+globalElements.workqueueBtn?.addEventListener('click', () => openTopbarWorkqueueAction());
 globalElements.fleetBtn?.addEventListener('click', (event) => {
   const forceNew = !!event?.altKey;
   openFleetPane({ forceNew });

--- a/app.js
+++ b/app.js
@@ -1833,7 +1833,7 @@ function buildCommandPaletteItems() {
       '?'
     ),
     withShortcut(
-      { id: 'cmd:open-workqueue', label: 'Workqueue: Open modal', detail: 'Open the Workqueue modal', run: () => openWorkqueue() },
+      { id: 'cmd:open-workqueue', label: 'Workqueue: Open', detail: 'Open Workqueue for the active chat target', run: () => openTopbarWorkqueueAction() },
       'g w'
     ),
     withShortcut(
@@ -2102,6 +2102,47 @@ function openAgentWorkqueueFromFleet() {
   if (!pane) return;
 
   paneManager.focusPanePrimary(pane);
+}
+
+function findActivePaneFromFocus() {
+  const active = document.activeElement;
+  if (!active) return null;
+  return paneManager.panes.find((pane) => {
+    const root = pane?.elements?.root;
+    return !!(root && (root === active || root.contains(active)));
+  }) || null;
+}
+
+function getActiveChatTargetForWorkqueuePairing() {
+  const focusedPane = findActivePaneFromFocus();
+  const rememberedPane = paneManager.panes.find((pane) => pane?.key && pane.key === paneManager.lastFocusedPaneKey) || null;
+  const activePane = focusedPane || rememberedPane;
+  if (activePane?.kind === 'chat') {
+    return normalizeAgentId(activePane.agentId || 'main');
+  }
+  return '';
+}
+
+function openOrFocusPairedWorkqueuePaneForTarget(target) {
+  const nextTarget = normalizeAgentId(target || '');
+  if (!nextTarget) return false;
+
+  const pane =
+    findExistingPane('workqueue', (p) => normalizeAgentId(p?.workqueue?.queue || '') === nextTarget) ||
+    paneManager.addPane('workqueue', { queue: nextTarget });
+  if (!pane) return false;
+
+  pane.workqueue = pane.workqueue || {};
+  pane.workqueue.queue = nextTarget;
+  paneManager.persistAdminPanes();
+  paneManager.focusPanePrimary(pane);
+  return true;
+}
+
+function openTopbarWorkqueueAction() {
+  const activeChatTarget = getActiveChatTargetForWorkqueuePairing();
+  if (activeChatTarget && openOrFocusPairedWorkqueuePaneForTarget(activeChatTarget)) return;
+  openWorkqueue();
 }
 
 function renderAgentsModalList() {
@@ -4978,6 +5019,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
   }
 
   elements.root?.addEventListener('focusin', () => {
+    paneManager.lastFocusedPaneKey = pane.key;
     clearPaneUnread(pane);
   });
 
@@ -6121,6 +6163,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
 const paneManager = {
   panes: [],
   maxPanes: 6,
+  lastFocusedPaneKey: '',
   init() {
     this.destroyAll();
 
@@ -6803,7 +6846,7 @@ window.addEventListener('focus', () => {
   refreshAgents({ reason: 'fleet_focus_resume' }).catch(() => {});
 });
 
-globalElements.workqueueBtn?.addEventListener('click', () => openWorkqueue());
+globalElements.workqueueBtn?.addEventListener('click', () => openTopbarWorkqueueAction());
 globalElements.fleetBtn?.addEventListener('click', (event) => {
   const forceNew = !!event?.altKey;
   openFleetPane({ forceNew });
@@ -7058,7 +7101,7 @@ window.addEventListener('keydown', (event) => {
     return;
   }
 
-  // 'g w' opens Workqueue modal.
+  // 'g w' opens Workqueue for the active chat target when available.
   const now = Date.now();
   if (!event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey) {
     if (key.toLowerCase() === 'g') {
@@ -7068,7 +7111,7 @@ window.addEventListener('keydown', (event) => {
     if (key.toLowerCase() === 'w' && shortcutState.lastGAtMs && now - shortcutState.lastGAtMs < 1000) {
       shortcutState.lastGAtMs = 0;
       event.preventDefault();
-      openWorkqueue();
+      openTopbarWorkqueueAction();
       return;
     }
   }

--- a/tests/ui/chat-pane.spec.js
+++ b/tests/ui/chat-pane.spec.js
@@ -77,3 +77,28 @@ test('chat pane: stop button can cancel a running response', async ({ page }) =>
   // Cancel should not still emit a completed reply after stream is stopped.
   await expect(pane.locator('.chat-bubble.assistant')).not.toContainText('mock-reply: please stream this', { timeout: 3000 });
 });
+
+test('topbar workqueue action reuses paired pane for active chat target and falls back to modal', async ({ page }) => {
+  test.setTimeout(120000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+
+  // Default layout already has Chat + Workqueue; with active chat focus,
+  // topbar Workqueue should focus/reuse the paired pane (not open modal).
+  const chatPane = page.locator('[data-pane][data-pane-kind="chat"]').first();
+  await chatPane.locator('[data-pane-input]').focus();
+
+  await page.locator('#workqueueBtn').click();
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
+  await expect(page.locator('#workqueueModal')).not.toHaveClass(/open/);
+
+  // When a non-chat pane is active, preserve modal fallback behavior.
+  const workqueuePane = page.locator('[data-pane][data-pane-kind="workqueue"]').first();
+  await workqueuePane.locator('[data-wq-queue-select]').focus();
+
+  await page.locator('#workqueueBtn').click();
+  await expect(page.locator('#workqueueModal')).toHaveClass(/open/);
+});


### PR DESCRIPTION
## Summary
- make topbar **Open workqueue** action prefer the active chat pane target
- reuse an existing Workqueue pane already targeted to that agent, otherwise create one pre-targeted to that agent
- preserve existing fallback: when no chat pane is active, keep opening the Workqueue modal
- add Playwright coverage for paired-pane reuse and fallback behavior

Closes #397

## Testing
- node --check app.js
- npm test -- tests/ui/chat-pane.spec.js *(fails in this environment due missing optional test dependency: ws in unit preflight)*
