### PR TITLE
Add Workqueue control focus shortcuts

### DIFF
--- a/app.js
+++ b/app.js
@@ -3055,7 +3055,28 @@ function renderWorkqueuePaneItems(pane) {
     if (scope === 'assigned') return !!activeTarget && owner === activeTarget;
     return true;
   });
-  const items = sortWorkqueueItems(scopedItems, { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
+  const searchQuery = String(pane.workqueue?.searchQuery || '').trim().toLowerCase();
+  const searchedItems = !searchQuery
+    ? scopedItems
+    : scopedItems.filter((it) => {
+      const haystack = [
+        it?.title,
+        it?.instructions,
+        it?.id,
+        it?.queue,
+        it?.status,
+        it?.claimedBy,
+        it?.assignee,
+        it?.assignedTo,
+        it?.agentId,
+        it?.source,
+        it?.dedupeKey,
+        it?.meta?.repo,
+        it?.meta?.issueNumber
+      ].map((v) => String(v || '').toLowerCase()).join(' ');
+      return haystack.includes(searchQuery);
+    });
+  const items = sortWorkqueueItems(searchedItems, { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
 
   if (empty) {
     const hasItems = items.length > 0;
@@ -3065,10 +3086,11 @@ function renderWorkqueuePaneItems(pane) {
       const statuses = Array.isArray(pane.workqueue?.statusFilter) ? pane.workqueue.statusFilter : [];
       const statusLabel = statuses.length ? statuses.join(', ') : 'default';
       const scopeLabel = pane.workqueue?.scopeFilter || 'all';
+      const searchLabel = String(pane.workqueue?.searchQuery || '').trim();
       empty.innerHTML = `
         <div class="empty-state">
           <div style="font-weight:700; margin-bottom:6px;">No items in this queue.</div>
-          <div class="hint">Queue: <span class="mono">${escapeHtml(queue)}</span> · Status: <span class="mono">${escapeHtml(statusLabel)}</span> · Scope: <span class="mono">${escapeHtml(scopeLabel)}</span></div>
+          <div class="hint">Queue: <span class="mono">${escapeHtml(queue)}</span> · Status: <span class="mono">${escapeHtml(statusLabel)}</span> · Scope: <span class="mono">${escapeHtml(scopeLabel)}</span>${searchLabel ? ` · Search: <span class="mono">${escapeHtml(searchLabel)}</span>` : ''}</div>
           <div style="display:flex; gap:8px; margin-top:10px; flex-wrap:wrap;">
             <button type="button" class="secondary" data-wq-empty-enqueue>Enqueue item</button>
             <button type="button" class="secondary" data-wq-empty-refresh>Refresh</button>
@@ -5237,6 +5259,11 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
             <button type="button" class="wq-scope-btn" data-wq-scope="all">All</button>
           </div>
 
+          <label class="wq-field">
+            <span class="wq-label">Search items</span>
+            <input data-wq-item-search type="search" placeholder="Search items" aria-label="Search workqueue items" autocomplete="off" />
+          </label>
+
           <button data-wq-refresh class="secondary" type="button">Refresh</button>
 
           <div class="wq-sort" role="group" aria-label="Sort workqueue items">
@@ -5315,6 +5342,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     const queueSearchEl = elements.thread.querySelector('[data-wq-queue-search]');
     const queueSelectEl = elements.thread.querySelector('[data-wq-queue-select]');
     const queueCustomEl = elements.thread.querySelector('[data-wq-queue-custom]');
+    const itemSearchEl = elements.thread.querySelector('[data-wq-item-search]');
 
     // Make header pill focus the queue selector in the body (no duplicated selector state).
     paneSetHeaderTarget(pane, {
@@ -5527,7 +5555,14 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     });
 
     renderStatusMultiSelect();
+    if (itemSearchEl) itemSearchEl.value = String(pane.workqueue?.searchQuery || '').trim();
     populateQueueSelect().then(() => doRefresh());
+
+    itemSearchEl?.addEventListener('input', () => {
+      pane.workqueue.searchQuery = String(itemSearchEl.value || '').trim();
+      renderWorkqueuePaneItems(pane);
+      paneManager.persistAdminPanes();
+    });
 
     refreshBtn?.addEventListener('click', () => doRefresh());
     queueCustomEl?.addEventListener('keydown', (e) => {
@@ -7073,6 +7108,62 @@ function isTypingContext(target) {
   return false;
 }
 
+function isPaneElementVisible(el) {
+  if (!(el instanceof HTMLElement)) return false;
+  try {
+    if (el.hidden) return false;
+    if (el.getClientRects && el.getClientRects().length === 0) return false;
+    return true;
+  } catch {
+    return true;
+  }
+}
+
+function getActivePaneByFocus() {
+  const active = document.activeElement;
+  if (!active) return null;
+  return (Array.isArray(paneManager?.panes) ? paneManager.panes : []).find((pane) =>
+    pane?.elements?.root && (pane.elements.root === active || pane.elements.root.contains(active))
+  ) || null;
+}
+
+function focusWorkqueueControlByShortcut(target) {
+  const activePane = getActivePaneByFocus();
+  if (activePane?.kind !== 'workqueue') {
+    showToast('Workqueue shortcut blocked: focus a Workqueue pane first.', { kind: 'info', timeoutMs: 2200 });
+    return false;
+  }
+
+  const thread = activePane.elements?.thread;
+  const selectorByTarget = {
+    queueSearch: '[data-wq-queue-search]',
+    itemSearch: '[data-wq-item-search]',
+    statusFilter: '[data-wq-status-details] > summary'
+  };
+  const selector = selectorByTarget[target] || '';
+  const control = selector ? thread?.querySelector?.(selector) : null;
+
+  if (!(control instanceof HTMLElement)) {
+    showToast('Workqueue shortcut blocked: target control is unavailable.', { kind: 'info', timeoutMs: 2200 });
+    return false;
+  }
+  if (!isPaneElementVisible(control)) {
+    showToast('Workqueue shortcut blocked: target control is hidden.', { kind: 'info', timeoutMs: 2200 });
+    return false;
+  }
+  if (control.disabled || String(control.getAttribute('aria-disabled') || '').toLowerCase() === 'true') {
+    showToast('Workqueue shortcut blocked: target control is disabled.', { kind: 'info', timeoutMs: 2200 });
+    return false;
+  }
+
+  try { activePane.elements?.root?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' }); } catch {}
+  control.focus();
+  if (target === 'queueSearch' || target === 'itemSearch') {
+    try { control.select?.(); } catch {}
+  }
+  return true;
+}
+
 function focusPaneIndex(idx) {
   const pane = paneManager.panes[idx];
   if (!pane) return;
@@ -7201,6 +7292,17 @@ window.addEventListener('keydown', (event) => {
       event.preventDefault();
     }
     return;
+  }
+
+  // Explicit Workqueue focus accelerators are safe to use even from another input.
+  if ((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey) {
+    const keyLower = String(event.key || '').toLowerCase();
+    if (keyLower === 'q' || keyLower === 'i' || keyLower === 's') {
+      event.preventDefault();
+      const target = keyLower === 'q' ? 'queueSearch' : keyLower === 'i' ? 'itemSearch' : 'statusFilter';
+      focusWorkqueueControlByShortcut(target);
+      return;
+    }
   }
 
   // Never steal focus / override browser shortcuts while typing.

--- a/index.html
+++ b/index.html
@@ -268,6 +268,9 @@
           <div class="shortcut-group">
             <h3 class="shortcut-group-title">Workqueue actions</h3>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>g</kbd> <kbd>w</kbd></div><div class="shortcut-desc">Open Workqueue modal</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Q</kbd></div><div class="shortcut-desc">Focus Workqueue queue search</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>I</kbd></div><div class="shortcut-desc">Focus Workqueue item search</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>S</kbd></div><div class="shortcut-desc">Focus Workqueue status filter</div></div>
           </div>
         </div>
       </div>

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -36,6 +36,9 @@ test('shortcuts overlay: ? opens, Esc closes, content renders', async ({ page })
   await expect(modal).toContainText('Pane focus/navigation');
   await expect(modal).toContainText('Pane actions');
   await expect(modal).toContainText('Workqueue actions');
+  await expect(modal).toContainText('Focus Workqueue queue search');
+  await expect(modal).toContainText('Focus Workqueue item search');
+  await expect(modal).toContainText('Focus Workqueue status filter');
   await expect(modal).toContainText('disabled while typing');
 
   await page.keyboard.press('Escape');
@@ -162,6 +165,50 @@ test('add-pane shortcuts do not fire while typing in chat input', async ({ page 
   await page.keyboard.press('Control+Shift+W');
 
   await expect(panes).toHaveCount(2);
+});
+
+test('workqueue shortcuts focus queue search, item search, status filter, and blocked states', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const wqPane = page.locator('[data-pane][data-pane-kind="workqueue"]').first();
+  await expect(wqPane).toBeVisible();
+
+  await page.locator('[data-pane][data-pane-kind="chat"] [data-pane-input]').first().focus();
+  await page.keyboard.press('ControlOrMeta+Shift+Q');
+  await expect(page.getByTestId('toast').last()).toContainText('Workqueue shortcut blocked: focus a Workqueue pane first.');
+
+  const queueSelect = wqPane.locator('[data-wq-queue-select]');
+  await queueSelect.focus();
+  await expect(queueSelect).toBeFocused();
+
+  await page.keyboard.press('ControlOrMeta+Shift+Q');
+  await expect(wqPane.locator('[data-wq-queue-search]')).toBeFocused();
+
+  await page.keyboard.press('ControlOrMeta+Shift+I');
+  await expect(wqPane.locator('[data-wq-item-search]')).toBeFocused();
+
+  await page.keyboard.press('ControlOrMeta+Shift+S');
+  await expect(wqPane.locator('[data-wq-status-details] > summary')).toBeFocused();
+
+  await page.evaluate(() => {
+    document.querySelector('[data-pane][data-pane-kind="workqueue"] [data-wq-queue-search]')?.setAttribute('hidden', '');
+  });
+  await page.keyboard.press('ControlOrMeta+Shift+Q');
+  await expect(page.getByTestId('toast').last()).toContainText('Workqueue shortcut blocked: target control is hidden.');
+
+  await page.evaluate(() => {
+    document.querySelector('[data-pane][data-pane-kind="workqueue"] [data-wq-item-search]')?.setAttribute('aria-disabled', 'true');
+  });
+  await page.keyboard.press('ControlOrMeta+Shift+I');
+  await expect(page.getByTestId('toast').last()).toContainText('Workqueue shortcut blocked: target control is disabled.');
 });
 
 test('fleet quick action button + keyboard shortcut focus existing timeline pane without duplicates', async ({ page }) => {


### PR DESCRIPTION
Closes #379

## Summary
- Add Cmd/Ctrl+Shift+Q/I/S shortcuts for Workqueue queue search, item search, and status filter focus
- Add pane-level item search filtering so the item search target exists and is useful
- Show non-disruptive blocked toasts when the target pane/control is unavailable, hidden, or disabled

## Verification
- npm run test:syntax
- npx playwright test tests/pane.shortcuts.e2e.spec.js -g "workqueue shortcuts" --workers=1