### PR TITLE
Workqueue: make issue-backed enqueue idempotent

### DIFF
--- a/bin/clawnsole.js
+++ b/bin/clawnsole.js
@@ -53,7 +53,7 @@ Usage:
   clawnsole workqueue <command> [options]
 
 Workqueue commands:
-  enqueue            --queue <name> --title <t> --instructions <text> [--priority <n>] [--dedupeKey <k>]
+  enqueue            --queue <name> --title <t> --instructions <text> [--priority <n>] [--dedupeKey <k>] [--repo <owner/name> --issueNumber <n>]
   claim-next         --agent <id> [--queues <q1,q2>] [--leaseMs <ms>]
   done               <itemId> --agent <id> [--result <json|@file>]
   fail               <itemId> --agent <id> --error <text>
@@ -117,10 +117,13 @@ async function main() {
     const instructions = args.instructions;
     const priority = args.priority !== undefined ? Number(args.priority) : 0;
     const dedupeKey = args.dedupeKey !== undefined ? String(args.dedupeKey) : '';
+    const repo = args.repo !== undefined ? String(args.repo) : '';
+    const issueNumber = args.issueNumber !== undefined ? args.issueNumber : undefined;
     if (!queue) die('enqueue requires --queue');
     if (!instructions) die('enqueue requires --instructions');
-    const item = enqueueItem(null, { queue, title, instructions, priority, dedupeKey });
-    printJson({ ok: true, item });
+    const item = enqueueItem(null, { queue, title, instructions, priority, dedupeKey, repo, issueNumber });
+    const result = item && item._enqueueAction === 'updated_existing' ? 'updated_existing' : 'created';
+    printJson({ ok: true, result, item });
     return;
   }
 

--- a/clawnsole-server.js
+++ b/clawnsole-server.js
@@ -782,6 +782,9 @@ function createClawnsoleServer(options = {}) {
           const instructions = String(payload.instructions || '').trim();
           const priority = Number.isFinite(Number(payload.priority)) ? Number(payload.priority) : 0;
           const dedupeKey = String(payload.dedupeKey || '').trim();
+          const meta = payload.meta && typeof payload.meta === 'object' && !Array.isArray(payload.meta) ? payload.meta : {};
+          const repo = String(payload.repo ?? meta.repo ?? '').trim();
+          const issueNumber = payload.issueNumber ?? meta.issueNumber ?? meta.issue;
 
           if (!queue) {
             sendJson(res, 400, { ok: false, error: 'queue_required' });
@@ -789,8 +792,9 @@ function createClawnsoleServer(options = {}) {
           }
 
           const { enqueueItem } = require('./lib/workqueue');
-          const item = enqueueItem(null, { queue, title, instructions, priority, dedupeKey });
-          sendJson(res, 200, { ok: true, item });
+          const item = enqueueItem(null, { queue, title, instructions, priority, dedupeKey, repo, issueNumber, meta });
+          const enqueueResult = item && item._enqueueAction === 'updated_existing' ? 'updated_existing' : 'created';
+          sendJson(res, 200, { ok: true, result: enqueueResult, item });
         } catch (err) {
           sendJson(res, 400, { ok: false, error: 'invalid_request' });
         }

--- a/docs/WORKQUEUE_HTTP_API.md
+++ b/docs/WORKQUEUE_HTTP_API.md
@@ -91,7 +91,9 @@ Create a new item in a queue.
   "title": "Review open PRs",
   "instructions": "Review and ship any safe PRs.",
   "priority": 50,
-  "dedupeKey": "hourly-pr-review:2026-02-09T20" 
+  "dedupeKey": "hourly-pr-review:2026-02-09T20",
+  "repo": "rmdmattingly/clawnsole",
+  "issueNumber": 392
 }
 ```
 
@@ -101,19 +103,23 @@ Fields:
 - `instructions` (string, optional)
 - `priority` (number, optional; defaults to `0`)
 - `dedupeKey` (string, optional): idempotency key scoped to `{queue, dedupeKey}`
+- `repo` + `issueNumber` (optional): canonical issue-backed idempotency source. When both are present, enqueue uses stable key `owner/repo#issueNumber`; repeated non-terminal issue rows are updated instead of duplicated.
+- `meta` (object, optional): stored with the item. `meta.repo` and `meta.issueNumber` are also accepted as issue-backed idempotency inputs.
 
 **Responses:**
 - **200**
 
 ```json
-{ "ok": true, "item": { "id": "...", "queue": "..." } }
+{ "ok": true, "result": "created", "item": { "id": "...", "queue": "..." } }
 ```
 
-If a `dedupeKey` match already exists, the existing item is returned with an `_deduped: true` marker:
+If a non-terminal `dedupeKey` or issue-backed match already exists, the existing item is refreshed and returned with an `_deduped: true` marker:
 
 ```json
-{ "ok": true, "item": { "id": "...", "_deduped": true } }
+{ "ok": true, "result": "updated_existing", "item": { "id": "...", "_deduped": true } }
 ```
+
+If only terminal (`done`/`failed`) matches exist, enqueue creates a new row and returns `result: "created"`.
 
 - **400** on invalid JSON/body:
 

--- a/lib/workqueue.js
+++ b/lib/workqueue.js
@@ -136,10 +136,20 @@ function ensureQueue(state, queueName) {
   return state.queues[name];
 }
 
-function createItem({ queue, title, instructions, priority }) {
+function cleanMeta(meta) {
+  if (!meta || typeof meta !== 'object' || Array.isArray(meta)) return undefined;
+  const out = {};
+  for (const [key, value] of Object.entries(meta)) {
+    if (value === undefined) continue;
+    out[key] = value;
+  }
+  return Object.keys(out).length ? out : undefined;
+}
+
+function createItem({ queue, title, instructions, priority, meta }) {
   const id = crypto.randomUUID();
   const createdAt = new Date().toISOString();
-  return {
+  const item = {
     id,
     queue,
     title: String(title || '').trim() || '(untitled)',
@@ -154,41 +164,122 @@ function createItem({ queue, title, instructions, priority }) {
     createdAt,
     updatedAt: createdAt
   };
+  const normalizedMeta = cleanMeta(meta);
+  if (normalizedMeta) item.meta = normalizedMeta;
+  return item;
 }
 
 
 
-function findItemByDedupeKey(state, { queue, dedupeKey }) {
+const TERMINAL_STATUSES = new Set(['done', 'failed']);
+
+function normalizeIssueRepoName(repo) {
+  return String(repo || '').trim().toLowerCase().replace(/\s+/g, '');
+}
+
+function normalizeIssueNumber(raw) {
+  const n = Number.parseInt(String(raw || '').trim(), 10);
+  return Number.isFinite(n) && n > 0 ? String(n) : '';
+}
+
+function parseIssueRef(text) {
+  const src = String(text || '').trim();
+  if (!src) return null;
+
+  const fromUrl = src.match(/github\.com\/([a-z0-9_.-]+\/[a-z0-9_.-]+)\/issues\/(\d+)/i);
+  if (fromUrl) {
+    const repo = normalizeIssueRepoName(fromUrl[1]);
+    const issueNumber = normalizeIssueNumber(fromUrl[2]);
+    if (repo && issueNumber) return { repo, issueNumber };
+  }
+
+  const fromFullRef = src.match(/(?:^|[\s[(])(?:issue:)?([a-z0-9_.-]+\/[a-z0-9_.-]+)\s*#\s*(\d+)\b/i);
+  if (fromFullRef) {
+    const repo = normalizeIssueRepoName(fromFullRef[1]);
+    const issueNumber = normalizeIssueNumber(fromFullRef[2]);
+    if (repo && issueNumber) return { repo, issueNumber };
+  }
+
+  return null;
+}
+
+function canonicalizeIssueDedupeKey({ repo, issueNumber, dedupeKey, title, instructions, meta }) {
+  const metaObj = meta && typeof meta === 'object' ? meta : {};
+  const explicitRepo = normalizeIssueRepoName(repo ?? metaObj.repo);
+  const explicitIssue = normalizeIssueNumber(issueNumber ?? metaObj.issueNumber ?? metaObj.issue);
+  if (explicitRepo && explicitIssue) return `${explicitRepo}#${explicitIssue}`;
+
+  const parsed = parseIssueRef(dedupeKey) || parseIssueRef(instructions) || parseIssueRef(title);
+  if (parsed) return `${parsed.repo}#${parsed.issueNumber}`;
+
+  return String(dedupeKey || '').trim();
+}
+
+function findItemByDedupeKey(state, { queue, dedupeKey, title, instructions, repo, issueNumber, meta, includeTerminal = true }) {
   const q = String(queue || '').trim();
-  const key = String(dedupeKey || '').trim();
+  const key = canonicalizeIssueDedupeKey({ dedupeKey, title, instructions, repo, issueNumber, meta });
   if (!q || !key) return null;
   // Search newest-first so if there are multiple (e.g. old data), we return the most recent.
   for (let i = state.items.length - 1; i >= 0; i--) {
     const it = state.items[i];
-    if (it && it.queue === q && it.dedupeKey === key) return it;
+    if (!it || it.queue !== q) continue;
+    if (!includeTerminal && TERMINAL_STATUSES.has(String(it.status || '').trim())) continue;
+    const itemKey = canonicalizeIssueDedupeKey({
+      dedupeKey: it.dedupeKey,
+      title: it.title,
+      instructions: it.instructions,
+      repo: it.meta?.repo,
+      issueNumber: it.meta?.issueNumber ?? it.meta?.issue,
+      meta: it.meta
+    });
+    if (itemKey === key) return it;
   }
   return null;
 }
 
-function enqueueItem(rootDir, { queue, title, instructions, priority, dedupeKey }) {
+function enqueueItem(rootDir, { queue, title, instructions, priority, dedupeKey, repo, issueNumber, meta }) {
   const { lockFile } = statePaths(rootDir);
   return withFileLock(lockFile, () => {
     const state = loadState(rootDir);
     ensureQueue(state, queue);
 
-    const key = String(dedupeKey || '').trim();
+    const issueRepo = normalizeIssueRepoName(repo ?? meta?.repo);
+    const issue = normalizeIssueNumber(issueNumber ?? meta?.issueNumber ?? meta?.issue);
+    const mergedMeta = cleanMeta({
+      ...(meta && typeof meta === 'object' && !Array.isArray(meta) ? meta : {}),
+      ...(issueRepo ? { repo: issueRepo } : {}),
+      ...(issue ? { issueNumber: issue } : {})
+    });
+    const key = canonicalizeIssueDedupeKey({ dedupeKey, title, instructions, repo: issueRepo, issueNumber: issue, meta: mergedMeta });
     if (key) {
-      const existing = findItemByDedupeKey(state, { queue, dedupeKey: key });
+      const existing = findItemByDedupeKey(state, {
+        queue,
+        dedupeKey: key,
+        title,
+        instructions,
+        repo: issueRepo,
+        issueNumber: issue,
+        meta: mergedMeta,
+        includeTerminal: false
+      });
       if (existing) {
-        return { ...existing, _deduped: true };
+        const nextPriority = Number(priority);
+        if (Number.isFinite(nextPriority)) existing.priority = nextPriority;
+        if (title !== undefined) existing.title = String(title || '').trim() || '(untitled)';
+        if (instructions !== undefined) existing.instructions = String(instructions || '').trim();
+        if (mergedMeta) existing.meta = cleanMeta({ ...(existing.meta || {}), ...mergedMeta });
+        existing.dedupeKey = key;
+        existing.updatedAt = new Date().toISOString();
+        saveState(rootDir, state);
+        return { ...existing, _deduped: true, _enqueueAction: 'updated_existing' };
       }
     }
 
-    const item = createItem({ queue, title, instructions, priority });
+    const item = createItem({ queue, title, instructions, priority, meta: mergedMeta });
     if (key) item.dedupeKey = key;
     state.items.push(item);
     saveState(rootDir, state);
-    return item;
+    return { ...item, _enqueueAction: 'created' };
   });
 }
 

--- a/tests/unit/workqueue-api.test.js
+++ b/tests/unit/workqueue-api.test.js
@@ -166,6 +166,48 @@ test('workqueue API: enqueue creates item', async () => {
   }
 });
 
+test('workqueue API: issue-backed enqueue reports updated_existing for repeated automation', async () => {
+  const { openclawHome } = mkTempEnv();
+  fs.mkdirSync(openclawHome, { recursive: true });
+  fs.writeFileSync(path.join(openclawHome, 'clawnsole.json'), JSON.stringify({ adminPassword: 'admin', authVersion: 'test' }));
+
+  const { server, port } = await startServer({ openclawHome });
+  try {
+    const cookie = Buffer.from('admin::test', 'utf8').toString('base64');
+    const headers = { Cookie: 'clawnsole_auth=' + cookie + '; clawnsole_role=admin' };
+    let latest = null;
+
+    for (let i = 0; i < 10; i++) {
+      latest = await httpPostJson(
+        'http://127.0.0.1:' + port + '/api/workqueue/enqueue',
+        {
+          queue: 'dev-team',
+          title: `Automated issue enqueue ${i}`,
+          instructions: 'Ship issue-backed work',
+          priority: i,
+          repo: 'rmdmattingly/clawnsole',
+          issueNumber: 392,
+          meta: { source: 'hourly-auto-enqueue' }
+        },
+        headers
+      );
+      assert.equal(latest.status, 200);
+      assert.equal(latest.json?.ok, true);
+    }
+
+    assert.equal(latest.json?.result, 'updated_existing');
+    assert.equal(latest.json?.item?.dedupeKey, 'rmdmattingly/clawnsole#392');
+    assert.equal(latest.json?.item?.priority, 9);
+
+    const list = await httpGetJson(`http://127.0.0.1:${port}/api/workqueue/items?queue=dev-team`, headers);
+    assert.equal(list.status, 200);
+    assert.equal(list.json?.items?.length, 1);
+    assert.equal(list.json?.items?.[0]?.title, 'Automated issue enqueue 9');
+  } finally {
+    server.close();
+  }
+});
+
 test('workqueue API: claim-next claims a ready item', async () => {
   const { openclawHome } = mkTempEnv();
   fs.mkdirSync(openclawHome, { recursive: true });

--- a/tests/unit/workqueue.test.js
+++ b/tests/unit/workqueue.test.js
@@ -256,3 +256,65 @@ test('workqueue: enqueue supports dedupeKey idempotency', () => {
   const state = loadState(root);
   assert.equal(state.items.length, 1);
 });
+
+test('workqueue: issue-backed automated enqueue upserts one live item', () => {
+  const root = tempRoot();
+
+  let latest;
+  for (let i = 0; i < 10; i++) {
+    latest = enqueueItem(root, {
+      queue: 'dev-team',
+      title: `Issue coverage pass ${i}`,
+      instructions: `Ship https://github.com/rmdmattingly/clawnsole/issues/392`,
+      priority: i,
+      repo: 'RMDMATTINGLY/CLAWNSOLE',
+      issueNumber: 392,
+      meta: {
+        source: 'hourly-auto-enqueue'
+      }
+    });
+  }
+
+  assert.equal(latest._enqueueAction, 'updated_existing');
+  assert.equal(latest._deduped, true);
+  assert.equal(latest.priority, 9);
+  assert.equal(latest.dedupeKey, 'rmdmattingly/clawnsole#392');
+  assert.equal(latest.meta.repo, 'rmdmattingly/clawnsole');
+  assert.equal(latest.meta.issueNumber, '392');
+
+  const state = loadState(root);
+  assert.equal(state.items.length, 1);
+  assert.equal(state.items[0].title, 'Issue coverage pass 9');
+  assert.equal(state.items[0].priority, 9);
+});
+
+test('workqueue: issue-backed enqueue creates new row when only terminal matches exist', () => {
+  const root = tempRoot();
+
+  const first = enqueueItem(root, {
+    queue: 'dev-team',
+    title: 'Terminal issue task',
+    instructions: 'Done work',
+    priority: 1,
+    repo: 'rmdmattingly/clawnsole',
+    issueNumber: 392
+  });
+
+  const state = loadState(root);
+  state.items[0].status = 'done';
+  saveState(root, state);
+
+  const second = enqueueItem(root, {
+    queue: 'dev-team',
+    title: 'Fresh issue task',
+    instructions: 'New work',
+    priority: 2,
+    repo: 'rmdmattingly/clawnsole',
+    issueNumber: 392
+  });
+
+  assert.notEqual(second.id, first.id);
+  assert.equal(second._enqueueAction, 'created');
+  assert.equal(second.dedupeKey, 'rmdmattingly/clawnsole#392');
+  assert.equal(loadState(root).items.length, 2);
+});


### PR DESCRIPTION
## Summary\n- canonicalize issue-backed enqueue keys from repo + issueNumber as owner/repo#number\n- upsert matching non-terminal queue items with refreshed priority/title/instructions/meta/updatedAt\n- report enqueue result as created or updated_existing in API and CLI responses\n\n## Tests\n- npm test\n\nCloses #392