### PR TITLE
Add paired pane tab cues

### DIFF
--- a/app.js
+++ b/app.js
@@ -1988,6 +1988,50 @@ function paneDisplayTargetLabel(pane) {
   return ordinal > 0 ? `${target} (${ordinal})` : target;
 }
 
+const PANE_PAIR_COLORS = ['#7dd3fc', '#86efac', '#fbbf24', '#f0abfc', '#fca5a5', '#c4b5fd'];
+
+function panePairTarget(pane) {
+  const kind = String(pane?.kind || 'chat');
+  if (kind !== 'chat' && kind !== 'workqueue') return '';
+  return normalizeAgentId(pane?.agentId || 'main');
+}
+
+function panePairColor(target) {
+  const text = String(target || 'main');
+  let hash = 0;
+  for (let i = 0; i < text.length; i += 1) {
+    hash = ((hash << 5) - hash + text.charCodeAt(i)) | 0;
+  }
+  return PANE_PAIR_COLORS[Math.abs(hash) % PANE_PAIR_COLORS.length];
+}
+
+function panePairInfo(pane) {
+  const target = panePairTarget(pane);
+  const kind = String(pane?.kind || 'chat');
+  if (!target || (kind !== 'chat' && kind !== 'workqueue')) return null;
+  const siblingKind = kind === 'chat' ? 'workqueue' : 'chat';
+  const siblings = (paneManager?.panes || []).filter((candidate) => (
+    candidate &&
+    candidate !== pane &&
+    String(candidate.kind || '') === siblingKind &&
+    panePairTarget(candidate) === target
+  ));
+  return {
+    target,
+    color: panePairColor(target),
+    hasSibling: siblings.length > 0,
+    siblings
+  };
+}
+
+function setPanePairReveal(pane, reveal = false) {
+  const info = panePairInfo(pane);
+  if (!info?.siblings?.length) return;
+  info.siblings.forEach((sibling) => {
+    sibling.elements?.root?.classList.toggle('pane-pair-revealed', !!reveal);
+  });
+}
+
 function focusedPaneKey() {
   const active = document.activeElement;
   const panes = paneManager?.panes || [];
@@ -2315,12 +2359,14 @@ function renderPaneManager() {
         const isDuplicate = duplicateCount > 1;
         const unreadCount = paneUnreadCount(pane);
         const paneIdentity = paneSummaryLabel(pane);
+        const pair = panePairInfo(pane);
 
         row.innerHTML = `
           <div class="pane-manager-main">
             <div class="pane-manager-kind" title="${escapeHtml(paneIdentity)}">
               ${paneTypeBadgeMarkup(pane, { extraClass: 'pane-manager-type-badge', testId: 'pane-manager-type-badge' })}
               <span class="pane-manager-kind-label">${paneManagerHighlightHtml(paneIdentity, query)}</span>
+              ${pair ? `<span class="pane-manager-pair-cue${pair.hasSibling ? '' : ' solo'}" data-testid="pane-manager-pair-cue" style="--pane-pair-color:${escapeHtml(pair.color)}" title="${escapeHtml(pair.hasSibling ? `Paired ${paneLabel(pane)} target: ${pair.target}` : `No paired sibling for target: ${pair.target}`)}">${paneManagerHighlightHtml(pair.target.slice(0, 10), query)}</span>` : ''}
               <span class="pane-manager-pane-id" title="Internal pane id">${paneManagerHighlightHtml(String(pane?.key || ''), query)}</span>
               ${isDuplicate ? `<span class="pane-manager-duplicate-badge" data-testid="pane-manager-duplicate-badge" title="${escapeHtml(`${duplicateCount} duplicate panes`)}">duplicate</span>` : ''}
               ${unreadCount > 0 ? `<span class="pane-manager-unread-badge" data-testid="pane-manager-unread-badge" title="${escapeHtml(`${unreadCount} unread`)}">${escapeHtml(String(unreadCount))}</span>` : ''}
@@ -6827,6 +6873,35 @@ function renderPaneIdentity(pane) {
   }
   const activeKey = focusedPaneKey() || paneMruOrder()[0] || '';
   if (activeKey && String(pane.key || '') === activeKey) updateBrowserTitle(pane);
+  const pair = panePairInfo(pane);
+  if (pane.elements.root) {
+    pane.elements.root.classList.toggle('pane-paired', !!pair?.hasSibling);
+    pane.elements.root.classList.toggle('pane-pair-solo', !!pair && !pair.hasSibling);
+    if (pair) {
+      pane.elements.root.dataset.panePairTarget = pair.target;
+      pane.elements.root.style.setProperty('--pane-pair-color', pair.color);
+    } else {
+      delete pane.elements.root.dataset.panePairTarget;
+      pane.elements.root.style.removeProperty('--pane-pair-color');
+    }
+  }
+  if (pane.elements.pairCue) {
+    if (pair) {
+      pane.elements.pairCue.hidden = false;
+      pane.elements.pairCue.textContent = pair.target.slice(0, 10);
+      pane.elements.pairCue.classList.toggle('solo', !pair.hasSibling);
+      pane.elements.pairCue.title = pair.hasSibling
+        ? `Paired Chat + Workqueue target: ${pair.target}`
+        : `No paired sibling for target: ${pair.target}`;
+      pane.elements.pairCue.setAttribute('aria-label', pane.elements.pairCue.title);
+      pane.elements.pairCue.style.setProperty('--pane-pair-color', pair.color);
+    } else {
+      pane.elements.pairCue.hidden = true;
+      pane.elements.pairCue.textContent = '';
+      pane.elements.pairCue.removeAttribute('aria-label');
+      pane.elements.pairCue.style.removeProperty('--pane-pair-color');
+    }
+  }
 }
 
 function paneSetHeaderTarget(pane, { label, value, ariaLabel, onClick } = {}) {
@@ -7121,9 +7196,11 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
   const root = template.content.firstElementChild.cloneNode(true);
   const elements = {
     root,
+    header: root.querySelector('.pane-header'),
     name: root.querySelector('[data-pane-name]'),
     nameToken: root.querySelector('[data-pane-name-token]'),
     nameTarget: root.querySelector('[data-pane-name-target]'),
+    pairCue: root.querySelector('[data-pane-pair-cue]'),
     typePill: root.querySelector('[data-pane-type-pill]'),
     typeIcon: root.querySelector('[data-pane-type-icon]'),
     typeText: root.querySelector('[data-pane-type-text]'),
@@ -7332,6 +7409,11 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       paneAbortRun(pane);
     });
   }
+
+  elements.header?.addEventListener('mouseenter', () => setPanePairReveal(pane, true));
+  elements.header?.addEventListener('mouseleave', () => setPanePairReveal(pane, false));
+  elements.header?.addEventListener('focusin', () => setPanePairReveal(pane, true));
+  elements.header?.addEventListener('focusout', () => setPanePairReveal(pane, false));
 
   elements.root?.addEventListener('focusin', () => {
     notePaneFocused(pane);

--- a/index.html
+++ b/index.html
@@ -95,6 +95,7 @@
                   <span class="pane-type-icon" data-pane-type-icon aria-hidden="true">💬</span>
                   <span class="pane-type-text" data-pane-type-text>CHAT</span>
                 </div>
+                <span class="pane-pair-cue" data-pane-pair-cue data-testid="pane-pair-cue" hidden></span>
                 <div class="pane-name" data-pane-name data-testid="pane-type-label">
                   <span class="pane-name-token" data-pane-name-token data-testid="pane-name-token">A Chat</span>
                   <span class="pane-name-target" data-pane-name-target data-testid="pane-name-target"> · main</span>

--- a/styles.css
+++ b/styles.css
@@ -717,6 +717,43 @@ body::before {
   display: none !important;
 }
 
+.pane-pair-cue,
+.pane-manager-pair-cue {
+  --pane-pair-color: #7dd3fc;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 82px;
+  height: 22px;
+  padding: 0 8px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--pane-pair-color) 72%, transparent);
+  background: color-mix(in srgb, var(--pane-pair-color) 18%, transparent);
+  color: color-mix(in srgb, var(--pane-pair-color) 84%, white);
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.pane-pair-cue.solo,
+.pane-manager-pair-cue.solo {
+  border-style: dashed;
+  opacity: 0.62;
+}
+
+.pane.pane-paired .pane-header {
+  box-shadow: inset 3px 0 0 var(--pane-pair-color);
+}
+
+.pane.pane-pair-revealed .pane-header {
+  border-color: color-mix(in srgb, var(--pane-pair-color) 64%, rgba(255, 255, 255, 0.14));
+  background: color-mix(in srgb, var(--pane-pair-color) 12%, rgba(255, 255, 255, 0.03));
+}
+
 .pane-help {
   position: relative;
 }

--- a/tests/ui/pane-add-menu.spec.js
+++ b/tests/ui/pane-add-menu.spec.js
@@ -154,3 +154,37 @@ test('pane add shortcuts: Ctrl/Cmd+Shift+T reuses timeline pane; Alt adds anyway
   const countAfterForce = await page.locator('[data-pane]').count();
   expect(countAfterForce).toBe(countAfter + 1);
 });
+
+test('pane pair cues: Chat and Workqueue siblings share header and manager markers', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+
+  const chatPane = page.locator('[data-pane][data-pane-kind="chat"]').first();
+  const wqPane = page.locator('[data-pane][data-pane-kind="workqueue"]').first();
+
+  await expect(chatPane.getByTestId('pane-pair-cue')).toBeVisible();
+  await expect(wqPane.getByTestId('pane-pair-cue')).toBeVisible();
+
+  const chatCue = await chatPane.getByTestId('pane-pair-cue').textContent();
+  const wqCue = await wqPane.getByTestId('pane-pair-cue').textContent();
+  expect(String(chatCue || '').trim()).toBeTruthy();
+  expect(String(wqCue || '').trim()).toBe(String(chatCue || '').trim());
+
+  await chatPane.locator('.pane-header').hover();
+  await expect(wqPane).toHaveClass(/pane-pair-revealed/);
+
+  await page.mouse.move(1, 1);
+  await expect(wqPane).not.toHaveClass(/pane-pair-revealed/);
+
+  await chatPane.locator('[data-pane-agent-button]').focus();
+  await expect(wqPane).toHaveClass(/pane-pair-revealed/);
+
+  await page.getByTestId('panes-indicator').click();
+  const manager = page.getByTestId('pane-manager-modal');
+  await expect(manager).toBeVisible();
+  await expect(manager.getByTestId('pane-manager-pair-cue')).toHaveCount(2);
+});

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -216,8 +216,9 @@ test('workqueue pane: queue switch updates pane identity everywhere', async ({ p
 
   await page.keyboard.press('Control+P');
   const managerRow = page.locator('.pane-manager-row[data-pane-kind="workqueue"]').first();
-  await expect(managerRow.locator('.pane-manager-kind-label')).toHaveText(`B Workqueue · ${queue}`);
-  await expect(managerRow).not.toContainText('main');
+  const managerKindLabel = managerRow.locator('.pane-manager-kind-label');
+  await expect(managerKindLabel).toHaveText(`B Workqueue · ${queue}`);
+  await expect(managerKindLabel).not.toContainText('main');
 });
 
 function seedKeyboardTriageWorkqueueItems(queue) {


### PR DESCRIPTION
## Summary
- Add shared pair markers for Chat/Workqueue panes with the same agent target
- Highlight the sibling pane when a paired header is hovered or focused
- Show the same pair marker in Pane Manager overflow/list rows

## Verification
- npm run test:syntax
- NODE_PATH=/Users/raysopenclaw/.openclaw/workspace-dev-deploy/repos/clawnsole/node_modules /Users/raysopenclaw/.openclaw/workspace-dev-deploy/repos/clawnsole/node_modules/.bin/playwright test tests/ui/pane-add-menu.spec.js -g "pane pair cues" --workers=1

Fixes #404