### PR TITLE
Add visible pane type badges

### DIFF
--- a/app.js
+++ b/app.js
@@ -1489,6 +1489,15 @@ function paneIcon(pane) {
   return '💬';
 }
 
+function paneTypeBadgeMarkup(pane, { extraClass = '', testId = '' } = {}) {
+  const kind = String(pane?.kind || 'chat');
+  const label = paneLabel(pane);
+  const icon = paneIcon(pane);
+  const classes = ['pane-type-badge', `pane-type-${kind}`, extraClass].filter(Boolean).join(' ');
+  const testAttr = testId ? ` data-testid="${escapeHtml(testId)}"` : '';
+  return `<span class="${escapeHtml(classes)}" data-pane-type-badge data-pane-accent="${escapeHtml(kind)}"${testAttr} aria-label="${escapeHtml(`Pane type: ${label}`)}"><span class="pane-type-icon" aria-hidden="true">${escapeHtml(icon)}</span><span class="pane-type-text">${escapeHtml(label)}</span></span>`;
+}
+
 function paneTargetLabel(pane) {
   if (!pane) return '';
   const current = String(pane?.elements?.agentLabel?.textContent || '').trim();
@@ -1756,7 +1765,7 @@ function renderPaneManager() {
         row.innerHTML = `
           <div class="pane-manager-main">
             <div class="pane-manager-kind" title="${escapeHtml(paneIdentity)}">
-              <span class="pane-manager-accent" data-pane-manager-accent="${escapeHtml(String(pane.kind || 'chat'))}" aria-hidden="true"></span>
+              ${paneTypeBadgeMarkup(pane, { extraClass: 'pane-manager-type-badge', testId: 'pane-manager-type-badge' })}
               <span class="pane-manager-kind-label">${escapeHtml(paneIdentity)}</span>
               <span class="pane-manager-pane-id" title="Internal pane id">${escapeHtml(String(pane?.key || ''))}</span>
               ${isDuplicate ? `<span class="pane-manager-duplicate-badge" data-testid="pane-manager-duplicate-badge" title="${escapeHtml(`${duplicateCount} duplicate panes`)}">duplicate</span>` : ''}
@@ -5368,9 +5377,9 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     if (elements.typeText) elements.typeText.textContent = String(paneLabel(pane) || pane.kind || 'chat').toUpperCase();
     if (elements.typePill) {
       elements.typePill.setAttribute('aria-label', `Pane type: ${paneLabel(pane)}`);
+      elements.typePill.classList.add('pane-type-badge');
       elements.typePill.classList.add(`pane-type-${pane.kind}`);
       elements.typePill.dataset.paneAccent = pane.kind;
-      elements.typePill.dataset.testid = 'pane-type-accent';
     }
   } catch {}
 

--- a/docs/pane-accent-tokens.md
+++ b/docs/pane-accent-tokens.md
@@ -12,11 +12,11 @@ These feed per-pane variables (`--pane-accent-rgb`, `--pane-accent`, `--pane-hea
 
 1. Pane container/card chrome (`.chat-panel.pane`)
 2. Pane header accent bar (`.pane-header`)
-3. Pane type pill (`.pane-type-*`)
-4. Pane Manager rows and swatch dots (`.pane-manager-row`, `.pane-manager-accent`)
+3. Pane type badge/pill (`.pane-type-badge`, `.pane-type-*`)
+4. Pane Manager rows and type badges (`.pane-manager-row`, `.pane-manager-type-badge`)
 
 Testing hook selectors:
 
 - Pane root: `[data-pane][data-pane-kind="<kind>"][data-pane-accent-kind="<kind>"]`
-- Type pill: `[data-pane-type-pill][data-pane-accent="<kind>"]`
-- Pane Manager row swatch: `[data-pane-manager-accent="<kind>"]`
+- Header type badge: `[data-pane-type-pill][data-pane-accent="<kind>"]`
+- Pane Manager type badge: `.pane-manager-row[data-pane-kind="<kind>"] [data-pane-type-badge][data-pane-accent="<kind>"]`

--- a/index.html
+++ b/index.html
@@ -91,11 +91,11 @@
           <section class="chat-panel pane" data-pane data-testid="pane">
             <div class="pane-header">
               <div class="pane-header-left">
-                <div class="pane-name" data-pane-name data-testid="pane-type-label">Pane</div>
-                <div class="pane-type-pill" data-pane-type-pill data-testid="pane-type-pill" aria-label="Pane type">
+                <div class="pane-type-badge pane-type-pill" data-pane-type-pill data-testid="pane-type-pill" aria-label="Pane type">
                   <span class="pane-type-icon" data-pane-type-icon aria-hidden="true">💬</span>
                   <span class="pane-type-text" data-pane-type-text>CHAT</span>
                 </div>
+                <div class="pane-name" data-pane-name data-testid="pane-type-label">Pane</div>
                 <div class="pane-agent" data-pane-agent-wrap>
                   <span class="agent-label" data-pane-target-label data-testid="pane-target-label">Agent</span>
                   <button class="agent-pill-btn" type="button" data-pane-agent-button aria-label="Change agent" data-testid="pane-agent-button">

--- a/styles.css
+++ b/styles.css
@@ -479,7 +479,7 @@ body::before {
   white-space: nowrap;
 }
 
-.pane-type-pill {
+.pane-type-badge {
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -493,6 +493,7 @@ body::before {
   letter-spacing: 0.1em;
   line-height: 1;
   user-select: none;
+  white-space: nowrap;
 }
 
 .pane-type-icon {
@@ -502,6 +503,10 @@ body::before {
 
 .pane-type-text {
   font-weight: 650;
+}
+
+.pane-type-pill {
+  flex: 0 0 auto;
 }
 
 /* Per-pane subtle treatment */
@@ -1298,13 +1303,11 @@ button.send-btn .btn-icon {
   min-width: 0;
 }
 
-.pane-manager-accent {
-  width: 10px;
-  height: 10px;
-  border-radius: 999px;
-  flex: 0 0 auto;
-  background: rgba(var(--pane-accent-rgb, 255, 255, 255), 0.95);
-  box-shadow: 0 0 0 1px rgba(8, 10, 14, 0.55);
+.pane-manager-type-badge {
+  padding: 4px 8px;
+  gap: 6px;
+  font-size: 10px;
+  letter-spacing: 0.06em;
 }
 
 .pane-manager-letter {

--- a/tests/ui/pane-accents.spec.js
+++ b/tests/ui/pane-accents.spec.js
@@ -37,6 +37,13 @@ test('pane accents: each pane kind exposes deterministic accent selectors', asyn
   await expect(page.locator('#paneManagerModal')).toHaveClass(/open/);
 
   for (const kind of ['chat', 'workqueue', 'cron', 'timeline']) {
-    await expect(page.locator(`[data-pane-manager-accent="${kind}"]`)).toHaveCount(1);
+    const badge = page.locator(`.pane-manager-row[data-pane-kind="${kind}"] [data-pane-type-badge][data-pane-accent="${kind}"]`);
+    await expect(badge).toHaveCount(1);
+    await expect(badge.locator('.pane-type-text')).toHaveText(paneLabelForKind(kind));
   }
 });
+
+function paneLabelForKind(kind) {
+  if (kind === 'workqueue') return 'Workqueue';
+  return kind.charAt(0).toUpperCase() + kind.slice(1);
+}


### PR DESCRIPTION
## Summary
- add text-first pane type badges before header identities
- reuse the same badge treatment in Pane Manager rows so pane type is visible, not color-only
- update pane accent docs and coverage for manager badge selectors

Fixes #249

## Verification
- npm test
- npx playwright test tests/ui/pane-accents.spec.js tests/pane.manager.e2e.spec.js --workers=1
