### PR TITLE
Collapse signed-out auth header state

### DIFF
--- a/app.js
+++ b/app.js
@@ -135,14 +135,17 @@ const deriveAuthOverlayState = __appCore.deriveAuthOverlayState || ((state) => (
   isAdmin: String(state?.role || '') === 'admin',
   startAgentAutoRefresh: String(state?.role || '') === 'admin' && !!state?.authed,
   stopAgentAutoRefresh: String(state?.role || '') !== 'admin' || !state?.authed,
-  rolePillText: String(state?.role || '') === 'admin' ? 'signed in' : (state?.role || 'signed out'),
-  rolePillAdmin: String(state?.role || '') === 'admin',
-  showAdminControls: String(state?.role || '') === 'admin',
+  rolePillText: state?.authed ? (String(state?.role || '') === 'admin' ? 'signed in' : (state?.role || 'signed in')) : 'Locked',
+  rolePillAdmin: String(state?.role || '') === 'admin' && !!state?.authed,
+  rolePillLocked: !state?.authed,
+  showAdminControls: String(state?.role || '') === 'admin' && !!state?.authed,
+  showUnlockedStatus: !!state?.authed,
+  showLogoutAction: !!state?.authed,
   logoutEnabled: !!state?.authed,
   logoutOpacity: !!state?.authed ? '1' : '0.5'
 }));
 const deriveGlobalConnectionState = __appCore.deriveGlobalConnectionState || ((state) => {
-  if (!state?.authed) return { state: 'disconnected', meta: 'sign in required' };
+  if (!state?.authed) return { state: 'locked', meta: '' };
   const panes = Array.isArray(state?.panes) ? state.panes : [];
   if (panes.length === 0) return { state: 'disconnected', meta: '' };
   const connectedCount = panes.filter((pane) => !!pane?.connected).length;
@@ -864,8 +867,20 @@ function setAuthState(authed) {
   }
 
   if (globalElements.logoutBtn) {
+    globalElements.logoutBtn.hidden = !authUi.showLogoutAction;
     globalElements.logoutBtn.disabled = !authUi.logoutEnabled;
     globalElements.logoutBtn.style.opacity = authUi.logoutOpacity;
+  }
+  if (globalElements.status) {
+    globalElements.status.hidden = !authUi.showUnlockedStatus;
+  }
+  if (globalElements.paneManagerBtn) {
+    globalElements.paneManagerBtn.hidden = !authUi.showUnlockedStatus;
+  }
+  if (globalElements.rolePill) {
+    globalElements.rolePill.textContent = authUi.rolePillText;
+    globalElements.rolePill.classList.toggle('admin', authUi.rolePillAdmin);
+    globalElements.rolePill.classList.toggle('locked', authUi.rolePillLocked);
   }
 }
 
@@ -875,6 +890,7 @@ function setRole(role) {
   if (globalElements.rolePill) {
     globalElements.rolePill.textContent = authUi.rolePillText;
     globalElements.rolePill.classList.toggle('admin', authUi.rolePillAdmin);
+    globalElements.rolePill.classList.toggle('locked', authUi.rolePillLocked);
   }
 
   const isAdmin = authUi.isAdmin;
@@ -935,10 +951,6 @@ function showLogin(message = '') {
   // Guest role selection removed.
 
   setAuthState(false);
-  if (globalElements.rolePill) {
-    globalElements.rolePill.textContent = 'signed out';
-    globalElements.rolePill.classList.remove('admin');
-  }
   globalElements.settingsBtn?.setAttribute('disabled', 'disabled');
   if (globalElements.settingsBtn) globalElements.settingsBtn.style.opacity = '0.5';
   globalElements.shortcutsBtn?.setAttribute('disabled', 'disabled');

--- a/lib/app-core.js
+++ b/lib/app-core.js
@@ -148,21 +148,25 @@
 
   function deriveAuthOverlayState({ authed, role = null } = {}) {
     const isAdmin = role === 'admin';
+    const isAuthed = !!authed;
     return {
       isAdmin,
-      startAgentAutoRefresh: isAdmin && !!authed,
-      stopAgentAutoRefresh: !isAdmin || !authed,
-      rolePillText: isAdmin ? 'signed in' : (role || 'signed out'),
-      rolePillAdmin: isAdmin,
-      showAdminControls: isAdmin,
-      logoutEnabled: !!authed,
-      logoutOpacity: authed ? '1' : '0.5'
+      startAgentAutoRefresh: isAdmin && isAuthed,
+      stopAgentAutoRefresh: !isAdmin || !isAuthed,
+      rolePillText: isAuthed ? (isAdmin ? 'signed in' : (role || 'signed in')) : 'Locked',
+      rolePillAdmin: isAdmin && isAuthed,
+      rolePillLocked: !isAuthed,
+      showAdminControls: isAdmin && isAuthed,
+      showUnlockedStatus: isAuthed,
+      showLogoutAction: isAuthed,
+      logoutEnabled: isAuthed,
+      logoutOpacity: isAuthed ? '1' : '0.5'
     };
   }
 
   function deriveGlobalConnectionState({ authed, panes } = {}) {
     if (!authed) {
-      return { state: 'disconnected', meta: 'sign in required' };
+      return { state: 'locked', meta: '' };
     }
 
     const list = Array.isArray(panes) ? panes : [];

--- a/styles.css
+++ b/styles.css
@@ -83,6 +83,10 @@ body::before {
   z-index: 0;
 }
 
+[hidden] {
+  display: none !important;
+}
+
 .app {
   position: relative;
   z-index: 1;
@@ -226,6 +230,12 @@ body::before {
   background: rgba(127, 209, 185, 0.18);
   border-color: rgba(127, 209, 185, 0.45);
   color: var(--accent-2);
+}
+
+.role-pill.locked {
+  background: rgba(229, 115, 115, 0.18);
+  border-color: rgba(229, 115, 115, 0.45);
+  color: #ffb3ad;
 }
 
 .channel-switch select {

--- a/tests/ui/auth-lifecycle.spec.js
+++ b/tests/ui/auth-lifecycle.spec.js
@@ -7,7 +7,11 @@ test('visiting /admin without auth shows login overlay', async ({ page, clawnsol
 
   await page.goto(clawnsole.adminUrl);
   await expect(page.getByTestId('login-overlay')).toHaveClass(/open/);
-  await expect(page.getByTestId('role-pill')).toContainText('signed out');
+  await expect(page.getByTestId('role-pill')).toHaveText('Locked');
+  await expect(page.getByTestId('connection-status')).toBeHidden();
+  await expect(page.getByTestId('panes-indicator')).toBeHidden();
+  await expect(page.locator('#logoutBtn')).toBeHidden();
+  await expect(page.getByTestId('login-button')).toBeVisible();
 });
 
 test('after successful login, reload stays authed; clearing cookies forces re-login', async ({ page, context, clawnsole }) => {
@@ -15,6 +19,9 @@ test('after successful login, reload stays authed; clearing cookies forces re-lo
 
   await clawnsole.gotoAndLoginAdmin(page);
   await expect(page.getByTestId('login-overlay')).not.toHaveClass(/open/);
+  await expect(page.getByTestId('role-pill')).toContainText('signed in');
+  await expect(page.getByTestId('connection-status')).toBeVisible();
+  await expect(page.locator('#logoutBtn')).toBeVisible();
 
   await page.reload();
   await expect(page.getByTestId('login-overlay')).not.toHaveClass(/open/);

--- a/tests/unit/app-core.test.js
+++ b/tests/unit/app-core.test.js
@@ -98,13 +98,19 @@ test('deriveAuthOverlayState captures auth/role transition flags', () => {
     stopAgentAutoRefresh: false,
     rolePillText: 'signed in',
     rolePillAdmin: true,
+    rolePillLocked: false,
     showAdminControls: true,
+    showUnlockedStatus: true,
+    showLogoutAction: true,
     logoutEnabled: true,
     logoutOpacity: '1'
   });
 
   assert.equal(deriveAuthOverlayState({ authed: false, role: 'admin' }).startAgentAutoRefresh, false);
   assert.equal(deriveAuthOverlayState({ authed: true, role: 'guest' }).rolePillText, 'guest');
+  assert.equal(deriveAuthOverlayState({ authed: false, role: 'guest' }).rolePillText, 'Locked');
+  assert.equal(deriveAuthOverlayState({ authed: false, role: 'guest' }).showUnlockedStatus, false);
+  assert.equal(deriveAuthOverlayState({ authed: false, role: 'guest' }).showLogoutAction, false);
   assert.equal(deriveAuthOverlayState({ authed: false, role: 'guest' }).logoutOpacity, '0.5');
 });
 
@@ -141,8 +147,8 @@ test('normalizeHistoryEntries supports gateway payload variants', () => {
 
 test('deriveGlobalConnectionState handles signed-out, reconnecting, and hard error transitions', () => {
   assert.deepEqual(deriveGlobalConnectionState({ authed: false, panes: [{ connected: true }] }), {
-    state: 'disconnected',
-    meta: 'sign in required'
+    state: 'locked',
+    meta: ''
   });
 
   assert.deepEqual(deriveGlobalConnectionState({ authed: true, panes: [] }), {


### PR DESCRIPTION
## Summary
- show one locked auth chip while signed out and hide unlocked-only header status/actions
- restore connection/status/logout controls after unlock
- add auth lifecycle and shared app-core coverage for the locked state

Fixes #313

## Tests
- npm run test:syntax
- node --test tests/unit/app-core.test.js
- npx playwright test tests/ui/auth-lifecycle.spec.js
- npm test

🚢 Ship sign-off requested.