### PR TITLE
Add recurring prompt trigger worker

### DIFF
--- a/clawnsole-server.js
+++ b/clawnsole-server.js
@@ -174,6 +174,101 @@ function createClawnsoleServer(options = {}) {
     }
   }
 
+  function computeRecurringPromptSessionKey(agentId, deviceLabel = 'scheduler') {
+    const resolved = String(agentId || 'main').trim() || 'main';
+    const device = String(deviceLabel || 'scheduler').trim() || 'scheduler';
+    return `agent:${resolved}:admin:${device}`;
+  }
+
+  async function defaultDeliverRecurringPrompt({ prompt, idempotencyKey, deviceLabel = 'scheduler' }) {
+    const socket = new WebSocketImpl(gatewayWsUrl());
+    const pending = new Map();
+
+    const sendReq = (method, params) => {
+      const id = randomId();
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          pending.delete(id);
+          reject(new Error('gateway request timeout'));
+        }, 15_000);
+        pending.set(id, (msg) => {
+          clearTimeout(timer);
+          resolve(msg);
+        });
+        socket.send(JSON.stringify({ type: 'req', id, method, params: params || {} }));
+      });
+    };
+
+    socket.on('message', (raw) => {
+      let msg = null;
+      try {
+        msg = JSON.parse(String(raw || ''));
+      } catch {
+        return;
+      }
+      if (!msg || msg.type !== 'res' || !msg.id) return;
+      const resolver = pending.get(msg.id);
+      if (!resolver) return;
+      pending.delete(msg.id);
+      resolver(msg);
+    });
+
+    await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('gateway socket open timeout')), 10_000);
+      socket.on('open', () => {
+        clearTimeout(timer);
+        resolve();
+      });
+      socket.on('error', (err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+    });
+
+    const { token } = readToken();
+    try {
+      const connectRes = await sendReq('connect', {
+        minProtocol: 3,
+        maxProtocol: 3,
+        client: {
+          id: 'recurring-prompt-trigger',
+          version: '0.1.0',
+          platform: 'node',
+          mode: 'scheduler',
+          instanceId: 'recurring-prompt-trigger'
+        },
+        role: 'operator',
+        scopes: ['operator.read', 'operator.write', 'operator.admin'],
+        caps: [],
+        commands: [],
+        permissions: {},
+        auth: token ? { token } : undefined,
+        locale: 'en-US',
+        userAgent: 'clawnsole-recurring-trigger/0.1.0'
+      });
+
+      if (!connectRes?.ok) {
+        throw new Error(connectRes?.error?.message || 'gateway connect failed');
+      }
+
+      const sendRes = await sendReq('chat.send', {
+        sessionKey: computeRecurringPromptSessionKey(prompt.agentId, deviceLabel),
+        message: prompt.message || '',
+        deliver: true,
+        idempotencyKey
+      });
+      if (!sendRes?.ok) {
+        throw new Error(sendRes?.error?.message || 'chat.send failed');
+      }
+    } finally {
+      try {
+        socket.close();
+      } catch {}
+    }
+  }
+
+  const deliverRecurringPrompt = options.deliverRecurringPrompt || defaultDeliverRecurringPrompt;
+
   function sanitizeRecurringPrompt(input = {}, now) {
     const title = typeof input.title === 'string' ? input.title.trim() : '';
     const agentId = typeof input.agentId === 'string' ? input.agentId.trim() : 'main';
@@ -196,7 +291,19 @@ function createClawnsoleServer(options = {}) {
         if (!ts) return null;
         const status = String(row.status || row.lastStatus || 'unknown').trim() || 'unknown';
         const error = String(row.error || row.lastError || '').trim();
-        return { ts, status, error };
+        const scheduledAtRaw = Number(row.scheduledAt ?? row.scheduled_at ?? 0);
+        const scheduledAt = Number.isFinite(scheduledAtRaw) && scheduledAtRaw > 0 ? scheduledAtRaw : undefined;
+        const deliveredAtRaw = Number(row.deliveredAt ?? row.delivered_at ?? 0);
+        const deliveredAt = Number.isFinite(deliveredAtRaw) && deliveredAtRaw > 0 ? deliveredAtRaw : undefined;
+        const idempotencyKey = String(row.idempotencyKey || row.idempotency_key || '').trim();
+        return {
+          ts,
+          status,
+          error,
+          ...(scheduledAt ? { scheduledAt } : {}),
+          ...(deliveredAt ? { deliveredAt } : {}),
+          ...(idempotencyKey ? { idempotencyKey } : {})
+        };
       })
       .filter(Boolean)
       .sort((a, b) => Number(b.ts || 0) - Number(a.ts || 0));
@@ -490,6 +597,102 @@ function createClawnsoleServer(options = {}) {
         } catch (err) {
           sendJson(res, 400, { ok: false, error: 'invalid_request' });
         }
+      });
+      return;
+    }
+
+    if (req.url.startsWith('/api/recurring-prompts/') && req.url.includes('/trigger')) {
+      if (!requireAuth(req, res)) return;
+      if (req.clawnsoleRole !== 'admin') {
+        sendJson(res, 403, { error: 'forbidden' });
+        return;
+      }
+      if (req.method !== 'POST') {
+        sendJson(res, 405, { error: 'method_not_allowed' });
+        return;
+      }
+
+      const parsed = new URL(req.url, 'http://127.0.0.1');
+      const parts = parsed.pathname.split('/').filter(Boolean);
+      const id = parts[2] || '';
+      if (!id || parts[3] !== 'trigger') {
+        sendJson(res, 404, { error: 'not_found' });
+        return;
+      }
+
+      readJsonBody(req, res, { maxBytes: 100_000 }).then(async (payload) => {
+        if (!payload) return;
+        const now = Date.now();
+        const state = readRecurringPrompts();
+        const idx = state.prompts.findIndex((p) => p && p.id === id);
+        if (idx < 0) {
+          sendJson(res, 404, { ok: false, error: 'not_found' });
+          return;
+        }
+
+        const prompt = state.prompts[idx];
+        const scheduledAtRaw = Number(payload.scheduledAt ?? payload.scheduled_at ?? prompt.nextRunAt ?? now);
+        const scheduledAt = Number.isFinite(scheduledAtRaw) && scheduledAtRaw > 0 ? Math.floor(scheduledAtRaw) : now;
+        const idempotencyKey = String(
+          payload.idempotencyKey ||
+            payload.idempotency_key ||
+            req.headers['idempotency-key'] ||
+            `${id}:${scheduledAt}`
+        ).trim();
+        const runs = normalizeRecurringRuns(prompt.runHistory);
+        const existingOk = runs.find(
+          (row) =>
+            idempotencyKey &&
+            row.idempotencyKey === idempotencyKey &&
+            (row.status === 'ok' || row.status === 'dry_run')
+        );
+        if (existingOk) {
+          sendJson(res, 200, { ok: true, duplicate: true, prompt: serializeRecurringPrompt(prompt), run: existingOk });
+          return;
+        }
+
+        const dryRun = payload.dryRun === true || payload.dry_run === true;
+        const deviceLabel = typeof payload.deviceLabel === 'string' ? payload.deviceLabel.trim() : 'scheduler';
+        let status = dryRun ? 'dry_run' : 'ok';
+        let error = '';
+
+        try {
+          if (!dryRun) {
+            await deliverRecurringPrompt({ prompt, idempotencyKey, scheduledAt, deviceLabel });
+          }
+        } catch (err) {
+          status = 'error';
+          error = String(err?.message || err || 'delivery failed');
+        }
+
+        const intervalMinutes = Math.max(1, Number(prompt.intervalMinutes) || 60);
+        const baseForNext = Math.max(now, scheduledAt);
+        const updatedRun = {
+          ts: now,
+          scheduledAt,
+          deliveredAt: status === 'ok' || status === 'dry_run' ? now : undefined,
+          status,
+          error,
+          idempotencyKey
+        };
+        const nextRuns = [updatedRun, ...runs.filter((row) => row.idempotencyKey !== idempotencyKey)].slice(0, 200);
+        const updated = {
+          ...prompt,
+          lastRunAt: now,
+          lastStatus: status,
+          lastError: error,
+          nextRunAt: baseForNext + intervalMinutes * 60 * 1000,
+          runHistory: nextRuns,
+          updatedAt: now
+        };
+        state.prompts[idx] = updated;
+        writeRecurringPrompts(state);
+        sendJson(res, status === 'error' ? 502 : 200, {
+          ok: status !== 'error',
+          prompt: serializeRecurringPrompt(updated),
+          run: updatedRun,
+          ...(error ? { error } : {})
+        });
       });
       return;
     }

--- a/scripts/recurring_prompts_worker.py
+++ b/scripts/recurring_prompts_worker.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""External worker for Clawnsole recurring admin prompts.
+
+This process is intentionally outside OpenClaw Gateway scheduling. It polls
+Clawnsole for due prompts and asks Clawnsole to trigger each delivery, so
+credentials and delivery behavior stay server-owned.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+def _json_request(base_url: str, method: str, path: str, *, data=None, headers=None, timeout=15):
+    url = urllib.parse.urljoin(base_url.rstrip("/") + "/", path.lstrip("/"))
+    body = None
+    req_headers = {"Accept": "application/json"}
+    if headers:
+        req_headers.update(headers)
+    if data is not None:
+        body = json.dumps(data).encode("utf-8")
+        req_headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=body, headers=req_headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8")
+            return resp.status, json.loads(raw or "{}"), resp.headers
+    except urllib.error.HTTPError as err:
+        raw = err.read().decode("utf-8", errors="replace")
+        try:
+            payload = json.loads(raw or "{}")
+        except json.JSONDecodeError:
+            payload = {"error": raw or str(err)}
+        return err.code, payload, err.headers
+
+
+def _login(base_url: str, password: str, timeout: int) -> str:
+    status, payload, headers = _json_request(
+        base_url,
+        "POST",
+        "/auth/login",
+        data={"password": password},
+        timeout=timeout,
+    )
+    if status != 200:
+        raise RuntimeError(f"login failed: HTTP {status} {payload.get('error', '')}".strip())
+    cookies = headers.get_all("Set-Cookie") if hasattr(headers, "get_all") else headers.get("Set-Cookie", "").split(",")
+    cookie_pairs = []
+    for cookie in cookies or []:
+        pair = str(cookie).split(";", 1)[0].strip()
+        if pair:
+            cookie_pairs.append(pair)
+    if not cookie_pairs:
+        raise RuntimeError("login failed: missing auth cookie")
+    return "; ".join(cookie_pairs)
+
+
+def _load_prompts(base_url: str, cookie: str, timeout: int):
+    status, payload, _ = _json_request(
+        base_url,
+        "GET",
+        "/api/recurring-prompts",
+        headers={"Cookie": cookie},
+        timeout=timeout,
+    )
+    if status != 200:
+        raise RuntimeError(f"prompt poll failed: HTTP {status} {payload.get('error', '')}".strip())
+    prompts = payload.get("prompts", [])
+    return prompts if isinstance(prompts, list) else []
+
+
+def _trigger_prompt(base_url: str, cookie: str, prompt: dict, now_ms: int, timeout: int, dry_run: bool):
+    prompt_id = str(prompt.get("id") or "").strip()
+    if not prompt_id:
+        return {"ok": False, "error": "missing prompt id"}
+    scheduled_at = prompt.get("nextRunAt") or prompt.get("nextRun") or now_ms
+    try:
+        scheduled_at = int(float(scheduled_at))
+    except (TypeError, ValueError):
+        scheduled_at = now_ms
+    idempotency_key = f"{prompt_id}:{scheduled_at}"
+    status, payload, _ = _json_request(
+        base_url,
+        "POST",
+        f"/api/recurring-prompts/{urllib.parse.quote(prompt_id)}/trigger",
+        data={
+            "scheduledAt": scheduled_at,
+            "idempotencyKey": idempotency_key,
+            "deviceLabel": "python-worker",
+            "dryRun": dry_run,
+        },
+        headers={"Cookie": cookie, "Idempotency-Key": idempotency_key},
+        timeout=timeout,
+    )
+    return {
+        "ok": status == 200 and bool(payload.get("ok")),
+        "status": status,
+        "duplicate": bool(payload.get("duplicate")),
+        "error": payload.get("error") or "",
+        "id": prompt_id,
+    }
+
+
+def run_once(args) -> dict:
+    password = args.admin_password or os.environ.get("CLAWNSOLE_ADMIN_PASSWORD", "")
+    cookie = args.cookie or os.environ.get("CLAWNSOLE_ADMIN_COOKIE", "")
+    if not cookie:
+        if not password:
+            raise RuntimeError("set --admin-password, CLAWNSOLE_ADMIN_PASSWORD, or CLAWNSOLE_ADMIN_COOKIE")
+        cookie = _login(args.base_url, password, args.timeout)
+
+    now_ms = int(time.time() * 1000)
+    prompts = _load_prompts(args.base_url, cookie, args.timeout)
+    due = []
+    for prompt in prompts:
+        if not isinstance(prompt, dict) or prompt.get("enabled") is False:
+            continue
+        next_run = prompt.get("nextRunAt") or prompt.get("nextRun") or 0
+        try:
+            next_run_ms = int(float(next_run))
+        except (TypeError, ValueError):
+            next_run_ms = 0
+        if next_run_ms <= now_ms:
+            due.append(prompt)
+
+    delivered = 0
+    duplicates = 0
+    errors = []
+    for prompt in due:
+        last_error = None
+        for attempt in range(args.retries + 1):
+            result = _trigger_prompt(args.base_url, cookie, prompt, now_ms, args.timeout, args.dry_run)
+            if result.get("ok"):
+                delivered += 1
+                if result.get("duplicate"):
+                    duplicates += 1
+                break
+            last_error = result.get("error") or f"HTTP {result.get('status')}"
+            if attempt < args.retries:
+                time.sleep(min(args.max_backoff, args.backoff * (2**attempt)))
+        else:
+            errors.append({"id": prompt.get("id"), "error": last_error or "trigger failed"})
+
+    return {
+        "ok": not errors,
+        "due": len(due),
+        "delivered": delivered,
+        "duplicates": duplicates,
+        "errors": errors,
+    }
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(description="Run Clawnsole recurring admin prompts externally.")
+    parser.add_argument("--base-url", default=os.environ.get("CLAWNSOLE_BASE_URL", "http://127.0.0.1:5173"))
+    parser.add_argument("--admin-password", default="")
+    parser.add_argument("--cookie", default="")
+    parser.add_argument("--once", action="store_true", help="Run one poll/trigger pass and exit.")
+    parser.add_argument("--loop-seconds", type=int, default=60)
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--retries", type=int, default=2)
+    parser.add_argument("--backoff", type=float, default=1.0)
+    parser.add_argument("--max-backoff", type=float, default=10.0)
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    while True:
+        try:
+            result = run_once(args)
+        except Exception as err:  # noqa: BLE001 - CLI should report concise failures.
+            print(json.dumps({"ok": False, "error": str(err)}), flush=True)
+            if args.once:
+                return 1
+        else:
+            print(json.dumps(result, separators=(",", ":")), flush=True)
+            if args.once:
+                return 0 if result.get("ok") else 1
+        time.sleep(max(5, args.loop_seconds))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/clawnsole-server.test.js
+++ b/tests/unit/clawnsole-server.test.js
@@ -530,3 +530,80 @@ test('recurring prompt runs endpoint returns bounded recent rows', async () => {
   });
   assert.equal(missing.statusCode, 404);
 });
+
+test('recurring prompt trigger records run and dedupes by idempotency key', async () => {
+  const { homeDir, openclawDir } = makeTempHome();
+  writeJson(path.join(openclawDir, 'openclaw.json'), { gateway: { port: 18789, auth: { mode: 'token', token: 't' } } });
+  writeJson(path.join(openclawDir, 'clawnsole.json'), { adminPassword: 'admin', authVersion: 'v1' });
+
+  const now = Date.now();
+  writeJson(path.join(openclawDir, 'clawnsole-recurring-prompts.json'), {
+    prompts: [
+      {
+        id: 'p-trigger',
+        title: 'Trigger me',
+        agentId: 'dev',
+        message: 'admin prompt body',
+        intervalMinutes: 15,
+        enabled: true,
+        createdAt: now - 10_000,
+        updatedAt: now - 10_000,
+        nextRunAt: now - 1_000,
+        lastRunAt: null,
+        lastStatus: 'never',
+        lastError: '',
+        runHistory: []
+      }
+    ]
+  });
+
+  const deliveries = [];
+  const { handleRequest } = createClawnsoleServer({
+    homeDir,
+    deliverRecurringPrompt: async (payload) => deliveries.push(payload)
+  });
+  const login = await invoke(handleRequest, {
+    url: '/auth/login',
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ password: 'admin' })
+  });
+  const adminCookie = parseCookiesFromSetCookie(login.headers['set-cookie']);
+  const triggerBody = JSON.stringify({ scheduledAt: now - 1_000, idempotencyKey: 'p-trigger:slot-1' });
+
+  const first = await invoke(handleRequest, {
+    url: '/api/recurring-prompts/p-trigger/trigger',
+    method: 'POST',
+    headers: { cookie: adminCookie, 'content-type': 'application/json' },
+    body: triggerBody
+  });
+  assert.equal(first.statusCode, 200);
+  const firstPayload = JSON.parse(first.body.toString('utf8'));
+  assert.equal(firstPayload.ok, true);
+  assert.equal(firstPayload.run.status, 'ok');
+  assert.equal(firstPayload.run.idempotencyKey, 'p-trigger:slot-1');
+  assert.equal(deliveries.length, 1);
+  assert.equal(deliveries[0].prompt.agentId, 'dev');
+  assert.equal(deliveries[0].idempotencyKey, 'p-trigger:slot-1');
+  assert.ok(firstPayload.prompt.nextRunAt > now);
+
+  const second = await invoke(handleRequest, {
+    url: '/api/recurring-prompts/p-trigger/trigger',
+    method: 'POST',
+    headers: { cookie: adminCookie, 'content-type': 'application/json' },
+    body: triggerBody
+  });
+  assert.equal(second.statusCode, 200);
+  const secondPayload = JSON.parse(second.body.toString('utf8'));
+  assert.equal(secondPayload.ok, true);
+  assert.equal(secondPayload.duplicate, true);
+  assert.equal(deliveries.length, 1);
+
+  const runs = await invoke(handleRequest, {
+    url: '/api/recurring-prompts/p-trigger/runs',
+    headers: { cookie: adminCookie }
+  });
+  const runsPayload = JSON.parse(runs.body.toString('utf8'));
+  assert.equal(runsPayload.runs.length, 1);
+  assert.equal(runsPayload.runs[0].idempotencyKey, 'p-trigger:slot-1');
+});


### PR DESCRIPTION
## Summary
- add a server-owned recurring prompt trigger endpoint that sends via Gateway and records run history
- add deterministic idempotency handling for scheduled prompt slots
- add a standalone Python worker that polls due recurring prompts and calls the trigger API

## Validation
- npm test
- python3 -m py_compile scripts/recurring_prompts_worker.py

Refs #56
Refs #208