### PR TITLE
Add pane menu exact-count regression

### DIFF
--- a/tests/ui/pane-add-menu.spec.js
+++ b/tests/ui/pane-add-menu.spec.js
@@ -29,6 +29,14 @@ test('pane add menu: opens + adds explicit pane kinds + focuses sane defaults', 
   const addBtn = page.locator('#addPaneBtn');
   await expect(addBtn).toBeVisible();
 
+  const panes = page.locator('[data-pane]');
+  while (await panes.count() > 1) {
+    await panes.last().locator('button[aria-label="Close pane"]').click();
+  }
+  await expect(panes).toHaveCount(1);
+  await expect(page.locator('[data-pane][data-pane-kind="chat"]')).toHaveCount(1);
+  const countBefore = await panes.count();
+
   await addBtn.click();
   const menu = page.locator('[data-testid="pane-add-menu"]');
   await expect(menu).toBeVisible();
@@ -41,6 +49,7 @@ test('pane add menu: opens + adds explicit pane kinds + focuses sane defaults', 
   // Add a workqueue pane and ensure it exists + focus lands on primary control.
   await menu.locator('[data-testid="pane-add-menu-workqueue"]').click();
 
+  await expect(panes).toHaveCount(countBefore + 1);
   const wqPane = page.locator('[data-pane][data-pane-kind="workqueue"]').last();
   await expect(wqPane).toBeVisible();
 


### PR DESCRIPTION
## Summary
- Add explicit Playwright coverage that normalizes to one chat pane before using the Add Pane menu
- Assert one Workqueue menu click increases pane count by exactly one

## Tests
- npm run test:syntax
- NODE_PATH=/Users/raysopenclaw/src/clawnsole/node_modules /Users/raysopenclaw/src/clawnsole/node_modules/.bin/playwright test tests/ui/pane-add-menu.spec.js --workers=1

Issue: #161