### PR TITLE
test: cover Workqueue modal golden path

### DIFF
--- a/app.js
+++ b/app.js
@@ -2619,6 +2619,7 @@ function renderWorkqueueStatusFilters() {
     const id = `wq-status-${s}`;
     const label = document.createElement('label');
     label.className = 'wq-status-chip';
+    label.dataset.testid = `wq-modal-status-filter-${s}`;
     label.innerHTML = `<input type="checkbox" id="${id}" ${workqueueState.statusFilter.has(s) ? 'checked' : ''} /> <span>${escapeHtml(s)}</span>`;
     const checkbox = label.querySelector('input');
     checkbox.addEventListener('change', () => {
@@ -2831,6 +2832,7 @@ function renderWorkqueueItems() {
     const col = document.createElement('section');
     col.className = 'wq-board-col';
     col.setAttribute('data-wq-col', colDef.status);
+    col.dataset.testid = `wq-modal-col-${colDef.status}`;
 
     const colItems = Array.isArray(itemsByStatus[colDef.status]) ? itemsByStatus[colDef.status] : [];
 
@@ -2843,6 +2845,7 @@ function renderWorkqueueItems() {
 
     const lane = document.createElement('div');
     lane.className = 'wq-board-lane';
+    lane.dataset.testid = `wq-modal-lane-${colDef.status}`;
 
     // Drag/drop: drop a card to change status.
     lane.addEventListener('dragover', (e) => {
@@ -2867,6 +2870,7 @@ function renderWorkqueueItems() {
       const card = document.createElement('button');
       card.type = 'button';
       card.className = 'wq-card';
+      card.dataset.testid = 'wq-modal-card';
       if (it.id && it.id === workqueueState.selectedItemId) card.classList.add('selected');
       if (it.id) card.setAttribute('data-wq-item', it.id);
 
@@ -2957,6 +2961,8 @@ function renderWorkqueueInspect(item) {
 
   const editBtn = actions.querySelector('[data-wq-action="edit"]');
   const deleteBtn = actions.querySelector('[data-wq-action="delete"]');
+  editBtn?.setAttribute('data-testid', 'wq-modal-edit');
+  deleteBtn?.setAttribute('data-testid', 'wq-modal-delete');
 
   editBtn?.addEventListener('click', () => workqueueEditItem(item));
   deleteBtn?.addEventListener('click', () => workqueueDeleteItem(item));

--- a/index.html
+++ b/index.html
@@ -294,7 +294,7 @@
       </div>
     </div>
 
-    <div id="workqueueModal" class="modal" aria-hidden="true">
+    <div id="workqueueModal" class="modal" aria-hidden="true" data-testid="wq-modal">
       <div class="modal-card wide" role="dialog" aria-modal="true" aria-labelledby="workqueueTitle">
         <div class="modal-header">
           <h2 id="workqueueTitle">Workqueue</h2>
@@ -306,11 +306,11 @@
           <div class="wq-toolbar">
             <label class="wq-field">
               Queue
-              <select id="wqQueueSelect" aria-label="Select workqueue"></select>
+              <select id="wqQueueSelect" aria-label="Select workqueue" data-testid="wq-modal-queue-select"></select>
             </label>
             <div class="wq-field">
               Status
-              <div id="wqStatusFilters" class="wq-status-filters" aria-label="Status filters"></div>
+              <div id="wqStatusFilters" class="wq-status-filters" aria-label="Status filters" data-testid="wq-modal-status-filters"></div>
             </div>
             <label class="wq-field">
               Auto-refresh
@@ -384,13 +384,13 @@
                 <button type="button" class="wq-list-sort" data-wq-modal-sort="claimedBy">Claimed By</button>
                 <button type="button" class="wq-list-sort" data-wq-modal-sort="leaseUntil">Lease</button>
               </div>
-              <div id="wqListBody" class="wq-list-body"></div>
+              <div id="wqListBody" class="wq-list-body" data-testid="wq-modal-list"></div>
               <div id="wqListEmpty" class="hint" hidden>No items match.</div>
             </div>
 
             <div class="wq-inspect" aria-label="Inspect workqueue item">
               <div class="wq-inspect-header">Item</div>
-              <div id="wqInspectBody" class="wq-inspect-body">
+              <div id="wqInspectBody" class="wq-inspect-body" data-testid="wq-modal-inspect">
                 <div class="hint">Select an item to inspect.</div>
               </div>
             </div>

--- a/tests/ui/workqueue-modal-golden-path.spec.js
+++ b/tests/ui/workqueue-modal-golden-path.spec.js
@@ -1,0 +1,88 @@
+const { test, expect } = require('@playwright/test');
+
+const { startTestEnv, loginAdmin, attachConsoleErrorAsserts } = require('./_helpers');
+
+let env;
+
+test.beforeAll(async () => {
+  env = await startTestEnv();
+});
+
+test.afterAll(() => {
+  env?.stop?.();
+});
+
+test.afterEach(async ({ page }) => {
+  if (page.__consoleAsserts) {
+    page.__consoleAsserts.assertNoErrors();
+  }
+});
+
+test('workqueue modal: golden path covers filters, kanban transition, edit, and delete', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+
+  await page.evaluate(async () => {
+    const res = await fetch('/api/workqueue/enqueue', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({
+        queue: 'dev-team',
+        title: 'Golden path item',
+        instructions: 'Exercise workqueue UI',
+        priority: 42,
+        dedupeKey: 'ui-golden-path'
+      })
+    });
+    const data = await res.json().catch(() => null);
+    if (!res.ok || !data?.ok) throw new Error(data?.error || `enqueue failed: ${res.status}`);
+  });
+
+  await page.locator('#workqueueBtn').click();
+
+  const modal = page.getByTestId('wq-modal');
+  await expect(modal).toHaveClass(/open/);
+  await expect(modal.getByTestId('wq-modal-queue-select')).toBeVisible();
+  await expect(modal.getByTestId('wq-modal-status-filters')).toBeVisible();
+  await expect(modal.getByTestId('wq-modal-status-filter-ready')).toBeVisible();
+
+  await modal.getByTestId('wq-modal-queue-select').selectOption('dev-team');
+  const readyLane = modal.getByTestId('wq-modal-lane-ready');
+  const inProgressLane = modal.getByTestId('wq-modal-lane-in_progress');
+  const itemCard = readyLane.getByTestId('wq-modal-card').filter({ hasText: 'Golden path item' }).first();
+  await expect(itemCard).toBeVisible();
+
+  const dataTransfer = await page.evaluateHandle(() => new DataTransfer());
+  await itemCard.dispatchEvent('dragstart', { dataTransfer });
+  await inProgressLane.dispatchEvent('dragover', { dataTransfer });
+  await inProgressLane.dispatchEvent('drop', { dataTransfer });
+
+  const movedCard = inProgressLane.getByTestId('wq-modal-card').filter({ hasText: 'Golden path item' }).first();
+  await expect(movedCard).toBeVisible();
+  await movedCard.click();
+  await expect(modal.getByTestId('wq-modal-inspect')).toContainText('Golden path item');
+
+  const editAnswers = ['Golden path item edited', 'Updated instructions', '77', 'in_progress'];
+  const editDialogHandler = async (dialog) => {
+    await dialog.accept(editAnswers.shift());
+  };
+  page.on('dialog', editDialogHandler);
+  await modal.getByTestId('wq-modal-edit').click();
+  await expect(inProgressLane).toContainText('Golden path item edited');
+  page.off('dialog', editDialogHandler);
+  expect(editAnswers).toHaveLength(0);
+
+  page.once('dialog', async (dialog) => {
+    expect(dialog.message()).toContain('Delete workqueue item?');
+    await dialog.accept();
+  });
+  await modal.getByTestId('wq-modal-delete').click();
+
+  await expect(modal.getByTestId('wq-modal-list')).not.toContainText('Golden path item edited');
+  await expect(modal.getByTestId('wq-modal-inspect')).toContainText('Select an item to inspect.');
+});


### PR DESCRIPTION
## Summary
- add stable test IDs for Workqueue modal filters, kanban lanes/cards, inspect actions
- add Playwright golden-path coverage for queue/status rendering, kanban status transition, edit prompts, delete confirmation, and console/page error assertions

## Verification
- node --check app.js
- NODE_PATH=/Users/raysopenclaw/src/clawnsole/node_modules /Users/raysopenclaw/src/clawnsole/node_modules/.bin/playwright test tests/ui/workqueue-modal-golden-path.spec.js --workers=1

Closes #123