### PR TITLE
feat(recurring): add external prompt worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ Clawnsole can store recurring prompts targeted at individual agents. Delivery is
 node scripts/recurring-prompts-scheduler.js --once
 # or loop
 node scripts/recurring-prompts-scheduler.js --loopSeconds 60
+# Python worker wrapper (retry/backoff; suitable for launchd/systemd/cron)
+python3 scripts/recurring-prompts-worker.py --once
+python3 scripts/recurring-prompts-worker.py --loopSeconds 60
 ```
 
 Prompts are stored in `~/.openclaw/clawnsole-recurring-prompts*.json` (instance-aware).

--- a/scripts/recurring-prompts-worker.py
+++ b/scripts/recurring-prompts-worker.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""
+External scheduler worker for recurring prompts.
+
+Runs independently (launchd/systemd/cron friendly) and delegates each delivery
+tick to the Node scheduler with retry/backoff.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def log(event: str, **fields: object) -> None:
+    payload = {"ts": utc_now(), "event": event, **fields}
+    print(json.dumps(payload, separators=(",", ":")), flush=True)
+
+
+@dataclass
+class RunnerConfig:
+    node_bin: str
+    scheduler_js: str
+    prompts_path: Optional[str]
+    openclaw_config: Optional[str]
+    device_label: str
+    dry_run: bool
+    max_retries: int
+    backoff_base_seconds: float
+    backoff_jitter_seconds: float
+    loop_seconds: int
+    once: bool
+
+
+def build_tick_cmd(cfg: RunnerConfig) -> list[str]:
+    cmd = [cfg.node_bin, cfg.scheduler_js, "--once", "--deviceLabel", cfg.device_label]
+    if cfg.prompts_path:
+        cmd.extend(["--promptsPath", cfg.prompts_path])
+    if cfg.openclaw_config:
+        cmd.extend(["--openclawConfig", cfg.openclaw_config])
+    if cfg.dry_run:
+        cmd.append("--dryRun")
+    return cmd
+
+
+def run_tick(cfg: RunnerConfig) -> bool:
+    cmd = build_tick_cmd(cfg)
+    for attempt in range(0, max(0, cfg.max_retries) + 1):
+        started = time.time()
+        proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        elapsed_ms = int((time.time() - started) * 1000)
+        output = (proc.stdout or "").strip() or (proc.stderr or "").strip()
+        if proc.returncode == 0:
+            log("tick_ok", attempt=attempt, elapsedMs=elapsed_ms, output=output)
+            return True
+        if attempt >= cfg.max_retries:
+            log("tick_failed", attempt=attempt, elapsedMs=elapsed_ms, code=proc.returncode, output=output)
+            return False
+        sleep_s = cfg.backoff_base_seconds * (2**attempt) + random.uniform(0, max(0.0, cfg.backoff_jitter_seconds))
+        log("tick_retry", attempt=attempt, code=proc.returncode, sleepSeconds=round(sleep_s, 3), output=output)
+        time.sleep(max(0.0, sleep_s))
+    return False
+
+
+def parse_args(argv: list[str]) -> RunnerConfig:
+    parser = argparse.ArgumentParser(description="Recurring prompt external scheduler worker (Python)")
+    parser.add_argument("--nodeBin", default=os.environ.get("NODE_BIN", "node"))
+    parser.add_argument("--schedulerJs", default=str(Path(__file__).with_name("recurring-prompts-scheduler.js")))
+    parser.add_argument("--promptsPath", default=os.environ.get("CLAWNSOLE_RECURRING_PROMPTS_PATH"))
+    parser.add_argument("--openclawConfig", default=os.environ.get("OPENCLAW_CONFIG"))
+    parser.add_argument("--deviceLabel", default="scheduler")
+    parser.add_argument("--dryRun", action="store_true")
+    parser.add_argument("--maxRetries", type=int, default=3)
+    parser.add_argument("--backoffBaseSeconds", type=float, default=0.75)
+    parser.add_argument("--backoffJitterSeconds", type=float, default=0.25)
+    parser.add_argument("--loopSeconds", type=int, default=60)
+    parser.add_argument("--once", action="store_true")
+    args = parser.parse_args(argv)
+    return RunnerConfig(
+        node_bin=args.nodeBin,
+        scheduler_js=args.schedulerJs,
+        prompts_path=args.promptsPath,
+        openclaw_config=args.openclawConfig,
+        device_label=args.deviceLabel,
+        dry_run=args.dryRun,
+        max_retries=max(0, args.maxRetries),
+        backoff_base_seconds=max(0.0, args.backoffBaseSeconds),
+        backoff_jitter_seconds=max(0.0, args.backoffJitterSeconds),
+        loop_seconds=max(5, args.loopSeconds),
+        once=bool(args.once),
+    )
+
+
+def main(argv: list[str]) -> int:
+    cfg = parse_args(argv)
+    if not Path(cfg.scheduler_js).exists():
+        log("config_error", message="schedulerJs not found", schedulerJs=cfg.scheduler_js)
+        return 2
+    if cfg.once:
+        return 0 if run_tick(cfg) else 1
+    while True:
+        run_tick(cfg)
+        time.sleep(cfg.loop_seconds)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/unit/recurring-prompts-worker.test.js
+++ b/tests/unit/recurring-prompts-worker.test.js
@@ -1,0 +1,79 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { test } = require('node:test');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const WORKER = path.join(ROOT, 'scripts', 'recurring-prompts-worker.py');
+
+function runWorker(args) {
+  return spawnSync('python3', [WORKER, ...args], {
+    cwd: ROOT,
+    encoding: 'utf8'
+  });
+}
+
+function parseJsonLines(stdout) {
+  return stdout
+    .trim()
+    .split(/\n+/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+test('recurring prompts worker exits with config error when scheduler is missing', () => {
+  const result = runWorker(['--once', '--schedulerJs', path.join(os.tmpdir(), 'missing-recurring-scheduler.js')]);
+
+  assert.equal(result.status, 2);
+  const [event] = parseJsonLines(result.stdout);
+  assert.equal(event.event, 'config_error');
+  assert.match(event.message, /schedulerJs not found/);
+});
+
+test('recurring prompts worker retries failed scheduler ticks before succeeding', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'clawnsole-recurring-worker-'));
+  const attemptsPath = path.join(dir, 'attempts.json');
+  const schedulerPath = path.join(dir, 'scheduler.js');
+  fs.writeFileSync(
+    schedulerPath,
+    `
+const fs = require('fs');
+const attemptsPath = ${JSON.stringify(attemptsPath)};
+let attempts = 0;
+try { attempts = JSON.parse(fs.readFileSync(attemptsPath, 'utf8')).attempts || 0; } catch {}
+attempts += 1;
+fs.writeFileSync(attemptsPath, JSON.stringify({ attempts }));
+if (attempts < 2) {
+  console.error('temporary scheduler failure');
+  process.exit(7);
+}
+console.log('scheduler ok');
+`,
+    'utf8'
+  );
+
+  const result = runWorker([
+    '--once',
+    '--schedulerJs',
+    schedulerPath,
+    '--maxRetries',
+    '2',
+    '--backoffBaseSeconds',
+    '0',
+    '--backoffJitterSeconds',
+    '0'
+  ]);
+
+  assert.equal(result.status, 0, result.stderr);
+  const events = parseJsonLines(result.stdout);
+  assert.deepEqual(
+    events.map((event) => event.event),
+    ['tick_retry', 'tick_ok']
+  );
+  assert.equal(events[0].code, 7);
+  assert.match(events[0].output, /temporary scheduler failure/);
+  assert.equal(events[1].attempt, 1);
+  assert.match(events[1].output, /scheduler ok/);
+});


### PR DESCRIPTION
## Summary
- add a Python recurring prompt worker wrapper for launchd/systemd/cron usage
- delegate ticks to the existing Node scheduler with retry/backoff and JSON-line status logs
- document worker usage and cover config-error + retry success paths in unit tests

## Tests
- npm test

Closes #56