### PR TITLE
Fix #170: pane status source of truth

### DIFF
--- a/app.js
+++ b/app.js
@@ -141,11 +141,18 @@ const deriveAuthOverlayState = __appCore.deriveAuthOverlayState || ((state) => (
   logoutEnabled: !!state?.authed,
   logoutOpacity: !!state?.authed ? '1' : '0.5'
 }));
+const paneIsConnected = __appCore.paneIsConnected || ((pane) => {
+  if (!pane) return false;
+  const status = String(pane.statusState || '').toLowerCase();
+  if (status === 'connected') return true;
+  if (status === 'disconnected' || status === 'error' || status === 'offline') return false;
+  return Boolean(pane.connected);
+});
 const deriveGlobalConnectionState = __appCore.deriveGlobalConnectionState || ((state) => {
   if (!state?.authed) return { state: 'disconnected', meta: 'sign in required' };
   const panes = Array.isArray(state?.panes) ? state.panes : [];
   if (panes.length === 0) return { state: 'disconnected', meta: '' };
-  const connectedCount = panes.filter((pane) => !!pane?.connected).length;
+  const connectedCount = panes.filter((pane) => paneIsConnected(pane)).length;
   const total = panes.length;
   const anyConnecting = panes.some((pane) => pane?.statusState === 'connecting' || pane?.statusState === 'reconnecting');
   const anyError = panes.some((pane) => pane?.statusState === 'error');
@@ -4609,9 +4616,11 @@ function buildClientForPane(pane) {
     onStatus: (state, meta) => {
       pane.statusState = state;
       pane.statusMeta = meta || '';
+      if (state === 'connected') pane.connected = true;
+      if (state === 'disconnected' || state === 'error' || state === 'offline') pane.connected = false;
       setStatusPill(pane.elements.status, state, meta || '');
       if (pane.elements.root) {
-        pane.elements.root.dataset.connected = pane.connected ? 'true' : 'false';
+        pane.elements.root.dataset.connected = paneIsConnected(pane) ? 'true' : 'false';
         pane.elements.root.dataset.wsState = String(state || '');
       }
       updateGlobalStatus();
@@ -4648,6 +4657,9 @@ function buildClientForPane(pane) {
     onDisconnected: () => {
       paneStopThinking(pane);
       pane.connected = false;
+      pane.statusState = 'disconnected';
+      pane.statusMeta = '';
+      setStatusPill(pane.elements.status, 'disconnected', '');
       if (pane.elements.root) pane.elements.root.dataset.connected = 'false';
       paneSetChatEnabled(pane);
       updateGlobalStatus();

--- a/lib/app-core.js
+++ b/lib/app-core.js
@@ -170,7 +170,7 @@
       return { state: 'disconnected', meta: '' };
     }
 
-    const connectedCount = list.filter((pane) => !!pane?.connected).length;
+    const connectedCount = list.filter((pane) => paneIsConnected(pane)).length;
     const total = list.length;
     const anyConnecting = list.some((pane) => pane?.statusState === 'connecting' || pane?.statusState === 'reconnecting');
     const anyError = list.some((pane) => pane?.statusState === 'error');
@@ -191,6 +191,14 @@
         : `panes: ${connectedCount}/${total} connected`;
 
     return { state, meta };
+  }
+
+  function paneIsConnected(pane) {
+    if (!pane) return false;
+    const status = String(pane.statusState || '').toLowerCase();
+    if (status === 'connected') return true;
+    if (status === 'disconnected' || status === 'error' || status === 'offline') return false;
+    return Boolean(pane.connected);
   }
 
   function deriveDisconnectButtonState({ authed, panes } = {}) {
@@ -326,6 +334,7 @@
     sortWorkqueueItems,
     inferPaneCols,
     normalizePaneKind,
+    paneIsConnected,
     deriveAuthOverlayState,
     deriveGlobalConnectionState,
     deriveDisconnectButtonState,

--- a/tests/unit/app-core.test.js
+++ b/tests/unit/app-core.test.js
@@ -7,6 +7,7 @@ const {
   sortWorkqueueItems,
   inferPaneCols,
   normalizePaneKind,
+  paneIsConnected,
   deriveAuthOverlayState,
   deriveGlobalConnectionState,
   deriveDisconnectButtonState,
@@ -89,6 +90,30 @@ test('normalizePaneKind handles aliases safely', () => {
   assert.equal(normalizePaneKind('timeline'), 'timeline');
   assert.equal(normalizePaneKind('ti'), 'timeline');
   assert.equal(normalizePaneKind('x'), 'chat');
+});
+
+test('paneIsConnected prefers explicit websocket status over stale connected flag', () => {
+  assert.equal(paneIsConnected({ connected: true, statusState: 'disconnected' }), false);
+  assert.equal(paneIsConnected({ connected: true, statusState: 'error' }), false);
+  assert.equal(paneIsConnected({ connected: false, statusState: 'connected' }), true);
+  assert.equal(paneIsConnected({ connected: true, statusState: 'reconnecting' }), true);
+  assert.equal(paneIsConnected({ connected: false, statusState: 'reconnecting' }), false);
+});
+
+test('deriveGlobalConnectionState uses websocket status source of truth', () => {
+  const disconnected = deriveGlobalConnectionState({
+    authed: true,
+    panes: [{ connected: true, statusState: 'disconnected' }]
+  });
+  assert.equal(disconnected.state, 'disconnected');
+  assert.equal(disconnected.meta, 'panes: 0/1 connected');
+
+  const connected = deriveGlobalConnectionState({
+    authed: true,
+    panes: [{ connected: false, statusState: 'connected' }]
+  });
+  assert.equal(connected.state, 'connected');
+  assert.equal(connected.meta, 'panes: 1/1 connected');
 });
 
 test('deriveAuthOverlayState captures auth/role transition flags', () => {


### PR DESCRIPTION
## Summary
- add a shared pane status helper that prefers websocket status over stale connected flags
- keep pane.connected and data-connected synchronized from status events
- clear pane header status on disconnect callbacks so Pane Manager and header stay aligned

## Tests
- npm test
- npx playwright test tests/pane.manager.e2e.spec.js -g "status stays in sync" --workers=1

Fixes #170