### PR TITLE
Add Workqueue all-scope guardrail

### DIFF
--- a/app.js
+++ b/app.js
@@ -3044,6 +3044,7 @@ function renderWorkqueuePaneItems(pane) {
     return true;
   });
   const items = sortWorkqueueItems(scopedItems, { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
+  renderWorkqueueAllScopeGuardrail(pane, { totalCount: itemsRaw.length, visibleCount: items.length, scope });
 
   if (empty) {
     const hasItems = items.length > 0;
@@ -3112,6 +3113,68 @@ function renderWorkqueuePaneItems(pane) {
     pane.workqueue.selectedItemId = null;
     renderWorkqueuePaneInspect(pane, null);
   }
+}
+
+function renderWorkqueueAllScopeGuardrail(pane, { totalCount, visibleCount, scope } = {}) {
+  const root = pane.elements?.thread?.querySelector('[data-wq-all-scope-guardrail]');
+  if (!root) return;
+
+  const count = Number(visibleCount ?? totalCount ?? 0);
+  const threshold = getWorkqueueAllScopeGuardrailThreshold();
+  const dismissed = !!pane.workqueue?.allScopeGuardrailDismissed;
+  const show = scope === 'all' && count > threshold && !dismissed;
+  root.hidden = !show;
+  root.innerHTML = '';
+  if (!show) return;
+
+  if (pane.workqueue.allScopeGuardrailLastShownCount !== count) {
+    pane.workqueue.allScopeGuardrailLastShownCount = count;
+    addFeed('event', 'workqueue', `all-scope guardrail shown count=${count} threshold=${threshold}`);
+  }
+
+  const text = document.createElement('span');
+  text.className = 'wq-all-scope-guardrail-text';
+  text.textContent = `Viewing all items (${count}). Narrow scope?`;
+  root.appendChild(text);
+
+  const assignedBtn = document.createElement('button');
+  assignedBtn.type = 'button';
+  assignedBtn.className = 'secondary';
+  assignedBtn.dataset.wqGuardrailAction = 'assigned';
+  assignedBtn.textContent = 'Assigned to active target';
+
+  const unassignedBtn = document.createElement('button');
+  unassignedBtn.type = 'button';
+  unassignedBtn.className = 'secondary';
+  unassignedBtn.dataset.wqGuardrailAction = 'unassigned';
+  unassignedBtn.textContent = 'Unassigned';
+
+  const dismissBtn = document.createElement('button');
+  dismissBtn.type = 'button';
+  dismissBtn.className = 'secondary subtle';
+  dismissBtn.dataset.wqGuardrailDismiss = 'true';
+  dismissBtn.setAttribute('aria-label', 'Dismiss all scope guardrail');
+  dismissBtn.textContent = 'Dismiss';
+
+  const chooseScope = (nextScope) => {
+    addFeed('event', 'workqueue', `all-scope guardrail action=${nextScope} count=${count} threshold=${threshold}`);
+    if (typeof pane.workqueue?.setScope === 'function') pane.workqueue.setScope(nextScope);
+    else {
+      pane.workqueue.scopeFilter = normalizeWorkqueueScope(nextScope);
+      storage.set(WORKQUEUE_SCOPE_PREF_KEY, pane.workqueue.scopeFilter);
+      renderWorkqueuePaneItems(pane);
+    }
+  };
+
+  assignedBtn.addEventListener('click', () => chooseScope('assigned'));
+  unassignedBtn.addEventListener('click', () => chooseScope('unassigned'));
+  dismissBtn.addEventListener('click', () => {
+    pane.workqueue.allScopeGuardrailDismissed = true;
+    addFeed('event', 'workqueue', `all-scope guardrail dismissed count=${count} threshold=${threshold}`);
+    renderWorkqueuePaneItems(pane);
+  });
+
+  root.append(assignedBtn, unassignedBtn, dismissBtn);
 }
 
 function renderWorkqueuePaneInspect(pane, item) {
@@ -3615,9 +3678,17 @@ const ADMIN_PANES_KEY = 'clawnsole.admin.panes.v1';
 // Layout is inferred from pane count; no manual layout toggle.
 const ADMIN_DEFAULT_AGENT_KEY = 'clawnsole.admin.agentId';
 const WORKQUEUE_SCOPE_PREF_KEY = 'clawnsole.admin.workqueue.scope.v1';
+const WORKQUEUE_ALL_SCOPE_GUARDRAIL_THRESHOLD_KEY = 'clawnsole.admin.workqueue.allScopeGuardrailThreshold.v1';
+const WORKQUEUE_ALL_SCOPE_GUARDRAIL_DEFAULT_THRESHOLD = 200;
 
 function normalizeWorkqueueScope(scope) {
   return scope === 'assigned' || scope === 'unassigned' ? scope : 'all';
+}
+
+function getWorkqueueAllScopeGuardrailThreshold() {
+  const raw = storage.get(WORKQUEUE_ALL_SCOPE_GUARDRAIL_THRESHOLD_KEY, String(WORKQUEUE_ALL_SCOPE_GUARDRAIL_DEFAULT_THRESHOLD));
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : WORKQUEUE_ALL_SCOPE_GUARDRAIL_DEFAULT_THRESHOLD;
 }
 
 function getDefaultWorkqueueScope() {
@@ -5225,6 +5296,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
             <button type="button" class="wq-scope-btn" data-wq-scope="all">All</button>
           </div>
 
+          <div class="wq-all-scope-guardrail" data-wq-all-scope-guardrail role="status" aria-live="polite" hidden></div>
+
           <button data-wq-refresh class="secondary" type="button">Refresh</button>
 
           <div class="wq-sort" role="group" aria-label="Sort workqueue items">
@@ -5550,11 +5623,13 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     };
     const setScope = (scope) => {
       pane.workqueue.scopeFilter = normalizeWorkqueueScope(scope);
+      pane.workqueue.allScopeGuardrailDismissed = false;
       storage.set(WORKQUEUE_SCOPE_PREF_KEY, pane.workqueue.scopeFilter);
       updateScopeUi();
       renderWorkqueuePaneItems(pane);
       paneManager.persistAdminPanes();
     };
+    pane.workqueue.setScope = setScope;
     scopeBtns.forEach((btn) => {
       btn.addEventListener('click', () => setScope(btn.getAttribute('data-wq-scope')));
     });

--- a/styles.css
+++ b/styles.css
@@ -1929,6 +1929,27 @@ kbd {
   background: rgba(127, 209, 185, 0.12);
 }
 
+.wq-all-scope-guardrail {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-height: 32px;
+  padding: 5px 8px;
+  border: 1px solid rgba(255, 179, 71, 0.38);
+  border-radius: 8px;
+  background: rgba(255, 179, 71, 0.1);
+}
+
+.wq-all-scope-guardrail[hidden] {
+  display: none;
+}
+
+.wq-all-scope-guardrail-text {
+  font-size: 12px;
+  color: var(--text);
+}
+
 .wq-enqueue {
   margin-top: 10px;
 }

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -18,6 +18,35 @@ test.afterEach(async ({ page }) => {
   }
 });
 
+async function stubWorkqueueItems(page, items) {
+  await page.route('**/api/workqueue/queues', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ ok: true, queues: ['dev-team'] })
+    });
+  });
+  await page.route('**/api/workqueue/items**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ ok: true, items })
+    });
+  });
+}
+
+function makeGuardrailItems(count) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `guardrail-${i + 1}`,
+    queue: 'dev-team',
+    title: `Guardrail item ${i + 1}`,
+    status: 'ready',
+    priority: count - i,
+    attempts: 0,
+    claimedBy: i === 0 ? 'main' : ''
+  }));
+}
+
 test('workqueue pane: renders + has queue dropdown + does not show chat composer', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);
@@ -115,4 +144,49 @@ test('workqueue pane: controls toolbar is sticky and list scrolls independently'
     return { overflowY: cs.overflowY };
   });
   expect(['auto', 'scroll']).toContain(listStyles.overflowY);
+});
+
+test('workqueue pane: all-scope guardrail appears over threshold and downscopes', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+  await stubWorkqueueItems(page, makeGuardrailItems(3));
+
+  await loginAdmin(page, env.serverPort);
+  await page.evaluate(() => {
+    localStorage.setItem('clawnsole.admin.workqueue.scope.v1', 'all');
+    localStorage.setItem('clawnsole.admin.workqueue.allScopeGuardrailThreshold.v1', '2');
+  });
+
+  await addPane(page, 'Workqueue pane');
+  const wqPane = page.locator('[data-pane]').last();
+  const guardrail = wqPane.locator('[data-wq-all-scope-guardrail]');
+
+  await expect(guardrail).toBeVisible();
+  await expect(guardrail).toContainText('Viewing all items (3). Narrow scope?');
+
+  await guardrail.locator('[data-wq-guardrail-action="unassigned"]').click();
+  await expect(wqPane.locator('[data-wq-scope="unassigned"]')).toHaveAttribute('aria-pressed', 'true');
+  await expect(guardrail).toBeHidden();
+  await expect(wqPane.locator('[data-wq-list-body] .wq-row')).toHaveCount(2);
+});
+
+test('workqueue pane: all-scope guardrail stays hidden below threshold', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+  await stubWorkqueueItems(page, makeGuardrailItems(3));
+
+  await loginAdmin(page, env.serverPort);
+  await page.evaluate(() => {
+    localStorage.setItem('clawnsole.admin.workqueue.scope.v1', 'all');
+    localStorage.setItem('clawnsole.admin.workqueue.allScopeGuardrailThreshold.v1', '5');
+  });
+
+  await addPane(page, 'Workqueue pane');
+  const wqPane = page.locator('[data-pane]').last();
+  await expect(wqPane.locator('[data-wq-all-scope-guardrail]')).toBeHidden();
+  await expect(wqPane.locator('[data-wq-list-body] .wq-row')).toHaveCount(3);
 });


### PR DESCRIPTION
## Summary
- add a high-volume guardrail chip when Workqueue panes view All scope over the configured threshold
- provide one-click downscope actions for assigned-to-active-target and unassigned items, plus session-scoped dismiss
- log guardrail shown/action/dismiss events and cover threshold behavior in Playwright

## Tests
- npm test
- npx playwright test tests/ui/workqueue-pane.spec.js --workers=1

Closes #408