### PR TITLE
Preserve admin destination through auth unlock

### DIFF
--- a/app.js
+++ b/app.js
@@ -131,6 +131,32 @@ const normalizePaneKind = __appCore.normalizePaneKind || ((rawKind) => {
             ? 'timeline'
             : 'chat';
 });
+const normalizeAdminDestination = __appCore.normalizeAdminDestination || ((candidate, { origin = '', now = Date.now(), ttlMs = 10 * 60 * 1000 } = {}) => {
+  const value = candidate && typeof candidate === 'object' ? candidate : {};
+  const href = typeof value.href === 'string' ? value.href.trim() : '';
+  if (!href) return { ok: false, reason: 'missing' };
+  const createdAt = Number(value.createdAt || 0);
+  if (createdAt > 0 && Number.isFinite(ttlMs) && ttlMs > 0 && now - createdAt > ttlMs) return { ok: false, reason: 'stale' };
+  let url;
+  try {
+    url = new URL(href, origin || 'http://127.0.0.1');
+  } catch {
+    return { ok: false, reason: 'invalid' };
+  }
+  if (origin) {
+    try {
+      if (url.origin !== new URL(origin).origin) return { ok: false, reason: 'external' };
+    } catch {
+      return { ok: false, reason: 'invalid_origin' };
+    }
+  }
+  if (!(url.pathname === '/admin' || url.pathname.startsWith('/admin/'))) return { ok: false, reason: 'outside_admin' };
+  return {
+    ok: true,
+    href: `${url.pathname}${url.search}${url.hash}` || '/admin',
+    activePaneKey: typeof value.activePaneKey === 'string' ? value.activePaneKey : ''
+  };
+});
 const deriveAuthOverlayState = __appCore.deriveAuthOverlayState || ((state) => ({
   isAdmin: String(state?.role || '') === 'admin',
   startAgentAutoRefresh: String(state?.role || '') === 'admin' && !!state?.authed,
@@ -217,6 +243,10 @@ const ADMIN_AGENT_SORT_KEY = 'clawnsole.admin.agents.sort';
 const ADMIN_AGENT_ACTIVE_MINUTES_KEY = 'clawnsole.admin.agents.activeMinutes';
 const ADMIN_AGENT_HEALTHY_COLLAPSED_KEY = 'clawnsole.admin.agents.healthyCollapsed';
 const ADMIN_AGENT_HEALTHY_COLLAPSE_THRESHOLD = 10;
+const ADMIN_AUTH_DESTINATION_KEY = 'clawnsole.admin.authDestination.v1';
+const ADMIN_AUTH_RESTORE_PENDING_KEY = 'clawnsole.admin.authRestorePending.v1';
+const ADMIN_AUTH_RESTORE_NOTICE_KEY = 'clawnsole.admin.authRestoreNotice.v1';
+const ADMIN_AUTH_DESTINATION_TTL_MS = 10 * 60 * 1000;
 const WQ_RECENT_TARGETS_KEY = 'clawnsole.wq.recentTargets';
 const WQ_RECENT_TARGETS_MAX = 6;
 
@@ -236,6 +266,95 @@ function writeJsonToStorage(key, value) {
   } catch {
     // ignore storage failures
   }
+}
+
+function getActiveAdminPaneKey() {
+  try {
+    const active = document.activeElement;
+    const pane = active?.closest?.('[data-pane]');
+    return typeof pane?.dataset?.paneKey === 'string' ? pane.dataset.paneKey : '';
+  } catch {
+    return '';
+  }
+}
+
+function readStoredAdminDestination(key = ADMIN_AUTH_DESTINATION_KEY) {
+  const value = readJsonFromStorage(key, null);
+  return normalizeAdminDestination(value, {
+    origin: window.location.origin,
+    now: Date.now(),
+    ttlMs: ADMIN_AUTH_DESTINATION_TTL_MS
+  });
+}
+
+function captureAdminAuthDestination() {
+  try {
+    const current = normalizeAdminDestination(
+      {
+        href: `${window.location.pathname || '/'}${window.location.search || ''}${window.location.hash || ''}`,
+        createdAt: Date.now(),
+        activePaneKey: getActiveAdminPaneKey()
+      },
+      { origin: window.location.origin, now: Date.now(), ttlMs: ADMIN_AUTH_DESTINATION_TTL_MS }
+    );
+    if (!current.ok) return;
+
+    const existing = readStoredAdminDestination();
+    if (existing.ok) return;
+
+    writeJsonToStorage(ADMIN_AUTH_DESTINATION_KEY, {
+      href: current.href,
+      createdAt: Date.now(),
+      activePaneKey: current.activePaneKey
+    });
+  } catch {}
+}
+
+function consumeAdminAuthDestination() {
+  const raw = readJsonFromStorage(ADMIN_AUTH_DESTINATION_KEY, null);
+  storage.remove(ADMIN_AUTH_DESTINATION_KEY);
+  return normalizeAdminDestination(raw, {
+    origin: window.location.origin,
+    now: Date.now(),
+    ttlMs: ADMIN_AUTH_DESTINATION_TTL_MS
+  });
+}
+
+function buildDefaultAdminPanes(defaultAgent = 'main') {
+  const agentId = defaultAgent || 'main';
+  return [
+    { key: `p${randomId().slice(0, 8)}`, kind: 'chat', agentId },
+    {
+      key: `p${randomId().slice(0, 8)}`,
+      kind: 'workqueue',
+      queue: 'dev-team',
+      statusFilter: ['ready', 'pending', 'claimed', 'in_progress'],
+      scopeFilter: getDefaultWorkqueueScope(),
+      sortKey: 'priority',
+      sortDir: 'desc'
+    }
+  ];
+}
+
+function fallbackToDefaultAdminDestination() {
+  const storedDefault = storage.get(ADMIN_DEFAULT_AGENT_KEY, 'main');
+  storage.set(ADMIN_PANES_KEY, JSON.stringify(buildDefaultAdminPanes(storedDefault || 'main')));
+  storage.set(ADMIN_AUTH_RESTORE_NOTICE_KEY, 'Saved admin destination expired. Restored the default admin layout.');
+  return '/admin';
+}
+
+function applyPendingAdminRestore() {
+  const pending = readStoredAdminDestination(ADMIN_AUTH_RESTORE_PENDING_KEY);
+  storage.remove(ADMIN_AUTH_RESTORE_PENDING_KEY);
+
+  const notice = storage.get(ADMIN_AUTH_RESTORE_NOTICE_KEY, '');
+  storage.remove(ADMIN_AUTH_RESTORE_NOTICE_KEY);
+  if (notice) showToast(notice, { kind: 'info', timeoutMs: 4200 });
+
+  if (!pending.ok || !pending.activePaneKey) return;
+  const pane = paneManager.panes.find((p) => p.key === pending.activePaneKey);
+  if (!pane) return;
+  paneManager.focusPanePrimary(pane);
 }
 
 function readRecentWorkqueueTargets() {
@@ -927,6 +1046,7 @@ function setRole(role) {
 }
 
 function showLogin(message = '') {
+  captureAdminAuthDestination();
   globalElements.loginOverlay.classList.add('open');
   globalElements.loginOverlay.setAttribute('aria-hidden', 'false');
   globalElements.loginError.textContent = message;
@@ -977,7 +1097,19 @@ async function attemptLogin() {
       return;
     }
     await res.json();
-    window.location.replace('/admin');
+    const destination = consumeAdminAuthDestination();
+    let nextHref = '/admin';
+    if (destination.ok) {
+      nextHref = destination.href || '/admin';
+      writeJsonToStorage(ADMIN_AUTH_RESTORE_PENDING_KEY, {
+        href: nextHref,
+        createdAt: Date.now(),
+        activePaneKey: destination.activePaneKey || ''
+      });
+    } else {
+      nextHref = fallbackToDefaultAdminDestination();
+    }
+    window.location.replace(nextHref);
   } catch {
     showLogin('Login failed. Please retry.');
   }
@@ -6570,17 +6702,7 @@ const paneManager = {
     } catch {}
 
     // Default: Chat + Workqueue.
-    const paneA = { key: `p${randomId().slice(0, 8)}`, kind: 'chat', agentId: defaultAgent };
-    const paneB = {
-      key: `p${randomId().slice(0, 8)}`,
-      kind: 'workqueue',
-      queue: 'dev-team',
-      statusFilter: ['ready', 'pending', 'claimed', 'in_progress'],
-      scopeFilter: getDefaultWorkqueueScope(),
-      sortKey: 'priority',
-      sortDir: 'desc'
-    };
-    const list = [paneA, paneB].slice(0, this.maxPanes);
+    const list = buildDefaultAdminPanes(defaultAgent).slice(0, this.maxPanes);
     storage.set(ADMIN_PANES_KEY, JSON.stringify(list));
     return list;
   },
@@ -6619,17 +6741,7 @@ const paneManager = {
 
     const storedDefault = storage.get(ADMIN_DEFAULT_AGENT_KEY, 'main');
     const defaultAgent = normalizeAgentId(storedDefault || 'main');
-    const paneA = { key: `p${randomId().slice(0, 8)}`, kind: 'chat', agentId: defaultAgent };
-    const paneB = {
-      key: `p${randomId().slice(0, 8)}`,
-      kind: 'workqueue',
-      queue: 'dev-team',
-      statusFilter: ['ready', 'pending', 'claimed', 'in_progress'],
-      scopeFilter: getDefaultWorkqueueScope(),
-      sortKey: 'priority',
-      sortDir: 'desc'
-    };
-    storage.set(ADMIN_PANES_KEY, JSON.stringify([paneA, paneB]));
+    storage.set(ADMIN_PANES_KEY, JSON.stringify(buildDefaultAdminPanes(defaultAgent)));
 
     this.init();
 
@@ -7594,6 +7706,7 @@ window.addEventListener('load', () => {
       }
 
       paneManager.init();
+      applyPendingAdminRestore();
 
       // Update agent options now that we have a definitive list.
       if (role === 'admin') {

--- a/clawnsole-server.js
+++ b/clawnsole-server.js
@@ -1324,10 +1324,14 @@ function createClawnsoleServer(options = {}) {
     }
 
 
+    let requestPath = req.url;
+    try {
+      requestPath = new URL(req.url, 'http://127.0.0.1').pathname;
+    } catch {}
     const urlPath =
-      req.url === '/' || req.url === '/admin' || req.url === '/admin/'
+      requestPath === '/' || requestPath === '/admin' || requestPath.startsWith('/admin/')
         ? '/index.html'
-        : req.url;
+        : requestPath;
     const filePath = path.join(root, decodeURIComponent(urlPath));
     if (!filePath.startsWith(root)) {
       res.writeHead(403);

--- a/lib/app-core.js
+++ b/lib/app-core.js
@@ -146,6 +146,45 @@
               : 'chat';
   }
 
+  function normalizeAdminDestination(candidate, { origin = '', now = Date.now(), ttlMs = 10 * 60 * 1000 } = {}) {
+    const value = candidate && typeof candidate === 'object' ? candidate : {};
+    const href = typeof value.href === 'string' ? value.href.trim() : '';
+    if (!href) return { ok: false, reason: 'missing' };
+
+    const createdAt = Number(value.createdAt || 0);
+    if (createdAt > 0 && Number.isFinite(ttlMs) && ttlMs > 0 && now - createdAt > ttlMs) {
+      return { ok: false, reason: 'stale' };
+    }
+
+    let url;
+    try {
+      url = new URL(href, origin || 'http://127.0.0.1');
+    } catch {
+      return { ok: false, reason: 'invalid' };
+    }
+
+    if (origin) {
+      let base;
+      try {
+        base = new URL(origin);
+      } catch {
+        return { ok: false, reason: 'invalid_origin' };
+      }
+      if (url.origin !== base.origin) return { ok: false, reason: 'external' };
+    }
+
+    if (!(url.pathname === '/admin' || url.pathname.startsWith('/admin/'))) {
+      return { ok: false, reason: 'outside_admin' };
+    }
+
+    const normalized = `${url.pathname}${url.search}${url.hash}`;
+    return {
+      ok: true,
+      href: normalized || '/admin',
+      activePaneKey: typeof value.activePaneKey === 'string' ? value.activePaneKey : ''
+    };
+  }
+
   function deriveAuthOverlayState({ authed, role = null } = {}) {
     const isAdmin = role === 'admin';
     return {
@@ -326,6 +365,7 @@
     sortWorkqueueItems,
     inferPaneCols,
     normalizePaneKind,
+    normalizeAdminDestination,
     deriveAuthOverlayState,
     deriveGlobalConnectionState,
     deriveDisconnectButtonState,

--- a/tests/ui/auth-lifecycle.spec.js
+++ b/tests/ui/auth-lifecycle.spec.js
@@ -10,6 +10,71 @@ test('visiting /admin without auth shows login overlay', async ({ page, clawnsol
   await expect(page.getByTestId('role-pill')).toContainText('signed out');
 });
 
+test('admin login restores the intended in-app destination', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  await page.goto(clawnsole.serverUrl);
+  await page.evaluate(() => {
+    localStorage.setItem(
+      'clawnsole.admin.authDestination.v1',
+      JSON.stringify({ href: '/admin?pane=workqueue#item-315', createdAt: Date.now() })
+    );
+  });
+  await expect(page.getByTestId('login-overlay')).toHaveClass(/open/);
+
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\?pane=workqueue#item-315$/, { timeout: 10000 });
+  await page.locator('#addPaneBtn').waitFor({ state: 'visible', timeout: 90000 });
+
+  await expect(page).toHaveURL(/\/admin\?pane=workqueue#item-315$/);
+});
+
+test('stale admin restore falls back to default layout with a notice', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  await page.goto(clawnsole.serverUrl);
+  await page.evaluate(() => {
+    localStorage.setItem(
+      'clawnsole.admin.authDestination.v1',
+      JSON.stringify({ href: '/admin?pane=stale#old', createdAt: Date.now() - 700000 })
+    );
+    localStorage.setItem(
+      'clawnsole.admin.panes.v1',
+      JSON.stringify([{ key: 'pstale', kind: 'cron' }])
+    );
+  });
+
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await clawnsole.waitForAdminUiReady(page);
+
+  await expect(page).toHaveURL(/\/admin\/?$/);
+  await expect(page.getByTestId('toast')).toContainText(/default admin layout/i);
+  await expect(page.locator('[data-pane]')).toHaveCount(2);
+  await expect(page.locator('[data-pane][data-pane-kind="chat"]')).toHaveCount(1);
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
+});
+
+test('admin restore ignores external destinations', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  await page.goto(clawnsole.serverUrl);
+  await page.evaluate(() => {
+    localStorage.setItem(
+      'clawnsole.admin.authDestination.v1',
+      JSON.stringify({ href: 'https://evil.test/admin', createdAt: Date.now() })
+    );
+  });
+
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await clawnsole.waitForAdminUiReady(page);
+
+  await expect(page).toHaveURL(/\/admin\/?$/);
+  await expect(page.getByTestId('toast')).toContainText(/default admin layout/i);
+});
+
 test('after successful login, reload stays authed; clearing cookies forces re-login', async ({ page, context, clawnsole }) => {
   if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
 

--- a/tests/unit/app-core.test.js
+++ b/tests/unit/app-core.test.js
@@ -7,6 +7,7 @@ const {
   sortWorkqueueItems,
   inferPaneCols,
   normalizePaneKind,
+  normalizeAdminDestination,
   deriveAuthOverlayState,
   deriveGlobalConnectionState,
   deriveDisconnectButtonState,
@@ -29,6 +30,32 @@ test('fmtRemaining formats remaining time', () => {
   assert.equal(fmtRemaining(61_000), '1m 1s');
   assert.equal(fmtRemaining(3_600_000), '1h 0m');
   assert.equal(fmtRemaining(3_660_000), '1h 1m');
+});
+
+test('normalizeAdminDestination accepts only fresh same-origin admin destinations', () => {
+  const origin = 'https://clawnsole.test';
+  const now = 2_000_000;
+
+  assert.deepEqual(
+    normalizeAdminDestination(
+      { href: '/admin?pane=workqueue#item-1', activePaneKey: 'pabc', createdAt: now - 1000 },
+      { origin, now }
+    ),
+    { ok: true, href: '/admin?pane=workqueue#item-1', activePaneKey: 'pabc' }
+  );
+
+  assert.equal(
+    normalizeAdminDestination({ href: 'https://evil.test/admin', createdAt: now }, { origin, now }).reason,
+    'external'
+  );
+  assert.equal(
+    normalizeAdminDestination({ href: '/settings', createdAt: now }, { origin, now }).reason,
+    'outside_admin'
+  );
+  assert.equal(
+    normalizeAdminDestination({ href: '/admin', createdAt: now - 700_000 }, { origin, now, ttlMs: 600_000 }).reason,
+    'stale'
+  );
 });
 
 test('sortWorkqueueItems default groups by status then priority then timestamps', () => {


### PR DESCRIPTION
## Summary
- preserve a safe same-origin `/admin` destination through auth unlock
- fall back to the default Chat + Workqueue layout with a notice when the saved destination is stale or unsafe
- serve `/admin` subpaths/query URLs through the app shell

Fixes #315

## Tests
- npm test
- npx playwright test tests/ui/auth-lifecycle.spec.js --workers=1