### PR TITLE
Add recurring prompt admin UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ Clawnsole can store recurring prompts targeted at individual agents. Delivery is
 node scripts/recurring-prompts-scheduler.js --once
 # or loop
 node scripts/recurring-prompts-scheduler.js --loopSeconds 60
+# python worker wrapper (with retry/backoff)
+python3 scripts/recurring-prompts-worker.py --once
+python3 scripts/recurring-prompts-worker.py --loopSeconds 60
 ```
 
 Prompts are stored in `~/.openclaw/clawnsole-recurring-prompts*.json` (instance-aware).

--- a/app.js
+++ b/app.js
@@ -72,6 +72,15 @@ const globalElements = {
   settingsBtn: document.getElementById('settingsBtn'),
   settingsModal: document.getElementById('settingsModal'),
   settingsCloseBtn: document.getElementById('settingsCloseBtn'),
+  recurringPromptTitle: document.getElementById('recurringPromptTitle'),
+  recurringPromptAgent: document.getElementById('recurringPromptAgent'),
+  recurringPromptInterval: document.getElementById('recurringPromptInterval'),
+  recurringPromptEnabled: document.getElementById('recurringPromptEnabled'),
+  recurringPromptMessage: document.getElementById('recurringPromptMessage'),
+  recurringPromptCreateBtn: document.getElementById('recurringPromptCreateBtn'),
+  recurringPromptRefreshBtn: document.getElementById('recurringPromptRefreshBtn'),
+  recurringPromptStatus: document.getElementById('recurringPromptStatus'),
+  recurringPromptList: document.getElementById('recurringPromptList'),
   rolePill: document.getElementById('rolePill'),
   loginOverlay: document.getElementById('loginOverlay'),
   loginPassword: document.getElementById('loginPassword'),
@@ -2442,6 +2451,197 @@ function renderAgentsModalList() {
 
   const empty = ordered.length === 0;
   if (globalElements.agentsEmpty) globalElements.agentsEmpty.hidden = !empty;
+}
+
+function setRecurringPromptStatus(message, kind = 'info') {
+  const root = globalElements.recurringPromptStatus;
+  if (!root) return;
+  root.textContent = String(message || '');
+  root.classList.toggle('error', kind === 'error');
+}
+
+function formatRecurringPromptTime(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return 'never';
+  try {
+    return new Date(n).toLocaleString();
+  } catch {
+    return 'unknown';
+  }
+}
+
+async function loadRecurringPromptAgents() {
+  const select = globalElements.recurringPromptAgent;
+  if (!select) return;
+
+  const current = select.value || 'main';
+  const agents = Array.isArray(uiState.agents) && uiState.agents.length
+    ? uiState.agents
+    : await refreshAgents({ reason: 'recurring-prompts' }).catch(() => []);
+
+  select.innerHTML = '';
+  const seen = new Set();
+  const addOption = (id, label) => {
+    const cleanId = normalizeAgentId(id || 'main');
+    if (seen.has(cleanId)) return;
+    seen.add(cleanId);
+    const option = document.createElement('option');
+    option.value = cleanId;
+    option.textContent = label || cleanId;
+    select.appendChild(option);
+  };
+
+  addOption('main', 'main');
+  (Array.isArray(agents) ? agents : []).forEach((agent) => {
+    const id = normalizeAgentId(agent?.id || 'main');
+    addOption(id, formatAgentLabel(agent, { includeId: true }));
+  });
+  select.value = seen.has(current) ? current : 'main';
+}
+
+async function recurringPromptRequest(url, options = {}) {
+  const res = await fetch(url, {
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
+    ...options
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok || data?.ok === false) throw new Error(String(data?.error || res.status));
+  return data;
+}
+
+function renderRecurringPrompts(prompts) {
+  const root = globalElements.recurringPromptList;
+  if (!root) return;
+  root.innerHTML = '';
+
+  const items = Array.isArray(prompts) ? prompts : [];
+  if (!items.length) {
+    root.innerHTML = '<div class="hint">No recurring prompts configured.</div>';
+    return;
+  }
+
+  items
+    .slice()
+    .sort((a, b) => String(a?.title || '').localeCompare(String(b?.title || '')))
+    .forEach((prompt) => {
+      const card = document.createElement('article');
+      card.className = 'recurring-prompt-card';
+      const status = String(prompt?.lastStatus || 'never');
+      const enabled = prompt?.enabled !== false;
+      const id = String(prompt?.id || '');
+      card.innerHTML = `
+        <div class="recurring-prompt-card-main">
+          <div class="recurring-prompt-card-title">${escapeHtml(String(prompt?.title || 'Recurring prompt'))}</div>
+          <div class="recurring-prompt-card-meta">
+            <span>${escapeHtml(String(prompt?.agentId || 'main'))}</span>
+            <span>${escapeHtml(String(prompt?.intervalMinutes || 60))}m</span>
+            <span>${enabled ? 'enabled' : 'disabled'}</span>
+            <span>${escapeHtml(status)}</span>
+          </div>
+          <div class="recurring-prompt-card-times">
+            Last: ${escapeHtml(formatRecurringPromptTime(prompt?.lastRunAt))}
+            <span>Next: ${escapeHtml(formatRecurringPromptTime(prompt?.nextRunAt))}</span>
+          </div>
+          ${prompt?.lastError ? `<div class="recurring-prompt-error">${escapeHtml(String(prompt.lastError))}</div>` : ''}
+        </div>
+        <div class="recurring-prompt-card-actions">
+          <button class="secondary" type="button" data-rp-action="toggle">${enabled ? 'Disable' : 'Enable'}</button>
+          <button class="secondary" type="button" data-rp-action="edit">Edit</button>
+          <button class="secondary danger" type="button" data-rp-action="delete">Delete</button>
+        </div>
+      `;
+
+      card.querySelector('[data-rp-action="toggle"]')?.addEventListener('click', async () => {
+        try {
+          await recurringPromptRequest(`/api/recurring-prompts/${encodeURIComponent(id)}`, {
+            method: 'PUT',
+            body: JSON.stringify({ enabled: !enabled })
+          });
+          await loadRecurringPrompts();
+        } catch (err) {
+          setRecurringPromptStatus(`Toggle failed: ${String(err)}`, 'error');
+        }
+      });
+
+      card.querySelector('[data-rp-action="edit"]')?.addEventListener('click', async () => {
+        const title = prompt('Edit title', String(prompt?.title || 'Recurring prompt'));
+        if (title === null) return;
+        const intervalRaw = prompt('Edit interval in minutes', String(prompt?.intervalMinutes || 60));
+        if (intervalRaw === null) return;
+        const message = prompt('Edit prompt text', String(prompt?.message || ''));
+        if (message === null) return;
+        const intervalMinutes = Number(intervalRaw);
+        try {
+          await recurringPromptRequest(`/api/recurring-prompts/${encodeURIComponent(id)}`, {
+            method: 'PUT',
+            body: JSON.stringify({
+              title,
+              intervalMinutes: Number.isFinite(intervalMinutes) ? intervalMinutes : prompt?.intervalMinutes,
+              message
+            })
+          });
+          await loadRecurringPrompts();
+        } catch (err) {
+          setRecurringPromptStatus(`Edit failed: ${String(err)}`, 'error');
+        }
+      });
+
+      card.querySelector('[data-rp-action="delete"]')?.addEventListener('click', async () => {
+        if (!confirm(`Delete recurring prompt?\n\n${String(prompt?.title || id)}`)) return;
+        try {
+          await recurringPromptRequest(`/api/recurring-prompts/${encodeURIComponent(id)}`, { method: 'DELETE' });
+          await loadRecurringPrompts();
+        } catch (err) {
+          setRecurringPromptStatus(`Delete failed: ${String(err)}`, 'error');
+        }
+      });
+
+      root.appendChild(card);
+    });
+}
+
+async function loadRecurringPrompts() {
+  if (!globalElements.recurringPromptList) return;
+  setRecurringPromptStatus('Loading recurring prompts...');
+  try {
+    const data = await recurringPromptRequest('/api/recurring-prompts');
+    renderRecurringPrompts(data.prompts);
+    setRecurringPromptStatus('');
+  } catch (err) {
+    renderRecurringPrompts([]);
+    setRecurringPromptStatus(`Load failed: ${String(err)}`, 'error');
+  }
+}
+
+async function createRecurringPromptFromUi() {
+  const message = String(globalElements.recurringPromptMessage?.value || '').trim();
+  if (!message) {
+    setRecurringPromptStatus('Prompt text is required.', 'error');
+    return;
+  }
+
+  const intervalMinutes = Number(globalElements.recurringPromptInterval?.value || 60);
+  const payload = {
+    title: String(globalElements.recurringPromptTitle?.value || '').trim() || 'Recurring prompt',
+    agentId: normalizeAgentId(globalElements.recurringPromptAgent?.value || 'main'),
+    intervalMinutes: Number.isFinite(intervalMinutes) ? intervalMinutes : 60,
+    enabled: globalElements.recurringPromptEnabled?.checked !== false,
+    message
+  };
+
+  try {
+    await recurringPromptRequest('/api/recurring-prompts', {
+      method: 'POST',
+      body: JSON.stringify(payload)
+    });
+    if (globalElements.recurringPromptTitle) globalElements.recurringPromptTitle.value = '';
+    if (globalElements.recurringPromptMessage) globalElements.recurringPromptMessage.value = '';
+    await loadRecurringPrompts();
+    setRecurringPromptStatus('Created recurring prompt.');
+  } catch (err) {
+    setRecurringPromptStatus(`Create failed: ${String(err)}`, 'error');
+  }
 }
 
 // Workqueue (admin-only)

--- a/index.html
+++ b/index.html
@@ -554,6 +554,45 @@
             <div>New Cron pane: <code>Ctrl/Cmd</code> + <code>Shift</code> + <code>R</code></div>
             <div>New Timeline pane: <code>Ctrl/Cmd</code> + <code>Shift</code> + <code>T</code></div>
           </div>
+
+          <section class="recurring-prompts" aria-label="Recurring agent prompts">
+            <div class="recurring-prompts-head">
+              <div>
+                <div class="recurring-prompts-title">Recurring Agent Prompts</div>
+                <div class="hint">Stored by Clawnsole; delivered by the external scheduler worker.</div>
+              </div>
+              <button id="recurringPromptRefreshBtn" class="secondary" type="button">Refresh</button>
+            </div>
+
+            <div class="recurring-prompt-form">
+              <label>
+                Title
+                <input id="recurringPromptTitle" type="text" placeholder="Daily checklist" />
+              </label>
+              <label>
+                Agent
+                <select id="recurringPromptAgent"></select>
+              </label>
+              <label>
+                Interval
+                <input id="recurringPromptInterval" type="number" value="1440" min="1" step="1" />
+              </label>
+              <label class="recurring-prompt-toggle">
+                <input id="recurringPromptEnabled" type="checkbox" checked />
+                <span>Enabled</span>
+              </label>
+              <label class="recurring-prompt-message">
+                Prompt
+                <textarea id="recurringPromptMessage" rows="4" placeholder="Admin prompt content"></textarea>
+              </label>
+              <div class="recurring-prompt-actions">
+                <button id="recurringPromptCreateBtn" class="primary" type="button">Create</button>
+              </div>
+            </div>
+
+            <div id="recurringPromptStatus" class="hint" role="status" aria-live="polite"></div>
+            <div id="recurringPromptList" class="recurring-prompt-list" aria-label="Recurring prompt list"></div>
+          </section>
         </div>
       </div>
     </div>

--- a/scripts/recurring-prompts-worker.py
+++ b/scripts/recurring-prompts-worker.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""
+External scheduler worker for recurring prompts.
+
+Runs independently (launchd/systemd/cron friendly) and delegates a single
+delivery tick to the existing Node scheduler with retry/backoff.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def log(event: str, **fields: object) -> None:
+    payload = {"ts": utc_now(), "event": event, **fields}
+    print(json.dumps(payload, separators=(",", ":")), flush=True)
+
+
+@dataclass
+class RunnerConfig:
+    node_bin: str
+    scheduler_js: str
+    prompts_path: Optional[str]
+    openclaw_config: Optional[str]
+    device_label: str
+    dry_run: bool
+    max_retries: int
+    backoff_base_seconds: float
+    backoff_jitter_seconds: float
+    loop_seconds: int
+    once: bool
+
+
+def build_tick_cmd(cfg: RunnerConfig) -> list[str]:
+    cmd = [cfg.node_bin, cfg.scheduler_js, "--once", "--deviceLabel", cfg.device_label]
+    if cfg.prompts_path:
+        cmd.extend(["--promptsPath", cfg.prompts_path])
+    if cfg.openclaw_config:
+        cmd.extend(["--openclawConfig", cfg.openclaw_config])
+    if cfg.dry_run:
+        cmd.append("--dryRun")
+    return cmd
+
+
+def run_tick(cfg: RunnerConfig) -> bool:
+    cmd = build_tick_cmd(cfg)
+    for attempt in range(0, max(0, cfg.max_retries) + 1):
+        started = time.time()
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+        elapsed_ms = int((time.time() - started) * 1000)
+        output = (proc.stdout or "").strip() or (proc.stderr or "").strip()
+        if proc.returncode == 0:
+            log("tick_ok", attempt=attempt, elapsedMs=elapsed_ms, output=output)
+            return True
+        if attempt >= cfg.max_retries:
+            log("tick_failed", attempt=attempt, elapsedMs=elapsed_ms, code=proc.returncode, output=output)
+            return False
+        sleep_s = cfg.backoff_base_seconds * (2 ** attempt) + random.uniform(0, max(0.0, cfg.backoff_jitter_seconds))
+        log("tick_retry", attempt=attempt, code=proc.returncode, sleepSeconds=round(sleep_s, 3), output=output)
+        time.sleep(max(0.0, sleep_s))
+    return False
+
+
+def parse_args(argv: list[str]) -> RunnerConfig:
+    parser = argparse.ArgumentParser(description="Recurring prompt external scheduler worker (Python)")
+    parser.add_argument("--nodeBin", default=os.environ.get("NODE_BIN", "node"))
+    parser.add_argument("--schedulerJs", default=str(Path(__file__).with_name("recurring-prompts-scheduler.js")))
+    parser.add_argument("--promptsPath", default=os.environ.get("CLAWNSOLE_RECURRING_PROMPTS_PATH"))
+    parser.add_argument("--openclawConfig", default=os.environ.get("OPENCLAW_CONFIG"))
+    parser.add_argument("--deviceLabel", default="scheduler")
+    parser.add_argument("--dryRun", action="store_true")
+    parser.add_argument("--maxRetries", type=int, default=3)
+    parser.add_argument("--backoffBaseSeconds", type=float, default=0.75)
+    parser.add_argument("--backoffJitterSeconds", type=float, default=0.25)
+    parser.add_argument("--loopSeconds", type=int, default=60)
+    parser.add_argument("--once", action="store_true")
+    args = parser.parse_args(argv)
+    return RunnerConfig(
+        node_bin=args.nodeBin,
+        scheduler_js=args.schedulerJs,
+        prompts_path=args.promptsPath,
+        openclaw_config=args.openclawConfig,
+        device_label=args.deviceLabel,
+        dry_run=args.dryRun,
+        max_retries=max(0, args.maxRetries),
+        backoff_base_seconds=max(0.0, args.backoffBaseSeconds),
+        backoff_jitter_seconds=max(0.0, args.backoffJitterSeconds),
+        loop_seconds=max(5, args.loopSeconds),
+        once=bool(args.once),
+    )
+
+
+def main(argv: list[str]) -> int:
+    cfg = parse_args(argv)
+    if not Path(cfg.scheduler_js).exists():
+        log("config_error", message="schedulerJs not found", schedulerJs=cfg.scheduler_js)
+        return 2
+    if cfg.once:
+        return 0 if run_tick(cfg) else 1
+    while True:
+        run_tick(cfg)
+        time.sleep(cfg.loop_seconds)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/styles.css
+++ b/styles.css
@@ -1638,6 +1638,123 @@ kbd {
   }
 }
 
+/* Recurring prompts */
+
+.recurring-prompts {
+  margin-top: 18px;
+  padding-top: 16px;
+  border-top: 1px solid var(--panel-border);
+}
+
+.recurring-prompts-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.recurring-prompts-title {
+  font-weight: 700;
+  color: var(--text);
+}
+
+.recurring-prompt-form {
+  display: grid;
+  grid-template-columns: 1fr 150px 110px auto;
+  gap: 10px;
+  align-items: end;
+}
+
+.recurring-prompt-toggle {
+  flex-direction: row !important;
+  align-items: center;
+  min-height: 42px;
+}
+
+.recurring-prompt-message,
+.recurring-prompt-actions {
+  grid-column: 1 / -1;
+}
+
+.recurring-prompt-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.recurring-prompt-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.recurring-prompt-card {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px;
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.recurring-prompt-card-main {
+  min-width: 0;
+}
+
+.recurring-prompt-card-title {
+  font-weight: 700;
+  color: var(--text);
+}
+
+.recurring-prompt-card-meta,
+.recurring-prompt-card-times {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.recurring-prompt-error {
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--danger);
+}
+
+.recurring-prompt-card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  align-content: flex-start;
+  gap: 8px;
+}
+
+.recurring-prompt-card-actions .danger {
+  border-color: rgba(255, 96, 96, 0.42);
+  color: #ff9a9a;
+}
+
+#recurringPromptStatus.error {
+  color: var(--danger);
+}
+
+@media (max-width: 760px) {
+  .recurring-prompt-form {
+    grid-template-columns: 1fr;
+  }
+
+  .recurring-prompt-card {
+    flex-direction: column;
+  }
+
+  .recurring-prompt-card-actions {
+    justify-content: flex-start;
+  }
+}
+
 /* Workqueue modal */
 
 .wq-toolbar {

--- a/tests/unit/clawnsole-server.test.js
+++ b/tests/unit/clawnsole-server.test.js
@@ -232,6 +232,70 @@ test('/token returns token_not_found when gateway token missing', async () => {
   assert.equal(JSON.parse(res.body.toString('utf8')).error, 'token_not_found');
 });
 
+test('recurring prompts API supports create, update, list, and delete', async () => {
+  const { homeDir, openclawDir } = makeTempHome();
+  writeJson(path.join(openclawDir, 'openclaw.json'), { gateway: { port: 18789, auth: { mode: 'token', token: 't' } } });
+  writeJson(path.join(openclawDir, 'clawnsole.json'), { adminPassword: 'admin', authVersion: 'v1' });
+
+  const promptsPath = path.join(openclawDir, 'recurring-prompts-test.json');
+  const { handleRequest } = createClawnsoleServer({ homeDir, recurringPromptsPath: promptsPath });
+
+  const login = await invoke(handleRequest, {
+    url: '/auth/login',
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ password: 'admin' })
+  });
+  const cookieHeader = parseCookiesFromSetCookie(login.headers['set-cookie']);
+
+  const create = await invoke(handleRequest, {
+    url: '/api/recurring-prompts',
+    method: 'POST',
+    headers: { cookie: cookieHeader, 'content-type': 'application/json' },
+    body: JSON.stringify({
+      title: 'Daily ops',
+      agentId: 'dev',
+      message: 'Review the daily checklist.',
+      intervalMinutes: 30,
+      enabled: true
+    })
+  });
+  assert.equal(create.statusCode, 200);
+  const created = JSON.parse(create.body.toString('utf8')).prompt;
+  assert.equal(created.title, 'Daily ops');
+  assert.equal(created.agentId, 'dev');
+  assert.equal(created.intervalMinutes, 30);
+  assert.equal(created.enabled, true);
+
+  const update = await invoke(handleRequest, {
+    url: `/api/recurring-prompts/${created.id}`,
+    method: 'PUT',
+    headers: { cookie: cookieHeader, 'content-type': 'application/json' },
+    body: JSON.stringify({ enabled: false, intervalMinutes: 45 })
+  });
+  assert.equal(update.statusCode, 200);
+  const updated = JSON.parse(update.body.toString('utf8')).prompt;
+  assert.equal(updated.enabled, false);
+  assert.equal(updated.intervalMinutes, 45);
+
+  const list = await invoke(handleRequest, { url: '/api/recurring-prompts', headers: { cookie: cookieHeader } });
+  assert.equal(list.statusCode, 200);
+  const listed = JSON.parse(list.body.toString('utf8')).prompts;
+  assert.equal(listed.length, 1);
+  assert.equal(listed[0].id, created.id);
+  assert.equal(listed[0].enabled, false);
+
+  const del = await invoke(handleRequest, {
+    url: `/api/recurring-prompts/${created.id}`,
+    method: 'DELETE',
+    headers: { cookie: cookieHeader }
+  });
+  assert.equal(del.statusCode, 200);
+
+  const listAfterDelete = await invoke(handleRequest, { url: '/api/recurring-prompts', headers: { cookie: cookieHeader } });
+  assert.deepEqual(JSON.parse(listAfterDelete.body.toString('utf8')).prompts, []);
+});
+
 test('authVersion rotation invalidates existing cookies', async () => {
   const { homeDir, openclawDir } = makeTempHome();
   const cfgPath = path.join(openclawDir, 'clawnsole.json');


### PR DESCRIPTION
## Summary\n- add Settings UI to create, list, edit, enable/disable, and delete recurring agent prompts\n- show last/next run and latest delivery status/error from the existing recurring prompt API\n- add a Python external worker wrapper with retry/backoff docs\n- cover recurring prompt CRUD with a unit test\n\n## Tests\n- npm run test:syntax\n- npm run test:unit\n- python3 -m py_compile scripts/recurring-prompts-worker.py\n\nCloses #56