### PR TITLE
Add MRU pane switch shortcuts

### DIFF
--- a/app.js
+++ b/app.js
@@ -1392,6 +1392,84 @@ function focusedPaneKey() {
   return pane?.key || '';
 }
 
+let paneFocusMruKeys = [];
+let paneMruTraversal = null;
+let paneMruSuppressFocusEvents = false;
+
+function paneMruOrder() {
+  const panes = paneManager?.panes || [];
+  const liveKeys = new Set(panes.map((pane) => String(pane?.key || '')).filter(Boolean));
+  paneFocusMruKeys = paneFocusMruKeys.filter((key) => liveKeys.has(key));
+  panes.forEach((pane) => {
+    const key = String(pane?.key || '');
+    if (key && !paneFocusMruKeys.includes(key)) paneFocusMruKeys.push(key);
+  });
+  return paneFocusMruKeys.slice();
+}
+
+function notePaneFocused(pane) {
+  if (paneMruSuppressFocusEvents) return;
+  const key = String(pane?.key || '');
+  if (!key) return;
+  paneMruTraversal = null;
+  paneMruOrder();
+  paneFocusMruKeys = [key, ...paneFocusMruKeys.filter((entry) => entry !== key)];
+}
+
+function paneIndexByKey(key) {
+  return (paneManager?.panes || []).findIndex((pane) => String(pane?.key || '') === String(key || ''));
+}
+
+function currentFocusedPaneIndex() {
+  const active = document.activeElement;
+  const panes = paneManager?.panes || [];
+  return panes.findIndex((pane) => {
+    const root = pane?.elements?.root;
+    return !!(root && active && (root === active || root.contains(active)));
+  });
+}
+
+function switchPaneByMru(direction = 1) {
+  const panes = paneManager?.panes || [];
+  if (panes.length < 2) return false;
+
+  const now = Date.now();
+  const currentIdx = currentFocusedPaneIndex();
+  const currentKey = currentIdx >= 0 ? panes[currentIdx]?.key : '';
+  const baseOrder = paneMruOrder();
+  const orderedKeys = currentKey
+    ? [currentKey, ...baseOrder.filter((key) => key !== currentKey)]
+    : baseOrder;
+
+  if (orderedKeys.length < 2) return false;
+
+  const canContinue =
+    paneMruTraversal &&
+    now - Number(paneMruTraversal.updatedAt || 0) < 1500 &&
+    Array.isArray(paneMruTraversal.order) &&
+    paneMruTraversal.order.length === orderedKeys.length &&
+    paneMruTraversal.order.every((key) => orderedKeys.includes(key));
+
+  const traversal = canContinue
+    ? paneMruTraversal
+    : { order: orderedKeys, index: 0, updatedAt: now };
+
+  const step = direction >= 0 ? 1 : -1;
+  const nextIndex = (Number(traversal.index || 0) + step + traversal.order.length) % traversal.order.length;
+  const nextKey = traversal.order[nextIndex];
+  const paneIdx = paneIndexByKey(nextKey);
+  if (paneIdx < 0) return false;
+
+  traversal.index = nextIndex;
+  traversal.updatedAt = now;
+  paneMruTraversal = traversal;
+
+  focusPaneIndex(paneIdx, { trackMru: false });
+  const pane = panes[paneIdx];
+  if (pane) showToast(`Switched to ${paneIdentityLabel(pane)}`, { kind: 'info', timeoutMs: 1400 });
+  return true;
+}
+
 function paneUnreadCount(pane) {
   return Math.max(0, Number(pane?.unreadCount || 0));
 }
@@ -1887,6 +1965,14 @@ function buildCommandPaletteItems() {
       '⌘/Ctrl+Shift+J'
     ),
     withShortcut(
+      { id: 'cmd:pane-mru-next', label: 'Panes: Switch to previous MRU pane', detail: 'Move through panes by most-recent focus order', run: () => switchPaneByMru(1) },
+      'Ctrl+Tab'
+    ),
+    withShortcut(
+      { id: 'cmd:pane-mru-prev', label: 'Panes: Reverse MRU switch', detail: 'Reverse most-recent pane traversal', run: () => switchPaneByMru(-1) },
+      'Ctrl+Shift+Tab'
+    ),
+    withShortcut(
       { id: 'cmd:pane-next-unread', label: 'Panes: Next unread', detail: 'Jump to next pane with unread activity', run: () => cycleUnreadPaneFocus(1) },
       '⌘/Ctrl+Shift+]'
     ),
@@ -1920,7 +2006,7 @@ function buildCommandPaletteItems() {
     const label = String(item.label || '');
     const enriched = { ...item, group: 'Advanced', subgroup: '', priority: 20, kind: 'action' };
 
-    if (id.startsWith('cmd:focus-pane-') || id === 'cmd:pane-cycle' || id === 'cmd:pane-cycle-backward' || id === 'cmd:pane-next-unread' || id === 'cmd:pane-prev-unread') {
+    if (id.startsWith('cmd:focus-pane-') || id === 'cmd:pane-cycle' || id === 'cmd:pane-cycle-backward' || id === 'cmd:pane-mru-next' || id === 'cmd:pane-mru-prev' || id === 'cmd:pane-next-unread' || id === 'cmd:pane-prev-unread') {
       enriched.group = 'Panes';
       enriched.priority = 110;
       return enriched;
@@ -5117,6 +5203,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     elements.root.classList.add(`pane-kind-${pane.kind}`);
   } catch {}
 
+  elements.root.addEventListener('click', () => notePaneFocused(pane));
+
   // Pane header: kind label + type pill (icon + text)
   try {
     if (elements.name) elements.name.textContent = paneLabel(pane);
@@ -6710,6 +6798,7 @@ const paneManager = {
   },
   focusPanePrimary(pane) {
     if (!pane?.elements?.root) return;
+    notePaneFocused(pane);
 
     // Defer until DOM has painted.
     setTimeout(() => {
@@ -7212,10 +7301,11 @@ function isTypingContext(target) {
   return false;
 }
 
-function focusPaneIndex(idx) {
+function focusPaneIndex(idx, { trackMru = true } = {}) {
   const pane = paneManager.panes[idx];
   if (!pane) return;
   clearPaneUnread(pane);
+  if (trackMru) notePaneFocused(pane);
 
   try {
     pane.elements?.root?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
@@ -7235,7 +7325,18 @@ function focusPaneIndex(idx) {
       }
     })();
     if (isVisible) {
-      input.focus();
+      if (trackMru) {
+        input.focus();
+      } else {
+        paneMruSuppressFocusEvents = true;
+        try {
+          input.focus();
+        } finally {
+          queueMicrotask(() => {
+            paneMruSuppressFocusEvents = false;
+          });
+        }
+      }
       return;
     }
   }
@@ -7247,7 +7348,18 @@ function focusPaneIndex(idx) {
     root.querySelector &&
     root.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
   if (focusable && typeof focusable.focus === 'function') {
-    focusable.focus();
+    if (trackMru) {
+      focusable.focus();
+    } else {
+      paneMruSuppressFocusEvents = true;
+      try {
+        focusable.focus();
+      } finally {
+        queueMicrotask(() => {
+          paneMruSuppressFocusEvents = false;
+        });
+      }
+    }
   }
 }
 
@@ -7258,6 +7370,16 @@ function cyclePaneFocus() {
   const active = document.activeElement;
   const idx = panes.findIndex((p) => p.elements?.root && (p.elements.root === active || p.elements.root.contains(active)));
   const next = idx >= 0 ? (idx + 1) % panes.length : 0;
+  focusPaneIndex(next);
+}
+
+function cyclePaneFocusBackward() {
+  const panes = paneManager.panes;
+  if (!panes || panes.length === 0) return;
+
+  const active = document.activeElement;
+  const idx = panes.findIndex((p) => p.elements?.root && (p.elements.root === active || p.elements.root.contains(active)));
+  const next = idx >= 0 ? (idx - 1 + panes.length) % panes.length : panes.length - 1;
   focusPaneIndex(next);
 }
 
@@ -7346,6 +7468,13 @@ window.addEventListener('keydown', (event) => {
   if (isTypingContext(event.target)) return;
 
   const key = String(event.key || '');
+
+  // Ctrl+Tab walks panes in most-recently-used order; Shift reverses the traversal.
+  if (event.ctrlKey && !event.metaKey && !event.altKey && key === 'Tab') {
+    event.preventDefault();
+    switchPaneByMru(event.shiftKey ? -1 : 1);
+    return;
+  }
 
   const isQuestion = key === '?' || (key === '/' && event.shiftKey);
   if (isQuestion && !event.metaKey && !event.ctrlKey && !event.altKey) {

--- a/index.html
+++ b/index.html
@@ -253,6 +253,8 @@
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>P</kbd></div><div class="shortcut-desc">Open Pane Manager</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Focus next pane</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd></div><div class="shortcut-desc">Focus previous pane</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Ctrl</kbd>+<kbd>Tab</kbd></div><div class="shortcut-desc">Switch panes by most-recent focus order</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Tab</kbd></div><div class="shortcut-desc">Reverse most-recent pane traversal</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>]</kbd></div><div class="shortcut-desc">Next unread pane</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>[</kbd></div><div class="shortcut-desc">Previous unread pane</div></div>
           </div>

--- a/tests/pane.manager.e2e.spec.js
+++ b/tests/pane.manager.e2e.spec.js
@@ -165,8 +165,9 @@ test('pane manager: unread-only filter toggle', async ({ page }) => {
   await page.click('#loginBtn');
   await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
 
-  await page.keyboard.press('Control+P');
-  await page.getByTestId('pane-manager-unread-only').check();
+  await page.getByTestId('panes-indicator').click();
+  await expect(page.getByTestId('pane-manager-modal')).toHaveAttribute('aria-hidden', 'false');
+  await page.locator('.pane-manager-unread-only').click();
   await expect(page.locator('.pane-manager-row')).toHaveCount(0);
 
   await page.keyboard.press('Escape');

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -80,6 +80,7 @@ test('cmd/ctrl+shift+j focuses previous pane with wraparound from unfocused stat
   await page.getByTestId('add-pane-btn').click();
   await page.getByTestId('pane-add-menu-cron').click();
   await expect(page.locator('[data-pane]')).toHaveCount(3);
+  await page.click('#connectionStatus');
 
   const activePaneIndex = async () => page.evaluate(() => {
     const panes = Array.from(document.querySelectorAll('[data-pane]'));
@@ -138,6 +139,64 @@ test('alt+1..3 focuses panes by visible order and does not fire while typing', a
   await expect(firstPaneInput).toBeFocused();
 
   await page.keyboard.press('Alt+3');
+  await expect.poll(activePaneIndex).toBe(0);
+});
+
+test('ctrl+tab switches panes by MRU order and reverses with shift', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  await page.getByTestId('add-pane-btn').click();
+  await page.getByTestId('pane-add-menu-cron').click();
+  await expect(page.locator('[data-pane]')).toHaveCount(3);
+  await page.waitForTimeout(100);
+
+  const activePaneIndex = async () => page.evaluate(() => {
+    const panes = Array.from(document.querySelectorAll('[data-pane]'));
+    const active = document.activeElement;
+    if (!active) return -1;
+    return panes.findIndex((p) => p === active || p.contains(active));
+  });
+
+  const triggerMruShortcut = async ({ shiftKey = false } = {}) => page.evaluate(({ shiftKey }) => {
+    const event = new KeyboardEvent('keydown', {
+      key: 'Tab',
+      ctrlKey: true,
+      shiftKey,
+      bubbles: true,
+      cancelable: true
+    });
+    window.dispatchEvent(event);
+  }, { shiftKey });
+
+  await page.evaluate(() => focusPaneIndex(0));
+  await expect.poll(activePaneIndex).toBe(0);
+  await page.evaluate(() => focusPaneIndex(1));
+  await expect.poll(activePaneIndex).toBe(1);
+  await page.evaluate(() => focusPaneIndex(2));
+  await expect.poll(activePaneIndex).toBe(2);
+
+  await triggerMruShortcut();
+  await expect.poll(activePaneIndex).toBe(1);
+  await expect(page.getByTestId('toast').last()).toContainText('B Workqueue');
+
+  await triggerMruShortcut();
+  await expect.poll(activePaneIndex).toBe(0);
+
+  await triggerMruShortcut({ shiftKey: true });
+  await expect.poll(activePaneIndex).toBe(1);
+
+  const firstPaneInput = page.locator('[data-pane]').first().locator('[data-pane-input]');
+  await firstPaneInput.focus();
+  await expect(firstPaneInput).toBeFocused();
+  await triggerMruShortcut();
   await expect.poll(activePaneIndex).toBe(0);
 });
 


### PR DESCRIPTION
## Summary\n- Track most-recently-used pane focus order and add Ctrl+Tab / Ctrl+Shift+Tab traversal.\n- Show a brief destination toast when switching panes by MRU.\n- Add the shortcuts to the keyboard help and command palette.\n- Cover 3-pane forward/reverse MRU switching and typing guard behavior.\n\nFixes #212.\n\n## Tests\n- npm test\n- npx playwright test tests/pane.shortcuts.e2e.spec.js --workers=1