### PR TITLE
feat: active pane highlight + global active pane chip

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,6 +19,7 @@ const globalElements = {
   recurringPromptHistoryRows: document.getElementById('recurringPromptHistoryRows'),
   recurringPromptHistoryEmpty: document.getElementById('recurringPromptHistoryEmpty'),
   status: document.getElementById('connectionStatus'),
+  activePaneChip: document.getElementById('activePaneChip'),
   paneManagerBtn: document.getElementById('paneManagerBtn'),
   pulseCanvas: document.getElementById('pulseCanvas'),
   workqueueBtn: document.getElementById('workqueueBtn'),
@@ -1381,6 +1382,8 @@ function paneDuplicateKey(pane) {
 }
 
 function focusedPaneKey() {
+  const explicit = String(paneManager?.activePaneKey || '').trim();
+  if (explicit) return explicit;
   const active = document.activeElement;
   const panes = paneManager?.panes || [];
   const pane = panes.find((entry) => {
@@ -1388,6 +1391,32 @@ function focusedPaneKey() {
     return !!(root && active && (root === active || root.contains(active)));
   });
   return pane?.key || '';
+}
+
+function renderGlobalActivePaneChip() {
+  const chip = globalElements.activePaneChip;
+  if (!chip) return;
+  const key = String(paneManager?.activePaneKey || focusedPaneKey() || '').trim();
+  const pane = (paneManager?.panes || []).find((entry) => entry?.key === key) || null;
+  chip.textContent = `Active: ${pane ? paneSummaryLabel(pane) : '—'}`;
+}
+
+function updatePaneActiveVisualState() {
+  const activeKey = String(paneManager?.activePaneKey || '').trim();
+  (paneManager?.panes || []).forEach((pane) => {
+    const isActive = !!activeKey && pane?.key === activeKey;
+    pane?.elements?.root?.setAttribute('data-active', isActive ? 'true' : 'false');
+  });
+  renderGlobalActivePaneChip();
+}
+
+function setActivePaneKey(paneKey, { persist = true } = {}) {
+  const key = String(paneKey || '').trim();
+  if (!key) return;
+  if (!(paneManager?.panes || []).some((pane) => pane?.key === key)) return;
+  paneManager.activePaneKey = key;
+  if (persist && roleState.role === 'admin') storage.set(ADMIN_ACTIVE_PANE_KEY, key);
+  updatePaneActiveVisualState();
 }
 
 function paneUnreadCount(pane) {
@@ -3426,6 +3455,7 @@ renderPulse();
 // Panes
 
 const ADMIN_PANES_KEY = 'clawnsole.admin.panes.v1';
+const ADMIN_ACTIVE_PANE_KEY = 'clawnsole.admin.activePane.v1';
 // Layout is inferred from pane count; no manual layout toggle.
 const ADMIN_DEFAULT_AGENT_KEY = 'clawnsole.admin.agentId';
 const WORKQUEUE_SCOPE_PREF_KEY = 'clawnsole.admin.workqueue.scope.v1';
@@ -4978,8 +5008,10 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
   }
 
   elements.root?.addEventListener('focusin', () => {
+    setActivePaneKey(pane.key);
     clearPaneUnread(pane);
   });
+  elements.root?.addEventListener('pointerdown', () => setActivePaneKey(pane.key));
 
   // WORKQUEUE PANE
   if (pane.role === 'admin' && pane.kind === 'workqueue') {
@@ -6120,6 +6152,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
 /* inlined to AppCore */
 const paneManager = {
   panes: [],
+  activePaneKey: '',
   maxPanes: 6,
   init() {
     this.destroyAll();
@@ -6149,6 +6182,8 @@ const paneManager = {
       })
     );
     this.panes.forEach((pane) => globalElements.paneGrid.appendChild(pane.elements.root));
+    const storedActiveKey = String(storage.get(ADMIN_ACTIVE_PANE_KEY, '') || '').trim();
+    setActivePaneKey(storedActiveKey || this.panes[0]?.key || '', { persist: false });
     this.updatePaneLabels();
     this.updateCloseButtons();
     this.applyInferredLayout();
@@ -6164,6 +6199,8 @@ const paneManager = {
       } catch {}
     });
     this.panes = [];
+    this.activePaneKey = '';
+    updatePaneActiveVisualState();
   },
   loadAdminPanes() {
     const storedDefault = storage.get(ADMIN_DEFAULT_AGENT_KEY, 'main');
@@ -6347,6 +6384,7 @@ const paneManager = {
   },
   focusPanePrimary(pane) {
     if (!pane?.elements?.root) return;
+    setActivePaneKey(pane.key);
 
     // Defer until DOM has painted.
     setTimeout(() => {
@@ -6547,6 +6585,13 @@ const paneManager = {
     this.updateCloseButtons();
     this.applyInferredLayout();
     this.persistAdminPanes();
+    if (this.activePaneKey === key) {
+      const fallback = this.panes[Math.max(0, idx - 1)] || this.panes[0] || null;
+      setActivePaneKey(fallback?.key || '', { persist: true });
+      if (fallback) this.focusPanePrimary(fallback);
+    } else {
+      updatePaneActiveVisualState();
+    }
     updateGlobalStatus();
     updateConnectionControls();
   },
@@ -6576,6 +6621,7 @@ const paneManager = {
   updatePaneLabels() {
     this.panes.forEach((pane) => renderPaneIdentity(pane));
     this.updatePaneGridLabel();
+    updatePaneActiveVisualState();
   },
   updatePaneGridLabel() {
     const grid = globalElements.paneGrid;
@@ -7225,8 +7271,8 @@ window.addEventListener('load', () => {
 
       const isTouch = window.matchMedia && window.matchMedia('(hover: none) and (pointer: coarse)').matches;
       if (!isTouch) {
-        const firstPane = paneManager.panes[0];
-        firstPane?.elements.input?.focus();
+        const activePane = paneManager.panes.find((pane) => pane.key === paneManager.activePaneKey) || paneManager.panes[0];
+        paneManager.focusPanePrimary(activePane);
       }
     })
     .catch(() => {

--- a/app.js
+++ b/app.js
@@ -6898,7 +6898,6 @@ function isTypingShortcutExempt(event) {
   const key = String(event.key || '').toLowerCase();
   if (!event.metaKey && !event.ctrlKey) return false;
   if (event.altKey) return false;
-  if (event.shiftKey && ['c', 'w', 'r', 't', 'n'].includes(key)) return true;
   if (!event.shiftKey && ['k', 'p'].includes(key)) return true;
   return false;
 }

--- a/app.js
+++ b/app.js
@@ -6894,6 +6894,28 @@ function isTypingContext(target) {
   return false;
 }
 
+function isTypingShortcutExempt(event) {
+  const key = String(event.key || '').toLowerCase();
+  if (!event.metaKey && !event.ctrlKey) return false;
+  if (event.altKey) return false;
+  if (event.shiftKey && ['c', 'w', 'r', 't', 'n'].includes(key)) return true;
+  if (!event.shiftKey && ['k', 'p'].includes(key)) return true;
+  return false;
+}
+
+function isBlockingOverlayOpenForPaneShortcuts() {
+  const blockers = [
+    globalElements.loginOverlay,
+    globalElements.settingsModal,
+    globalElements.shortcutsModal,
+    globalElements.commandPaletteModal,
+    globalElements.paneManagerModal,
+    globalElements.workqueueModal,
+    globalElements.agentsModal
+  ];
+  return blockers.some((el) => !!el?.classList?.contains('open'));
+}
+
 function focusPaneIndex(idx) {
   const pane = paneManager.panes[idx];
   if (!pane) return;
@@ -6978,18 +7000,21 @@ window.addEventListener('keydown', (event) => {
   // If Pane Manager is open, it gets first dibs on keys.
   if (paneManagerHandleKeydown(event)) return;
 
+  // Never fire admin shortcuts while typing unless explicitly exempted.
+  if (isTypingContext(event.target) && !isTypingShortcutExempt(event)) return;
+
   // Add-pane shortcuts (admin-only)
   // Ctrl/Cmd+Shift+C → new chat
   // Ctrl/Cmd+Shift+W → new workqueue
   // Ctrl/Cmd+Shift+R → new cron
   // Ctrl/Cmd+Shift+T → new timeline
   const isAccel = (event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey;
-  if (isAccel && roleState.role === 'admin' && !isTypingContext(event.target)) {
+  if (isAccel && roleState.role === 'admin') {
     const key = String(event.key || '').toLowerCase();
     const map = { c: 'chat', w: 'workqueue', r: 'cron', t: 'timeline' };
     const kind = map[key];
     if (kind) {
-      // Don't hijack add-pane shortcuts while typing in inputs/editors.
+      if (isBlockingOverlayOpenForPaneShortcuts()) return;
       event.preventDefault();
       paneManager.closeAddPaneMenu();
       paneManager.addPane(kind);

--- a/index.html
+++ b/index.html
@@ -30,6 +30,9 @@
           </div>
         </div>
         <div class="topbar-actions">
+          <div class="active-pane-chip" id="activePaneChip" data-testid="active-pane-chip" aria-live="polite" title="Currently active pane">
+            Active: —
+          </div>
           <div class="status compact">
             <div class="status-pill" id="connectionStatus" data-testid="connection-status">disconnected</div>
             <button

--- a/styles.css
+++ b/styles.css
@@ -148,6 +148,24 @@ body::before {
   gap: 10px;
 }
 
+.active-pane-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 34px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(125, 211, 252, 0.45);
+  background: rgba(125, 211, 252, 0.14);
+  color: rgba(218, 242, 255, 0.98);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  max-width: 320px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .agent-switch {
   display: inline-flex;
   align-items: center;
@@ -378,6 +396,24 @@ body::before {
   gap: 10px;
   padding: 14px;
   padding-bottom: 6px;
+}
+
+.pane[data-active="true"] {
+  border-color: color-mix(in srgb, var(--pane-accent, rgba(125, 211, 252, 0.7)) 68%, white 12%);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--pane-accent, rgba(125, 211, 252, 0.6)) 58%, transparent),
+    0 16px 34px rgba(0, 0, 0, 0.34),
+    0 0 0 2px color-mix(in srgb, var(--pane-accent, rgba(125, 211, 252, 0.35)) 42%, transparent);
+}
+
+.pane[data-active="true"] .pane-header {
+  background:
+    linear-gradient(90deg,
+      color-mix(in srgb, var(--pane-header-tint, rgba(125, 211, 252, 0.12)) 120%, rgba(255, 255, 255, 0.03)),
+      color-mix(in srgb, var(--pane-header-tint, rgba(125, 211, 252, 0.08)) 112%, rgba(255, 255, 255, 0.02))
+    );
+  border-color: color-mix(in srgb, var(--pane-accent, rgba(125, 211, 252, 0.5)) 75%, rgba(255, 255, 255, 0.16));
+  border-left-color: color-mix(in srgb, var(--pane-accent, rgba(125, 211, 252, 0.9)) 88%, white 10%);
 }
 
 /* Workqueue pane should be full-height: never show chat composer UI in this pane. */

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -193,3 +193,36 @@ test('fleet quick action button + keyboard shortcut focus existing timeline pane
   await fleetBtn.click({ modifiers: ['Alt'] });
   await expect(timelinePanes).toHaveCount(2);
 });
+
+test('active pane visual + topbar Active chip track keyboard cycling', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  await page.getByTestId('add-pane-btn').click();
+  await page.getByTestId('pane-add-menu-cron').click();
+  await expect(page.locator('[data-pane]')).toHaveCount(3);
+
+  const activeChip = page.getByTestId('active-pane-chip');
+
+  const activePaneIndex = async () => page.evaluate(() => {
+    const panes = Array.from(document.querySelectorAll('[data-pane]'));
+    return panes.findIndex((pane) => pane.getAttribute('data-active') === 'true');
+  });
+
+  await expect.poll(activePaneIndex).toBe(2);
+  await expect(activeChip).toContainText('Active: C');
+
+  // Ensure shortcuts are not blocked by typing context.
+  await activeChip.click();
+  await page.keyboard.press('Control+Shift+K');
+  await expect.poll(activePaneIndex).toBe(0);
+  await expect(activeChip).toContainText('Active: A');
+
+});


### PR DESCRIPTION
## Summary
- add a global topbar chip showing the currently active pane (A/B/C + pane type)
- persist and restore active pane selection for admin layout
- add explicit active-pane visual state via `data-active=true` and stronger styling
- add e2e coverage for active chip + keyboard pane cycling behavior

## Testing
- npm run test:syntax
- npx playwright test tests/pane.shortcuts.e2e.spec.js --workers=1

Closes #407