### PR TITLE
Canonicalize issue workqueue dedupe keys

### DIFF
--- a/lib/workqueue.js
+++ b/lib/workqueue.js
@@ -156,16 +156,31 @@ function createItem({ queue, title, instructions, priority }) {
   };
 }
 
+function normalizeIssueDedupeKey(dedupeKey) {
+  const raw = String(dedupeKey || '').trim();
+  if (!raw) return '';
 
+  const githubUrl = raw.match(/^https?:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/issues\/(\d+)(?:[/?#].*)?$/i);
+  if (githubUrl) {
+    return `issue:${githubUrl[1].toLowerCase()}/${githubUrl[2].toLowerCase()}#${githubUrl[3]}`;
+  }
+
+  const issueKey = raw.match(/^(?:issue:)?([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)(?:#|:)(\d+)$/);
+  if (issueKey) {
+    return `issue:${issueKey[1].toLowerCase()}#${issueKey[2]}`;
+  }
+
+  return raw;
+}
 
 function findItemByDedupeKey(state, { queue, dedupeKey }) {
   const q = String(queue || '').trim();
-  const key = String(dedupeKey || '').trim();
+  const key = normalizeIssueDedupeKey(dedupeKey);
   if (!q || !key) return null;
   // Search newest-first so if there are multiple (e.g. old data), we return the most recent.
   for (let i = state.items.length - 1; i >= 0; i--) {
     const it = state.items[i];
-    if (it && it.queue === q && it.dedupeKey === key) return it;
+    if (it && it.queue === q && normalizeIssueDedupeKey(it.dedupeKey) === key) return it;
   }
   return null;
 }
@@ -176,10 +191,15 @@ function enqueueItem(rootDir, { queue, title, instructions, priority, dedupeKey 
     const state = loadState(rootDir);
     ensureQueue(state, queue);
 
-    const key = String(dedupeKey || '').trim();
+    const key = normalizeIssueDedupeKey(dedupeKey);
     if (key) {
       const existing = findItemByDedupeKey(state, { queue, dedupeKey: key });
       if (existing) {
+        if (existing.dedupeKey !== key) {
+          existing.dedupeKey = key;
+          existing.updatedAt = new Date().toISOString();
+          saveState(rootDir, state);
+        }
         return { ...existing, _deduped: true };
       }
     }
@@ -473,6 +493,7 @@ module.exports = {
   listAssignments,
   setAssignments,
   resolveClaimQueues,
+  normalizeIssueDedupeKey,
   // exported for tests
   findItemByDedupeKey
 };

--- a/tests/unit/workqueue-api.test.js
+++ b/tests/unit/workqueue-api.test.js
@@ -6,7 +6,7 @@ const path = require('node:path');
 const http = require('node:http');
 
 const { createClawnsoleServer } = require('../../clawnsole-server');
-const { enqueueItem } = require('../../lib/workqueue');
+const { enqueueItem, loadState } = require('../../lib/workqueue');
 
 function mkTempEnv() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'clawnsole-wq-api-'));
@@ -161,6 +161,52 @@ test('workqueue API: enqueue creates item', async () => {
     assert.equal(res.json?.ok, true);
     assert.equal(res.json?.item?.queue, 'dev-team');
     assert.equal(res.json?.item?.dedupeKey, 'k1');
+  } finally {
+    server.close();
+  }
+});
+
+test('workqueue API: enqueue canonicalizes issue-backed dedupe variants', async () => {
+  const { openclawHome } = mkTempEnv();
+  fs.mkdirSync(openclawHome, { recursive: true });
+  fs.writeFileSync(path.join(openclawHome, 'clawnsole.json'), JSON.stringify({ adminPassword: 'admin', authVersion: 'test' }));
+
+  const { server, port } = await startServer({ openclawHome });
+  try {
+    const cookie = Buffer.from('admin::test', 'utf8').toString('base64');
+    const headers = { Cookie: 'clawnsole_auth=' + cookie + '; clawnsole_role=admin' };
+    const first = await httpPostJson(
+      'http://127.0.0.1:' + port + '/api/workqueue/enqueue',
+      {
+        queue: 'dev-team',
+        title: 'from cron',
+        instructions: 'x',
+        priority: 1,
+        dedupeKey: 'issue:rmdmattingly/clawnsole:398'
+      },
+      headers
+    );
+    const second = await httpPostJson(
+      'http://127.0.0.1:' + port + '/api/workqueue/enqueue',
+      {
+        queue: 'dev-team',
+        title: 'from follow-up',
+        instructions: 'y',
+        priority: 1,
+        dedupeKey: 'rmdmattingly/clawnsole#398'
+      },
+      headers
+    );
+
+    assert.equal(first.status, 200);
+    assert.equal(second.status, 200);
+    assert.equal(second.json?.item?.id, first.json?.item?.id);
+    assert.equal(second.json?.item?._deduped, true);
+    assert.equal(second.json?.item?.dedupeKey, 'issue:rmdmattingly/clawnsole#398');
+
+    const state = loadState();
+    assert.equal(state.items.length, 1);
+    assert.equal(state.items[0].dedupeKey, 'issue:rmdmattingly/clawnsole#398');
   } finally {
     server.close();
   }

--- a/tests/unit/workqueue.test.js
+++ b/tests/unit/workqueue.test.js
@@ -4,7 +4,14 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
-const { enqueueItem, claimNext, loadState, saveState, transitionItem } = require('../../lib/workqueue');
+const {
+  enqueueItem,
+  claimNext,
+  loadState,
+  saveState,
+  transitionItem,
+  normalizeIssueDedupeKey
+} = require('../../lib/workqueue');
 
 function withFakeNow(ms, fn) {
   const realNow = Date.now;
@@ -255,4 +262,49 @@ test('workqueue: enqueue supports dedupeKey idempotency', () => {
 
   const state = loadState(root);
   assert.equal(state.items.length, 1);
+});
+
+test('workqueue: canonicalizes issue-backed dedupe key variants', () => {
+  assert.equal(normalizeIssueDedupeKey('rmdmattingly/clawnsole#398'), 'issue:rmdmattingly/clawnsole#398');
+  assert.equal(normalizeIssueDedupeKey('rmdmattingly/clawnsole:398'), 'issue:rmdmattingly/clawnsole#398');
+  assert.equal(normalizeIssueDedupeKey('issue:rmdmattingly/clawnsole:398'), 'issue:rmdmattingly/clawnsole#398');
+  assert.equal(normalizeIssueDedupeKey('https://github.com/rmdmattingly/clawnsole/issues/398'), 'issue:rmdmattingly/clawnsole#398');
+  assert.equal(normalizeIssueDedupeKey('hourly-pr-review:2026-02-08T21'), 'hourly-pr-review:2026-02-08T21');
+});
+
+test('workqueue: issue-backed dedupe variants upsert one active item', () => {
+  const root = tempRoot();
+
+  const first = enqueueItem(root, {
+    queue: 'dev',
+    title: 'Issue 398 from cron',
+    instructions: 'cron triage',
+    priority: 0,
+    dedupeKey: 'issue:rmdmattingly/clawnsole:398'
+  });
+
+  const second = enqueueItem(root, {
+    queue: 'dev',
+    title: 'Issue 398 from follow-up',
+    instructions: 'issue follow-up',
+    priority: 0,
+    dedupeKey: 'rmdmattingly/clawnsole#398'
+  });
+
+  const third = enqueueItem(root, {
+    queue: 'dev',
+    title: 'Issue 398 from URL producer',
+    instructions: 'coverage',
+    priority: 0,
+    dedupeKey: 'https://github.com/rmdmattingly/clawnsole/issues/398'
+  });
+
+  assert.equal(second.id, first.id);
+  assert.equal(third.id, first.id);
+  assert.equal(second._deduped, true);
+  assert.equal(third._deduped, true);
+
+  const state = loadState(root);
+  assert.equal(state.items.length, 1);
+  assert.equal(state.items[0].dedupeKey, 'issue:rmdmattingly/clawnsole#398');
 });


### PR DESCRIPTION
Fixes #398.\n\n## Summary\n- Normalize issue-backed workqueue dedupe keys in the shared enqueue path.\n- Treat legacy colon/hash/prefix/GitHub URL variants as one canonical key: `issue:owner/repo#number`.\n- Repair an existing legacy item key when a duplicate enqueue hits it.\n\n## Tests\n- npm test