### PR TITLE
Add Fleet quick action pane

### DIFF
--- a/app.js
+++ b/app.js
@@ -121,8 +121,10 @@ const normalizePaneKind = __appCore.normalizePaneKind || ((rawKind) => {
   const k = String(rawKind || 'chat').trim().toLowerCase();
   return k === 'chat'
     ? 'chat'
-    : k === 'workqueue' || k === 'cron' || k === 'timeline'
+    : k === 'workqueue' || k === 'cron' || k === 'timeline' || k === 'fleet'
       ? k
+      : k === 'f' || k.startsWith('fl')
+        ? 'fleet'
       : k.startsWith('w')
         ? 'workqueue'
         : k === 'c' || k.startsWith('cr')
@@ -525,6 +527,13 @@ async function refreshAgents({ reason = 'manual', showSuccessToast = false } = {
       if (pane.kind !== 'cron' && pane.kind !== 'timeline') return;
       try {
         pane._renderAgentFilterOptions?.();
+      } catch {}
+    });
+
+    paneManager.panes.forEach((pane) => {
+      if (!pane || pane.kind !== 'fleet') return;
+      try {
+        pane._renderFleet?.();
       } catch {}
     });
 
@@ -1331,6 +1340,7 @@ const paneManagerUiState = {
   visiblePaneKeys: [],
   collapsedKinds: {
     chat: false,
+    fleet: false,
     workqueue: false,
     cron: false,
     timeline: false
@@ -1343,6 +1353,7 @@ function isPaneManagerOpen() {
 
 function paneLabel(pane) {
   const kind = pane?.kind || 'chat';
+  if (kind === 'fleet') return 'Fleet';
   if (kind === 'workqueue') return 'Workqueue';
   if (kind === 'cron') return 'Cron';
   if (kind === 'timeline') return 'Timeline';
@@ -1351,6 +1362,7 @@ function paneLabel(pane) {
 
 function paneIcon(pane) {
   const kind = pane?.kind || 'chat';
+  if (kind === 'fleet') return 'FL';
   if (kind === 'workqueue') return 'WQ';
   if (kind === 'cron') return '⏰';
   if (kind === 'timeline') return '🕒';
@@ -1361,6 +1373,7 @@ function paneTargetLabel(pane) {
   if (!pane) return '';
   const current = String(pane?.elements?.agentLabel?.textContent || '').trim();
   if (current) return current;
+  if (pane.kind === 'fleet') return 'agents';
   if (pane.kind === 'workqueue') return String(pane.workqueue?.queue || 'dev-team');
   if (pane.kind === 'timeline' || pane.kind === 'cron') return 'gateway';
   return String(pane.agentId || 'main');
@@ -1426,7 +1439,7 @@ function paneSearchText(pane) {
 }
 
 function paneGroupOrder(kind) {
-  const order = { chat: 0, workqueue: 1, cron: 2, timeline: 3 };
+  const order = { chat: 0, fleet: 1, workqueue: 2, cron: 3, timeline: 4 };
   return Number.isInteger(order[kind]) ? order[kind] : 99;
 }
 
@@ -2253,16 +2266,8 @@ function openAgentTimelineFromFleet(agentId) {
 }
 
 function openFleetPane({ forceNew = false } = {}) {
-  const target = 'all';
-  const pane = forceNew
-    ? paneManager.addPane('timeline', { cronAgentId: target, forceNew: true })
-    : findExistingPane('timeline', (p) => String(p.cronAgentId || '').trim() === target) ||
-      findExistingPane('timeline') ||
-      paneManager.addPane('timeline', { cronAgentId: target });
+  const pane = paneManager.addPane('fleet', { forceNew });
   if (!pane) return;
-
-  pane.cronAgentId = target;
-  paneManager.persistAdminPanes();
   paneManager.focusPanePrimary(pane);
 }
 
@@ -5069,9 +5074,9 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     key,
     role,
     kind: (() => {
-      const allowed = new Set(['chat', 'workqueue', 'cron', 'timeline']);
+      const allowed = new Set(['chat', 'fleet', 'workqueue', 'cron', 'timeline']);
       const k = String(kind || 'chat').trim().toLowerCase();
-      return allowed.has(k) ? k : k.startsWith('w') ? 'workqueue' : 'chat';
+      return allowed.has(k) ? k : k.startsWith('fl') ? 'fleet' : k.startsWith('w') ? 'workqueue' : 'chat';
     })(),
     agentId: role === 'admin' ? normalizeAgentId(agentId || 'main') : null,
     workqueue: {
@@ -5142,6 +5147,17 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
             shortcuts: [
               ['g w', 'open Workqueue modal'],
               ['Cmd/Ctrl+K', 'cycle focus between panes']
+            ]
+          };
+        }
+        if (pane.kind === 'fleet') {
+          return {
+            title: 'Fleet',
+            lines: ['Shows the current agent fleet list.', 'Use Refresh to update agent identity data.', 'Use Open Agents for full filtering and triage controls.'],
+            shortcuts: [
+              ['Cmd/Ctrl+Shift+F', 'focus or open Fleet'],
+              ['Alt/Option+Cmd/Ctrl+Shift+F', 'open another Fleet pane'],
+              ['?', 'keyboard shortcuts overlay']
             ]
           };
         }
@@ -5220,6 +5236,85 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
   elements.root?.addEventListener('focusin', () => {
     clearPaneUnread(pane);
   });
+
+  // FLEET PANE
+  if (pane.role === 'admin' && pane.kind === 'fleet') {
+    if (elements.agentWrap) elements.agentWrap.hidden = false;
+    if (elements.inputRow) elements.inputRow.hidden = true;
+    if (elements.scrollDownBtn) elements.scrollDownBtn.hidden = true;
+
+    paneSetHeaderTarget(pane, {
+      label: 'Scope',
+      value: 'agents',
+      ariaLabel: 'Fleet scope: agents'
+    });
+
+    elements.thread.classList.add('fleet-pane');
+    elements.thread.innerHTML = `
+      <div class="wq-toolbar">
+        <div class="wq-toolbar-row">
+          <div class="wq-field" style="min-width: 120px; font-weight: 600;">Fleet</div>
+          <button data-fleet-refresh data-testid="fleet-refresh" class="secondary" type="button">Refresh</button>
+          <button data-fleet-open-agents data-testid="fleet-open-agents" class="secondary" type="button">Open Agents</button>
+        </div>
+        <div class="hint" data-fleet-statusline></div>
+      </div>
+      <div class="wq-layout" style="grid-template-columns: 1fr;">
+        <section class="wq-list" aria-label="Fleet agents">
+          <div class="wq-list-body" data-fleet-body data-testid="fleet-body"></div>
+        </section>
+      </div>
+    `;
+
+    const refreshBtn = elements.thread.querySelector('[data-fleet-refresh]');
+    const openAgentsBtn = elements.thread.querySelector('[data-fleet-open-agents]');
+    const statusline = elements.thread.querySelector('[data-fleet-statusline]');
+    const body = elements.thread.querySelector('[data-fleet-body]');
+
+    pane._renderFleet = () => {
+      const agents = Array.isArray(uiState.agents) ? uiState.agents : [];
+      if (statusline) {
+        const refreshed = agentsLastRefreshedAtMs ? ` · refreshed ${formatRelativeAge(Date.now() - agentsLastRefreshedAtMs)}` : '';
+        statusline.textContent = `${agents.length} agent${agents.length === 1 ? '' : 's'}${refreshed}`;
+      }
+      if (!body) return;
+      if (agents.length === 0) {
+        body.innerHTML = `
+          <div class="empty-state">
+            <div class="empty-state__title">No agents loaded</div>
+            <div class="hint">Refresh fleet to load the latest agent list.</div>
+          </div>
+        `;
+        return;
+      }
+      body.innerHTML = `<div class="cron-list">${agents
+        .map((agent) => {
+          const id = String(agent?.id || '').trim();
+          const label = formatAgentLabel(agent, { includeId: true });
+          return `<div class="cron-job" data-testid="fleet-agent-row" data-agent-id="${escapeHtml(id)}">
+            <div class="cron-job__top">
+              <div class="cron-job__title">${escapeHtml(label)}</div>
+              <div class="cron-job__badges"><span class="status-pill connected">agent</span></div>
+            </div>
+            <div class="hint">${escapeHtml(id)}</div>
+          </div>`;
+        })
+        .join('')}</div>`;
+    };
+
+    refreshBtn?.addEventListener('click', () => {
+      refreshAgents({ reason: 'fleet_pane', showSuccessToast: true }).then(() => pane._renderFleet?.()).catch(() => {
+        if (statusline) statusline.textContent = 'Refresh failed';
+      });
+    });
+    openAgentsBtn?.addEventListener('click', () => openAgentsModal());
+
+    setStatusPill(elements.status, 'connected', '');
+    pane.client = null;
+    pane.connected = true;
+    pane._renderFleet();
+    return pane;
+  }
 
   // WORKQUEUE PANE
   if (pane.role === 'admin' && pane.kind === 'workqueue') {
@@ -6510,12 +6605,15 @@ const paneManager = {
         const key = typeof item.key === 'string' && item.key ? item.key : '';
         const rawKind = typeof item.kind === 'string' ? item.kind.trim().toLowerCase() : '';
         const rawMode = typeof item.mode === 'string' ? item.mode.trim().toLowerCase() : '';
-        const kind = rawKind === 'workqueue' || rawKind === 'cron' || rawKind === 'timeline'
+        const kind = rawKind === 'workqueue' || rawKind === 'cron' || rawKind === 'timeline' || rawKind === 'fleet'
           ? rawKind
-          : rawMode === 'workqueue' || rawMode === 'cron' || rawMode === 'timeline'
+          : rawMode === 'workqueue' || rawMode === 'cron' || rawMode === 'timeline' || rawMode === 'fleet'
             ? rawMode
             : 'chat';
         if (!key) return null;
+        if (kind === 'fleet') {
+          return { key, kind };
+        }
         if (kind === 'workqueue') {
           const queue = typeof item.queue === 'string' && item.queue.trim() ? item.queue.trim() : 'dev-team';
           const statusFilter = Array.isArray(item.statusFilter)
@@ -6587,7 +6685,7 @@ const paneManager = {
           sortDir: pane.workqueue?.sortDir || 'desc'
         };
       }
-      if (pane.kind === 'cron' || pane.kind === 'timeline') {
+      if (pane.kind === 'fleet' || pane.kind === 'cron' || pane.kind === 'timeline') {
         return { key: pane.key, kind: pane.kind };
       }
       return { key: pane.key, kind: 'chat', agentId: pane.agentId || 'main' };
@@ -6634,6 +6732,9 @@ const paneManager = {
     const forceNew = Boolean(options?.forceNew);
 
     const findMatchingPane = () => {
+      if (normalizedKind === 'fleet') {
+        return this.panes.find((p) => p?.role === 'admin' && p.kind === 'fleet') || null;
+      }
       if (normalizedKind === 'workqueue') {
         return this.panes.find((p) => p?.role === 'admin' && p.kind === 'workqueue' && String(p.workqueue?.queue || '').trim() === nextQueue) || null;
       }
@@ -6652,6 +6753,23 @@ const paneManager = {
     }
 
     if (this.panes.length >= this.maxPanes) return;
+
+    if (normalizedKind === 'fleet') {
+      const pane = createPane({
+        key: `p${randomId().slice(0, 8)}`,
+        role: 'admin',
+        kind: 'fleet',
+        closable: true
+      });
+      this.panes.push(pane);
+      globalElements.paneGrid.appendChild(pane.elements.root);
+      this.updatePaneLabels();
+      this.updateCloseButtons();
+      this.applyInferredLayout();
+      this.persistAdminPanes();
+      this.focusPanePrimary(pane);
+      return pane;
+    }
 
     if (normalizedKind === 'workqueue') {
       const pane = createPane({
@@ -6725,6 +6843,12 @@ const paneManager = {
           return;
         }
 
+        if (pane.kind === 'fleet') {
+          const refresh = pane.elements.thread?.querySelector?.('[data-fleet-refresh]');
+          (refresh || pane.elements.thread)?.focus?.();
+          return;
+        }
+
         if (pane.kind === 'cron') {
           const search = pane.elements.thread?.querySelector?.('[data-cron-search]');
           const agentSel = pane.elements.thread?.querySelector?.('[data-cron-agent]');
@@ -6774,6 +6898,13 @@ const paneManager = {
       wqBtn.dataset.testid = 'pane-add-menu-workqueue';
       wqBtn.title = 'Shortcut: Ctrl/Cmd+Shift+W (Alt/Option+click = Open anyway)';
 
+      const fleetBtn = document.createElement('button');
+      fleetBtn.type = 'button';
+      fleetBtn.className = 'pane-add-menu__item';
+      fleetBtn.textContent = 'New Fleet pane';
+      fleetBtn.dataset.testid = 'pane-add-menu-fleet';
+      fleetBtn.title = 'Shortcut: Ctrl/Cmd+Shift+F (Alt/Option+click = Open anyway)';
+
       const cronBtn = document.createElement('button');
       cronBtn.type = 'button';
       cronBtn.className = 'pane-add-menu__item';
@@ -6789,6 +6920,7 @@ const paneManager = {
       timelineBtn.title = 'Shortcut: Ctrl/Cmd+Shift+T (Alt/Option+click = Open anyway)';
 
       menu.appendChild(chatBtn);
+      menu.appendChild(fleetBtn);
       menu.appendChild(wqBtn);
       menu.appendChild(cronBtn);
       menu.appendChild(timelineBtn);
@@ -6809,6 +6941,8 @@ const paneManager = {
 
       chatBtn.addEventListener('click', onMenuAdd('chat'));
 
+      fleetBtn.addEventListener('click', onMenuAdd('fleet'));
+
       wqBtn.addEventListener('click', onMenuAdd('workqueue'));
 
       cronBtn.addEventListener('click', onMenuAdd('cron'));
@@ -6817,6 +6951,7 @@ const paneManager = {
 
       state.menuEl = menu;
       state.chatBtn = chatBtn;
+      state.fleetBtn = fleetBtn;
       state.wqBtn = wqBtn;
       state.cronBtn = cronBtn;
       state.timelineBtn = timelineBtn;
@@ -6863,6 +6998,7 @@ const paneManager = {
 
     const atMax = this.panes.length >= this.maxPanes;
     state.chatBtn.disabled = atMax;
+    state.fleetBtn.disabled = atMax;
     state.wqBtn.disabled = atMax;
     state.cronBtn.disabled = atMax;
     state.timelineBtn.disabled = atMax;
@@ -7298,13 +7434,14 @@ window.addEventListener('keydown', (event) => {
 
   // Add-pane shortcuts (admin-only)
   // Ctrl/Cmd+Shift+C → new chat
+  // Ctrl/Cmd+Shift+F → focus Fleet pane (Alt/Option adds anyway)
   // Ctrl/Cmd+Shift+W → focus matching workqueue target (Alt/Option adds anyway)
   // Ctrl/Cmd+Shift+R → focus matching cron target (Alt/Option adds anyway)
   // Ctrl/Cmd+Shift+T → focus matching timeline target (Alt/Option adds anyway)
   const isAccel = (event.metaKey || event.ctrlKey) && event.shiftKey;
   if (isAccel && roleState.role === 'admin' && !isTypingContext(event.target)) {
     const key = String(event.key || '').toLowerCase();
-    const map = { c: 'chat', w: 'workqueue', r: 'cron', t: 'timeline' };
+    const map = { c: 'chat', f: 'fleet', w: 'workqueue', r: 'cron', t: 'timeline' };
     const kind = map[key];
     if (kind) {
       // Don't hijack add-pane shortcuts while typing in inputs/editors.

--- a/index.html
+++ b/index.html
@@ -62,8 +62,9 @@
             <span class="btn-icon" aria-hidden="true">★</span>
             <span class="btn-label">Agents</span>
           </button>
-          <button id="fleetBtn" class="icon-btn" type="button" aria-label="Open fleet pane" title="Open Fleet pane (Cmd/Ctrl+Shift+F)" hidden>
-            FL
+          <button id="fleetBtn" class="icon-btn action-btn" type="button" aria-label="Open fleet pane" title="Fleet (Cmd/Ctrl+Shift+F, Alt/Option for new)" hidden data-testid="fleet-btn">
+            <span class="btn-icon" aria-hidden="true">FL</span>
+            <span class="btn-label">Fleet</span>
           </button>
           <button id="workqueueBtn" class="icon-btn action-btn" type="button" aria-label="Open workqueue" title="Workqueue (g w)" hidden>
             <span class="btn-icon" aria-hidden="true">WQ</span>

--- a/lib/app-core.js
+++ b/lib/app-core.js
@@ -135,8 +135,10 @@
     const k = String(rawKind || 'chat').trim().toLowerCase();
     return k === 'chat'
       ? 'chat'
-      : k === 'workqueue' || k === 'cron' || k === 'timeline'
+      : k === 'workqueue' || k === 'cron' || k === 'timeline' || k === 'fleet'
         ? k
+        : k === 'f' || k.startsWith('fl')
+          ? 'fleet'
         : k.startsWith('w')
           ? 'workqueue'
           : k === 'c' || k.startsWith('cr')

--- a/tests/ui/pane-add-menu.spec.js
+++ b/tests/ui/pane-add-menu.spec.js
@@ -34,6 +34,7 @@ test('pane add menu: opens + adds explicit pane kinds + focuses sane defaults', 
   await expect(menu).toBeVisible();
 
   await expect(menu.locator('[data-testid="pane-add-menu-chat"]')).toHaveText(/New Chat pane/);
+  await expect(menu.locator('[data-testid="pane-add-menu-fleet"]')).toHaveText(/New Fleet pane/);
   await expect(menu.locator('[data-testid="pane-add-menu-workqueue"]')).toHaveText(/New Workqueue pane/);
   await expect(menu.locator('[data-testid="pane-add-menu-cron"]')).toHaveText(/New Cron pane/);
   await expect(menu.locator('[data-testid="pane-add-menu-timeline"]')).toHaveText(/New Timeline pane/);
@@ -74,6 +75,42 @@ test('pane add menu: single click reuses matching non-chat pane target', async (
   await menu.locator('[data-testid="pane-add-menu-workqueue"]').click({ modifiers: ['Alt'] });
   const countAfterAlt = await page.locator('[data-pane]').count();
   expect(countAfterAlt).toBe(countBefore + 1);
+});
+
+test('fleet quick action and shortcut open or focus Fleet pane without duplicates', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+
+  const fleetBtn = page.locator('[data-testid="fleet-btn"]');
+  await expect(fleetBtn).toBeVisible();
+
+  await fleetBtn.click();
+  const fleetPane = page.locator('[data-pane][data-pane-kind="fleet"]');
+  await expect(fleetPane).toHaveCount(1);
+  await expect(fleetPane.first().locator('[data-testid="fleet-refresh"]')).toBeFocused();
+
+  await fleetBtn.click();
+  await expect(fleetPane).toHaveCount(1);
+
+  await page.evaluate(() => document.activeElement?.blur?.());
+  await page.evaluate(() => {
+    window.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'F',
+      ctrlKey: true,
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true
+    }));
+  });
+  await expect(fleetPane).toHaveCount(1);
+  await expect(fleetPane.first().locator('[data-testid="fleet-refresh"]')).toBeFocused();
+
+  await fleetBtn.click({ modifiers: ['Alt'] });
+  await expect(fleetPane).toHaveCount(2);
 });
 
 test('pane add shortcuts: Ctrl/Cmd+Shift+T reuses timeline pane; Alt adds anyway', async ({ page }) => {

--- a/tests/unit/app-core.test.js
+++ b/tests/unit/app-core.test.js
@@ -84,6 +84,8 @@ test('normalizePaneKind handles aliases safely', () => {
   assert.equal(normalizePaneKind('chat'), 'chat');
   assert.equal(normalizePaneKind('workqueue'), 'workqueue');
   assert.equal(normalizePaneKind('w'), 'workqueue');
+  assert.equal(normalizePaneKind('fleet'), 'fleet');
+  assert.equal(normalizePaneKind('fl'), 'fleet');
   assert.equal(normalizePaneKind('cron'), 'cron');
   assert.equal(normalizePaneKind('cr'), 'cron');
   assert.equal(normalizePaneKind('timeline'), 'timeline');


### PR DESCRIPTION
## Summary
- make Fleet a first-class admin pane kind instead of routing the Fleet quick action to Timeline
- add header/menu/shortcut support with default reuse and Alt/Option open-anyway behavior
- render a lightweight Fleet pane with refresh and Open Agents actions

## Tests
- npm test
- npx playwright test tests/ui/pane-add-menu.spec.js --workers=1

Refs #205