### PR TITLE
Test: Workqueue pane golden path coverage (#123)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1324,8 +1324,21 @@ function renderWorkqueuePaneItems(pane) {
   body.innerHTML = '';
 
   const itemsRaw = Array.isArray(pane.workqueue?.items) ? pane.workqueue.items : [];
-  const items = sortWorkqueueItems(itemsRaw, { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
+  const scope = pane.workqueue?.scope === 'assigned' || pane.workqueue?.scope === 'unassigned' ? pane.workqueue.scope : 'all';
+  const target = normalizeAgentId(pane.agentId || 'main');
+  const scopedItems = itemsRaw.filter((it) => {
+    const assigned = String(it?.claimedBy || it?.assignedTo || it?.assignee || it?.meta?.assignedTo || it?.meta?.assignee || '').trim();
+    if (scope === 'assigned') return assigned && normalizeAgentId(assigned) === target;
+    if (scope === 'unassigned') return !assigned;
+    return true;
+  });
+  const items = sortWorkqueueItems(scopedItems, { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
   if (empty) empty.hidden = items.length > 0;
+  const statusLine = pane.elements?.thread?.querySelector('[data-wq-statusline]');
+  if (statusLine) {
+    const scopeLabel = scope === 'assigned' ? `assigned:${target}` : scope;
+    statusLine.textContent = `${items.length} shown (${scopeLabel}) / ${itemsRaw.length} total`;
+  }
 
   const now = Date.now();
   for (const it of items) {
@@ -2974,7 +2987,7 @@ function renderAgentOptions(selectEl, agentId) {
   selectEl.value = normalizeAgentId(agentId || 'main');
 }
 
-function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sortKey, sortDir, closable = true } = {}) {
+function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sortKey, sortDir, scope = 'all', closable = true } = {}) {
   const template = globalElements.paneTemplate;
   const root = template.content.firstElementChild.cloneNode(true);
   const elements = {
@@ -3012,6 +3025,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
     workqueue: {
       queue: (queue || 'dev-team').trim() || 'dev-team',
       statusFilter: Array.isArray(statusFilter) ? statusFilter : ['ready', 'pending', 'claimed', 'in_progress'],
+      scope: scope === 'assigned' || scope === 'unassigned' ? scope : 'all',
       items: [],
       selectedItemId: null,
       sortKey: typeof sortKey === 'string' && sortKey.trim() ? sortKey.trim() : 'default',
@@ -3099,6 +3113,13 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
 
           <button data-wq-refresh class="secondary" type="button">Refresh</button>
 
+          <div class="wq-scope" role="group" aria-label="Workqueue scope">
+            <span class="wq-sort-label">Scope</span>
+            <button type="button" class="wq-sort-btn" data-wq-scope="assigned">Assigned</button>
+            <button type="button" class="wq-sort-btn" data-wq-scope="unassigned">Unassigned</button>
+            <button type="button" class="wq-sort-btn" data-wq-scope="all">All</button>
+          </div>
+
           <div class="wq-sort" role="group" aria-label="Sort workqueue items">
             <span class="wq-sort-label">Sort</span>
             <button type="button" class="wq-sort-btn" data-wq-sort="default">Default</button>
@@ -3179,6 +3200,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
     const statusDetailsEl = elements.thread.querySelector('[data-wq-status-details]');
     const statusClearBtn = elements.thread.querySelector('[data-wq-status-clear]');
     const refreshBtn = elements.thread.querySelector('[data-wq-refresh]');
+    const scopeBtns = Array.from(elements.thread.querySelectorAll('[data-wq-scope]'));
 
     const DEFAULT_STATUSES = ['ready', 'pending', 'claimed', 'in_progress'];
 
@@ -3317,6 +3339,24 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
     queueCustomEl?.addEventListener('keydown', (e) => {
       if (e.key === 'Enter') doRefresh();
     });
+
+    const updateScopeUi = () => {
+      scopeBtns.forEach((btn) => {
+        const isActive = String(btn.getAttribute('data-wq-scope') || 'all') === pane.workqueue.scope;
+        btn.classList.toggle('active', isActive);
+        btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      });
+    };
+    scopeBtns.forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const next = String(btn.getAttribute('data-wq-scope') || 'all');
+        pane.workqueue.scope = next === 'assigned' || next === 'unassigned' ? next : 'all';
+        updateScopeUi();
+        renderWorkqueuePaneItems(pane);
+        paneManager.persistAdminPanes();
+      });
+    });
+    updateScopeUi();
 
     if (statusRootEl) {
       const presetBtns = Array.from(statusRootEl.querySelectorAll('[data-wq-status-preset]'));
@@ -4008,6 +4048,7 @@ const paneManager = {
         agentId: cfg.agentId,
         queue: cfg.queue,
         statusFilter: cfg.statusFilter,
+        scope: cfg.scope,
         closable: true
       })
     );
@@ -4046,7 +4087,8 @@ const paneManager = {
             : ['ready', 'pending', 'claimed', 'in_progress'];
           const sortKey = typeof item.sortKey === 'string' ? item.sortKey : 'default';
           const sortDir = item.sortDir === 'asc' ? 'asc' : 'desc';
-          return { key, kind, queue, statusFilter, sortKey, sortDir };
+          const scope = item.scope === 'assigned' || item.scope === 'unassigned' ? item.scope : 'all';
+          return { key, kind, queue, statusFilter, sortKey, sortDir, scope };
         }
         if (kind === 'cron' || kind === 'timeline') {
           return { key, kind };
@@ -4091,7 +4133,8 @@ const paneManager = {
           queue: pane.workqueue?.queue || 'dev-team',
           statusFilter: Array.isArray(pane.workqueue?.statusFilter) ? pane.workqueue.statusFilter : [],
           sortKey: pane.workqueue?.sortKey || 'default',
-          sortDir: pane.workqueue?.sortDir || 'desc'
+          sortDir: pane.workqueue?.sortDir || 'desc',
+          scope: pane.workqueue?.scope || 'all'
         };
       }
       if (pane.kind === 'cron' || pane.kind === 'timeline') {
@@ -4129,6 +4172,7 @@ const paneManager = {
         kind: 'workqueue',
         queue: 'dev-team',
         statusFilter: ['ready', 'pending', 'claimed', 'in_progress'],
+        scope: 'all',
         closable: true
       });
       this.panes.push(pane);

--- a/app.js
+++ b/app.js
@@ -213,12 +213,17 @@ async function refreshAgents({ reason = 'manual', showSuccessToast = false } = {
 
     // Preserve UI state (selected agent per pane).
     paneManager.panes.forEach((pane) => {
-      if (!pane?.elements?.agentSelect) return;
+      if (!pane) return;
       const prior = pane.agentId;
       pane.agentId = normalizeAgentId(prior);
-      renderAgentOptions(pane.elements.agentSelect, pane.agentId);
+      if (pane?.elements?.agentSelect) {
+        renderAgentOptions(pane.elements.agentSelect, pane.agentId);
+        try {
+          pane.elements.agentSelect.value = pane.agentId;
+        } catch {}
+      }
       try {
-        pane.elements.agentSelect.value = pane.agentId;
+        renderPaneAgentIdentity(pane);
       } catch {}
     });
 
@@ -2787,13 +2792,158 @@ function buildClientForPane(pane) {
   });
 }
 
+function agentIdExists(agentId) {
+  const id = normalizeAgentId(agentId || 'main');
+  return uiState.agents.some((a) => String(a?.id || '').trim() === id);
+}
+
+function renderPaneAgentIdentity(pane) {
+  if (!pane || pane.role !== 'admin') return;
+  const elements = pane.elements;
+  if (!elements) return;
+
+  const agentId = normalizeAgentId(pane.agentId || 'main');
+  const known = uiState.agents.length === 0 ? true : agentIdExists(agentId);
+  const agent = getAgentRecord(agentId);
+
+  if (elements.agentLabel) {
+    // Keep this short; the chooser shows full labels/ids.
+    const emoji = typeof agent?.emoji === 'string' ? agent.emoji.trim() : '';
+    const name = (typeof agent?.displayName === 'string' && agent.displayName.trim()) ||
+      (typeof agent?.name === 'string' && agent.name.trim()) ||
+      agentId;
+    elements.agentLabel.textContent = `${emoji ? `${emoji} ` : ''}${name}`;
+  }
+
+  if (elements.root) {
+    elements.root.dataset.agentMissing = known ? 'false' : 'true';
+  }
+
+  if (elements.agentWarning) {
+    if (known) {
+      elements.agentWarning.hidden = true;
+      elements.agentWarning.textContent = '';
+    } else {
+      elements.agentWarning.hidden = false;
+      elements.agentWarning.textContent = `Selected agent “${agentId}” is unavailable — choose a replacement.`;
+    }
+  }
+}
+
+let agentChooserState = { openForPaneKey: null, el: null };
+
+function closeAgentChooser() {
+  try {
+    agentChooserState.el?.remove();
+  } catch {}
+  agentChooserState = { openForPaneKey: null, el: null };
+}
+
+function openAgentChooser(pane) {
+  if (!pane || pane.role !== 'admin') return;
+  closeAgentChooser();
+
+  const backdrop = document.createElement('div');
+  backdrop.className = 'agent-chooser-backdrop';
+  backdrop.setAttribute('role', 'presentation');
+
+  const dialog = document.createElement('div');
+  dialog.className = 'agent-chooser';
+  dialog.setAttribute('role', 'dialog');
+  dialog.setAttribute('aria-modal', 'true');
+  dialog.setAttribute('aria-label', 'Choose agent');
+
+  const header = document.createElement('div');
+  header.className = 'agent-chooser-header';
+
+  const title = document.createElement('div');
+  title.className = 'agent-chooser-title';
+  title.textContent = 'Choose agent for this pane';
+
+  const closeBtn = document.createElement('button');
+  closeBtn.className = 'icon-btn';
+  closeBtn.type = 'button';
+  closeBtn.textContent = '✕';
+  closeBtn.setAttribute('aria-label', 'Close agent chooser');
+  closeBtn.addEventListener('click', () => closeAgentChooser());
+
+  header.appendChild(title);
+  header.appendChild(closeBtn);
+
+  const list = document.createElement('div');
+  list.className = 'agent-chooser-list';
+
+  const agents = uiState.agents.length > 0 ? uiState.agents : [{ id: 'main', displayName: 'main', name: 'main', emoji: '' }];
+  const current = normalizeAgentId(pane.agentId || 'main');
+
+  for (const agent of agents) {
+    const id = normalizeAgentId(agent?.id || 'main');
+    const item = document.createElement('button');
+    item.className = 'agent-chooser-item';
+    item.type = 'button';
+    item.setAttribute('aria-current', id === current ? 'true' : 'false');
+
+    const left = document.createElement('div');
+    left.style.minWidth = '0';
+
+    const label = document.createElement('div');
+    label.textContent = formatAgentLabel(agent, { includeId: false });
+
+    const meta = document.createElement('div');
+    meta.className = 'agent-chooser-meta';
+    meta.textContent = id;
+
+    left.appendChild(label);
+    left.appendChild(meta);
+
+    const right = document.createElement('div');
+    right.className = 'agent-chooser-meta';
+    right.textContent = id === current ? 'selected' : 'switch';
+
+    item.appendChild(left);
+    item.appendChild(right);
+
+    item.addEventListener('click', () => {
+      paneSetAgent(pane, id);
+      closeAgentChooser();
+    });
+
+    list.appendChild(item);
+  }
+
+  dialog.appendChild(header);
+  dialog.appendChild(list);
+  backdrop.appendChild(dialog);
+
+  backdrop.addEventListener('click', (e) => {
+    if (e.target === backdrop) closeAgentChooser();
+  });
+
+  document.addEventListener(
+    'keydown',
+    (e) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        closeAgentChooser();
+      }
+    },
+    { once: true }
+  );
+
+  document.body.appendChild(backdrop);
+  agentChooserState = { openForPaneKey: pane.key, el: backdrop };
+}
+
 function paneSetAgent(pane, nextAgentId) {
   if (pane.role !== 'admin') return;
   const next = normalizeAgentId(nextAgentId);
   if (next === pane.agentId) return;
   pane.agentId = next;
   storage.set(ADMIN_DEFAULT_AGENT_KEY, next);
-  pane.elements.agentSelect.value = next;
+  try {
+    if (pane.elements.agentSelect) pane.elements.agentSelect.value = next;
+  } catch {}
+  renderPaneAgentIdentity(pane);
 
   pane.attachments.files = [];
   paneRenderAttachments(pane);
@@ -2831,7 +2981,10 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
     root,
     name: root.querySelector('[data-pane-name]'),
     agentSelect: root.querySelector('[data-pane-agent-select]'),
-    agentWrap: root.querySelector('.pane-agent'),
+    agentWrap: root.querySelector('[data-pane-agent-wrap]') || root.querySelector('.pane-agent'),
+    agentButton: root.querySelector('[data-pane-agent-button]'),
+    agentLabel: root.querySelector('[data-pane-agent-label]'),
+    agentWarning: root.querySelector('[data-pane-agent-warning]'),
     status: root.querySelector('[data-pane-status]'),
     closeBtn: root.querySelector('[data-pane-close]'),
     thread: root.querySelector('[data-pane-thread]'),
@@ -3757,7 +3910,13 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
 
   if (pane.role === 'admin') {
     renderAgentOptions(elements.agentSelect, pane.agentId);
-    elements.agentSelect.addEventListener('change', (event) => {
+    renderPaneAgentIdentity(pane);
+
+    // Explicit switching: a single clear button opens a chooser.
+    elements.agentButton?.addEventListener('click', () => openAgentChooser(pane));
+
+    // Keep select handler for accessibility/debug (even though the select is hidden by default).
+    elements.agentSelect?.addEventListener('change', (event) => {
       paneSetAgent(pane, String(event.target.value || '').trim());
     });
   } else {

--- a/app.js
+++ b/app.js
@@ -539,7 +539,10 @@ function setStatusPill(el, state, meta = '') {
 }
 
 function paneIsConnected(pane) {
-  return Boolean((pane && pane.statusState === 'connected') || (pane && pane.connected));
+  if (!pane) return false;
+  if (pane.statusState === 'connected') return true;
+  if (pane.statusState === 'disconnected' || pane.statusState === 'error' || pane.statusState === 'offline') return false;
+  return Boolean(pane.connected);
 }
 
 function updateGlobalStatus() {
@@ -1105,8 +1108,8 @@ function renderWorkqueueInspect(item) {
   const actions = document.createElement('div');
   actions.className = 'wq-inspect-actions';
   actions.innerHTML = `
-    <button type="button" class="btn" data-wq-action="edit">Edit</button>
-    <button type="button" class="btn danger" data-wq-action="delete">Delete</button>
+    <button type="button" class="btn" data-wq-action="edit" data-testid="wq-item-edit">Edit</button>
+    <button type="button" class="btn danger" data-wq-action="delete" data-testid="wq-item-delete">Delete</button>
   `;
 
   const meta = root.querySelector('.wq-inspect-meta');
@@ -1426,6 +1429,7 @@ function renderWorkqueuePaneItems(pane) {
     const row = document.createElement('button');
     row.type = 'button';
     row.className = 'wq-row';
+    row.setAttribute('data-testid', 'wq-item-row');
     if (it.id && it.id === pane.workqueue.selectedItemId) row.classList.add('selected');
 
     const leaseMs = it.leaseUntil ? Number(it.leaseUntil) - now : NaN;
@@ -1541,6 +1545,72 @@ function renderWorkqueuePaneInspect(pane, item) {
     </div>
     ${item.lastError ? `<div class="wq-inspect-block"><div class="wq-inspect-label">Last error</div><pre class="wq-inspect-pre">${escapeHtml(String(item.lastError))}</pre></div>` : ''}
   `;
+
+  const actions = document.createElement('div');
+  actions.className = 'wq-inspect-actions';
+  actions.innerHTML = `
+    <button type="button" class="btn" data-wq-action="edit" data-testid="wq-pane-item-edit">Edit</button>
+    <button type="button" class="btn danger" data-wq-action="delete" data-testid="wq-pane-item-delete">Delete</button>
+  `;
+  const meta = root.querySelector('.wq-inspect-meta');
+  if (meta) meta.insertAdjacentElement('afterend', actions);
+  else root.prepend(actions);
+
+  const editBtn = actions.querySelector('[data-wq-action="edit"]');
+  const deleteBtn = actions.querySelector('[data-wq-action="delete"]');
+  editBtn?.addEventListener('click', () => workqueuePaneEditItem(pane, item));
+  deleteBtn?.addEventListener('click', () => workqueuePaneDeleteItem(pane, item));
+}
+
+async function workqueuePaneEditItem(pane, item) {
+  if (!pane || !item || !item.id) return;
+
+  const title = prompt('Edit title', String(item.title || ''));
+  if (title === null) return;
+  const instructions = prompt('Edit instructions', String(item.instructions || ''));
+  if (instructions === null) return;
+  const priorityRaw = prompt('Edit priority (number)', String(item.priority ?? '0'));
+  if (priorityRaw === null) return;
+  const priority = Number(priorityRaw);
+  const status = prompt('Edit status (ready|pending|claimed|in_progress|done|failed)', String(item.status || 'ready'));
+  if (status === null) return;
+
+  try {
+    await workqueueUpdateItem(item.id, {
+      title,
+      instructions,
+      priority: Number.isFinite(priority) ? priority : item.priority,
+      status
+    });
+    await fetchAndRenderWorkqueueItemsForPane(pane);
+    const updated = (Array.isArray(pane.workqueue?.items) ? pane.workqueue.items : []).find((it) => it && it.id === item.id) || null;
+    pane.workqueue.selectedItemId = updated?.id || null;
+    renderWorkqueuePaneItems(pane);
+    renderWorkqueuePaneInspect(pane, updated);
+  } catch (err) {
+    addFeed('err', 'workqueue', 'failed to update item: ' + String(err));
+  }
+}
+
+async function workqueuePaneDeleteItem(pane, item) {
+  if (!pane || !item || !item.id) return;
+  const ok = confirm('Delete workqueue item?\n\n' + String(item.title || '') + '\n' + item.id);
+  if (!ok) return;
+  try {
+    const res = await fetch('/api/workqueue/delete', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ itemId: item.id })
+    });
+    const data = await res.json().catch(() => null);
+    if (!res.ok || !data?.ok) throw new Error(data?.error || String(res.status));
+    if (pane.workqueue.selectedItemId === item.id) pane.workqueue.selectedItemId = null;
+    await fetchAndRenderWorkqueueItemsForPane(pane);
+    renderWorkqueuePaneInspect(pane, null);
+  } catch (err) {
+    addFeed('err', 'workqueue', 'failed to delete item: ' + String(err));
+  }
 }
 
 function startWorkqueueLeaseTicker() {
@@ -2887,6 +2957,8 @@ function buildClientForPane(pane) {
     onStatus: (state, meta) => {
       pane.statusState = state;
       pane.statusMeta = meta || '';
+      if (state === 'connected') pane.connected = true;
+      if (state === 'disconnected' || state === 'error' || state === 'offline') pane.connected = false;
       setStatusPill(pane.elements.status, state, meta || '');
       if (pane.elements.root) {
         pane.elements.root.dataset.connected = paneIsConnected(pane) ? 'true' : 'false';
@@ -3227,14 +3299,14 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
         <div class="wq-toolbar-row">
           <label class="wq-field">
             <span class="wq-label">Queue</span>
-            <select data-wq-queue-select aria-label="Select workqueue"></select>
-            <input data-wq-queue-custom type="text" value="${escapeHtml(pane.workqueue.queue)}" placeholder="Custom queue" hidden />
+            <select data-wq-queue-select data-testid="wq-pane-queue-select" aria-label="Select workqueue"></select>
+            <input data-wq-queue-custom data-testid="wq-pane-queue-custom" type="text" value="${escapeHtml(pane.workqueue.queue)}" placeholder="Custom queue" hidden />
           </label>
 
           <div class="wq-field wq-status-field">
             <span class="wq-label">Status filter</span>
-            <div class="wq-status-multiselect" data-wq-status>
-              <div class="wq-status-selected" data-wq-status-selected aria-live="polite"></div>
+            <div class="wq-status-multiselect" data-wq-status data-testid="wq-pane-status-filter">
+              <div class="wq-status-selected" data-wq-status-selected data-testid="wq-pane-status-selected" aria-live="polite"></div>
               <details class="wq-status-details" data-wq-status-details>
                 <summary type="button">Choose statuses…</summary>
                 <div class="wq-status-menu">
@@ -3251,7 +3323,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
             </div>
           </div>
 
-          <button data-wq-refresh class="secondary" type="button">Refresh</button>
+          <button data-wq-refresh data-testid="wq-pane-refresh" class="secondary" type="button">Refresh</button>
 
           <div class="wq-scope" role="group" aria-label="Workqueue scope">
             <span class="wq-sort-label">Scope</span>
@@ -3339,13 +3411,13 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
             <button type="button" class="wq-list-sort" data-wq-sort="claimedBy">claimedBy</button>
             <div>lease</div>
           </div>
-          <div class="wq-list-body" data-wq-list-body></div>
+          <div class="wq-list-body" data-wq-list-body data-testid="wq-pane-list-body"></div>
           <div data-wq-empty class="hint" style="padding: 10px 12px;" hidden>No items.</div>
         </section>
 
         <section class="wq-inspect" aria-label="Workqueue item details">
           <div class="wq-inspect-header">Inspect</div>
-          <div data-wq-inspect class="wq-inspect-body"></div>
+          <div data-wq-inspect data-testid="wq-pane-inspect" class="wq-inspect-body"></div>
         </section>
       </div>
     `;

--- a/app.js
+++ b/app.js
@@ -715,6 +715,8 @@ function closeSettings() {
 // Workqueue (admin-only)
 
 const WORKQUEUE_STATUSES = ['ready', 'pending', 'claimed', 'in_progress', 'done', 'failed'];
+const WORKQUEUE_ALL_SCOPE_GUARDRAIL_THRESHOLD_KEY = 'clawnsole.workqueue.allScopeGuardrailThreshold';
+const WORKQUEUE_ALL_SCOPE_GUARDRAIL_DEFAULT_THRESHOLD = 200;
 
 const workqueueState = {
   queues: [],
@@ -1338,6 +1340,24 @@ function renderWorkqueuePaneItems(pane) {
   if (statusLine) {
     const scopeLabel = scope === 'assigned' ? `assigned:${target}` : scope;
     statusLine.textContent = `${items.length} shown (${scopeLabel}) / ${itemsRaw.length} total`;
+  }
+
+  const guardrail = pane.elements?.thread?.querySelector('[data-wq-all-scope-guardrail]');
+  const guardrailText = pane.elements?.thread?.querySelector('[data-wq-all-scope-guardrail-text]');
+  const thresholdRaw = Number(storage.get(WORKQUEUE_ALL_SCOPE_GUARDRAIL_THRESHOLD_KEY, WORKQUEUE_ALL_SCOPE_GUARDRAIL_DEFAULT_THRESHOLD));
+  const threshold = Number.isFinite(thresholdRaw) && thresholdRaw > 0 ? Math.floor(thresholdRaw) : WORKQUEUE_ALL_SCOPE_GUARDRAIL_DEFAULT_THRESHOLD;
+  const isHighVolumeAllScope = scope === 'all' && itemsRaw.length > threshold;
+  if (guardrail && guardrailText) {
+    if (!pane.workqueue.allScopeGuardrailDismissed && isHighVolumeAllScope) {
+      guardrail.hidden = false;
+      guardrailText.textContent = `Viewing all items (${itemsRaw.length}). Narrow scope?`;
+      if (pane.workqueue.allScopeGuardrailLastShownCount !== itemsRaw.length) {
+        pane.workqueue.allScopeGuardrailLastShownCount = itemsRaw.length;
+        addFeed('event', 'workqueue.guardrail', `shown scope=all total=${itemsRaw.length} threshold=${threshold}`);
+      }
+    } else {
+      guardrail.hidden = true;
+    }
   }
 
   const now = Date.now();
@@ -3029,7 +3049,9 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
       items: [],
       selectedItemId: null,
       sortKey: typeof sortKey === 'string' && sortKey.trim() ? sortKey.trim() : 'default',
-      sortDir: sortDir === 'asc' ? 'asc' : 'desc'
+      sortDir: sortDir === 'asc' ? 'asc' : 'desc',
+      allScopeGuardrailDismissed: false,
+      allScopeGuardrailLastShownCount: 0
     },
     connected: false,
     statusState: 'disconnected',
@@ -3118,6 +3140,12 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
             <button type="button" class="wq-sort-btn" data-wq-scope="assigned">Assigned</button>
             <button type="button" class="wq-sort-btn" data-wq-scope="unassigned">Unassigned</button>
             <button type="button" class="wq-sort-btn" data-wq-scope="all">All</button>
+            <div class="wq-guardrail" data-wq-all-scope-guardrail hidden>
+              <span class="wq-guardrail-text" data-wq-all-scope-guardrail-text></span>
+              <button type="button" class="wq-sort-btn" data-wq-all-scope-action="assigned">Assigned to active target</button>
+              <button type="button" class="wq-sort-btn" data-wq-all-scope-action="unassigned">Unassigned</button>
+              <button type="button" class="wq-sort-btn" data-wq-all-scope-action="dismiss" aria-label="Dismiss all-scope guardrail">Dismiss</button>
+            </div>
           </div>
 
           <div class="wq-sort" role="group" aria-label="Sort workqueue items">
@@ -3354,6 +3382,27 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
         updateScopeUi();
         renderWorkqueuePaneItems(pane);
         paneManager.persistAdminPanes();
+      });
+    });
+    const guardrailActionBtns = Array.from(elements.thread.querySelectorAll('[data-wq-all-scope-action]'));
+    guardrailActionBtns.forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const action = String(btn.getAttribute('data-wq-all-scope-action') || '').trim();
+        if (action === 'dismiss') {
+          pane.workqueue.allScopeGuardrailDismissed = true;
+          addFeed('event', 'workqueue.guardrail', 'action=dismiss');
+          renderWorkqueuePaneItems(pane);
+          paneManager.persistAdminPanes();
+          return;
+        }
+        if (action === 'assigned' || action === 'unassigned') {
+          pane.workqueue.scope = action;
+          pane.workqueue.allScopeGuardrailDismissed = true;
+          addFeed('event', 'workqueue.guardrail', `action=${action}`);
+          updateScopeUi();
+          renderWorkqueuePaneItems(pane);
+          paneManager.persistAdminPanes();
+        }
       });
     });
     updateScopeUi();

--- a/app.js
+++ b/app.js
@@ -538,6 +538,10 @@ function setStatusPill(el, state, meta = '') {
   el.title = meta || '';
 }
 
+function paneIsConnected(pane) {
+  return Boolean((pane && pane.statusState === 'connected') || (pane && pane.connected));
+}
+
 function updateGlobalStatus() {
   const panes = paneManager.panes;
   if (!uiState.authed) {
@@ -551,7 +555,7 @@ function updateGlobalStatus() {
     return;
   }
 
-  const connectedCount = panes.filter((pane) => pane.connected).length;
+  const connectedCount = panes.filter((pane) => paneIsConnected(pane)).length;
   const total = panes.length;
   const anyConnecting = panes.some((pane) => pane.statusState === 'connecting' || pane.statusState === 'reconnecting');
   const anyError = panes.some((pane) => pane.statusState === 'error');
@@ -741,6 +745,22 @@ function openWorkqueue() {
   ensureWorkqueueModalSorting();
   ensureWorkqueueBootstrapped();
   startWorkqueueAutoRefresh();
+}
+
+function openOrFocusPairedWorkqueuePaneForActiveTarget() {
+  if (roleState.role !== 'admin') return;
+  const activePane = paneManager.getActivePane();
+  const fallback = storage.get(ADMIN_DEFAULT_AGENT_KEY, 'main');
+  const targetAgentId = normalizeAgentId(activePane?.kind === 'chat' ? activePane.agentId : fallback);
+  const existing = paneManager.panes.find((pane) => pane && pane.kind === 'workqueue' && normalizeAgentId(pane.agentId) === targetAgentId);
+  const targetPane = existing || paneManager.addPane('workqueue', { agentId: targetAgentId, scope: 'assigned' });
+  if (!targetPane) return;
+  targetPane.agentId = targetAgentId;
+  if (targetPane.workqueue) targetPane.workqueue.scope = 'assigned';
+  paneManager.focusPanePrimary(targetPane);
+  renderWorkqueuePaneItems(targetPane);
+  fetchAndRenderWorkqueueItemsForPane(targetPane);
+  paneManager.persistAdminPanes();
 }
 
 function closeWorkqueue() {
@@ -1197,6 +1217,28 @@ async function fetchWorkqueueItems({ queue = '', statuses = [] } = {}) {
   return Array.isArray(data.items) ? data.items : [];
 }
 
+const WORKQUEUE_SOURCE_KEYS = ['issue', 'routine', 'coordination', 'other'];
+
+function inferWorkqueueItemSource(item) {
+  const explicit = String(item?.meta?.source || '').trim().toLowerCase();
+  if (explicit === 'issue' || explicit === 'routine' || explicit === 'coordination') return explicit;
+  if (item?.meta?.issueNumber || item?.meta?.repo) return 'issue';
+  const title = String(item?.title || '').toLowerCase();
+  if (title.includes('coordination')) return 'coordination';
+  if (title.includes('routine') || title.includes('sweep')) return 'routine';
+  return 'other';
+}
+
+function extractWorkqueueItemRepo(item) {
+  const direct = String(item?.meta?.repo || '').trim();
+  if (direct) return direct;
+  const dedupe = String(item?.meta?.dedupeKey || '').trim();
+  if (dedupe.includes('#')) return dedupe.split('#')[0].trim();
+  const instructions = String(item?.instructions || '');
+  const match = instructions.match(/^Repo:\s*([^\s]+)\s*$/im);
+  return match?.[1] ? String(match[1]).trim() : '';
+}
+
 function renderWorkqueueCounts(rootEl, counts) {
   const statuses = ['ready', 'pending', 'claimed', 'in_progress', 'done', 'failed'];
   const list = document.createElement('dl');
@@ -1313,6 +1355,7 @@ async function fetchAndRenderWorkqueueItemsForPane(pane) {
     const items = Array.isArray(data.items) ? data.items : [];
     pane.workqueue.items = items;
     if (statusLine) statusLine.textContent = `${items.length} item(s)`;
+    renderWorkqueuePaneQuickFilters(pane);
     renderWorkqueuePaneItems(pane);
   } catch (err) {
     if (statusLine) statusLine.textContent = `Failed to load: ${String(err)}`;
@@ -1334,12 +1377,30 @@ function renderWorkqueuePaneItems(pane) {
     if (scope === 'unassigned') return !assigned;
     return true;
   });
-  const items = sortWorkqueueItems(scopedItems, { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
+  const sourceFilter = new Set(
+    (Array.isArray(pane.workqueue?.sourceFilter) && pane.workqueue.sourceFilter.length
+      ? pane.workqueue.sourceFilter
+      : WORKQUEUE_SOURCE_KEYS).map((s) => String(s || '').trim().toLowerCase()).filter(Boolean)
+  );
+  const repoFilter = new Set(
+    (Array.isArray(pane.workqueue?.repoFilter) ? pane.workqueue.repoFilter : []).map((s) => String(s || '').trim()).filter(Boolean)
+  );
+  const filteredItems = scopedItems.filter((it) => {
+    const source = inferWorkqueueItemSource(it);
+    if (sourceFilter.size && !sourceFilter.has(source)) return false;
+    if (repoFilter.size) {
+      const repo = extractWorkqueueItemRepo(it);
+      if (!repo || !repoFilter.has(repo)) return false;
+    }
+    return true;
+  });
+  const items = sortWorkqueueItems(filteredItems, { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
   if (empty) empty.hidden = items.length > 0;
   const statusLine = pane.elements?.thread?.querySelector('[data-wq-statusline]');
   if (statusLine) {
     const scopeLabel = scope === 'assigned' ? `assigned:${target}` : scope;
-    statusLine.textContent = `${items.length} shown (${scopeLabel}) / ${itemsRaw.length} total`;
+    const filtersLabel = `source:${Array.from(sourceFilter).join('|') || 'all'}${repoFilter.size ? ` repo:${Array.from(repoFilter).join('|')}` : ''}`;
+    statusLine.textContent = `${items.length} shown (${scopeLabel}; ${filtersLabel}) / ${itemsRaw.length} total`;
   }
 
   const guardrail = pane.elements?.thread?.querySelector('[data-wq-all-scope-guardrail]');
@@ -1394,6 +1455,61 @@ function renderWorkqueuePaneItems(pane) {
     pane.workqueue.selectedItemId = null;
     renderWorkqueuePaneInspect(pane, null);
   }
+}
+
+function renderWorkqueuePaneQuickFilters(pane) {
+  const sourceRoot = pane.elements?.thread?.querySelector('[data-wq-source-filters]');
+  const repoRoot = pane.elements?.thread?.querySelector('[data-wq-repo-filters]');
+  if (!sourceRoot || !repoRoot) return;
+
+  const itemsRaw = Array.isArray(pane.workqueue?.items) ? pane.workqueue.items : [];
+  const sourceSet = new Set(
+    (Array.isArray(pane.workqueue?.sourceFilter) && pane.workqueue.sourceFilter.length
+      ? pane.workqueue.sourceFilter
+      : WORKQUEUE_SOURCE_KEYS).map((s) => String(s || '').trim().toLowerCase()).filter(Boolean)
+  );
+  const repoSet = new Set((Array.isArray(pane.workqueue?.repoFilter) ? pane.workqueue.repoFilter : []).map((s) => String(s || '').trim()).filter(Boolean));
+  const repoCandidates = Array.from(new Set(itemsRaw.map((it) => extractWorkqueueItemRepo(it)).filter(Boolean))).sort((a, b) => a.localeCompare(b));
+
+  sourceRoot.innerHTML = '';
+  WORKQUEUE_SOURCE_KEYS.forEach((key) => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'wq-sort-btn';
+    btn.textContent = key;
+    const active = sourceSet.has(key);
+    btn.classList.toggle('active', active);
+    btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+    btn.addEventListener('click', () => {
+      if (sourceSet.has(key)) sourceSet.delete(key);
+      else sourceSet.add(key);
+      pane.workqueue.sourceFilter = Array.from(sourceSet);
+      paneManager.persistAdminPanes();
+      renderWorkqueuePaneQuickFilters(pane);
+      renderWorkqueuePaneItems(pane);
+    });
+    sourceRoot.appendChild(btn);
+  });
+
+  repoRoot.innerHTML = '';
+  repoCandidates.forEach((repo) => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'wq-sort-btn';
+    btn.textContent = repo;
+    const active = repoSet.has(repo);
+    btn.classList.toggle('active', active);
+    btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+    btn.addEventListener('click', () => {
+      if (repoSet.has(repo)) repoSet.delete(repo);
+      else repoSet.add(repo);
+      pane.workqueue.repoFilter = Array.from(repoSet);
+      paneManager.persistAdminPanes();
+      renderWorkqueuePaneQuickFilters(pane);
+      renderWorkqueuePaneItems(pane);
+    });
+    repoRoot.appendChild(btn);
+  });
 }
 
 function renderWorkqueuePaneInspect(pane, item) {
@@ -2773,7 +2889,7 @@ function buildClientForPane(pane) {
       pane.statusMeta = meta || '';
       setStatusPill(pane.elements.status, state, meta || '');
       if (pane.elements.root) {
-        pane.elements.root.dataset.connected = pane.connected ? 'true' : 'false';
+        pane.elements.root.dataset.connected = paneIsConnected(pane) ? 'true' : 'false';
         pane.elements.root.dataset.wsState = String(state || '');
       }
       updateGlobalStatus();
@@ -3007,7 +3123,7 @@ function renderAgentOptions(selectEl, agentId) {
   selectEl.value = normalizeAgentId(agentId || 'main');
 }
 
-function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sortKey, sortDir, scope = 'all', closable = true } = {}) {
+function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sortKey, sortDir, scope = 'all', sourceFilter, repoFilter, closable = true } = {}) {
   const template = globalElements.paneTemplate;
   const root = template.content.firstElementChild.cloneNode(true);
   const elements = {
@@ -3050,6 +3166,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
       selectedItemId: null,
       sortKey: typeof sortKey === 'string' && sortKey.trim() ? sortKey.trim() : 'default',
       sortDir: sortDir === 'asc' ? 'asc' : 'desc',
+      sourceFilter: Array.isArray(sourceFilter) && sourceFilter.length ? sourceFilter : WORKQUEUE_SOURCE_KEYS.slice(),
+      repoFilter: Array.isArray(repoFilter) ? repoFilter : [],
       allScopeGuardrailDismissed: false,
       allScopeGuardrailLastShownCount: 0
     },
@@ -3154,6 +3272,18 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
             <button type="button" class="wq-sort-btn" data-wq-sort="priority">Priority</button>
             <button type="button" class="wq-sort-btn" data-wq-sort="updatedAt">Updated</button>
             <button type="button" class="wq-sort-btn" data-wq-sort="createdAt">Created</button>
+          </div>
+
+          <div class="wq-sort" role="group" aria-label="Source filters">
+            <span class="wq-sort-label">Source</span>
+            <div data-wq-source-filters></div>
+          </div>
+
+          <div class="wq-sort" role="group" aria-label="Repo filters">
+            <span class="wq-sort-label">Repo</span>
+            <button type="button" class="wq-sort-btn" data-wq-repo-preset="clawnsole">Clawnsole only</button>
+            <button type="button" class="wq-sort-btn" data-wq-repo-preset="clear">All repos</button>
+            <div data-wq-repo-filters></div>
           </div>
         </div>
 
@@ -3403,6 +3533,17 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, so
           renderWorkqueuePaneItems(pane);
           paneManager.persistAdminPanes();
         }
+      });
+    });
+    const repoPresetBtns = Array.from(elements.thread.querySelectorAll('[data-wq-repo-preset]'));
+    repoPresetBtns.forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const preset = String(btn.getAttribute('data-wq-repo-preset') || '').trim();
+        if (preset === 'clawnsole') pane.workqueue.repoFilter = ['rmdmattingly/clawnsole'];
+        if (preset === 'clear') pane.workqueue.repoFilter = [];
+        paneManager.persistAdminPanes();
+        renderWorkqueuePaneQuickFilters(pane);
+        renderWorkqueuePaneItems(pane);
       });
     });
     updateScopeUi();
@@ -4076,6 +4217,7 @@ function inferPaneCols(count) {
 const paneManager = {
   panes: [],
   maxPanes: 6,
+  activePaneKey: '',
   init() {
     this.destroyAll();
 
@@ -4097,11 +4239,18 @@ const paneManager = {
         agentId: cfg.agentId,
         queue: cfg.queue,
         statusFilter: cfg.statusFilter,
+        sortKey: cfg.sortKey,
+        sortDir: cfg.sortDir,
         scope: cfg.scope,
+        sourceFilter: cfg.sourceFilter,
+        repoFilter: cfg.repoFilter,
         closable: true
       })
     );
-    this.panes.forEach((pane) => globalElements.paneGrid.appendChild(pane.elements.root));
+    this.panes.forEach((pane) => {
+      globalElements.paneGrid.appendChild(pane.elements.root);
+      this.bindPaneActivation(pane);
+    });
     this.updatePaneLabels();
     this.updateCloseButtons();
     this.applyInferredLayout();
@@ -4117,6 +4266,22 @@ const paneManager = {
       } catch {}
     });
     this.panes = [];
+    this.activePaneKey = '';
+  },
+  bindPaneActivation(pane) {
+    if (!pane?.elements?.root) return;
+    pane.elements.root.addEventListener('mousedown', () => this.setActivePane(pane.key));
+    pane.elements.root.addEventListener('focusin', () => this.setActivePane(pane.key));
+  },
+  setActivePane(paneKey) {
+    const key = String(paneKey || '').trim();
+    if (!key) return;
+    this.activePaneKey = key;
+  },
+  getActivePane() {
+    const key = String(this.activePaneKey || '').trim();
+    if (!key) return null;
+    return this.panes.find((pane) => pane && pane.key === key) || null;
   },
   loadAdminPanes() {
     const storedDefault = storage.get(ADMIN_DEFAULT_AGENT_KEY, 'main');
@@ -4137,7 +4302,13 @@ const paneManager = {
           const sortKey = typeof item.sortKey === 'string' ? item.sortKey : 'default';
           const sortDir = item.sortDir === 'asc' ? 'asc' : 'desc';
           const scope = item.scope === 'assigned' || item.scope === 'unassigned' ? item.scope : 'all';
-          return { key, kind, queue, statusFilter, sortKey, sortDir, scope };
+          const sourceFilter = Array.isArray(item.sourceFilter)
+            ? item.sourceFilter.map((s) => String(s || '').trim().toLowerCase()).filter((s) => WORKQUEUE_SOURCE_KEYS.includes(s))
+            : WORKQUEUE_SOURCE_KEYS.slice();
+          const repoFilter = Array.isArray(item.repoFilter)
+            ? item.repoFilter.map((s) => String(s || '').trim()).filter(Boolean)
+            : [];
+          return { key, kind, queue, statusFilter, sortKey, sortDir, scope, sourceFilter, repoFilter };
         }
         if (kind === 'cron' || kind === 'timeline') {
           return { key, kind };
@@ -4183,7 +4354,9 @@ const paneManager = {
           statusFilter: Array.isArray(pane.workqueue?.statusFilter) ? pane.workqueue.statusFilter : [],
           sortKey: pane.workqueue?.sortKey || 'default',
           sortDir: pane.workqueue?.sortDir || 'desc',
-          scope: pane.workqueue?.scope || 'all'
+          scope: pane.workqueue?.scope || 'all',
+          sourceFilter: Array.isArray(pane.workqueue?.sourceFilter) ? pane.workqueue.sourceFilter : WORKQUEUE_SOURCE_KEYS.slice(),
+          repoFilter: Array.isArray(pane.workqueue?.repoFilter) ? pane.workqueue.repoFilter : []
         };
       }
       if (pane.kind === 'cron' || pane.kind === 'timeline') {
@@ -4193,7 +4366,7 @@ const paneManager = {
     });
     storage.set(ADMIN_PANES_KEY, JSON.stringify(payload));
   },
-  addPane(kind = 'chat') {
+  addPane(kind = 'chat', opts = {}) {
     if (roleState.role !== 'admin') return;
     if (this.panes.length >= this.maxPanes) return;
 
@@ -4215,17 +4388,21 @@ const paneManager = {
                 : 'chat';
 
     if (normalizedKind === 'workqueue') {
+      const scopedAgentId = normalizeAgentId(opts?.agentId || storage.get(ADMIN_DEFAULT_AGENT_KEY, 'main'));
+      const scopedScope = opts?.scope === 'assigned' || opts?.scope === 'unassigned' ? opts.scope : 'all';
       const pane = createPane({
         key: `p${randomId().slice(0, 8)}`,
         role: 'admin',
         kind: 'workqueue',
+        agentId: scopedAgentId,
         queue: 'dev-team',
         statusFilter: ['ready', 'pending', 'claimed', 'in_progress'],
-        scope: 'all',
+        scope: scopedScope,
         closable: true
       });
       this.panes.push(pane);
       globalElements.paneGrid.appendChild(pane.elements.root);
+      this.bindPaneActivation(pane);
       this.updatePaneLabels();
       this.updateCloseButtons();
       this.applyInferredLayout();
@@ -4243,6 +4420,7 @@ const paneManager = {
       });
       this.panes.push(pane);
       globalElements.paneGrid.appendChild(pane.elements.root);
+      this.bindPaneActivation(pane);
       this.updatePaneLabels();
       this.updateCloseButtons();
       this.applyInferredLayout();
@@ -4258,6 +4436,7 @@ const paneManager = {
     const pane = createPane({ key: `p${randomId().slice(0, 8)}`, role: 'admin', kind: 'chat', agentId, closable: true });
     this.panes.push(pane);
     globalElements.paneGrid.appendChild(pane.elements.root);
+    this.bindPaneActivation(pane);
     this.updatePaneLabels();
     this.updateCloseButtons();
     this.applyInferredLayout();
@@ -4274,6 +4453,7 @@ const paneManager = {
     // Defer until DOM has painted.
     setTimeout(() => {
       try {
+        this.setActivePane(pane.key);
         if (pane.kind === 'chat') {
           pane.elements.input?.focus?.();
           return;
@@ -4543,7 +4723,7 @@ globalElements.refreshAgentsBtn?.addEventListener('click', () => {
   });
 });
 
-globalElements.workqueueBtn?.addEventListener('click', () => openWorkqueue());
+globalElements.workqueueBtn?.addEventListener('click', () => openOrFocusPairedWorkqueuePaneForActiveTarget());
 globalElements.workqueueCloseBtn?.addEventListener('click', () => closeWorkqueue());
 globalElements.workqueueModal?.addEventListener('click', (event) => {
   if (event.target === globalElements.workqueueModal) closeWorkqueue();

--- a/index.html
+++ b/index.html
@@ -71,9 +71,13 @@
             <div class="pane-header">
               <div class="pane-header-left">
                 <div class="pane-name" data-pane-name data-testid="pane-type-label">Pane</div>
-                <div class="pane-agent">
+                <div class="pane-agent" data-pane-agent-wrap>
                   <span class="agent-label">Agent</span>
+                  <button class="agent-pill-btn" type="button" data-pane-agent-button aria-label="Change agent" data-testid="pane-agent-button">
+                    <span class="agent-pill-label" data-pane-agent-label>main</span>
+                  </button>
                   <select data-pane-agent-select aria-label="Select agent" data-testid="pane-agent-select"></select>
+                  <div class="agent-warning" data-pane-agent-warning role="status" aria-live="polite" hidden></div>
                 </div>
               </div>
               <div class="pane-header-right">

--- a/index.html
+++ b/index.html
@@ -299,6 +299,14 @@
           <div class="hint">
             Auto-connecting with the gateway token from your local OpenClaw config.
           </div>
+
+          <div class="hint" style="margin-top: 12px;">
+            <div style="font-weight: 600; margin-bottom: 6px;">Keyboard shortcuts (admin)</div>
+            <div>New Chat pane: <code>Ctrl/Cmd</code> + <code>Shift</code> + <code>C</code></div>
+            <div>New Workqueue pane: <code>Ctrl/Cmd</code> + <code>Shift</code> + <code>W</code></div>
+            <div>New Cron pane: <code>Ctrl/Cmd</code> + <code>Shift</code> + <code>R</code></div>
+            <div>New Timeline pane: <code>Ctrl/Cmd</code> + <code>Shift</code> + <code>T</code></div>
+          </div>
         </div>
       </div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -1166,6 +1166,26 @@ button.send-btn .btn-icon {
   flex-wrap: wrap;
 }
 
+.wq-guardrail {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: 8px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 196, 106, 0.35);
+  background: rgba(255, 196, 106, 0.1);
+}
+
+.wq-guardrail[hidden] {
+  display: none !important;
+}
+
+.wq-guardrail-text {
+  font-size: 12px;
+  color: var(--text);
+}
+
 .wq-sort-label {
   font-size: 11px;
   color: var(--muted);

--- a/styles.css
+++ b/styles.css
@@ -1166,6 +1166,13 @@ button.send-btn .btn-icon {
   flex-wrap: wrap;
 }
 
+[data-wq-source-filters],
+[data-wq-repo-filters] {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
 .wq-guardrail {
   display: inline-flex;
   align-items: center;

--- a/styles.css
+++ b/styles.css
@@ -439,11 +439,117 @@ body::before {
 }
 
 .pane-agent select {
-  padding: 6px 10px;
+  /* Keep in DOM for a11y/tests, but don't make switching a subtle bumpable dropdown. */
+  display: none;
+}
+
+.agent-pill-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
   border-radius: 999px;
   min-height: 32px;
+  max-width: 260px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(11, 14, 19, 0.55);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.agent-pill-btn:hover {
+  background: rgba(11, 14, 19, 0.75);
+}
+
+.agent-pill-btn:focus-visible {
+  outline: 2px solid rgba(125, 211, 252, 0.65);
+  outline-offset: 2px;
+}
+
+.agent-pill-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   font-size: 12px;
-  max-width: 220px;
+}
+
+.pane[data-agent-missing="true"] .agent-pill-btn {
+  border-color: rgba(248, 113, 113, 0.65);
+}
+
+.agent-warning {
+  font-size: 11px;
+  color: rgba(248, 113, 113, 0.95);
+  margin-left: 8px;
+  max-width: 320px;
+}
+
+.agent-chooser-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 88px 14px 14px;
+}
+
+.agent-chooser {
+  width: min(720px, calc(100vw - 28px));
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(9, 11, 14, 0.96);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.55);
+  overflow: hidden;
+}
+
+.agent-chooser-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 14px;
+  gap: 10px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.agent-chooser-title {
+  font-size: 13px;
+  color: var(--text);
+  letter-spacing: 0.02em;
+}
+
+.agent-chooser-list {
+  padding: 10px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 10px;
+}
+
+.agent-chooser-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.10);
+  background: rgba(11, 14, 19, 0.55);
+  cursor: pointer;
+  color: var(--text);
+}
+
+.agent-chooser-item:hover {
+  background: rgba(11, 14, 19, 0.82);
+}
+
+.agent-chooser-item[aria-current="true"] {
+  border-color: rgba(125, 211, 252, 0.65);
+}
+
+.agent-chooser-meta {
+  font-size: 11px;
+  color: var(--muted);
 }
 
 .pane-header-right {

--- a/styles.css
+++ b/styles.css
@@ -1306,8 +1306,9 @@ button.send-btn .btn-icon {
   grid-auto-columns: minmax(250px, 1fr);
   gap: 10px;
   padding: 10px;
-  max-height: 520px;
-  overflow: auto;
+  height: 520px;
+  overflow-x: auto;
+  overflow-y: hidden;
 }
 
 .wq-board-col {
@@ -1317,6 +1318,7 @@ button.send-btn .btn-icon {
   display: flex;
   flex-direction: column;
   min-width: 250px;
+  min-height: 0;
 }
 
 .wq-board-col-header {
@@ -1326,6 +1328,9 @@ button.send-btn .btn-icon {
   padding: 10px 10px 8px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(0, 0, 0, 0.18);
+  position: sticky;
+  top: 0;
+  z-index: 1;
 }
 
 .wq-board-col-title {

--- a/tests/ui/_helpers.js
+++ b/tests/ui/_helpers.js
@@ -170,7 +170,11 @@ async function loginAdmin(page, serverPort) {
   await page.fill('#loginPassword', 'admin');
   await page.click('#loginBtn');
   await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
-  await page.waitForSelector('[data-pane] [data-pane-input]', { timeout: 90000 });
+  await page.waitForSelector('header.topbar', { timeout: 90000 });
+  await page.waitForFunction(() => {
+    const overlay = document.querySelector('[data-testid="login-overlay"]');
+    return !!overlay && !overlay.classList.contains('open');
+  }, { timeout: 90000 });
 }
 
 function attachConsoleErrorAsserts(page) {

--- a/tests/ui/fixtures.js
+++ b/tests/ui/fixtures.js
@@ -166,7 +166,11 @@ const test = base.test.extend({
           await page.fill('#loginPassword', password);
           await page.click('#loginBtn');
           await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
-          await page.waitForSelector('[data-pane] [data-pane-input]', { timeout: 90000 });
+          await page.waitForSelector('header.topbar', { timeout: 90000 });
+          await page.waitForFunction(() => {
+            const overlay = document.querySelector('[data-testid="login-overlay"]');
+            return !!overlay && !overlay.classList.contains('open');
+          }, { timeout: 90000 });
         }
       };
 

--- a/tests/ui/pane-add-menu.spec.js
+++ b/tests/ui/pane-add-menu.spec.js
@@ -1,0 +1,70 @@
+const { test, expect } = require('@playwright/test');
+
+const { startTestEnv, loginAdmin, attachConsoleErrorAsserts } = require('./_helpers');
+
+let env;
+
+test.beforeAll(async () => {
+  env = await startTestEnv();
+});
+
+test.afterAll(() => {
+  env?.stop?.();
+});
+
+test.afterEach(async ({ page }) => {
+  if (page.__consoleAsserts) {
+    page.__consoleAsserts.assertNoErrors();
+  }
+});
+
+test('pane add menu: opens + adds explicit pane kinds + focuses sane defaults', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+
+  const addBtn = page.locator('#addPaneBtn');
+  await expect(addBtn).toBeVisible();
+
+  await addBtn.click();
+  const menu = page.locator('[data-testid="pane-add-menu"]');
+  await expect(menu).toBeVisible();
+
+  await expect(menu.locator('[data-testid="pane-add-menu-chat"]')).toHaveText(/New Chat pane/);
+  await expect(menu.locator('[data-testid="pane-add-menu-workqueue"]')).toHaveText(/New Workqueue pane/);
+  await expect(menu.locator('[data-testid="pane-add-menu-cron"]')).toHaveText(/New Cron pane/);
+  await expect(menu.locator('[data-testid="pane-add-menu-timeline"]')).toHaveText(/New Timeline pane/);
+
+  // Add a workqueue pane and ensure it exists + focus lands on primary control.
+  await menu.locator('[data-testid="pane-add-menu-workqueue"]').click();
+
+  const wqPane = page.locator('[data-pane-kind="workqueue"]').last();
+  await expect(wqPane).toBeVisible();
+
+  const queueSelect = wqPane.locator('[data-wq-queue-select]');
+  await expect(queueSelect).toBeVisible();
+  await expect(queueSelect).toBeFocused();
+});
+
+test('pane add shortcuts: Ctrl/Cmd+Shift+T adds a timeline pane', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+
+  const countBefore = await page.locator('[data-pane]').count();
+
+  // Use a Playwright-friendly cross-platform modifier.
+  await page.keyboard.press('ControlOrMeta+Shift+T');
+
+  const tlPane = page.locator('[data-pane-kind="timeline"]').last();
+  await expect(tlPane).toBeVisible();
+
+  const countAfter = await page.locator('[data-pane]').count();
+  expect(countAfter).toBeGreaterThan(countBefore);
+});

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -38,3 +38,45 @@ test('workqueue pane: renders + has queue dropdown + does not show chat composer
   await expect(wqPane.locator('.chat-input-row')).toBeHidden();
   await expect(wqPane.locator('[data-pane-input]')).toBeHidden();
 });
+
+test('workqueue pane: scope filter toggles assigned/unassigned/all deterministically', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  await page.evaluate(async () => {
+    const post = async (url, body) => {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(body)
+      });
+      return res.json();
+    };
+
+    await post('/api/workqueue/enqueue', { queue: 'dev-team', title: 'a', instructions: 'x', priority: 1 });
+    await post('/api/workqueue/enqueue', { queue: 'dev-team', title: 'b', instructions: 'x', priority: 1 });
+    await post('/api/workqueue/enqueue', { queue: 'dev-team', title: 'c', instructions: 'x', priority: 1 });
+    await post('/api/workqueue/claim-next', { agentId: 'main', queues: ['dev-team'], leaseMs: 900000 });
+  });
+
+  const wqPane = page.locator('[data-pane-kind="workqueue"]').last();
+  await wqPane.locator('[data-wq-refresh]').click();
+
+  const rows = wqPane.locator('[data-wq-list-body] .wq-row');
+  const allBtn = wqPane.locator('[data-wq-scope="all"]');
+  const assignedBtn = wqPane.locator('[data-wq-scope="assigned"]');
+  const unassignedBtn = wqPane.locator('[data-wq-scope="unassigned"]');
+
+  await allBtn.click();
+  await expect(rows).toHaveCount(3);
+  await assignedBtn.click();
+  await expect(rows).toHaveCount(1);
+  await unassignedBtn.click();
+  await expect(rows).toHaveCount(2);
+});

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -80,3 +80,77 @@ test('workqueue pane: scope filter toggles assigned/unassigned/all deterministic
   await unassignedBtn.click();
   await expect(rows).toHaveCount(2);
 });
+
+test('workqueue pane: high-volume all-scope guardrail shows and downscopes with one click', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+  const queueName = `wq-guardrail-high-${Date.now()}`;
+  const wqPane = page.locator('[data-pane-kind="workqueue"]').last();
+  await wqPane.locator('[data-wq-queue-select]').selectOption('__custom__');
+  await wqPane.locator('[data-wq-queue-custom]').fill(queueName);
+  await wqPane.locator('[data-wq-queue-custom]').press('Enter');
+
+  await page.evaluate(async ({ queueName }) => {
+    const post = async (url, body) => {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(body)
+      });
+      return res.json();
+    };
+
+    for (let i = 0; i < 205; i += 1) {
+      await post('/api/workqueue/enqueue', { queue: queueName, title: `bulk-${i}`, instructions: 'x', priority: 1 });
+    }
+    await post('/api/workqueue/claim-next', { agentId: 'main', queues: [queueName], leaseMs: 900000 });
+  }, { queueName });
+
+  await wqPane.locator('[data-wq-refresh]').click();
+  await expect(wqPane.locator('[data-wq-all-scope-guardrail]')).toBeVisible();
+  await expect(wqPane.locator('[data-wq-all-scope-guardrail-text]')).toContainText('Viewing all items');
+
+  const rows = wqPane.locator('[data-wq-list-body] .wq-row');
+  await wqPane.locator('[data-wq-all-scope-action="assigned"]').click();
+  await expect(rows).toHaveCount(1);
+  await expect(wqPane.locator('[data-wq-all-scope-guardrail]')).toBeHidden();
+});
+
+test('workqueue pane: all-scope guardrail does not show under threshold', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+  const queueName = `wq-guardrail-low-${Date.now()}`;
+  const wqPane = page.locator('[data-pane-kind="workqueue"]').last();
+  await wqPane.locator('[data-wq-queue-select]').selectOption('__custom__');
+  await wqPane.locator('[data-wq-queue-custom]').fill(queueName);
+  await wqPane.locator('[data-wq-queue-custom]').press('Enter');
+
+  await page.evaluate(async ({ queueName }) => {
+    const post = async (url, body) => {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(body)
+      });
+      return res.json();
+    };
+    for (let i = 0; i < 10; i += 1) {
+      await post('/api/workqueue/enqueue', { queue: queueName, title: `small-${i}`, instructions: 'x', priority: 1 });
+    }
+  }, { queueName });
+
+  await wqPane.locator('[data-wq-refresh]').click();
+  await expect(wqPane.locator('[data-wq-all-scope-guardrail]')).toBeHidden();
+});

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -91,9 +91,9 @@ test('workqueue pane: high-volume all-scope guardrail shows and downscopes with 
   await addPane(page, 'Workqueue pane');
   const queueName = `wq-guardrail-high-${Date.now()}`;
   const wqPane = page.locator('[data-pane-kind="workqueue"]').last();
-  await wqPane.locator('[data-wq-queue-select]').selectOption('__custom__');
-  await wqPane.locator('[data-wq-queue-custom]').fill(queueName);
-  await wqPane.locator('[data-wq-queue-custom]').press('Enter');
+  await wqPane.getByTestId('wq-pane-queue-select').selectOption('__custom__');
+  await wqPane.getByTestId('wq-pane-queue-custom').fill(queueName);
+  await wqPane.getByTestId('wq-pane-queue-custom').press('Enter');
 
   await page.evaluate(async ({ queueName }) => {
     const post = async (url, body) => {
@@ -153,4 +153,146 @@ test('workqueue pane: all-scope guardrail does not show under threshold', async 
 
   await wqPane.locator('[data-wq-refresh]').click();
   await expect(wqPane.locator('[data-wq-all-scope-guardrail]')).toBeHidden();
+});
+
+test('topbar Open workqueue pairs to active chat target and reuses pane', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+  await loginAdmin(page, env.serverPort);
+
+  const panes = page.locator('[data-pane]');
+  const initialCount = await panes.count();
+
+  const lastChatPane = panes.filter({ has: page.locator('[data-pane-input]') }).last();
+  await lastChatPane.locator('[data-pane-input]').focus();
+
+  await page.click('#workqueueBtn');
+  await expect(page.locator('[data-pane-kind="workqueue"]')).toHaveCount(1);
+  await expect(page.locator('[data-pane-kind="workqueue"]').last().locator('[data-wq-scope="assigned"]')).toHaveClass(/active/);
+
+  const afterFirst = await panes.count();
+  expect(afterFirst).toBe(initialCount + 1);
+
+  await page.click('#workqueueBtn');
+  await expect(page.locator('[data-pane-kind="workqueue"]')).toHaveCount(1);
+  const afterSecond = await panes.count();
+  expect(afterSecond).toBe(afterFirst);
+});
+
+test('workqueue pane: repo preset "Clawnsole only" narrows cards by repo', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  const queueName = `wq-repo-${Date.now()}`;
+  const wqPane = page.locator('[data-pane-kind="workqueue"]').last();
+  await wqPane.locator('[data-wq-queue-select]').selectOption('__custom__');
+  await wqPane.locator('[data-wq-queue-custom]').fill(queueName);
+  await wqPane.locator('[data-wq-queue-custom]').press('Enter');
+
+  await page.evaluate(async ({ queueName }) => {
+    const post = async (url, body) => {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(body)
+      });
+      return res.json();
+    };
+    await post('/api/workqueue/enqueue', {
+      queue: queueName,
+      title: 'clawnsole task',
+      instructions: 'Repo: rmdmattingly/clawnsole',
+      priority: 10
+    });
+    await post('/api/workqueue/enqueue', {
+      queue: queueName,
+      title: 'speechee task',
+      instructions: 'Repo: rmdmattingly/speechee',
+      priority: 5
+    });
+  }, { queueName });
+
+  await wqPane.locator('[data-wq-refresh]').click();
+  const rows = wqPane.locator('[data-wq-list-body] .wq-row');
+  await expect(rows).toHaveCount(2);
+  await wqPane.locator('[data-wq-repo-preset="clawnsole"]').click();
+  await expect(rows).toHaveCount(1);
+  await expect(rows.first()).toContainText('clawnsole task');
+});
+
+test('workqueue pane: status transition + edit + delete golden path', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  const queueName = `wq-golden-${Date.now()}`;
+  const wqPane = page.locator('[data-pane-kind="workqueue"]').last();
+  await wqPane.locator('[data-wq-queue-select]').selectOption('__custom__');
+  await wqPane.locator('[data-wq-queue-custom]').fill(queueName);
+  await wqPane.locator('[data-wq-queue-custom]').press('Enter');
+
+  const seeded = await page.evaluate(async ({ queueName }) => {
+    const post = async (url, body) => {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(body)
+      });
+      return res.json();
+    };
+    const first = await post('/api/workqueue/enqueue', {
+      queue: queueName,
+      title: 'golden item A',
+      instructions: 'initial instructions',
+      priority: 5
+    });
+    await post('/api/workqueue/enqueue', {
+      queue: queueName,
+      title: 'golden item B',
+      instructions: 'second item',
+      priority: 1
+    });
+    return first?.item?.id || null;
+  }, { queueName });
+  expect(seeded).toBeTruthy();
+
+  await wqPane.getByTestId('wq-pane-refresh').click();
+  await expect(wqPane.getByTestId('wq-pane-status-filter')).toBeVisible();
+  await expect(wqPane.getByTestId('wq-pane-status-selected')).toBeVisible();
+  await expect(wqPane.getByTestId('wq-item-row')).toHaveCount(2);
+
+  const targetRow = wqPane.getByTestId('wq-item-row').filter({ hasText: 'golden item A' }).first();
+  await expect(targetRow).toBeVisible();
+  await targetRow.evaluate((el) => el.click());
+  await expect(wqPane.getByTestId('wq-pane-inspect')).toContainText('golden item A');
+  await expect(wqPane.getByTestId('wq-pane-inspect')).toContainText(seeded);
+
+  const promptValues = ['edited title', 'edited instructions', '9', 'in_progress'];
+  page.on('dialog', async (dialog) => {
+    if (dialog.type() === 'prompt') {
+      const next = promptValues.shift();
+      await dialog.accept(next);
+      return;
+    }
+    await dialog.accept();
+  });
+
+  await wqPane.getByTestId('wq-pane-item-edit').dispatchEvent('click');
+  await expect(wqPane.getByTestId('wq-pane-inspect')).toContainText('edited title');
+  await expect(wqPane.getByTestId('wq-pane-inspect')).toContainText('in_progress');
+  await expect(wqPane.getByTestId('wq-item-row').filter({ hasText: 'edited title' })).toHaveCount(1);
+
+  await wqPane.getByTestId('wq-pane-item-delete').dispatchEvent('click');
+  await expect(wqPane.getByTestId('wq-item-row').filter({ hasText: 'edited title' })).toHaveCount(0);
 });


### PR DESCRIPTION
## Summary
- add stable test ids for Workqueue pane controls, rows, inspect actions, and modal actions
- add pane inspect edit/delete handlers so the pane can exercise the full work item flow
- add Playwright coverage for open pane, status filter, item inspect, status transition, edit, and delete

## Tests
- npm run test:syntax
- npx playwright test tests/ui/workqueue-pane.spec.js --grep "status transition" --workers=1
- npx playwright test tests/ui/workqueue-pane.spec.js --workers=1

Stacked on #413 / dev/issue-408-all-scope-guardrail.

Closes #123