### PR TITLE
Add fleet triage row action

### DIFF
--- a/app.js
+++ b/app.js
@@ -2214,6 +2214,7 @@ function openAgentChatFromFleet(agentId) {
   if (!pane) return;
   paneSetAgent(pane, target);
   paneManager.focusPanePrimary(pane);
+  return pane;
 }
 
 function openAgentTimelineFromFleet(agentId) {
@@ -2254,19 +2255,48 @@ function openFleetPane({ forceNew = false } = {}) {
   paneManager.focusPanePrimary(pane);
 }
 
-function openAgentWorkqueueFromFleet() {
+function openAgentWorkqueueFromFleet(agentId, { scope = null } = {}) {
+  const target = normalizeAgentId(agentId || 'main');
   const preferredQueue =
     String(workqueueState?.selectedQueue || '').trim() ||
     String(findExistingPane('workqueue')?.workqueue?.queue || '').trim() ||
     'dev-team';
 
   const pane =
-    findExistingPane('workqueue', (p) => String(p.workqueue?.queue || '').trim() === preferredQueue) ||
+    findExistingPane(
+      'workqueue',
+      (p) => String(p.workqueue?.queue || '').trim() === preferredQueue && normalizeAgentId(p.agentId || 'main') === target
+    ) ||
     findExistingPane('workqueue') ||
-    paneManager.addPane('workqueue', { queue: preferredQueue });
+    paneManager.addPane('workqueue', { queue: preferredQueue, agentId: target });
   if (!pane) return;
 
+  pane.agentId = target;
+  if (pane.workqueue) {
+    pane.workqueue.queue = preferredQueue;
+    if (scope) pane.workqueue.scopeFilter = normalizeWorkqueueScope(scope);
+  }
+  paneManager.persistAdminPanes();
+  try {
+    const currentScope = pane.workqueue?.scopeFilter || 'all';
+    const scopeBtns = Array.from(pane.elements?.thread?.querySelectorAll?.('[data-wq-scope]') || []);
+    scopeBtns.forEach((btn) => {
+      const key = btn.getAttribute('data-wq-scope') || '';
+      const active = key && key === currentScope;
+      btn.classList.toggle('active', active);
+      btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+    });
+    renderWorkqueuePaneItems(pane);
+    if (isPaneManagerOpen()) renderPaneManager();
+  } catch {}
   paneManager.focusPanePrimary(pane);
+  return pane;
+}
+
+function openAgentTriageFromFleet(agentId) {
+  const chatPane = openAgentChatFromFleet(agentId);
+  const workqueuePane = openAgentWorkqueueFromFleet(agentId, { scope: 'assigned' });
+  return { chatPane, workqueuePane };
 }
 
 function renderAgentsModalList() {
@@ -2372,6 +2402,7 @@ function renderAgentsModalList() {
           <div class="agents-row-meta">${escapeHtml(id)} · ${escapeHtml(bucketLabel)} · <span class="agents-age-chip">${escapeHtml(heartbeatAge)}</span>${statusSnippetHtml}</div>
         </div>
         <div class="agents-row-actions agents-row-actions-inline" role="group" aria-label="Quick actions for ${escapeHtml(label)}">
+          <button type="button" class="secondary agents-action-btn agents-action-primary" data-agent-action="triage" data-agent-id="${escapeHtml(id)}" title="Triage agent" aria-label="Triage agent ${escapeHtml(label)}">Triage</button>
           <button type="button" class="secondary agents-action-btn" data-agent-action="open-chat" data-agent-id="${escapeHtml(id)}" title="Open Chat" aria-label="Open Chat for ${escapeHtml(label)}">Chat</button>
           <button type="button" class="secondary agents-action-btn" data-agent-action="open-timeline" data-agent-id="${escapeHtml(id)}" title="Open Timeline" aria-label="Open Timeline for ${escapeHtml(label)}">Timeline</button>
           <button type="button" class="secondary agents-action-btn" data-agent-action="open-workqueue" data-agent-id="${escapeHtml(id)}" title="Open Workqueue" aria-label="Open Workqueue">Workqueue</button>
@@ -2379,6 +2410,7 @@ function renderAgentsModalList() {
         <details class="agents-row-actions-overflow">
           <summary class="secondary" aria-label="More actions for ${escapeHtml(label)}" title="More actions">⋯</summary>
           <div class="agents-row-actions-menu" role="group" aria-label="Quick actions for ${escapeHtml(label)}">
+            <button type="button" class="secondary agents-action-btn" data-agent-action="triage" data-agent-id="${escapeHtml(id)}" title="Triage agent" aria-label="Triage agent ${escapeHtml(label)}">Triage agent</button>
             <button type="button" class="secondary agents-action-btn" data-agent-action="open-chat" data-agent-id="${escapeHtml(id)}" title="Open Chat" aria-label="Open Chat for ${escapeHtml(label)}">Open Chat</button>
             <button type="button" class="secondary agents-action-btn" data-agent-action="open-timeline" data-agent-id="${escapeHtml(id)}" title="Open Timeline" aria-label="Open Timeline for ${escapeHtml(label)}">Open Timeline</button>
             <button type="button" class="secondary agents-action-btn" data-agent-action="open-workqueue" data-agent-id="${escapeHtml(id)}" title="Open Workqueue" aria-label="Open Workqueue">Open Workqueue</button>
@@ -2402,9 +2434,10 @@ function renderAgentsModalList() {
           e.preventDefault();
           e.stopPropagation();
           const action = String(btn.getAttribute('data-agent-action') || '').trim();
-          if (action === 'open-chat') openAgentChatFromFleet(id);
+          if (action === 'triage') openAgentTriageFromFleet(id);
+          else if (action === 'open-chat') openAgentChatFromFleet(id);
           else if (action === 'open-timeline') openAgentTimelineFromFleet(id);
-          else if (action === 'open-workqueue') openAgentWorkqueueFromFleet();
+          else if (action === 'open-workqueue') openAgentWorkqueueFromFleet(id);
         });
       });
 
@@ -6375,13 +6408,14 @@ const paneManager = {
         if (!key) return null;
         if (kind === 'workqueue') {
           const queue = typeof item.queue === 'string' && item.queue.trim() ? item.queue.trim() : 'dev-team';
+          const agentId = normalizeAgentId(typeof item.agentId === 'string' ? item.agentId : defaultAgent);
           const statusFilter = Array.isArray(item.statusFilter)
             ? item.statusFilter.map((s) => String(s || '').trim()).filter(Boolean)
             : ['ready', 'pending', 'claimed', 'in_progress'];
           const scopeFilter = normalizeWorkqueueScope(item.scopeFilter ?? getDefaultWorkqueueScope());
           const sortKey = typeof item.sortKey === 'string' ? item.sortKey : 'priority';
           const sortDir = item.sortDir === 'asc' ? 'asc' : 'desc';
-          return { key, kind, queue, statusFilter, scopeFilter, sortKey, sortDir };
+          return { key, kind, agentId, queue, statusFilter, scopeFilter, sortKey, sortDir };
         }
         if (kind === 'cron' || kind === 'timeline') {
           return { key, kind };
@@ -6429,6 +6463,7 @@ const paneManager = {
         return {
           key: pane.key,
           kind: 'workqueue',
+          agentId: pane.agentId || 'main',
           queue: pane.workqueue?.queue || 'dev-team',
           statusFilter: Array.isArray(pane.workqueue?.statusFilter) ? pane.workqueue.statusFilter : [],
           scopeFilter: pane.workqueue?.scopeFilter || 'all',
@@ -6487,6 +6522,7 @@ const paneManager = {
         key: `p${randomId().slice(0, 8)}`,
         role: 'admin',
         kind: 'workqueue',
+        agentId: options?.agentId,
         queue: nextQueue,
         statusFilter: ['ready', 'pending', 'claimed', 'in_progress'],
         scopeFilter: getDefaultWorkqueueScope(),

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -108,6 +108,7 @@ test('agents modal quick actions open/reuse chat, timeline, and workqueue contex
   await expect(page.locator('#agentsModal')).toHaveClass(/open/);
 
   const firstRow = page.locator('#agentsList .agents-row').first();
+  await expect(firstRow.locator('[data-agent-action="triage"]').first()).toBeVisible();
   await expect(firstRow.locator('[data-agent-action="open-chat"]').first()).toBeVisible();
   await expect(firstRow.locator('[data-agent-action="open-timeline"]').first()).toBeVisible();
   await expect(firstRow.locator('[data-agent-action="open-workqueue"]').first()).toBeVisible();
@@ -123,4 +124,59 @@ test('agents modal quick actions open/reuse chat, timeline, and workqueue contex
 
   await firstRow.locator('[data-agent-action="open-workqueue"]').first().click();
   await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
+});
+
+test('agents modal triage action opens missing counterpart from minimal layout', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  await clawnsole.gotoAndLoginAdmin(page);
+
+  while ((await page.locator('[data-pane]').count()) > 1) {
+    await page.locator('[data-pane] [data-pane-close]').first().click();
+  }
+  await expect(page.locator('[data-pane]')).toHaveCount(1);
+
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  const firstRow = page.locator('#agentsList .agents-row').first();
+  const agentId = await firstRow.locator('[data-agent-action="triage"]').first().getAttribute('data-agent-id');
+
+  await firstRow.locator('[data-agent-action="triage"]').first().click();
+
+  await expect(page.locator('[data-pane][data-pane-kind="chat"]')).toHaveCount(1);
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"] [data-wq-scope="assigned"]')).toHaveAttribute('aria-pressed', 'true');
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"] [data-wq-queue-select]')).toBeFocused();
+
+  const panes = await page.evaluate(() => JSON.parse(localStorage.getItem('clawnsole.admin.panes.v1') || '[]'));
+  const workqueuePane = panes.find((pane) => pane.kind === 'workqueue');
+  expect(workqueuePane?.agentId).toBe(agentId);
+  expect(workqueuePane?.scopeFilter).toBe('assigned');
+});
+
+test('agents modal triage action reuses existing chat and workqueue panes', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  await clawnsole.gotoAndLoginAdmin(page);
+  await expect(page.locator('[data-pane][data-pane-kind="chat"]')).toHaveCount(1);
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
+
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  const firstRow = page.locator('#agentsList .agents-row').first();
+  const agentId = await firstRow.locator('[data-agent-action="triage"]').first().getAttribute('data-agent-id');
+
+  await firstRow.locator('[data-agent-action="triage"]').first().click();
+  await firstRow.locator('[data-agent-action="triage"]').first().click();
+
+  await expect(page.locator('[data-pane][data-pane-kind="chat"]')).toHaveCount(1);
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"] [data-wq-scope="assigned"]')).toHaveAttribute('aria-pressed', 'true');
+
+  const panes = await page.evaluate(() => JSON.parse(localStorage.getItem('clawnsole.admin.panes.v1') || '[]'));
+  const chatPanes = panes.filter((pane) => pane.kind === 'chat');
+  const workqueuePanes = panes.filter((pane) => pane.kind === 'workqueue');
+  expect(chatPanes).toHaveLength(1);
+  expect(workqueuePanes).toHaveLength(1);
+  expect(chatPanes[0]?.agentId).toBe(agentId);
+  expect(workqueuePanes[0]?.agentId).toBe(agentId);
+  expect(workqueuePanes[0]?.scopeFilter).toBe('assigned');
 });


### PR DESCRIPTION
## Summary
- add a visible Fleet/Agents row Triage action that opens Chat and Workqueue for the same agent
- persist Workqueue pane agent targets so assigned-scope triage survives pane reloads
- cover missing-counterpart and reuse states in Agents modal Playwright tests

## Tests
- npm run test:syntax
- npm run test:unit
- npm run test:proxy
- npx playwright test tests/ui/agents-modal.spec.js --workers=1

Closes #288