### PR TITLE
Add actionable auth session chip

### DIFF
--- a/app.js
+++ b/app.js
@@ -73,6 +73,15 @@ const globalElements = {
   settingsModal: document.getElementById('settingsModal'),
   settingsCloseBtn: document.getElementById('settingsCloseBtn'),
   rolePill: document.getElementById('rolePill'),
+  authSessionPopover: document.getElementById('authSessionPopover'),
+  authSessionState: document.querySelector('[data-testid="auth-session-state"]'),
+  authSessionPrincipal: document.querySelector('[data-testid="auth-session-principal"]'),
+  authSessionRole: document.querySelector('[data-testid="auth-session-role"]'),
+  authSessionEnv: document.querySelector('[data-testid="auth-session-env"]'),
+  authSessionSignOutBtn: document.getElementById('authSessionSignOutBtn'),
+  sessionChipState: document.querySelector('[data-testid="session-chip-state"]'),
+  sessionChipPrincipal: document.querySelector('[data-testid="session-chip-principal"]'),
+  sessionChipEnv: document.querySelector('[data-testid="session-chip-env"]'),
   loginOverlay: document.getElementById('loginOverlay'),
   loginPassword: document.getElementById('loginPassword'),
   loginBtn: document.getElementById('loginBtn'),
@@ -131,16 +140,31 @@ const normalizePaneKind = __appCore.normalizePaneKind || ((rawKind) => {
             ? 'timeline'
             : 'chat';
 });
-const deriveAuthOverlayState = __appCore.deriveAuthOverlayState || ((state) => ({
-  isAdmin: String(state?.role || '') === 'admin',
-  startAgentAutoRefresh: String(state?.role || '') === 'admin' && !!state?.authed,
-  stopAgentAutoRefresh: String(state?.role || '') !== 'admin' || !state?.authed,
-  rolePillText: String(state?.role || '') === 'admin' ? 'signed in' : (state?.role || 'signed out'),
-  rolePillAdmin: String(state?.role || '') === 'admin',
-  showAdminControls: String(state?.role || '') === 'admin',
-  logoutEnabled: !!state?.authed,
-  logoutOpacity: !!state?.authed ? '1' : '0.5'
-}));
+const deriveAuthOverlayState = __appCore.deriveAuthOverlayState || ((state) => {
+  const role = String(state?.role || '');
+  const isAdmin = role === 'admin';
+  const authed = !!state?.authed;
+  const authStateText = authed ? 'Signed in' : role ? 'Locked' : 'Signed out';
+  const principalLabel = authed ? (isAdmin ? 'Admin session' : `${role || 'User'} session`) : role ? `${role} session locked` : 'No active session';
+  const environmentLabel = String(state?.environment || '').trim() || 'local';
+  return {
+    isAdmin,
+    startAgentAutoRefresh: isAdmin && authed,
+    stopAgentAutoRefresh: !isAdmin || !authed,
+    rolePillText: `${authStateText} · ${principalLabel}`,
+    authStateText,
+    principalLabel,
+    environmentLabel,
+    roleLabel: role || 'none',
+    sessionTitle: `${authStateText}: ${principalLabel} (${environmentLabel})`,
+    rolePillAdmin: isAdmin,
+    rolePillLocked: !authed && !!role,
+    rolePillSignedOut: !authed && !role,
+    showAdminControls: isAdmin,
+    logoutEnabled: authed,
+    logoutOpacity: authed ? '1' : '0.5'
+  };
+});
 const deriveGlobalConnectionState = __appCore.deriveGlobalConnectionState || ((state) => {
   if (!state?.authed) return { state: 'disconnected', meta: 'sign in required' };
   const panes = Array.isArray(state?.panes) ? state.panes : [];
@@ -850,9 +874,51 @@ function updateConnectionControls() {
   globalElements.disconnectBtn.textContent = control.text;
 }
 
+function getSessionEnvironmentLabel() {
+  const host = String(window.location?.hostname || '').trim().toLowerCase();
+  if (!host || host === 'localhost' || host === '127.0.0.1' || host === '::1') return 'local';
+  return host;
+}
+
+function getAuthUiState({ authed = uiState.authed, role = roleState.role } = {}) {
+  return deriveAuthOverlayState({ authed, role, environment: getSessionEnvironmentLabel() });
+}
+
+function setAuthSessionPopoverOpen(open) {
+  const isOpen = !!open;
+  if (globalElements.authSessionPopover) {
+    globalElements.authSessionPopover.classList.toggle('open', isOpen);
+    globalElements.authSessionPopover.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
+  }
+  if (globalElements.rolePill) {
+    globalElements.rolePill.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+  }
+}
+
+function updateAuthSessionUi(authUi = getAuthUiState()) {
+  if (globalElements.rolePill) {
+    globalElements.rolePill.title = authUi.sessionTitle || '';
+    globalElements.rolePill.setAttribute('aria-label', authUi.sessionTitle || authUi.rolePillText || 'Session details');
+    globalElements.rolePill.classList.toggle('admin', !!authUi.rolePillAdmin);
+    globalElements.rolePill.classList.toggle('locked', !!authUi.rolePillLocked);
+    globalElements.rolePill.classList.toggle('signed-out', !!authUi.rolePillSignedOut);
+  }
+  if (globalElements.sessionChipState) globalElements.sessionChipState.textContent = authUi.authStateText || '';
+  if (globalElements.sessionChipPrincipal) globalElements.sessionChipPrincipal.textContent = authUi.principalLabel || '';
+  if (globalElements.sessionChipEnv) globalElements.sessionChipEnv.textContent = authUi.environmentLabel || '';
+  if (globalElements.authSessionState) globalElements.authSessionState.textContent = authUi.authStateText || '';
+  if (globalElements.authSessionPrincipal) globalElements.authSessionPrincipal.textContent = authUi.principalLabel || '';
+  if (globalElements.authSessionRole) globalElements.authSessionRole.textContent = authUi.roleLabel || 'none';
+  if (globalElements.authSessionEnv) globalElements.authSessionEnv.textContent = authUi.environmentLabel || '';
+  if (globalElements.authSessionSignOutBtn) {
+    globalElements.authSessionSignOutBtn.disabled = !authUi.logoutEnabled;
+  }
+}
+
 function setAuthState(authed) {
   uiState.authed = authed;
-  const authUi = deriveAuthOverlayState({ authed, role: roleState.role });
+  const authUi = getAuthUiState({ authed, role: roleState.role });
+  updateAuthSessionUi(authUi);
   updateGlobalStatus();
   updateConnectionControls();
   paneManager.refreshChatEnabled();
@@ -871,11 +937,8 @@ function setAuthState(authed) {
 
 function setRole(role) {
   roleState.role = role;
-  const authUi = deriveAuthOverlayState({ authed: uiState.authed, role });
-  if (globalElements.rolePill) {
-    globalElements.rolePill.textContent = authUi.rolePillText;
-    globalElements.rolePill.classList.toggle('admin', authUi.rolePillAdmin);
-  }
+  const authUi = getAuthUiState({ authed: uiState.authed, role });
+  updateAuthSessionUi(authUi);
 
   const isAdmin = authUi.isAdmin;
   const visibleOpacity = isAdmin ? '1' : '0.5';
@@ -935,10 +998,7 @@ function showLogin(message = '') {
   // Guest role selection removed.
 
   setAuthState(false);
-  if (globalElements.rolePill) {
-    globalElements.rolePill.textContent = 'signed out';
-    globalElements.rolePill.classList.remove('admin');
-  }
+  setAuthSessionPopoverOpen(false);
   globalElements.settingsBtn?.setAttribute('disabled', 'disabled');
   if (globalElements.settingsBtn) globalElements.settingsBtn.style.opacity = '0.5';
   globalElements.shortcutsBtn?.setAttribute('disabled', 'disabled');
@@ -7498,7 +7558,7 @@ globalElements.loginPassword?.addEventListener('keydown', (event) => {
   }
 });
 
-globalElements.logoutBtn?.addEventListener('click', async () => {
+async function logoutCurrentSession() {
   try {
     await fetch('/auth/logout', { method: 'POST' });
   } catch {}
@@ -7506,7 +7566,37 @@ globalElements.logoutBtn?.addEventListener('click', async () => {
   paneManager.disconnectAll({ silent: true });
   roleState.role = null;
   window.location.replace('/');
+}
+
+globalElements.rolePill?.addEventListener('click', (event) => {
+  event.preventDefault();
+  const isOpen = globalElements.rolePill.getAttribute('aria-expanded') === 'true';
+  setAuthSessionPopoverOpen(!isOpen);
 });
+
+globalElements.rolePill?.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape') {
+    setAuthSessionPopoverOpen(false);
+    globalElements.rolePill.focus();
+  }
+});
+
+document.addEventListener('click', (event) => {
+  if (
+    globalElements.authSessionPopover?.classList?.contains('open') &&
+    !globalElements.authSessionPopover.contains(event.target) &&
+    !globalElements.rolePill?.contains(event.target)
+  ) {
+    setAuthSessionPopoverOpen(false);
+  }
+});
+
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape') setAuthSessionPopoverOpen(false);
+});
+
+globalElements.logoutBtn?.addEventListener('click', logoutCurrentSession);
+globalElements.authSessionSignOutBtn?.addEventListener('click', logoutCurrentSession);
 
 globalElements.addPaneBtn?.addEventListener('click', (event) => {
   event?.preventDefault?.();

--- a/index.html
+++ b/index.html
@@ -53,7 +53,32 @@
               <option value="3">3-up</option>
             </select>
           </div>
-          <div class="role-pill" id="rolePill" data-testid="role-pill">signed out</div>
+          <div class="session-chip-wrap">
+            <button class="role-pill" id="rolePill" type="button" aria-haspopup="dialog" aria-expanded="false" aria-controls="authSessionPopover" data-testid="role-pill">
+              <span class="session-chip-state" data-testid="session-chip-state">Signed out</span>
+              <span class="session-chip-principal" data-testid="session-chip-principal">No active session</span>
+              <span class="session-chip-env" data-testid="session-chip-env">local</span>
+            </button>
+            <div class="auth-session-popover" id="authSessionPopover" role="dialog" aria-hidden="true" aria-label="Session details" data-testid="auth-session-popover">
+              <div class="auth-session-row">
+                <span>State</span>
+                <strong data-testid="auth-session-state">Signed out</strong>
+              </div>
+              <div class="auth-session-row">
+                <span>Principal</span>
+                <strong data-testid="auth-session-principal">No active session</strong>
+              </div>
+              <div class="auth-session-row">
+                <span>Role</span>
+                <strong data-testid="auth-session-role">none</strong>
+              </div>
+              <div class="auth-session-row">
+                <span>Mode</span>
+                <strong data-testid="auth-session-env">local</strong>
+              </div>
+              <button id="authSessionSignOutBtn" class="auth-session-signout" type="button" data-testid="auth-session-signout">Sign out</button>
+            </div>
+          </div>
           <button id="refreshAgentsBtn" class="icon-btn action-btn" type="button" aria-label="Refresh agent list" title="Refresh (Ctrl/Cmd+R)" hidden>
             <span class="btn-icon" aria-hidden="true">⟳</span>
             <span class="btn-label">Refresh</span>

--- a/lib/app-core.js
+++ b/lib/app-core.js
@@ -146,14 +146,33 @@
               : 'chat';
   }
 
-  function deriveAuthOverlayState({ authed, role = null } = {}) {
+  function deriveAuthOverlayState({ authed, role = null, environment = '' } = {}) {
     const isAdmin = role === 'admin';
+    const hasPriorRole = !!role;
+    const authStateText = authed ? 'Signed in' : hasPriorRole ? 'Locked' : 'Signed out';
+    const principalLabel = authed
+      ? isAdmin
+        ? 'Admin session'
+        : `${role || 'User'} session`
+      : hasPriorRole
+        ? `${role} session locked`
+        : 'No active session';
+    const envLabel = String(environment || '').trim() || 'local';
+    const roleLabel = role || 'none';
+    const sessionTitle = `${authStateText}: ${principalLabel} (${envLabel})`;
     return {
       isAdmin,
       startAgentAutoRefresh: isAdmin && !!authed,
       stopAgentAutoRefresh: !isAdmin || !authed,
-      rolePillText: isAdmin ? 'signed in' : (role || 'signed out'),
+      rolePillText: `${authStateText} · ${principalLabel}`,
+      authStateText,
+      principalLabel,
+      environmentLabel: envLabel,
+      roleLabel,
+      sessionTitle,
       rolePillAdmin: isAdmin,
+      rolePillLocked: !authed && hasPriorRole,
+      rolePillSignedOut: !authed && !hasPriorRole,
       showAdminControls: isAdmin,
       logoutEnabled: !!authed,
       logoutOpacity: authed ? '1' : '0.5'

--- a/styles.css
+++ b/styles.css
@@ -211,21 +211,122 @@ body::before {
   padding: 0 12px;
 }
 
+.session-chip-wrap {
+  position: relative;
+}
+
 .role-pill {
-  padding: 6px 12px;
-  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 34px;
+  max-width: 320px;
+  padding: 6px 10px;
+  border-radius: 12px;
   background: rgba(255, 179, 71, 0.18);
   border: 1px solid rgba(255, 179, 71, 0.45);
   font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  font-family: inherit;
+  letter-spacing: 0;
   color: var(--accent);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.role-pill:hover,
+.role-pill[aria-expanded="true"] {
+  background: rgba(255, 179, 71, 0.24);
+  border-color: rgba(255, 179, 71, 0.65);
 }
 
 .role-pill.admin {
   background: rgba(127, 209, 185, 0.18);
   border-color: rgba(127, 209, 185, 0.45);
   color: var(--accent-2);
+}
+
+.role-pill.admin:hover,
+.role-pill.admin[aria-expanded="true"] {
+  background: rgba(127, 209, 185, 0.24);
+  border-color: rgba(127, 209, 185, 0.65);
+}
+
+.role-pill.locked {
+  background: rgba(255, 107, 107, 0.16);
+  border-color: rgba(255, 107, 107, 0.5);
+  color: var(--warning);
+}
+
+.session-chip-state {
+  font-weight: 700;
+}
+
+.session-chip-principal {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text);
+}
+
+.session-chip-env {
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--muted);
+  font-size: 10px;
+}
+
+.auth-session-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 80;
+  width: min(280px, calc(100vw - 32px));
+  padding: 12px;
+  border-radius: 12px;
+  background: rgba(12, 15, 20, 0.98);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: var(--shadow);
+  display: none;
+}
+
+.auth-session-popover.open {
+  display: grid;
+  gap: 8px;
+}
+
+.auth-session-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  align-items: baseline;
+  font-size: 12px;
+}
+
+.auth-session-row span {
+  color: var(--muted);
+}
+
+.auth-session-row strong {
+  color: var(--text);
+  text-align: right;
+  overflow-wrap: anywhere;
+}
+
+.auth-session-signout {
+  margin-top: 4px;
+  min-height: 34px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 107, 107, 0.45);
+  background: rgba(255, 107, 107, 0.14);
+  color: #ffd6d6;
+  font: inherit;
+  cursor: pointer;
+}
+
+.auth-session-signout:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
 }
 
 .channel-switch select {
@@ -2915,6 +3016,21 @@ kbd {
     padding: 4px 8px;
     font-size: 9px;
     letter-spacing: 0.06em;
+  }
+
+  .role-pill {
+    max-width: 150px;
+    gap: 5px;
+    letter-spacing: 0;
+  }
+
+  .session-chip-principal {
+    display: none;
+  }
+
+  .session-chip-env {
+    font-size: 9px;
+    padding: 1px 5px;
   }
 
   .icon-btn {

--- a/tests/ui/auth-lifecycle.spec.js
+++ b/tests/ui/auth-lifecycle.spec.js
@@ -7,7 +7,8 @@ test('visiting /admin without auth shows login overlay', async ({ page, clawnsol
 
   await page.goto(clawnsole.adminUrl);
   await expect(page.getByTestId('login-overlay')).toHaveClass(/open/);
-  await expect(page.getByTestId('role-pill')).toContainText('signed out');
+  await expect(page.getByTestId('role-pill')).toContainText('Signed out');
+  await expect(page.getByTestId('session-chip-principal')).toContainText('No active session');
 });
 
 test('after successful login, reload stays authed; clearing cookies forces re-login', async ({ page, context, clawnsole }) => {
@@ -15,13 +16,23 @@ test('after successful login, reload stays authed; clearing cookies forces re-lo
 
   await clawnsole.gotoAndLoginAdmin(page);
   await expect(page.getByTestId('login-overlay')).not.toHaveClass(/open/);
+  await expect(page.getByTestId('role-pill')).toContainText('Signed in');
+  await expect(page.getByTestId('role-pill')).toContainText('Admin session');
+
+  await page.getByTestId('role-pill').click();
+  await expect(page.getByTestId('auth-session-popover')).toHaveClass(/open/);
+  await expect(page.getByTestId('auth-session-state')).toContainText('Signed in');
+  await expect(page.getByTestId('auth-session-principal')).toContainText('Admin session');
+  await expect(page.getByTestId('auth-session-role')).toContainText('admin');
 
   await page.reload();
   await expect(page.getByTestId('login-overlay')).not.toHaveClass(/open/);
+  await expect(page.getByTestId('role-pill')).toContainText('Signed in');
 
   await context.clearCookies();
   await page.goto(clawnsole.adminUrl);
   await expect(page.getByTestId('login-overlay')).toHaveClass(/open/);
+  await expect(page.getByTestId('role-pill')).toContainText('Signed out');
 });
 
 test('authVersion rotation invalidates existing cookies (forces re-login)', async ({ page, clawnsole }) => {

--- a/tests/unit/app-core.test.js
+++ b/tests/unit/app-core.test.js
@@ -92,19 +92,28 @@ test('normalizePaneKind handles aliases safely', () => {
 });
 
 test('deriveAuthOverlayState captures auth/role transition flags', () => {
-  assert.deepEqual(deriveAuthOverlayState({ authed: true, role: 'admin' }), {
+  assert.deepEqual(deriveAuthOverlayState({ authed: true, role: 'admin', environment: 'qa' }), {
     isAdmin: true,
     startAgentAutoRefresh: true,
     stopAgentAutoRefresh: false,
-    rolePillText: 'signed in',
+    rolePillText: 'Signed in · Admin session',
+    authStateText: 'Signed in',
+    principalLabel: 'Admin session',
+    environmentLabel: 'qa',
+    roleLabel: 'admin',
+    sessionTitle: 'Signed in: Admin session (qa)',
     rolePillAdmin: true,
+    rolePillLocked: false,
+    rolePillSignedOut: false,
     showAdminControls: true,
     logoutEnabled: true,
     logoutOpacity: '1'
   });
 
   assert.equal(deriveAuthOverlayState({ authed: false, role: 'admin' }).startAgentAutoRefresh, false);
-  assert.equal(deriveAuthOverlayState({ authed: true, role: 'guest' }).rolePillText, 'guest');
+  assert.equal(deriveAuthOverlayState({ authed: false, role: 'admin' }).authStateText, 'Locked');
+  assert.equal(deriveAuthOverlayState({ authed: false, role: null }).authStateText, 'Signed out');
+  assert.equal(deriveAuthOverlayState({ authed: true, role: 'guest' }).principalLabel, 'guest session');
   assert.equal(deriveAuthOverlayState({ authed: false, role: 'guest' }).logoutOpacity, '0.5');
 });
 


### PR DESCRIPTION
## Summary
- replace the passive /admin auth badge with an interactive session identity chip
- show signed-in/locked/signed-out state, principal, role, and local environment context
- add a session details popover with a sign-out action and focused auth UI coverage

Closes #402

## Tests
- npm test
- npx playwright test tests/ui/auth-lifecycle.spec.js --workers=1