### PR TITLE
Guard global pane shortcuts while typing

### DIFF
--- a/app.js
+++ b/app.js
@@ -6952,7 +6952,7 @@ window.addEventListener('keydown', (event) => {
   // Ctrl/Cmd+Shift+R → new cron
   // Ctrl/Cmd+Shift+T → new timeline
   const isAccel = (event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey;
-  if (isAccel && roleState.role === 'admin' && !isTypingContext(event.target)) {
+  if (isAccel && roleState.role === 'admin' && !shouldIgnoreGlobalPaneShortcut(event)) {
     const key = String(event.key || '').toLowerCase();
     const map = { c: 'chat', w: 'workqueue', r: 'cron', t: 'timeline' };
     const kind = map[key];

--- a/app.js
+++ b/app.js
@@ -6841,11 +6841,31 @@ let shortcutState = { lastGAtMs: 0 };
 
 function isTypingContext(target) {
   const el = target || document.activeElement;
-  if (!el) return false;
-  const tag = String(el.tagName || '').toUpperCase();
+  if (!el || el === document || el === window) return false;
+
+  const node = el.nodeType === Node.TEXT_NODE ? el.parentElement : el;
+  if (!node) return false;
+
+  const tag = String(node.tagName || '').toUpperCase();
   if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
-  if (el.isContentEditable) return true;
+  if (node.isContentEditable) return true;
+  if (typeof node.closest === 'function') {
+    if (node.closest('[contenteditable=""], [contenteditable="true"]')) return true;
+    if (node.closest('[role="textbox"], [role="searchbox"]')) return true;
+    if (node.closest('.monaco-editor, .cm-editor, .CodeMirror, .ace_editor, .ProseMirror')) return true;
+  }
   return false;
+}
+
+function isOpenModalContext(target) {
+  const el = target || document.activeElement;
+  if (!el || el === document || el === window) return false;
+  const node = el.nodeType === Node.TEXT_NODE ? el.parentElement : el;
+  return !!node?.closest?.('.modal.open, .login-overlay.open, [aria-modal="true"]');
+}
+
+function shouldIgnoreGlobalPaneShortcut(event) {
+  return isTypingContext(event?.target) || isOpenModalContext(event?.target);
 }
 
 function focusPaneIndex(idx) {
@@ -6921,13 +6941,7 @@ function cycleUnreadPaneFocus(direction = 1) {
 }
 
 window.addEventListener('keydown', (event) => {
-  const isEditableTarget = (() => {
-    const el = event.target;
-    if (!el) return false;
-    if (el.isContentEditable) return true;
-    const tag = String(el.tagName || '').toUpperCase();
-    return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
-  })();
+  const isEditableTarget = isTypingContext(event.target);
 
   // If Pane Manager is open, it gets first dibs on keys.
   if (paneManagerHandleKeydown(event)) return;
@@ -6978,8 +6992,8 @@ window.addEventListener('keydown', (event) => {
     return;
   }
 
-  // Never steal focus / override browser shortcuts while typing.
-  if (isTypingContext(event.target)) return;
+  // Never steal focus / override browser shortcuts while typing or inside focus-trapped overlays.
+  if (shouldIgnoreGlobalPaneShortcut(event)) return;
 
   const key = String(event.key || '');
 

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -141,6 +141,64 @@ test('alt+1..3 focuses panes by visible order and does not fire while typing', a
   await expect.poll(activePaneIndex).toBe(0);
 });
 
+test('global pane shortcuts are ignored while typing or in modal fields', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+  await expect(page.locator('[data-pane]')).toHaveCount(2);
+
+  const activePaneIndex = () =>
+    page.evaluate(() => {
+      const active = document.activeElement;
+      const panes = Array.from(document.querySelectorAll('[data-pane]'));
+      return panes.findIndex((pane) => pane === active || (active && pane.contains(active)));
+    });
+
+  const composer = page.locator('[data-pane-input]').first();
+  await composer.focus();
+  await expect(composer).toBeFocused();
+  expect(await activePaneIndex()).toBe(0);
+
+  await page.keyboard.press('ControlOrMeta+2');
+  expect(await activePaneIndex()).toBe(0);
+
+  await page.keyboard.press('ControlOrMeta+Shift+K');
+  expect(await activePaneIndex()).toBe(0);
+
+  await page.keyboard.press('g');
+  await page.keyboard.press('w');
+  await expect(page.locator('#workqueueModal')).toHaveAttribute('aria-hidden', 'true');
+
+  await page.click('#connectionStatus');
+  await page.keyboard.press('ControlOrMeta+2');
+  expect(await activePaneIndex()).toBe(1);
+
+  await page.click('#agentsBtn');
+  const agentsSearch = page.locator('#agentsSearch');
+  await agentsSearch.click();
+  await expect(agentsSearch).toBeFocused();
+  await page.keyboard.press('ControlOrMeta+1');
+  await expect(agentsSearch).toBeFocused();
+  await expect(page.locator('#agentsModal')).toHaveAttribute('aria-hidden', 'false');
+
+  await page.locator('#agentsModal button[aria-label="Close agents"]').click();
+  await expect(page.locator('#agentsModal')).toHaveAttribute('aria-hidden', 'true');
+
+  await page.click('#workqueueBtn');
+  const enqueueTitle = page.locator('#wqEnqueueTitle');
+  await enqueueTitle.click();
+  await expect(enqueueTitle).toBeFocused();
+  await page.keyboard.press('ControlOrMeta+1');
+  await expect(enqueueTitle).toBeFocused();
+  await expect(page.locator('#workqueueModal')).toHaveAttribute('aria-hidden', 'false');
+});
+
 test('add-pane shortcuts do not fire while typing in chat input', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!app?.skipReason, app?.skipReason);

--- a/tests/ui/keyboard-shortcut-guard.spec.js
+++ b/tests/ui/keyboard-shortcut-guard.spec.js
@@ -1,0 +1,87 @@
+const { test, expect } = require('@playwright/test');
+
+const { startTestEnv, loginAdmin, attachConsoleErrorAsserts } = require('./_helpers');
+
+let env;
+
+test.beforeAll(async () => {
+  env = await startTestEnv();
+});
+
+test.afterAll(() => {
+  env?.stop?.();
+});
+
+test.afterEach(async ({ page }) => {
+  if (page.__consoleAsserts) {
+    page.__consoleAsserts.assertNoErrors();
+  }
+});
+
+async function focusedPaneIndex(page) {
+  return page.evaluate(() => {
+    const panes = Array.from(document.querySelectorAll('[data-pane]'));
+    const active = document.activeElement;
+    return panes.findIndex((pane) => pane === active || (active && pane.contains(active)));
+  });
+}
+
+test('pane shortcuts: composer focus blocks global pane navigation', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+
+  const input = page.locator('[data-pane][data-pane-kind="chat"]').first().locator('[data-pane-input]');
+  await input.fill('draft should keep focus');
+  await expect(input).toBeFocused();
+  expect(await focusedPaneIndex(page)).toBe(0);
+
+  await page.keyboard.press('ControlOrMeta+Shift+K');
+
+  await expect(input).toBeFocused();
+  expect(await focusedPaneIndex(page)).toBe(0);
+});
+
+test('pane shortcuts: workqueue filter focus blocks global pane navigation', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+
+  const search = page.locator('[data-pane][data-pane-kind="workqueue"]').first().locator('[data-wq-queue-search]');
+  await expect(search).toBeVisible();
+  await search.fill('dev');
+  await expect(search).toBeFocused();
+  expect(await focusedPaneIndex(page)).toBe(1);
+
+  await page.keyboard.press('ControlOrMeta+Shift+J');
+
+  await expect(search).toBeFocused();
+  expect(await focusedPaneIndex(page)).toBe(1);
+});
+
+test('pane shortcuts: modal text field focus blocks global pane navigation', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+
+  await page.keyboard.press('ControlOrMeta+P');
+  const modal = page.locator('#paneManagerModal');
+  const search = page.getByTestId('pane-manager-search');
+  await expect(modal).toHaveAttribute('aria-hidden', 'false');
+  await search.click();
+  await expect(search).toBeFocused();
+
+  await page.keyboard.press('ControlOrMeta+1');
+
+  await expect(modal).toHaveAttribute('aria-hidden', 'false');
+  await expect(search).toBeFocused();
+});

--- a/tests/ui/pane-add-menu.spec.js
+++ b/tests/ui/pane-add-menu.spec.js
@@ -79,6 +79,7 @@ test('pane add shortcuts: Ctrl/Cmd+Shift+T adds a timeline pane', async ({ page 
   await loginAdmin(page, env.serverPort);
 
   const countBefore = await page.locator('[data-pane]').count();
+  await page.evaluate(() => document.activeElement?.blur?.());
 
   // Use a Playwright-friendly cross-platform modifier.
   await page.keyboard.press('ControlOrMeta+Shift+T');


### PR DESCRIPTION
## Summary
- expand typing-context detection for contenteditable, role=textbox/searchbox, and code-editor surfaces
- block global pane navigation shortcuts while focus is in editable fields or modal/focus-trapped overlays
- route admin add-pane shortcuts through the shared global pane shortcut guard
- add Playwright regression coverage for composer, search/filter, and modal text fields

Closes #255.

## Tests
- npx playwright test tests/ui/keyboard-shortcut-guard.spec.js --reporter=line
- npx playwright test tests/ui/keyboard-shortcut-guard.spec.js tests/ui/pane-add-menu.spec.js tests/pane.manager.e2e.spec.js --reporter=line
- npm test -- --runInBand
