### PR TITLE
Add chat composer focus shortcut

### DIFF
--- a/app.js
+++ b/app.js
@@ -2519,6 +2519,15 @@ function buildCommandPaletteItems() {
       'g w'
     ),
     withShortcut(
+      {
+        id: 'cmd:focus-chat-composer',
+        label: 'Chat: Focus composer',
+        detail: 'Focus the active or most recent Chat pane composer',
+        run: () => focusChatComposer()
+      },
+      '⌘/Ctrl+Shift+L'
+    ),
+    withShortcut(
       { id: 'cmd:refresh-agents', label: 'Agents: Refresh', detail: 'Refresh agent list', run: () => globalElements.refreshAgentsBtn?.click?.() },
       ''
     ),
@@ -2585,7 +2594,7 @@ function buildCommandPaletteItems() {
     const label = String(item.label || '');
     const enriched = { ...item, group: 'Advanced', subgroup: '', priority: 20, kind: 'action' };
 
-    if (id.startsWith('cmd:focus-pane-') || id === 'cmd:pane-cycle' || id === 'cmd:pane-cycle-backward' || id === 'cmd:pane-return-last-chat' || id === 'cmd:pane-mru-next' || id === 'cmd:pane-mru-prev' || id === 'cmd:pane-next-unread' || id === 'cmd:pane-prev-unread') {
+    if (id.startsWith('cmd:focus-pane-') || id === 'cmd:focus-chat-composer' || id === 'cmd:pane-cycle' || id === 'cmd:pane-cycle-backward' || id === 'cmd:pane-return-last-chat' || id === 'cmd:pane-mru-next' || id === 'cmd:pane-mru-prev' || id === 'cmd:pane-next-unread' || id === 'cmd:pane-prev-unread') {
       enriched.group = 'Panes';
       enriched.priority = id.startsWith('cmd:focus-pane-') ? 130 : 110;
       return enriched;
@@ -8177,6 +8186,10 @@ globalElements.wqClaimBtn?.addEventListener('click', () => workqueueClaimNextFro
 
 let shortcutState = { lastGAtMs: 0 };
 
+function isFocusChatComposerShortcut(event) {
+  return !!((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey && String(event.key || '').toLowerCase() === 'l');
+}
+
 function isTypingContext(target) {
   const el = target || document.activeElement;
   if (!el) return false;
@@ -8329,6 +8342,33 @@ function returnToLastActiveChatPane() {
   return false;
 }
 
+function focusChatComposer() {
+  const panes = paneManager?.panes || [];
+  const activeKey = focusedPaneKey();
+  const activeChatIdx = panes.findIndex((pane) => pane.kind === 'chat' && pane.key === activeKey);
+  if (activeChatIdx >= 0) {
+    focusPaneIndex(activeChatIdx);
+    return true;
+  }
+
+  for (const key of paneMruOrder()) {
+    const idx = panes.findIndex((pane) => pane.kind === 'chat' && pane.key === key);
+    if (idx >= 0) {
+      focusPaneIndex(idx);
+      return true;
+    }
+  }
+
+  const fallbackIdx = panes.findIndex((pane) => pane.kind === 'chat');
+  if (fallbackIdx >= 0) {
+    focusPaneIndex(fallbackIdx);
+    return true;
+  }
+
+  const pane = paneManager.addPane('chat');
+  return !!pane;
+}
+
 function cyclePaneFocus() {
   const panes = paneManager.panes;
   if (!panes || panes.length === 0) return;
@@ -8439,10 +8479,24 @@ window.addEventListener('keydown', (event) => {
     return;
   }
 
-  // Never steal focus / override browser shortcuts while typing.
-  if (isTypingContext(event.target)) return;
+  const shouldFocusChatComposer = isFocusChatComposerShortcut(event);
+
+  // Never steal focus / override browser shortcuts while typing, except for the
+  // explicit composer-focus shortcut.
+  if (isTypingContext(event.target) && !shouldFocusChatComposer) return;
 
   const key = String(event.key || '');
+
+  if (shouldFocusChatComposer) {
+    event.preventDefault();
+    if (isBlockingOverlayOpenForPaneShortcuts()) {
+      showShortcutBlockedFeedback();
+      return;
+    }
+    paneManager.closeAddPaneMenu();
+    focusChatComposer();
+    return;
+  }
 
   // Ctrl+Tab walks panes in most-recently-used order; Shift reverses the traversal.
   if (event.ctrlKey && !event.metaKey && !event.altKey && key === 'Tab') {

--- a/index.html
+++ b/index.html
@@ -254,6 +254,7 @@
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>P</kbd></div><div class="shortcut-desc">Open Pane Manager</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Focus next pane</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd></div><div class="shortcut-desc">Focus previous pane</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>L</kbd></div><div class="shortcut-desc">Focus active Chat composer</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>g</kbd> <kbd>c</kbd></div><div class="shortcut-desc">Return to last active Chat pane</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Ctrl</kbd>+<kbd>Tab</kbd></div><div class="shortcut-desc">Switch panes by most-recent focus order</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Tab</kbd></div><div class="shortcut-desc">Reverse most-recent pane traversal</div></div>

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -126,6 +126,35 @@ test('shortcuts modal restores prior focus on close', async ({ page }) => {
   await expect(openBtn).toBeFocused();
 });
 
+test('cmd/ctrl+shift+l focuses chat composer from non-chat pane', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const chatInput = page.locator('[data-pane][data-pane-kind="chat"]').first().locator('[data-pane-input]');
+  const workqueuePane = page.locator('[data-pane][data-pane-kind="workqueue"]').first();
+  const queueSelect = workqueuePane.locator('[data-wq-queue-select]');
+
+  await expect(chatInput).toBeVisible();
+  await expect(queueSelect).toBeVisible();
+
+  await queueSelect.focus();
+  await expect(queueSelect).toBeFocused();
+
+  await page.keyboard.press('Control+Shift+L');
+  await expect(chatInput).toBeFocused();
+
+  await page.click('#connectionStatus');
+  await page.keyboard.press('Shift+/');
+  await expect(page.locator('#shortcutsModal')).toContainText('Focus active Chat composer');
+});
+
 test('cmd/ctrl+shift+j focuses previous pane with wraparound from unfocused state', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!app?.skipReason, app?.skipReason);


### PR DESCRIPTION
## Summary
- add Cmd/Ctrl+Shift+L to focus the active or most-recent chat composer
- block composer focusing while overlays are open with a toast
- document the shortcut and cover the non-chat-to-chat path in Playwright

Fixes #277

## Tests
- npm test
- npx playwright test tests/pane.shortcuts.e2e.spec.js --workers=1 --grep "cmd/ctrl\+shift\+l"