### PR TITLE
Add fleet attention sections

### DIFF
--- a/app.js
+++ b/app.js
@@ -215,6 +215,8 @@ const ADMIN_AGENT_LAST_SEEN_KEY = 'clawnsole.admin.agentLastSeenAtMs';
 const ADMIN_AGENT_FILTER_KEY = 'clawnsole.admin.agents.filter';
 const ADMIN_AGENT_SORT_KEY = 'clawnsole.admin.agents.sort';
 const ADMIN_AGENT_ACTIVE_MINUTES_KEY = 'clawnsole.admin.agents.activeMinutes';
+const ADMIN_AGENT_HEALTHY_COLLAPSED_KEY = 'clawnsole.admin.agents.healthyCollapsed';
+const ADMIN_AGENT_HEALTHY_COLLAPSE_THRESHOLD = 10;
 const WQ_RECENT_TARGETS_KEY = 'clawnsole.wq.recentTargets';
 const WQ_RECENT_TARGETS_MAX = 6;
 
@@ -2316,17 +2318,38 @@ function renderAgentsModalList() {
   const filtered = baseAgents.filter(matches);
   const pinned = sortAgents(filtered.filter((a) => pins.has(String(a?.id || '').trim())));
   const rest = sortAgents(filtered.filter((a) => !pins.has(String(a?.id || '').trim())));
+  const ordered = [...pinned, ...rest];
+  const needsAttention = ordered.filter((agent) => classify(agent?.id).bucket !== 'active');
+  const healthy = ordered.filter((agent) => classify(agent?.id).bucket === 'active');
+  const healthyCollapseDefault = baseAgents.length > ADMIN_AGENT_HEALTHY_COLLAPSE_THRESHOLD;
+  const healthyCollapsed = String(storage.get(ADMIN_AGENT_HEALTHY_COLLAPSED_KEY, healthyCollapseDefault ? '1' : '0')) === '1';
 
   root.innerHTML = '';
 
-  const renderSection = (title, agents) => {
-    if (!agents || agents.length === 0) return;
+  const renderSection = (title, agents, { collapsible = false, collapsed = false } = {}) => {
     const section = document.createElement('div');
     section.className = 'agents-section';
-    section.innerHTML = `<div class="agents-section-title">${escapeHtml(title)}</div>`;
+    section.classList.toggle('is-collapsed', collapsible && collapsed);
+
+    const header = document.createElement(collapsible ? 'button' : 'div');
+    header.className = 'agents-section-title';
+    header.innerHTML = `
+      <span>${escapeHtml(title)} (${agents.length})</span>
+      ${collapsible ? `<span class="agents-section-toggle">${collapsed ? 'Show' : 'Hide'}</span>` : ''}
+    `;
+    if (collapsible) {
+      header.type = 'button';
+      header.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+      header.addEventListener('click', () => {
+        storage.set(ADMIN_AGENT_HEALTHY_COLLAPSED_KEY, collapsed ? '0' : '1');
+        renderAgentsModalList();
+      });
+    }
+    section.appendChild(header);
 
     const list = document.createElement('div');
     list.className = 'agents-rows';
+    if (collapsible && collapsed) list.hidden = true;
 
     for (const agent of agents) {
       const id = String(agent?.id || '').trim();
@@ -2392,10 +2415,10 @@ function renderAgentsModalList() {
     root.appendChild(section);
   };
 
-  renderSection('Pinned', pinned);
-  renderSection('Agents', rest);
+  renderSection('Needs attention', needsAttention);
+  renderSection('Healthy', healthy, { collapsible: true, collapsed: healthyCollapsed });
 
-  const empty = pinned.length === 0 && rest.length === 0;
+  const empty = ordered.length === 0;
   if (globalElements.agentsEmpty) globalElements.agentsEmpty.hidden = !empty;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1438,17 +1438,45 @@ button.send-btn .btn-icon {
 }
 
 .agents-section-title {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border: 0;
+  padding: 0;
+  background: transparent;
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.1em;
   color: var(--muted);
   margin-bottom: 8px;
+  text-align: left;
+}
+
+button.agents-section-title {
+  cursor: pointer;
+}
+
+button.agents-section-title:hover {
+  color: var(--text);
+}
+
+.agents-section-toggle {
+  font-size: 11px;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--text);
 }
 
 .agents-rows {
   display: flex;
   flex-direction: column;
   gap: 8px;
+}
+
+.agents-rows[hidden] {
+  display: none;
 }
 
 .agents-row {

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -58,6 +58,47 @@ test('agents modal quick filter narrows list and Esc clears it', async ({ page, 
   await expect(rows).toHaveCount(initialCount);
 });
 
+test('fleet attention mode sections healthy agents and keeps filters while expanding', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  const agents = Array.from({ length: 12 }, (_, index) => {
+    const id = `agent-${index + 1}`;
+    return { id, name: id, displayName: id };
+  });
+
+  await clawnsole.gotoAndLoginAdmin(page);
+  await page.route(/\/agents(?:\?|$)/, async (route) => {
+    await route.fulfill({ json: { agents } });
+  });
+  await page.evaluate(() => {
+    const now = Date.now();
+    const lastSeen = {};
+    for (let index = 2; index <= 12; index += 1) {
+      lastSeen[`agent-${index}`] = now;
+    }
+    localStorage.setItem('clawnsole.admin.agentLastSeenAtMs', JSON.stringify(lastSeen));
+  });
+  await page.getByRole('button', { name: 'Refresh agent list' }).click();
+
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsModal')).toHaveClass(/open/);
+
+  await expect(page.locator('#agentsList .agents-section-title').first()).toContainText('Needs attention (1)');
+  const healthyToggle = page.getByRole('button', { name: /Healthy \(11\) Show/ });
+  await expect(healthyToggle).toHaveAttribute('aria-expanded', 'false');
+  await expect(page.locator('#agentsList .agents-row:visible')).toHaveCount(1);
+
+  await healthyToggle.click();
+  await expect(page.getByRole('button', { name: /Healthy \(11\) Hide/ })).toHaveAttribute('aria-expanded', 'true');
+  await expect(page.locator('#agentsList .agents-row:visible')).toHaveCount(12);
+
+  await page.getByRole('button', { name: 'Offline/Error' }).click();
+  await expect(page.getByRole('button', { name: 'Offline/Error' })).toHaveAttribute('aria-pressed', 'true');
+  await expect(page.locator('#agentsList .agents-section-title').first()).toContainText('Needs attention (1)');
+  await expect(page.getByRole('button', { name: /Healthy \(0\) Hide/ })).toHaveAttribute('aria-expanded', 'true');
+  await expect(page.locator('#agentsList .agents-row:visible')).toHaveCount(1);
+});
+
 test('agents modal quick actions open/reuse chat, timeline, and workqueue context', async ({ page, clawnsole }) => {
   if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
 


### PR DESCRIPTION
Closes #256.

## Summary
- Split the Agents/Fleet modal into explicit Needs attention and Healthy sections with counts.
- Collapse Healthy by default for larger fleets and add a one-click expand/collapse toggle that preserves current filters.
- Add a UI regression covering a 12-agent fleet, section counts, collapsed healthy rows, expansion, and filter preservation.

## Tests
- npm run test:syntax
- npx playwright test tests/ui/agents-modal.spec.js --grep "fleet attention mode"
- npx playwright test tests/ui/agents-modal.spec.js