### PR TITLE
UX: keep Workqueue header sticky

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2038,13 +2038,17 @@ kbd {
 }
 
 .wq-list-header {
+  position: sticky;
+  top: 0;
+  z-index: 4;
   padding: 10px 12px;
   font-size: 11px;
   letter-spacing: 0.04em;
   text-transform: uppercase;
   color: var(--muted);
-  background: rgba(0, 0, 0, 0.2);
+  background: var(--panel);
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.03);
 }
 
 .wq-list-body {

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -126,9 +126,12 @@ test('workqueue pane: controls toolbar is sticky and list scrolls independently'
 
   const wqPane = page.locator('[data-pane]').last();
   const toolbar = wqPane.locator('.wq-pane .wq-toolbar');
+  const list = wqPane.locator('.wq-pane .wq-list').first();
+  const listHeader = list.locator('.wq-list-header');
   const listBody = wqPane.locator('.wq-pane [data-wq-list-body]').first();
 
   await expect(toolbar).toBeVisible();
+  await expect(listHeader).toBeVisible();
   await expect(listBody).toHaveCount(1);
 
   const itemsResP = page.waitForResponse((res) => res.url().includes('/api/workqueue/items') && res.ok(), { timeout: 15000 });
@@ -149,6 +152,33 @@ test('workqueue pane: controls toolbar is sticky and list scrolls independently'
   expect(styles.top).toBe('0px');
   expect(Number(styles.zIndex)).toBeGreaterThanOrEqual(5);
   expect(styles.backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
+
+  await listBody.evaluate((el) => {
+    el.scrollTop = 160;
+  });
+
+  const headerStyles = await listHeader.evaluate((el) => {
+    const cs = window.getComputedStyle(el);
+    const rect = el.getBoundingClientRect();
+    const listRect = el.parentElement.getBoundingClientRect();
+    return {
+      position: cs.position,
+      top: cs.top,
+      zIndex: cs.zIndex,
+      backgroundColor: cs.backgroundColor,
+      headerTop: Math.round(rect.top),
+      listTop: Math.round(listRect.top)
+    };
+  });
+
+  expect(headerStyles.position).toBe('sticky');
+  expect(headerStyles.top).toBe('0px');
+  expect(Number(headerStyles.zIndex)).toBeGreaterThanOrEqual(4);
+  expect(headerStyles.backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
+  expect(headerStyles.headerTop).toBeGreaterThanOrEqual(headerStyles.listTop);
+
+  await listHeader.locator('[data-wq-sort="title"]').click();
+  await expect(listHeader.locator('[data-wq-sort="title"]')).toHaveClass(/active/);
 
   const listStyles = await listBody.evaluate((el) => {
     const cs = window.getComputedStyle(el);


### PR DESCRIPTION
## Summary
- Make the Workqueue list header sticky with an opaque themed background.
- Extend the Workqueue UI spec to verify sticky header styling, scroll behavior, and clickable sort controls.

## Tests
- npm run test:ui -- tests/ui/workqueue-pane.spec.js
- npm test

Closes #382