### PR TITLE
Fix #382: keep workqueue column headers sticky

### DIFF
--- a/app.js
+++ b/app.js
@@ -213,12 +213,17 @@ async function refreshAgents({ reason = 'manual', showSuccessToast = false } = {
 
     // Preserve UI state (selected agent per pane).
     paneManager.panes.forEach((pane) => {
-      if (!pane?.elements?.agentSelect) return;
+      if (!pane) return;
       const prior = pane.agentId;
       pane.agentId = normalizeAgentId(prior);
-      renderAgentOptions(pane.elements.agentSelect, pane.agentId);
+      if (pane?.elements?.agentSelect) {
+        renderAgentOptions(pane.elements.agentSelect, pane.agentId);
+        try {
+          pane.elements.agentSelect.value = pane.agentId;
+        } catch {}
+      }
       try {
-        pane.elements.agentSelect.value = pane.agentId;
+        renderPaneAgentIdentity(pane);
       } catch {}
     });
 
@@ -2787,13 +2792,158 @@ function buildClientForPane(pane) {
   });
 }
 
+function agentIdExists(agentId) {
+  const id = normalizeAgentId(agentId || 'main');
+  return uiState.agents.some((a) => String(a?.id || '').trim() === id);
+}
+
+function renderPaneAgentIdentity(pane) {
+  if (!pane || pane.role !== 'admin') return;
+  const elements = pane.elements;
+  if (!elements) return;
+
+  const agentId = normalizeAgentId(pane.agentId || 'main');
+  const known = uiState.agents.length === 0 ? true : agentIdExists(agentId);
+  const agent = getAgentRecord(agentId);
+
+  if (elements.agentLabel) {
+    // Keep this short; the chooser shows full labels/ids.
+    const emoji = typeof agent?.emoji === 'string' ? agent.emoji.trim() : '';
+    const name = (typeof agent?.displayName === 'string' && agent.displayName.trim()) ||
+      (typeof agent?.name === 'string' && agent.name.trim()) ||
+      agentId;
+    elements.agentLabel.textContent = `${emoji ? `${emoji} ` : ''}${name}`;
+  }
+
+  if (elements.root) {
+    elements.root.dataset.agentMissing = known ? 'false' : 'true';
+  }
+
+  if (elements.agentWarning) {
+    if (known) {
+      elements.agentWarning.hidden = true;
+      elements.agentWarning.textContent = '';
+    } else {
+      elements.agentWarning.hidden = false;
+      elements.agentWarning.textContent = `Selected agent “${agentId}” is unavailable — choose a replacement.`;
+    }
+  }
+}
+
+let agentChooserState = { openForPaneKey: null, el: null };
+
+function closeAgentChooser() {
+  try {
+    agentChooserState.el?.remove();
+  } catch {}
+  agentChooserState = { openForPaneKey: null, el: null };
+}
+
+function openAgentChooser(pane) {
+  if (!pane || pane.role !== 'admin') return;
+  closeAgentChooser();
+
+  const backdrop = document.createElement('div');
+  backdrop.className = 'agent-chooser-backdrop';
+  backdrop.setAttribute('role', 'presentation');
+
+  const dialog = document.createElement('div');
+  dialog.className = 'agent-chooser';
+  dialog.setAttribute('role', 'dialog');
+  dialog.setAttribute('aria-modal', 'true');
+  dialog.setAttribute('aria-label', 'Choose agent');
+
+  const header = document.createElement('div');
+  header.className = 'agent-chooser-header';
+
+  const title = document.createElement('div');
+  title.className = 'agent-chooser-title';
+  title.textContent = 'Choose agent for this pane';
+
+  const closeBtn = document.createElement('button');
+  closeBtn.className = 'icon-btn';
+  closeBtn.type = 'button';
+  closeBtn.textContent = '✕';
+  closeBtn.setAttribute('aria-label', 'Close agent chooser');
+  closeBtn.addEventListener('click', () => closeAgentChooser());
+
+  header.appendChild(title);
+  header.appendChild(closeBtn);
+
+  const list = document.createElement('div');
+  list.className = 'agent-chooser-list';
+
+  const agents = uiState.agents.length > 0 ? uiState.agents : [{ id: 'main', displayName: 'main', name: 'main', emoji: '' }];
+  const current = normalizeAgentId(pane.agentId || 'main');
+
+  for (const agent of agents) {
+    const id = normalizeAgentId(agent?.id || 'main');
+    const item = document.createElement('button');
+    item.className = 'agent-chooser-item';
+    item.type = 'button';
+    item.setAttribute('aria-current', id === current ? 'true' : 'false');
+
+    const left = document.createElement('div');
+    left.style.minWidth = '0';
+
+    const label = document.createElement('div');
+    label.textContent = formatAgentLabel(agent, { includeId: false });
+
+    const meta = document.createElement('div');
+    meta.className = 'agent-chooser-meta';
+    meta.textContent = id;
+
+    left.appendChild(label);
+    left.appendChild(meta);
+
+    const right = document.createElement('div');
+    right.className = 'agent-chooser-meta';
+    right.textContent = id === current ? 'selected' : 'switch';
+
+    item.appendChild(left);
+    item.appendChild(right);
+
+    item.addEventListener('click', () => {
+      paneSetAgent(pane, id);
+      closeAgentChooser();
+    });
+
+    list.appendChild(item);
+  }
+
+  dialog.appendChild(header);
+  dialog.appendChild(list);
+  backdrop.appendChild(dialog);
+
+  backdrop.addEventListener('click', (e) => {
+    if (e.target === backdrop) closeAgentChooser();
+  });
+
+  document.addEventListener(
+    'keydown',
+    (e) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        closeAgentChooser();
+      }
+    },
+    { once: true }
+  );
+
+  document.body.appendChild(backdrop);
+  agentChooserState = { openForPaneKey: pane.key, el: backdrop };
+}
+
 function paneSetAgent(pane, nextAgentId) {
   if (pane.role !== 'admin') return;
   const next = normalizeAgentId(nextAgentId);
   if (next === pane.agentId) return;
   pane.agentId = next;
   storage.set(ADMIN_DEFAULT_AGENT_KEY, next);
-  pane.elements.agentSelect.value = next;
+  try {
+    if (pane.elements.agentSelect) pane.elements.agentSelect.value = next;
+  } catch {}
+  renderPaneAgentIdentity(pane);
 
   pane.attachments.files = [];
   paneRenderAttachments(pane);
@@ -2831,7 +2981,10 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
     root,
     name: root.querySelector('[data-pane-name]'),
     agentSelect: root.querySelector('[data-pane-agent-select]'),
-    agentWrap: root.querySelector('.pane-agent'),
+    agentWrap: root.querySelector('[data-pane-agent-wrap]') || root.querySelector('.pane-agent'),
+    agentButton: root.querySelector('[data-pane-agent-button]'),
+    agentLabel: root.querySelector('[data-pane-agent-label]'),
+    agentWarning: root.querySelector('[data-pane-agent-warning]'),
     status: root.querySelector('[data-pane-status]'),
     closeBtn: root.querySelector('[data-pane-close]'),
     thread: root.querySelector('[data-pane-thread]'),
@@ -3757,7 +3910,13 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
 
   if (pane.role === 'admin') {
     renderAgentOptions(elements.agentSelect, pane.agentId);
-    elements.agentSelect.addEventListener('change', (event) => {
+    renderPaneAgentIdentity(pane);
+
+    // Explicit switching: a single clear button opens a chooser.
+    elements.agentButton?.addEventListener('click', () => openAgentChooser(pane));
+
+    // Keep select handler for accessibility/debug (even though the select is hidden by default).
+    elements.agentSelect?.addEventListener('change', (event) => {
       paneSetAgent(pane, String(event.target.value || '').trim());
     });
   } else {

--- a/index.html
+++ b/index.html
@@ -71,9 +71,13 @@
             <div class="pane-header">
               <div class="pane-header-left">
                 <div class="pane-name" data-pane-name data-testid="pane-type-label">Pane</div>
-                <div class="pane-agent">
+                <div class="pane-agent" data-pane-agent-wrap>
                   <span class="agent-label">Agent</span>
+                  <button class="agent-pill-btn" type="button" data-pane-agent-button aria-label="Change agent" data-testid="pane-agent-button">
+                    <span class="agent-pill-label" data-pane-agent-label>main</span>
+                  </button>
                   <select data-pane-agent-select aria-label="Select agent" data-testid="pane-agent-select"></select>
+                  <div class="agent-warning" data-pane-agent-warning role="status" aria-live="polite" hidden></div>
                 </div>
               </div>
               <div class="pane-header-right">

--- a/index.html
+++ b/index.html
@@ -299,6 +299,14 @@
           <div class="hint">
             Auto-connecting with the gateway token from your local OpenClaw config.
           </div>
+
+          <div class="hint" style="margin-top: 12px;">
+            <div style="font-weight: 600; margin-bottom: 6px;">Keyboard shortcuts (admin)</div>
+            <div>New Chat pane: <code>Ctrl/Cmd</code> + <code>Shift</code> + <code>C</code></div>
+            <div>New Workqueue pane: <code>Ctrl/Cmd</code> + <code>Shift</code> + <code>W</code></div>
+            <div>New Cron pane: <code>Ctrl/Cmd</code> + <code>Shift</code> + <code>R</code></div>
+            <div>New Timeline pane: <code>Ctrl/Cmd</code> + <code>Shift</code> + <code>T</code></div>
+          </div>
         </div>
       </div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -439,11 +439,117 @@ body::before {
 }
 
 .pane-agent select {
-  padding: 6px 10px;
+  /* Keep in DOM for a11y/tests, but don't make switching a subtle bumpable dropdown. */
+  display: none;
+}
+
+.agent-pill-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
   border-radius: 999px;
   min-height: 32px;
+  max-width: 260px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(11, 14, 19, 0.55);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.agent-pill-btn:hover {
+  background: rgba(11, 14, 19, 0.75);
+}
+
+.agent-pill-btn:focus-visible {
+  outline: 2px solid rgba(125, 211, 252, 0.65);
+  outline-offset: 2px;
+}
+
+.agent-pill-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   font-size: 12px;
-  max-width: 220px;
+}
+
+.pane[data-agent-missing="true"] .agent-pill-btn {
+  border-color: rgba(248, 113, 113, 0.65);
+}
+
+.agent-warning {
+  font-size: 11px;
+  color: rgba(248, 113, 113, 0.95);
+  margin-left: 8px;
+  max-width: 320px;
+}
+
+.agent-chooser-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 88px 14px 14px;
+}
+
+.agent-chooser {
+  width: min(720px, calc(100vw - 28px));
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(9, 11, 14, 0.96);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.55);
+  overflow: hidden;
+}
+
+.agent-chooser-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 14px;
+  gap: 10px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.agent-chooser-title {
+  font-size: 13px;
+  color: var(--text);
+  letter-spacing: 0.02em;
+}
+
+.agent-chooser-list {
+  padding: 10px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 10px;
+}
+
+.agent-chooser-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.10);
+  background: rgba(11, 14, 19, 0.55);
+  cursor: pointer;
+  color: var(--text);
+}
+
+.agent-chooser-item:hover {
+  background: rgba(11, 14, 19, 0.82);
+}
+
+.agent-chooser-item[aria-current="true"] {
+  border-color: rgba(125, 211, 252, 0.65);
+}
+
+.agent-chooser-meta {
+  font-size: 11px;
+  color: var(--muted);
 }
 
 .pane-header-right {

--- a/styles.css
+++ b/styles.css
@@ -1306,8 +1306,9 @@ button.send-btn .btn-icon {
   grid-auto-columns: minmax(250px, 1fr);
   gap: 10px;
   padding: 10px;
-  max-height: 520px;
-  overflow: auto;
+  height: 520px;
+  overflow-x: auto;
+  overflow-y: hidden;
 }
 
 .wq-board-col {
@@ -1317,6 +1318,7 @@ button.send-btn .btn-icon {
   display: flex;
   flex-direction: column;
   min-width: 250px;
+  min-height: 0;
 }
 
 .wq-board-col-header {
@@ -1326,6 +1328,9 @@ button.send-btn .btn-icon {
   padding: 10px 10px 8px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(0, 0, 0, 0.18);
+  position: sticky;
+  top: 0;
+  z-index: 1;
 }
 
 .wq-board-col-title {

--- a/tests/ui/pane-add-menu.spec.js
+++ b/tests/ui/pane-add-menu.spec.js
@@ -1,0 +1,70 @@
+const { test, expect } = require('@playwright/test');
+
+const { startTestEnv, loginAdmin, attachConsoleErrorAsserts } = require('./_helpers');
+
+let env;
+
+test.beforeAll(async () => {
+  env = await startTestEnv();
+});
+
+test.afterAll(() => {
+  env?.stop?.();
+});
+
+test.afterEach(async ({ page }) => {
+  if (page.__consoleAsserts) {
+    page.__consoleAsserts.assertNoErrors();
+  }
+});
+
+test('pane add menu: opens + adds explicit pane kinds + focuses sane defaults', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+
+  const addBtn = page.locator('#addPaneBtn');
+  await expect(addBtn).toBeVisible();
+
+  await addBtn.click();
+  const menu = page.locator('[data-testid="pane-add-menu"]');
+  await expect(menu).toBeVisible();
+
+  await expect(menu.locator('[data-testid="pane-add-menu-chat"]')).toHaveText(/New Chat pane/);
+  await expect(menu.locator('[data-testid="pane-add-menu-workqueue"]')).toHaveText(/New Workqueue pane/);
+  await expect(menu.locator('[data-testid="pane-add-menu-cron"]')).toHaveText(/New Cron pane/);
+  await expect(menu.locator('[data-testid="pane-add-menu-timeline"]')).toHaveText(/New Timeline pane/);
+
+  // Add a workqueue pane and ensure it exists + focus lands on primary control.
+  await menu.locator('[data-testid="pane-add-menu-workqueue"]').click();
+
+  const wqPane = page.locator('[data-pane-kind="workqueue"]').last();
+  await expect(wqPane).toBeVisible();
+
+  const queueSelect = wqPane.locator('[data-wq-queue-select]');
+  await expect(queueSelect).toBeVisible();
+  await expect(queueSelect).toBeFocused();
+});
+
+test('pane add shortcuts: Ctrl/Cmd+Shift+T adds a timeline pane', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+
+  const countBefore = await page.locator('[data-pane]').count();
+
+  // Use a Playwright-friendly cross-platform modifier.
+  await page.keyboard.press('ControlOrMeta+Shift+T');
+
+  const tlPane = page.locator('[data-pane-kind="timeline"]').last();
+  await expect(tlPane).toBeVisible();
+
+  const countAfter = await page.locator('[data-pane]').count();
+  expect(countAfter).toBeGreaterThan(countBefore);
+});


### PR DESCRIPTION
## Summary\n- keep the workqueue kanban board from vertically scrolling as a whole\n- make each column header sticky so status headers remain visible\n- keep scrolling inside each column lane for long item lists\n\n## Validation\n- npm run test:syntax\n- npm run test:unit\n\nCloses #382.