### PR TITLE
UX safety: confirm chat sends after draft retarget

### DIFF
--- a/app.js
+++ b/app.js
@@ -81,6 +81,7 @@ const globalElements = {
   settingsModal: document.getElementById('settingsModal'),
   settingsCloseBtn: document.getElementById('settingsCloseBtn'),
   paneSwitchHudEnabled: document.getElementById('paneSwitchHudEnabled'),
+  draftRetargetConfirmEnabled: document.getElementById('draftRetargetConfirmEnabled'),
   shortcutOverridesList: document.getElementById('shortcutOverridesList'),
   shortcutOverridesSave: document.getElementById('shortcutOverridesSave'),
   shortcutOverridesResetAll: document.getElementById('shortcutOverridesResetAll'),
@@ -282,6 +283,7 @@ const ADMIN_AUTH_DESTINATION_KEY = 'clawnsole.admin.authDestination.v1';
 const ADMIN_AUTH_RESTORE_PENDING_KEY = 'clawnsole.admin.authRestorePending.v1';
 const ADMIN_AUTH_RESTORE_NOTICE_KEY = 'clawnsole.admin.authRestoreNotice.v1';
 const PANE_SWITCH_HUD_ENABLED_KEY = 'clawnsole.admin.paneSwitchHud.enabled';
+const DRAFT_RETARGET_CONFIRM_ENABLED_KEY = 'clawnsole.admin.draftRetargetConfirm.enabled';
 const SHORTCUT_OVERRIDES_KEY = 'clawnsole.admin.shortcutOverrides.v1';
 const ADMIN_AUTH_DESTINATION_TTL_MS = 10 * 60 * 1000;
 const WQ_RECENT_TARGETS_KEY = 'clawnsole.wq.recentTargets';
@@ -1555,6 +1557,9 @@ function openSettings() {
   if (globalElements.paneSwitchHudEnabled) {
     globalElements.paneSwitchHudEnabled.checked = isPaneSwitchHudEnabled();
   }
+  if (globalElements.draftRetargetConfirmEnabled) {
+    globalElements.draftRetargetConfirmEnabled.checked = isDraftRetargetConfirmEnabled();
+  }
   shortcutOverridesDraft = readShortcutOverrides();
   renderShortcutOverrideSettings();
   globalElements.settingsModal.classList.add('open');
@@ -2397,6 +2402,64 @@ function paneSummaryLabel(pane) {
 
 function isPaneSwitchHudEnabled() {
   return String(storage.get(PANE_SWITCH_HUD_ENABLED_KEY, '1') || '1') !== '0';
+}
+
+function isDraftRetargetConfirmEnabled() {
+  return String(storage.get(DRAFT_RETARGET_CONFIRM_ENABLED_KEY, '1') || '1') !== '0';
+}
+
+function paneDraftOrigin(pane) {
+  if (!pane || pane.kind !== 'chat') return null;
+  return {
+    paneKey: String(pane.key || ''),
+    kind: String(pane.kind || 'chat'),
+    targetKey: normalizeAgentId(pane.agentId || 'main'),
+    label: paneSummaryLabel(pane)
+  };
+}
+
+function paneDraftOriginsMatch(a, b) {
+  if (!a || !b) return true;
+  return String(a.kind || '') === String(b.kind || '') &&
+    String(a.targetKey || '') === String(b.targetKey || '');
+}
+
+function paneRememberDraftOrigin(pane) {
+  if (!pane || pane.kind !== 'chat') return;
+  if (paneHasDraftChanges(pane)) {
+    if (!pane.draftOrigin) pane.draftOrigin = paneDraftOrigin(pane);
+  } else {
+    pane.draftOrigin = null;
+  }
+}
+
+function focusPaneByKey(key) {
+  const pane = (paneManager?.panes || []).find((entry) => String(entry?.key || '') === String(key || ''));
+  if (!pane) return false;
+  notePaneFocused(pane);
+  pane.elements?.input?.focus?.({ preventScroll: true });
+  pane.elements?.root?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
+  return true;
+}
+
+function confirmPaneDraftRetargetSend(pane) {
+  if (!isDraftRetargetConfirmEnabled()) return true;
+  paneRememberDraftOrigin(pane);
+  const origin = pane?.draftOrigin;
+  const current = paneDraftOrigin(pane);
+  if (!origin || paneDraftOriginsMatch(origin, current)) return true;
+
+  const ok = window.confirm(
+    `Send this draft to ${current?.label || 'the current target'}?\n\n` +
+    `It started in ${origin.label || 'another pane target'}.\n\n` +
+    'Press OK to send to the current target, or Cancel to return to the origin pane.'
+  );
+  if (ok) {
+    pane.draftOrigin = current;
+    return true;
+  }
+  focusPaneByKey(origin.paneKey);
+  return false;
 }
 
 let paneSwitchHudHideTimer = null;
@@ -4964,6 +5027,16 @@ async function renderWorkqueuePane(rootEl, { queue = '' } = {}) {
 window.__debug = window.__debug || {};
 window.__debug.renderWorkqueuePane = renderWorkqueuePane;
 window.__debug.refreshAgents = refreshAgents;
+window.__debug.setChatPaneDraftOrigin = (paneIndex = 0, origin = {}) => {
+  const chatPanes = (paneManager?.panes || []).filter((pane) => pane?.kind === 'chat');
+  const pane = chatPanes[Number(paneIndex) || 0];
+  if (!pane) return false;
+  pane.draftOrigin = {
+    ...paneDraftOrigin(pane),
+    ...(origin && typeof origin === 'object' ? origin : {})
+  };
+  return true;
+};
 
 function getWorkqueueItemRepo(item) {
   const repo = String(item?.meta?.repo || '').trim();
@@ -7149,6 +7222,8 @@ async function paneSendChat(pane) {
     return;
   }
 
+  if (!confirmPaneDraftRetargetSend(pane)) return;
+
   const message = raw;
 
   // Guest mode removed.
@@ -7246,6 +7321,7 @@ async function paneSendChat(pane) {
   panePumpOutbox(pane);
 
   pane.elements.input.value = '';
+  pane.draftOrigin = null;
   paneUpdateCommandHints(pane);
 }
 
@@ -7712,6 +7788,9 @@ function paneSetAgent(pane, nextAgentId, { requireDraftConfirm = true } = {}) {
 
   pane.attachments.files = [];
   paneRenderAttachments(pane);
+  if (pane.elements?.input) pane.elements.input.value = '';
+  pane.draftOrigin = null;
+  paneUpdateCommandHints(pane);
   paneStopThinking(pane);
   paneClearChatHistory(pane, { wipeStorage: false });
   paneRestoreChatHistory(pane);
@@ -9330,6 +9409,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
   });
 
   elements.input.addEventListener('input', () => {
+    paneRememberDraftOrigin(pane);
     paneUpdateCommandHints(pane);
   });
 
@@ -9339,6 +9419,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
 
   elements.fileInput.addEventListener('change', (event) => {
     paneHandleFileSelection(pane, event);
+    paneRememberDraftOrigin(pane);
   });
 
   elements.thread.addEventListener('scroll', () => {
@@ -10106,6 +10187,9 @@ globalElements.settingsModal?.addEventListener('click', (event) => {
 });
 globalElements.paneSwitchHudEnabled?.addEventListener('change', () => {
   storage.set(PANE_SWITCH_HUD_ENABLED_KEY, globalElements.paneSwitchHudEnabled.checked ? '1' : '0');
+});
+globalElements.draftRetargetConfirmEnabled?.addEventListener('change', () => {
+  storage.set(DRAFT_RETARGET_CONFIRM_ENABLED_KEY, globalElements.draftRetargetConfirmEnabled.checked ? '1' : '0');
 });
 function handleShortcutOverrideInputKeydown(event) {
   const input = event.target?.closest?.('[data-shortcut-action]');

--- a/index.html
+++ b/index.html
@@ -533,6 +533,10 @@
               <input id="paneSwitchHudEnabled" type="checkbox" checked />
               Show pane-switch HUD
             </label>
+            <label class="inline-checkbox">
+              <input id="draftRetargetConfirmEnabled" type="checkbox" checked />
+              Confirm sends when a draft target changed
+            </label>
           </section>
 
           <section class="settings-section" aria-label="Shortcut overrides">

--- a/tests/ui/chat-pane.spec.js
+++ b/tests/ui/chat-pane.spec.js
@@ -49,6 +49,40 @@ test('chat pane: send/receive + upload attachment', async ({ page }, testInfo) =
   await expect(pane.locator('[data-chat-role="user"]').last()).toContainText('with file');
 });
 
+test('chat pane: confirms before sending a draft whose origin target changed', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+
+  const pane = page.locator('[data-pane][data-pane-kind="chat"]').first();
+  await expect(pane.locator('[data-pane-send]')).toBeEnabled({ timeout: 90000 });
+  await pane.locator('[data-pane-input]').fill('retarget guard');
+
+  await expect.poll(() => page.evaluate(() => {
+    return window.__debug?.setChatPaneDraftOrigin?.(0, { targetKey: 'dev', label: 'A Chat · dev' }) === true;
+  })).toBe(true);
+
+  let sawCancelConfirm = false;
+  page.once('dialog', async (dialog) => {
+    sawCancelConfirm = true;
+    expect(dialog.message()).toMatch(/Press OK to send to the current target/i);
+    await dialog.dismiss();
+  });
+  await pane.locator('[data-pane-send]').click();
+  await expect.poll(() => sawCancelConfirm).toBe(true);
+  await expect(pane.locator('[data-pane-input]')).toHaveValue('retarget guard');
+  await expect(pane.locator('[data-chat-role="user"]')).toHaveCount(0);
+
+  page.once('dialog', async (dialog) => {
+    await dialog.accept();
+  });
+  await pane.locator('[data-pane-send]').click();
+  await expect(pane.locator('[data-chat-role="user"]').last()).toContainText('retarget guard');
+});
+
 test('chat pane: stop button can cancel a running response', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);


### PR DESCRIPTION
Closes #390.

## Summary
- Track chat draft origin metadata when a draft or attachment starts.
- Confirm before sending when the current chat target differs from the draft origin, with Cancel returning focus to the origin pane.
- Add a settings opt-out and focused chat-pane regression coverage.

## Tests
- npm run test:syntax
- npx playwright test tests/ui/chat-pane.spec.js -g "confirms before sending"
