### PR TITLE
Canonicalize issue workqueue dedupe variants

### DIFF
--- a/lib/workqueue.js
+++ b/lib/workqueue.js
@@ -200,6 +200,13 @@ function parseIssueRef(text) {
     if (repo && issueNumber) return { repo, issueNumber };
   }
 
+  const fromColonRef = src.match(/(?:^|[\s[(])(?:issue:)?([a-z0-9_.-]+\/[a-z0-9_.-]+)\s*:\s*(\d+)\b/i);
+  if (fromColonRef) {
+    const repo = normalizeIssueRepoName(fromColonRef[1]);
+    const issueNumber = normalizeIssueNumber(fromColonRef[2]);
+    if (repo && issueNumber) return { repo, issueNumber };
+  }
+
   return null;
 }
 
@@ -209,7 +216,7 @@ function canonicalizeIssueDedupeKey({ repo, issueNumber, dedupeKey, title, instr
   const explicitIssue = normalizeIssueNumber(issueNumber ?? metaObj.issueNumber ?? metaObj.issue);
   if (explicitRepo && explicitIssue) return `${explicitRepo}#${explicitIssue}`;
 
-  const parsed = parseIssueRef(dedupeKey) || parseIssueRef(instructions) || parseIssueRef(title);
+  const parsed = parseIssueRef(dedupeKey) || parseIssueRef(metaObj.dedupeKey) || parseIssueRef(instructions) || parseIssueRef(title);
   if (parsed) return `${parsed.repo}#${parsed.issueNumber}`;
 
   return String(dedupeKey || '').trim();

--- a/tests/unit/workqueue-api.test.js
+++ b/tests/unit/workqueue-api.test.js
@@ -208,6 +208,60 @@ test('workqueue API: issue-backed enqueue reports updated_existing for repeated 
   }
 });
 
+test('workqueue API: issue-backed enqueue canonicalizes payload dedupe variants', async () => {
+  const { openclawHome } = mkTempEnv();
+  fs.mkdirSync(openclawHome, { recursive: true });
+  fs.writeFileSync(path.join(openclawHome, 'clawnsole.json'), JSON.stringify({ adminPassword: 'admin', authVersion: 'test' }));
+
+  const { server, port } = await startServer({ openclawHome });
+  try {
+    const cookie = Buffer.from('admin::test', 'utf8').toString('base64');
+    const headers = { Cookie: 'clawnsole_auth=' + cookie + '; clawnsole_role=admin' };
+    const payloads = [
+      {
+        queue: 'dev-team',
+        title: 'Colon issue key',
+        instructions: 'Ship issue work',
+        priority: 1,
+        dedupeKey: 'issue:rmdmattingly/clawnsole:392'
+      },
+      {
+        queue: 'dev-team',
+        title: 'Meta issue key',
+        instructions: 'Ship issue work',
+        priority: 2,
+        meta: { dedupeKey: 'rmdmattingly/clawnsole#392' }
+      },
+      {
+        queue: 'dev-team',
+        title: 'Explicit issue',
+        instructions: 'Ship issue work',
+        priority: 3,
+        repo: 'rmdmattingly/clawnsole',
+        issueNumber: 392
+      }
+    ];
+
+    let latest = null;
+    for (const payload of payloads) {
+      latest = await httpPostJson('http://127.0.0.1:' + port + '/api/workqueue/enqueue', payload, headers);
+      assert.equal(latest.status, 200);
+      assert.equal(latest.json?.ok, true);
+    }
+
+    assert.equal(latest.json?.result, 'updated_existing');
+    assert.equal(latest.json?.item?.dedupeKey, 'rmdmattingly/clawnsole#392');
+    assert.equal(latest.json?.item?.title, 'Explicit issue');
+
+    const list = await httpGetJson(`http://127.0.0.1:${port}/api/workqueue/items?queue=dev-team`, headers);
+    assert.equal(list.status, 200);
+    assert.equal(list.json?.items?.length, 1);
+    assert.equal(list.json?.items?.[0]?.dedupeKey, 'rmdmattingly/clawnsole#392');
+  } finally {
+    server.close();
+  }
+});
+
 test('workqueue API: claim-next claims a ready item', async () => {
   const { openclawHome } = mkTempEnv();
   fs.mkdirSync(openclawHome, { recursive: true });

--- a/tests/unit/workqueue.test.js
+++ b/tests/unit/workqueue.test.js
@@ -288,6 +288,57 @@ test('workqueue: issue-backed automated enqueue upserts one live item', () => {
   assert.equal(state.items[0].priority, 9);
 });
 
+test('workqueue: issue-backed enqueue canonicalizes producer dedupe variants', () => {
+  const root = tempRoot();
+
+  const variants = [
+    {
+      title: 'Colon key producer',
+      instructions: 'Ship queued issue',
+      dedupeKey: 'issue:rmdmattingly/clawnsole:392',
+      priority: 1
+    },
+    {
+      title: 'Hash key producer',
+      instructions: 'Ship queued issue',
+      dedupeKey: 'issue:RMDMATTINGLY/CLAWNSOLE#392',
+      priority: 2
+    },
+    {
+      title: 'Meta key producer',
+      instructions: 'Ship queued issue',
+      priority: 3,
+      meta: { dedupeKey: 'rmdmattingly/clawnsole:392', source: 'coverage' }
+    },
+    {
+      title: 'URL producer',
+      instructions: 'Ship https://github.com/rmdmattingly/clawnsole/issues/392',
+      priority: 4
+    },
+    {
+      title: 'Explicit issue producer',
+      instructions: 'Ship queued issue',
+      priority: 5,
+      repo: 'rmdmattingly/clawnsole',
+      issueNumber: 392
+    }
+  ];
+
+  const results = variants.map((input) => enqueueItem(root, { queue: 'dev-team', ...input }));
+  const latest = results.at(-1);
+
+  assert.equal(latest._enqueueAction, 'updated_existing');
+  assert.equal(latest._deduped, true);
+  assert.equal(latest.dedupeKey, 'rmdmattingly/clawnsole#392');
+  assert.equal(latest.title, 'Explicit issue producer');
+  assert.equal(latest.priority, 5);
+
+  const state = loadState(root);
+  assert.equal(state.items.length, 1);
+  assert.equal(state.items[0].dedupeKey, 'rmdmattingly/clawnsole#392');
+  assert.equal(state.items[0].title, 'Explicit issue producer');
+});
+
 test('workqueue: issue-backed enqueue creates new row when only terminal matches exist', () => {
   const root = tempRoot();
 


### PR DESCRIPTION
Fixes #398.\n\nSummary:\n- Normalize legacy issue dedupe keys using either repo#issue or repo:issue forms.\n- Include meta.dedupeKey in issue-backed canonicalization.\n- Add library and HTTP API regressions proving producer variants collapse to one live row.\n\nTests:\n- npm run test:syntax\n- node --test tests/unit/workqueue.test.js tests/unit/workqueue-api.test.js\n\nRequesting ship sign-off: 🚢