### PR TITLE
Workqueue: add high-volume all-scope downscope guardrail

### DIFF
--- a/app.js
+++ b/app.js
@@ -2849,6 +2849,7 @@ function renderWorkqueuePaneItems(pane) {
 
   const itemsRaw = Array.isArray(pane.workqueue?.items) ? pane.workqueue.items : [];
   const scope = pane.workqueue?.scopeFilter || 'all';
+  const guardrailThreshold = getWorkqueueAllScopeGuardrailThreshold();
   const activeTarget = String(pane.agentId || '').trim();
   const getOwner = (it) => String(it?.claimedBy || it?.assignee || it?.assignedTo || it?.agentId || '').trim();
   const scopedItems = itemsRaw.filter((it) => {
@@ -2858,6 +2859,29 @@ function renderWorkqueuePaneItems(pane) {
     return true;
   });
   const items = sortWorkqueueItems(scopedItems, { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
+
+  const guardrailEl = pane.elements?.thread?.querySelector('[data-wq-all-scope-guardrail]');
+  const shouldShowGuardrail = scope === 'all'
+    && items.length > guardrailThreshold
+    && !pane.workqueue?.allScopeGuardrailDismissed;
+  if (guardrailEl) {
+    if (shouldShowGuardrail) {
+      guardrailEl.hidden = false;
+      const countEl = guardrailEl.querySelector('[data-wq-all-scope-count]');
+      if (countEl) countEl.textContent = String(items.length);
+      if (!pane.workqueue?.allScopeGuardrailShownOnce) {
+        pane.workqueue.allScopeGuardrailShownOnce = true;
+        logWorkqueueGuardrailEvent('shown', {
+          paneId: pane.id,
+          queue: String(pane.workqueue?.queue || 'dev-team'),
+          count: items.length,
+          threshold: guardrailThreshold
+        });
+      }
+    } else {
+      guardrailEl.hidden = true;
+    }
+  }
 
   if (empty) {
     const hasItems = items.length > 0;
@@ -3429,6 +3453,19 @@ const ADMIN_PANES_KEY = 'clawnsole.admin.panes.v1';
 // Layout is inferred from pane count; no manual layout toggle.
 const ADMIN_DEFAULT_AGENT_KEY = 'clawnsole.admin.agentId';
 const WORKQUEUE_SCOPE_PREF_KEY = 'clawnsole.admin.workqueue.scope.v1';
+const WORKQUEUE_ALL_SCOPE_GUARDRAIL_THRESHOLD_DEFAULT = 200;
+
+function getWorkqueueAllScopeGuardrailThreshold() {
+  const raw = Number(window?.CLAWNSOLE_CONFIG?.workqueueAllScopeGuardrailThreshold);
+  if (Number.isFinite(raw) && raw > 0) return Math.floor(raw);
+  return WORKQUEUE_ALL_SCOPE_GUARDRAIL_THRESHOLD_DEFAULT;
+}
+
+function logWorkqueueGuardrailEvent(event, payload = {}) {
+  try {
+    console.info('[workqueue-guardrail]', JSON.stringify({ event, at: new Date().toISOString(), ...payload }));
+  } catch {}
+}
 
 function normalizeWorkqueueScope(scope) {
   return scope === 'assigned' || scope === 'unassigned' ? scope : 'all';
@@ -4850,6 +4887,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       scopeFilter: normalizeWorkqueueScope(scopeFilter ?? getDefaultWorkqueueScope()),
       items: [],
       selectedItemId: null,
+      allScopeGuardrailDismissed: false,
+      allScopeGuardrailShownOnce: false,
       sortKey: typeof sortKey === 'string' && sortKey.trim() ? sortKey.trim() : 'priority',
       sortDir: sortDir === 'asc' ? 'asc' : 'desc'
     },
@@ -5031,6 +5070,13 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
             <button type="button" class="wq-scope-btn" data-wq-scope="assigned">Assigned to active target</button>
             <button type="button" class="wq-scope-btn" data-wq-scope="unassigned">Unassigned</button>
             <button type="button" class="wq-scope-btn" data-wq-scope="all">All</button>
+          </div>
+
+          <div class="wq-all-scope-guardrail" data-wq-all-scope-guardrail hidden>
+            <span class="wq-all-scope-guardrail-copy">Viewing all items (<span data-wq-all-scope-count>0</span>). Narrow scope?</span>
+            <button type="button" class="secondary" data-wq-all-scope-action="assigned">Assigned to active target</button>
+            <button type="button" class="secondary" data-wq-all-scope-action="unassigned">Unassigned</button>
+            <button type="button" class="ghost" data-wq-all-scope-dismiss>Dismiss</button>
           </div>
 
           <button data-wq-refresh class="secondary" type="button">Refresh</button>
@@ -5358,6 +5404,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     };
     const setScope = (scope) => {
       pane.workqueue.scopeFilter = normalizeWorkqueueScope(scope);
+      pane.workqueue.allScopeGuardrailDismissed = false;
+      pane.workqueue.allScopeGuardrailShownOnce = false;
       storage.set(WORKQUEUE_SCOPE_PREF_KEY, pane.workqueue.scopeFilter);
       updateScopeUi();
       renderWorkqueuePaneItems(pane);
@@ -5365,6 +5413,28 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     };
     scopeBtns.forEach((btn) => {
       btn.addEventListener('click', () => setScope(btn.getAttribute('data-wq-scope')));
+    });
+
+    const allScopeGuardrailEl = elements.thread.querySelector('[data-wq-all-scope-guardrail]');
+    allScopeGuardrailEl?.querySelectorAll('[data-wq-all-scope-action]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const nextScope = String(btn.getAttribute('data-wq-all-scope-action') || '').trim();
+        logWorkqueueGuardrailEvent('action', {
+          paneId: pane.id,
+          queue: String(pane.workqueue?.queue || 'dev-team'),
+          fromScope: 'all',
+          toScope: nextScope
+        });
+        setScope(nextScope);
+      });
+    });
+    allScopeGuardrailEl?.querySelector('[data-wq-all-scope-dismiss]')?.addEventListener('click', () => {
+      pane.workqueue.allScopeGuardrailDismissed = true;
+      logWorkqueueGuardrailEvent('dismissed', {
+        paneId: pane.id,
+        queue: String(pane.workqueue?.queue || 'dev-team')
+      });
+      renderWorkqueuePaneItems(pane);
     });
     updateScopeUi();
 

--- a/app.js
+++ b/app.js
@@ -4273,6 +4273,31 @@ function renderWorkqueuePaneItems(pane) {
     Number(pane.workqueue?.renderLimit || WORKQUEUE_PANE_INITIAL_RENDER_LIMIT)
   );
   const visibleItems = items.slice(0, renderLimit);
+  const scope = pane.workqueue?.scopeFilter || 'all';
+  const guardrailThreshold = getWorkqueueAllScopeGuardrailThreshold();
+
+  const guardrailEl = pane.elements?.thread?.querySelector('[data-wq-all-scope-guardrail]');
+  const shouldShowGuardrail = scope === 'all'
+    && items.length > guardrailThreshold
+    && !pane.workqueue?.allScopeGuardrailDismissed;
+  if (guardrailEl) {
+    if (shouldShowGuardrail) {
+      guardrailEl.hidden = false;
+      const countEl = guardrailEl.querySelector('[data-wq-all-scope-count]');
+      if (countEl) countEl.textContent = String(items.length);
+      if (!pane.workqueue?.allScopeGuardrailShownOnce) {
+        pane.workqueue.allScopeGuardrailShownOnce = true;
+        logWorkqueueGuardrailEvent('shown', {
+          paneId: pane.id,
+          queue: String(pane.workqueue?.queue || 'dev-team'),
+          count: items.length,
+          threshold: guardrailThreshold
+        });
+      }
+    } else {
+      guardrailEl.hidden = true;
+    }
+  }
 
   if (empty) {
     const hasItems = items.length > 0;
@@ -4864,6 +4889,19 @@ const ADMIN_PANES_KEY = 'clawnsole.admin.panes.v1';
 const ADMIN_LAYOUT_MODE_KEY = 'clawnsole.admin.layoutMode';
 const ADMIN_DEFAULT_AGENT_KEY = 'clawnsole.admin.agentId';
 const WORKQUEUE_SCOPE_PREF_KEY = 'clawnsole.admin.workqueue.scope.v1';
+const WORKQUEUE_ALL_SCOPE_GUARDRAIL_THRESHOLD_DEFAULT = 200;
+
+function getWorkqueueAllScopeGuardrailThreshold() {
+  const raw = Number(window?.CLAWNSOLE_CONFIG?.workqueueAllScopeGuardrailThreshold);
+  if (Number.isFinite(raw) && raw > 0) return Math.floor(raw);
+  return WORKQUEUE_ALL_SCOPE_GUARDRAIL_THRESHOLD_DEFAULT;
+}
+
+function logWorkqueueGuardrailEvent(event, payload = {}) {
+  try {
+    console.info('[workqueue-guardrail]', JSON.stringify({ event, at: new Date().toISOString(), ...payload }));
+  } catch {}
+}
 
 function normalizeWorkqueueScope(scope) {
   return scope === 'assigned' || scope === 'unassigned' ? scope : 'all';
@@ -6299,6 +6337,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       countItems: [],
       selectedItemId: null,
       renderLimit: WORKQUEUE_PANE_INITIAL_RENDER_LIMIT,
+      allScopeGuardrailDismissed: false,
+      allScopeGuardrailShownOnce: false,
       sortKey: typeof sortKey === 'string' && sortKey.trim() ? sortKey.trim() : 'priority',
       sortDir: sortDir === 'asc' ? 'asc' : 'desc'
     },
@@ -6518,6 +6558,14 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
 
           <button data-wq-preset-clawnsole class="secondary" type="button">Clawnsole only</button>
           <button data-wq-clear-quick class="secondary" type="button">Clear filters</button>
+
+          <div class="wq-all-scope-guardrail" data-wq-all-scope-guardrail hidden>
+            <span class="wq-all-scope-guardrail-copy">Viewing all items (<span data-wq-all-scope-count>0</span>). Narrow scope?</span>
+            <button type="button" class="secondary" data-wq-all-scope-action="assigned">Assigned to active target</button>
+            <button type="button" class="secondary" data-wq-all-scope-action="unassigned">Unassigned</button>
+            <button type="button" class="ghost" data-wq-all-scope-dismiss>Dismiss</button>
+          </div>
+
           <button data-wq-refresh class="secondary" type="button">Refresh</button>
 
           <div class="wq-sort" role="group" aria-label="Sort workqueue items">
@@ -6906,6 +6954,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     const setScope = (scope) => {
       pane.workqueue.scopeFilter = normalizeWorkqueueScope(scope);
       resetRenderLimit();
+      pane.workqueue.allScopeGuardrailDismissed = false;
+      pane.workqueue.allScopeGuardrailShownOnce = false;
       storage.set(WORKQUEUE_SCOPE_PREF_KEY, pane.workqueue.scopeFilter);
       pane.workqueue.statusCounts = buildWorkqueueStatusCounts(filterWorkqueuePaneItemsByScope(pane, pane.workqueue.countItems));
       if (typeof pane.workqueue.renderStatusMultiSelect === 'function') pane.workqueue.renderStatusMultiSelect();
@@ -6915,6 +6965,28 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     };
     scopeBtns.forEach((btn) => {
       btn.addEventListener('click', () => setScope(btn.getAttribute('data-wq-scope')));
+    });
+
+    const allScopeGuardrailEl = elements.thread.querySelector('[data-wq-all-scope-guardrail]');
+    allScopeGuardrailEl?.querySelectorAll('[data-wq-all-scope-action]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const nextScope = String(btn.getAttribute('data-wq-all-scope-action') || '').trim();
+        logWorkqueueGuardrailEvent('action', {
+          paneId: pane.id,
+          queue: String(pane.workqueue?.queue || 'dev-team'),
+          fromScope: 'all',
+          toScope: nextScope
+        });
+        setScope(nextScope);
+      });
+    });
+    allScopeGuardrailEl?.querySelector('[data-wq-all-scope-dismiss]')?.addEventListener('click', () => {
+      pane.workqueue.allScopeGuardrailDismissed = true;
+      logWorkqueueGuardrailEvent('dismissed', {
+        paneId: pane.id,
+        queue: String(pane.workqueue?.queue || 'dev-team')
+      });
+      renderWorkqueuePaneItems(pane);
     });
     updateScopeUi();
 

--- a/styles.css
+++ b/styles.css
@@ -1828,6 +1828,26 @@ kbd {
   background: rgba(127, 209, 185, 0.12);
 }
 
+.wq-all-scope-guardrail {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+  flex-wrap: wrap;
+  padding: 6px 8px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 193, 102, 0.35);
+  background: rgba(255, 193, 102, 0.12);
+}
+
+.wq-all-scope-guardrail-copy {
+  font-size: 11px;
+  color: var(--text);
+}
+
+.wq-all-scope-guardrail[hidden] {
+  display: none !important;
+}
+
 .wq-enqueue {
   margin-top: 10px;
 }

--- a/styles.css
+++ b/styles.css
@@ -2218,6 +2218,26 @@ kbd {
   background: rgba(127, 209, 185, 0.12);
 }
 
+.wq-all-scope-guardrail {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+  flex-wrap: wrap;
+  padding: 6px 8px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 193, 102, 0.35);
+  background: rgba(255, 193, 102, 0.12);
+}
+
+.wq-all-scope-guardrail-copy {
+  font-size: 11px;
+  color: var(--text);
+}
+
+.wq-all-scope-guardrail[hidden] {
+  display: none !important;
+}
+
 .wq-enqueue {
   margin-top: 10px;
 }

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -116,3 +116,63 @@ test('workqueue pane: controls toolbar is sticky and list scrolls independently'
   });
   expect(['auto', 'scroll']).toContain(listStyles.overflowY);
 });
+
+test('workqueue pane: all-scope guardrail shows over threshold, downscopes, and stays hidden under threshold', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  const wqPane = page.locator('[data-pane]').last();
+  await wqPane.locator('[data-wq-scope="all"]').click();
+
+  // Keep the threshold tiny so we deterministically trigger with normal queue volume.
+  await page.evaluate(() => {
+    window.CLAWNSOLE_CONFIG = window.CLAWNSOLE_CONFIG || {};
+    window.CLAWNSOLE_CONFIG.workqueueAllScopeGuardrailThreshold = 1;
+  });
+
+  // Ensure enough visible items for threshold trigger.
+  await page.evaluate(async () => {
+    const mk = async (suffix) => {
+      await fetch('/api/workqueue/enqueue', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          queue: 'dev-team',
+          title: `guardrail-seed-${Date.now()}-${suffix}`,
+          priority: 0,
+          instructions: 'seed item for ui test'
+        })
+      });
+    };
+    await mk('a');
+    await mk('b');
+  });
+
+  const refreshRes = page.waitForResponse((res) => res.url().includes('/api/workqueue/items') && res.ok(), { timeout: 15000 });
+  await wqPane.locator('[data-wq-refresh]').click();
+  await refreshRes;
+
+  const guardrail = wqPane.locator('[data-wq-all-scope-guardrail]');
+  await expect(guardrail).toBeVisible();
+
+  await guardrail.locator('[data-wq-all-scope-action="unassigned"]').click();
+  await expect(wqPane.locator('[data-wq-scope="unassigned"]')).toHaveAttribute('aria-pressed', 'true');
+  await expect(guardrail).toBeHidden();
+
+  // Under threshold, prompt should not display.
+  await wqPane.locator('[data-wq-scope="all"]').click();
+  await page.evaluate(() => {
+    window.CLAWNSOLE_CONFIG = window.CLAWNSOLE_CONFIG || {};
+    window.CLAWNSOLE_CONFIG.workqueueAllScopeGuardrailThreshold = 999999;
+  });
+  const refreshRes2 = page.waitForResponse((res) => res.url().includes('/api/workqueue/items') && res.ok(), { timeout: 15000 });
+  await wqPane.locator('[data-wq-refresh]').click();
+  await refreshRes2;
+  await expect(guardrail).toBeHidden();
+});

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -578,3 +578,63 @@ test('workqueue pane: large queues render an initial capped slice and load more 
   await expect(pane.locator('.wq-row .wq-col.title')).toContainText('needle large list item');
   await expect(pane.locator('[data-wq-load-more]')).toHaveCount(0);
 });
+
+test('workqueue pane: all-scope guardrail shows over threshold, downscopes, and stays hidden under threshold', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  const wqPane = page.locator('[data-pane]').last();
+  await wqPane.locator('[data-wq-scope="all"]').click();
+
+  // Keep the threshold tiny so we deterministically trigger with normal queue volume.
+  await page.evaluate(() => {
+    window.CLAWNSOLE_CONFIG = window.CLAWNSOLE_CONFIG || {};
+    window.CLAWNSOLE_CONFIG.workqueueAllScopeGuardrailThreshold = 1;
+  });
+
+  // Ensure enough visible items for threshold trigger.
+  await page.evaluate(async () => {
+    const mk = async (suffix) => {
+      await fetch('/api/workqueue/enqueue', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          queue: 'dev-team',
+          title: `guardrail-seed-${Date.now()}-${suffix}`,
+          priority: 0,
+          instructions: 'seed item for ui test'
+        })
+      });
+    };
+    await mk('a');
+    await mk('b');
+  });
+
+  const refreshRes = page.waitForResponse((res) => res.url().includes('/api/workqueue/items') && res.ok(), { timeout: 15000 });
+  await wqPane.locator('[data-wq-refresh]').click();
+  await refreshRes;
+
+  const guardrail = wqPane.locator('[data-wq-all-scope-guardrail]');
+  await expect(guardrail).toBeVisible();
+
+  await guardrail.locator('[data-wq-all-scope-action="unassigned"]').click();
+  await expect(wqPane.locator('[data-wq-scope="unassigned"]')).toHaveAttribute('aria-pressed', 'true');
+  await expect(guardrail).toBeHidden();
+
+  // Under threshold, prompt should not display.
+  await wqPane.locator('[data-wq-scope="all"]').click();
+  await page.evaluate(() => {
+    window.CLAWNSOLE_CONFIG = window.CLAWNSOLE_CONFIG || {};
+    window.CLAWNSOLE_CONFIG.workqueueAllScopeGuardrailThreshold = 999999;
+  });
+  const refreshRes2 = page.waitForResponse((res) => res.url().includes('/api/workqueue/items') && res.ok(), { timeout: 15000 });
+  await wqPane.locator('[data-wq-refresh]').click();
+  await refreshRes2;
+  await expect(guardrail).toBeHidden();
+});


### PR DESCRIPTION
## Summary\n- add an inline all-scope guardrail when visible workqueue rows exceed a configurable threshold (default 200)\n- provide one-click downscope actions (Assigned to active target / Unassigned) plus session-scoped dismiss\n- emit structured console telemetry for guardrail shown/action/dismissed events\n- add Playwright coverage for threshold display, downscope action, and non-display under threshold\n\n## Test\n- npx playwright test tests/ui/workqueue-pane.spec.js -g "all-scope guardrail" --reporter=line\n