### PR TITLE
UX/Workqueue: high-volume All scope guardrail with one-click downscope (#408)

### DIFF
--- a/app.js
+++ b/app.js
@@ -4267,6 +4267,11 @@ function renderWorkqueuePaneItems(pane) {
 
   const scopedItems = filterWorkqueuePaneItemsByScope(pane, pane.workqueue?.items);
   const filteredItems = applyWorkqueueQuickFilters(scopedItems, pane.workqueue?.quickFilters);
+  renderWorkqueueAllScopeGuardrail(pane, {
+    visibleCount: filteredItems.length,
+    scope: pane.workqueue?.scopeFilter || 'all',
+    activeTarget: String(pane.agentId || '').trim()
+  });
   const items = sortWorkqueueItems(filteredItems, { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
   const renderLimit = Math.max(
     WORKQUEUE_PANE_INITIAL_RENDER_LIMIT,
@@ -4360,6 +4365,40 @@ function renderWorkqueuePaneItems(pane) {
     pane.workqueue.selectedItemId = null;
     renderWorkqueuePaneInspect(pane, null);
   }
+}
+
+function renderWorkqueueAllScopeGuardrail(pane, { visibleCount, scope, activeTarget }) {
+  const root = pane.elements?.thread?.querySelector('[data-wq-all-scope-guardrail]');
+  if (!root) return;
+
+  const threshold = getWorkqueueAllScopeGuardrailThreshold();
+  const shouldShow = scope === 'all' && visibleCount > threshold && !pane.workqueue?.allScopeGuardrailDismissed;
+  root.hidden = !shouldShow;
+  root.innerHTML = '';
+  if (!shouldShow) return;
+
+  root.innerHTML = `
+    <div class="wq-all-scope-guardrail-copy">
+      <strong>Viewing all items (${escapeHtml(String(visibleCount))}).</strong>
+      <span>Narrow scope?</span>
+    </div>
+    <div class="wq-all-scope-guardrail-actions">
+      <button type="button" class="secondary" data-wq-all-scope-action="assigned" ${activeTarget ? '' : 'disabled'}>Assigned to active target</button>
+      <button type="button" class="secondary" data-wq-all-scope-action="unassigned">Unassigned</button>
+      <button type="button" class="secondary" data-wq-all-scope-action="dismiss" aria-label="Dismiss all scope warning">Dismiss</button>
+    </div>
+  `;
+
+  root.querySelector('[data-wq-all-scope-action="assigned"]')?.addEventListener('click', () => {
+    pane.elements?.thread?.querySelector?.('[data-wq-scope="assigned"]')?.click();
+  });
+  root.querySelector('[data-wq-all-scope-action="unassigned"]')?.addEventListener('click', () => {
+    pane.elements?.thread?.querySelector?.('[data-wq-scope="unassigned"]')?.click();
+  });
+  root.querySelector('[data-wq-all-scope-action="dismiss"]')?.addEventListener('click', () => {
+    pane.workqueue.allScopeGuardrailDismissed = true;
+    renderWorkqueuePaneItems(pane);
+  });
 }
 
 function renderWorkqueuePaneInspect(pane, item) {
@@ -4864,9 +4903,16 @@ const ADMIN_PANES_KEY = 'clawnsole.admin.panes.v1';
 const ADMIN_LAYOUT_MODE_KEY = 'clawnsole.admin.layoutMode';
 const ADMIN_DEFAULT_AGENT_KEY = 'clawnsole.admin.agentId';
 const WORKQUEUE_SCOPE_PREF_KEY = 'clawnsole.admin.workqueue.scope.v1';
+const WORKQUEUE_ALL_SCOPE_GUARDRAIL_THRESHOLD_KEY = 'clawnsole.admin.workqueue.allScopeGuardrailThreshold';
+const WORKQUEUE_ALL_SCOPE_GUARDRAIL_DEFAULT_THRESHOLD = 200;
 
 function normalizeWorkqueueScope(scope) {
   return scope === 'assigned' || scope === 'unassigned' ? scope : 'all';
+}
+
+function getWorkqueueAllScopeGuardrailThreshold() {
+  const raw = Number(storage.get(WORKQUEUE_ALL_SCOPE_GUARDRAIL_THRESHOLD_KEY, WORKQUEUE_ALL_SCOPE_GUARDRAIL_DEFAULT_THRESHOLD));
+  return Number.isFinite(raw) && raw > 0 ? raw : WORKQUEUE_ALL_SCOPE_GUARDRAIL_DEFAULT_THRESHOLD;
 }
 
 function getDefaultWorkqueueScope() {
@@ -6500,6 +6546,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
             <button type="button" class="wq-scope-btn" data-wq-scope="unassigned">Unassigned</button>
             <button type="button" class="wq-scope-btn" data-wq-scope="all">All</button>
           </div>
+
+          <div class="wq-all-scope-guardrail" data-wq-all-scope-guardrail data-testid="wq-all-scope-guardrail" hidden></div>
 
           <div class="wq-field" data-wq-source-group role="group" aria-label="Filter by source">
             <span class="wq-label">Source</span>

--- a/styles.css
+++ b/styles.css
@@ -2218,6 +2218,41 @@ kbd {
   background: rgba(127, 209, 185, 0.12);
 }
 
+.wq-all-scope-guardrail {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 8px 10px;
+  border: 1px solid rgba(255, 198, 109, 0.38);
+  border-radius: 8px;
+  background: rgba(255, 198, 109, 0.1);
+  color: var(--text);
+}
+
+.wq-all-scope-guardrail[hidden] {
+  display: none;
+}
+
+.wq-all-scope-guardrail-copy {
+  display: flex;
+  gap: 6px;
+  align-items: baseline;
+  flex-wrap: wrap;
+  font-size: 12px;
+}
+
+.wq-all-scope-guardrail-actions {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.wq-all-scope-guardrail-actions button {
+  font-size: 11px;
+  padding: 5px 8px;
+}
+
 .wq-enqueue {
   margin-top: 10px;
 }

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -314,6 +314,73 @@ test('workqueue pane: scope filter toggles assigned/unassigned/all deterministic
   await expect(rows).toHaveCount(2);
 });
 
+test('workqueue pane: all-scope guardrail offers one-click downscope and session dismiss', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  const queue = `all-scope-guardrail-${Date.now()}`;
+  const dataDir = path.join(env.tempHome, '.openclaw', 'clawnsole');
+  fs.mkdirSync(dataDir, { recursive: true });
+  const now = new Date().toISOString();
+  const items = Array.from({ length: 201 }, (_, idx) => ({
+    id: `bulk-${idx}`,
+    queue,
+    title: idx === 0 ? 'main assigned item' : `other assigned item ${idx}`,
+    instructions: 'bulk all-scope guardrail test',
+    priority: idx,
+    status: 'ready',
+    claimedBy: idx === 0 ? 'main' : 'other-agent',
+    claimedAt: '',
+    leaseUntil: 0,
+    attempts: 0,
+    lastError: '',
+    createdAt: now,
+    updatedAt: now
+  }));
+  fs.writeFileSync(
+    path.join(dataDir, 'work-queues.json'),
+    JSON.stringify(
+      {
+        version: 1,
+        queues: { [queue]: { name: queue, createdAt: now } },
+        assignments: {},
+        items
+      },
+      null,
+      2
+    )
+  );
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  const wqPane = page.locator('[data-pane]').last();
+  await wqPane.locator('[data-wq-queue-select]').selectOption('__custom__');
+  await wqPane.locator('[data-wq-queue-custom]').fill(queue);
+  await wqPane.locator('[data-wq-queue-custom]').press('Enter');
+  await wqPane.locator('[data-wq-scope="all"]').click();
+
+  const guardrail = wqPane.getByTestId('wq-all-scope-guardrail');
+  await expect(guardrail).toBeVisible();
+  await expect(guardrail).toContainText('Viewing all items (201).');
+
+  await guardrail.getByRole('button', { name: 'Assigned to active target' }).click();
+  await expect(guardrail).toBeHidden();
+  await expect(wqPane.locator('[data-wq-list-body]')).toContainText('main assigned item');
+  await expect(wqPane.locator('[data-wq-list-body]')).not.toContainText('other assigned item 1');
+
+  await wqPane.locator('[data-wq-scope="all"]').click();
+  await expect(guardrail).toBeVisible();
+  await guardrail.getByRole('button', { name: 'Dismiss all scope warning' }).click();
+  await expect(guardrail).toBeHidden();
+
+  await wqPane.locator('[data-wq-scope="assigned"]').click();
+  await wqPane.locator('[data-wq-scope="all"]').click();
+  await expect(guardrail).toBeHidden();
+});
+
 test('workqueue pane: source chips + clawnsole preset filter items without reload', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);


### PR DESCRIPTION
Implements #408.\n\nWhat changed:\n- Adds an inline Workqueue pane guardrail when scope is `All` and the visible filtered item count exceeds the default threshold of 200.\n- Adds one-click downscope actions for `Assigned to active target` and `Unassigned`.\n- Keeps dismissals session-scoped on the pane state, so they do not permanently disable the prompt.\n- Adds focused Playwright coverage for threshold display, downscope behavior, and session dismiss.\n\nValidation:\n- `npm run test:syntax`\n- `npx playwright test tests/ui/workqueue-pane.spec.js --grep "all-scope guardrail"`