### PR TITLE
Add fleet heartbeat heatmap mode

### DIFF
--- a/app.js
+++ b/app.js
@@ -31,6 +31,10 @@ const globalElements = {
   agentsSearch: document.getElementById('agentsSearch'),
   agentsFilterButtons: Array.from(document.querySelectorAll('[data-agents-filter]')),
   agentsSort: document.getElementById('agentsSort'),
+  agentsHeatmapToggle: document.getElementById('agentsHeatmapToggle'),
+  agentsHeartbeatSortBtn: document.getElementById('agentsHeartbeatSortBtn'),
+  agentsSortResetBtn: document.getElementById('agentsSortResetBtn'),
+  agentsSortIndicator: document.getElementById('agentsSortIndicator'),
   agentsActiveMinutes: document.getElementById('agentsActiveMinutes'),
   agentsLastRefreshed: document.getElementById('agentsLastRefreshed'),
   agentsList: document.getElementById('agentsList'),
@@ -240,6 +244,8 @@ const ADMIN_AGENT_PINS_KEY = 'clawnsole.admin.agentPins';
 const ADMIN_AGENT_LAST_SEEN_KEY = 'clawnsole.admin.agentLastSeenAtMs';
 const ADMIN_AGENT_FILTER_KEY = 'clawnsole.admin.agents.filter';
 const ADMIN_AGENT_SORT_KEY = 'clawnsole.admin.agents.sort';
+const ADMIN_AGENT_PRE_HEARTBEAT_SORT_KEY = 'clawnsole.admin.agents.preHeartbeatSort';
+const ADMIN_AGENT_HEATMAP_KEY = 'clawnsole.admin.agents.heartbeatHeatmap';
 const ADMIN_AGENT_ACTIVE_MINUTES_KEY = 'clawnsole.admin.agents.activeMinutes';
 const ADMIN_AGENT_HEALTHY_COLLAPSED_KEY = 'clawnsole.admin.agents.healthyCollapsed';
 const ADMIN_AGENT_HEALTHY_COLLAPSE_THRESHOLD = 10;
@@ -425,6 +431,22 @@ function sortAgentsByLastSeen(agents) {
   });
 }
 
+function heartbeatAgeBucket(ageMs, { activeWindowMs = 10 * 60_000, paneState = 'unknown' } = {}) {
+  if (paneState === 'error' || paneState === 'offline') return 'critical';
+  if (!Number.isFinite(ageMs)) return 'critical';
+  if (ageMs <= activeWindowMs) return 'fresh';
+  if (ageMs <= activeWindowMs * 3) return 'warning';
+  if (ageMs <= activeWindowMs * 10) return 'stale';
+  return 'critical';
+}
+
+function heartbeatAgeBucketLabel(bucket) {
+  if (bucket === 'fresh') return 'fresh';
+  if (bucket === 'warning') return 'warning';
+  if (bucket === 'stale') return 'stale';
+  return 'critical';
+}
+
 function getFleetFilter() {
   const raw = String(storage.get(ADMIN_AGENT_FILTER_KEY, 'all') || 'all').trim();
   const allowed = new Set(['all', 'active', 'stale', 'offline_error']);
@@ -433,8 +455,12 @@ function getFleetFilter() {
 
 function getFleetSort() {
   const raw = String(storage.get(ADMIN_AGENT_SORT_KEY, 'recent_desc') || 'recent_desc').trim();
-  const allowed = new Set(['recent_desc', 'agent_id_asc']);
+  const allowed = new Set(['recent_desc', 'heartbeat_age_desc', 'agent_id_asc']);
   return allowed.has(raw) ? raw : 'recent_desc';
+}
+
+function getFleetHeatmapEnabled() {
+  return String(storage.get(ADMIN_AGENT_HEATMAP_KEY, '0')) === '1';
 }
 
 function getAgentPaneStateMap() {
@@ -2420,6 +2446,7 @@ function openAgentsModal() {
   // Bootstrap persisted controls.
   const filter = getFleetFilter();
   const sort = getFleetSort();
+  const heatmapEnabled = getFleetHeatmapEnabled();
   globalElements.agentsFilterButtons.forEach((btn) => {
     const key = btn.getAttribute('data-agents-filter') || '';
     const active = key === filter;
@@ -2427,6 +2454,7 @@ function openAgentsModal() {
     btn.setAttribute('aria-pressed', active ? 'true' : 'false');
   });
   if (globalElements.agentsSort) globalElements.agentsSort.value = sort;
+  if (globalElements.agentsHeatmapToggle) globalElements.agentsHeatmapToggle.checked = heatmapEnabled;
   if (globalElements.agentsActiveMinutes) {
     const minutes = Number(storage.get(ADMIN_AGENT_ACTIVE_MINUTES_KEY, '10')) || 10;
     globalElements.agentsActiveMinutes.value = String(Math.max(1, minutes));
@@ -2441,6 +2469,23 @@ function openAgentsModal() {
   try {
     globalElements.agentsSearch?.focus?.();
   } catch {}
+}
+
+function setFleetHeartbeatSort() {
+  const current = getFleetSort();
+  if (current !== 'heartbeat_age_desc') storage.set(ADMIN_AGENT_PRE_HEARTBEAT_SORT_KEY, current);
+  storage.set(ADMIN_AGENT_SORT_KEY, 'heartbeat_age_desc');
+  if (globalElements.agentsSort) globalElements.agentsSort.value = 'heartbeat_age_desc';
+  renderAgentsModalList();
+}
+
+function resetFleetSort() {
+  const previous = String(storage.get(ADMIN_AGENT_PRE_HEARTBEAT_SORT_KEY, '') || '').trim();
+  const next = previous && previous !== 'heartbeat_age_desc' ? previous : 'recent_desc';
+  storage.set(ADMIN_AGENT_SORT_KEY, next);
+  storage.remove(ADMIN_AGENT_PRE_HEARTBEAT_SORT_KEY);
+  if (globalElements.agentsSort) globalElements.agentsSort.value = next;
+  renderAgentsModalList();
 }
 
 function closeAgentsModal() {
@@ -2538,8 +2583,10 @@ function renderAgentsModalList() {
 
   const search = String(globalElements.agentsSearch?.value || '').trim().toLowerCase();
   const withinMinutes = Math.max(1, Number(globalElements.agentsActiveMinutes?.value) || 10);
+  const activeWindowMs = withinMinutes * 60_000;
   const filterMode = getFleetFilter();
   const sortMode = getFleetSort();
+  const heatmapEnabled = getFleetHeatmapEnabled();
 
   const pins = getPinnedAgentIds();
   const lastSeenMap = getAgentLastSeenMap();
@@ -2552,10 +2599,11 @@ function renderAgentsModalList() {
     const ts = Number(lastSeenMap[id]) || 0;
     const ageMs = ts > 0 ? Math.max(0, Date.now() - ts) : Number.POSITIVE_INFINITY;
     const paneState = paneStateMap[id] || 'unknown';
-    if (paneState === 'error' || paneState === 'offline') return { bucket: 'offline_error', ts, ageMs };
-    if (!Number.isFinite(ageMs)) return { bucket: 'offline_error', ts, ageMs };
-    if (ageMs <= withinMinutes * 60_000) return { bucket: 'active', ts, ageMs };
-    return { bucket: 'stale', ts, ageMs };
+    const ageBucket = heartbeatAgeBucket(ageMs, { activeWindowMs, paneState });
+    if (paneState === 'error' || paneState === 'offline') return { bucket: 'offline_error', ageBucket, ts, ageMs };
+    if (!Number.isFinite(ageMs)) return { bucket: 'offline_error', ageBucket, ts, ageMs };
+    if (ageMs <= activeWindowMs) return { bucket: 'active', ageBucket, ts, ageMs };
+    return { bucket: 'stale', ageBucket, ts, ageMs };
   };
 
   const matches = (agent) => {
@@ -2573,6 +2621,17 @@ function renderAgentsModalList() {
     const arr = (Array.isArray(list) ? list : []).slice();
     if (sortMode === 'agent_id_asc') {
       arr.sort((a, b) => String(a?.id || '').localeCompare(String(b?.id || '')));
+      return arr;
+    }
+    if (sortMode === 'heartbeat_age_desc') {
+      arr.sort((a, b) => {
+        const ca = classify(a?.id);
+        const cb = classify(b?.id);
+        const da = Number.isFinite(ca.ageMs) ? ca.ageMs : Number.MAX_SAFE_INTEGER;
+        const db = Number.isFinite(cb.ageMs) ? cb.ageMs : Number.MAX_SAFE_INTEGER;
+        if (db !== da) return db - da;
+        return formatAgentLabel(a, { includeId: true }).localeCompare(formatAgentLabel(b, { includeId: true }));
+      });
       return arr;
     }
     return sortAgentsByLastSeen(arr);
@@ -2625,14 +2684,17 @@ function renderAgentsModalList() {
       const heartbeatAge = heartbeatTs > 0 ? formatRelativeAge(Date.now() - heartbeatTs) : 'unknown';
       const triage = classify(id);
       const bucketLabel = triage.bucket === 'offline_error' ? 'offline/error' : triage.bucket;
+      const heatBucketLabel = heartbeatAgeBucketLabel(triage.ageBucket);
       const statusSnippet = String(statusSnippetMap[id] || '').trim();
       const statusSnippetHtml = statusSnippet ? ` · <span class="agents-status-snippet">${escapeHtml(statusSnippet)}</span>` : '';
+      row.dataset.heartbeatBucket = triage.ageBucket;
+      row.classList.toggle('agents-row-heatmap', heatmapEnabled);
 
       row.innerHTML = `
         <button type="button" class="agents-pin" aria-label="${pinnedNow ? 'Unpin agent' : 'Pin agent'}" aria-pressed="${pinnedNow ? 'true' : 'false'}" data-agent-pin="${escapeHtml(id)}">${pinnedNow ? '★' : '☆'}</button>
         <div class="agents-row-main">
           <div class="agents-row-title">${escapeHtml(label)}</div>
-          <div class="agents-row-meta">${escapeHtml(id)} · ${escapeHtml(bucketLabel)} · <span class="agents-age-chip">${escapeHtml(heartbeatAge)}</span>${statusSnippetHtml}</div>
+          <div class="agents-row-meta">${escapeHtml(id)} · ${escapeHtml(bucketLabel)} · <span class="agents-age-chip" data-heartbeat-bucket="${escapeHtml(triage.ageBucket)}">${escapeHtml(heartbeatAge)} · ${escapeHtml(heatBucketLabel)}</span>${statusSnippetHtml}</div>
         </div>
         <div class="agents-row-actions agents-row-actions-inline" role="group" aria-label="Quick actions for ${escapeHtml(label)}">
           <button type="button" class="secondary agents-action-btn" data-agent-action="open-chat" data-agent-id="${escapeHtml(id)}" title="Open Chat" aria-label="Open Chat for ${escapeHtml(label)}">Chat</button>
@@ -2680,6 +2742,22 @@ function renderAgentsModalList() {
 
   renderSection('Needs attention', needsAttention);
   renderSection('Healthy', healthy, { collapsible: true, collapsed: healthyCollapsed });
+
+  if (globalElements.agentsHeatmapToggle) globalElements.agentsHeatmapToggle.checked = heatmapEnabled;
+  if (globalElements.agentsHeartbeatSortBtn) {
+    const active = sortMode === 'heartbeat_age_desc';
+    globalElements.agentsHeartbeatSortBtn.classList.toggle('active', active);
+    globalElements.agentsHeartbeatSortBtn.setAttribute('aria-pressed', active ? 'true' : 'false');
+  }
+  if (globalElements.agentsSortResetBtn) {
+    globalElements.agentsSortResetBtn.disabled = sortMode === 'recent_desc';
+  }
+  if (globalElements.agentsSortIndicator) {
+    globalElements.agentsSortIndicator.textContent =
+      sortMode === 'heartbeat_age_desc'
+        ? 'Sorted by heartbeat age: stale first. Reset sort returns to the prior/default order.'
+        : '';
+  }
 
   const empty = ordered.length === 0;
   if (globalElements.agentsEmpty) globalElements.agentsEmpty.hidden = !empty;
@@ -7366,6 +7444,13 @@ globalElements.agentsCloseBtn?.addEventListener('click', () => closeAgentsModal(
 globalElements.agentsModal?.addEventListener('click', (event) => {
   if (event.target === globalElements.agentsModal) closeAgentsModal();
 });
+globalElements.agentsModal?.addEventListener('keydown', (event) => {
+  if (isTypingContext(event.target)) return;
+  if (String(event.key || '').toLowerCase() !== 'h' || event.metaKey || event.ctrlKey || event.altKey) return;
+  event.preventDefault();
+  if (event.shiftKey || getFleetSort() !== 'heartbeat_age_desc') setFleetHeartbeatSort();
+  else resetFleetSort();
+});
 
 globalElements.agentsSearch?.addEventListener('input', () => renderAgentsModalList());
 globalElements.agentsSearch?.addEventListener('keydown', (event) => {
@@ -7394,6 +7479,14 @@ globalElements.agentsSort?.addEventListener('change', () => {
   storage.set(ADMIN_AGENT_SORT_KEY, String(globalElements.agentsSort.value || 'recent_desc'));
   renderAgentsModalList();
 });
+
+globalElements.agentsHeatmapToggle?.addEventListener('change', () => {
+  storage.set(ADMIN_AGENT_HEATMAP_KEY, globalElements.agentsHeatmapToggle.checked ? '1' : '0');
+  renderAgentsModalList();
+});
+
+globalElements.agentsHeartbeatSortBtn?.addEventListener('click', () => setFleetHeartbeatSort());
+globalElements.agentsSortResetBtn?.addEventListener('click', () => resetFleetSort());
 
 globalElements.agentsActiveMinutes?.addEventListener('change', () => {
   const minutes = Math.max(1, Number(globalElements.agentsActiveMinutes.value) || 10);
@@ -7723,6 +7816,17 @@ window.addEventListener('keydown', (event) => {
   if ((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey && key.toLowerCase() === 'f') {
     event.preventDefault();
     openFleetPane();
+    return;
+  }
+
+  // Cmd/Ctrl+Shift+H opens Agents and sorts by heartbeat age (stale first).
+  if ((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey && key.toLowerCase() === 'h') {
+    event.preventDefault();
+    if (roleState.role === 'admin') {
+      openAgentsModal();
+      setFleetHeartbeatSort();
+      toast('Sorted fleet by heartbeat age.', 'info');
+    }
     return;
   }
 

--- a/index.html
+++ b/index.html
@@ -430,9 +430,22 @@
               <span class="agents-label">Sort</span>
               <select id="agentsSort" aria-label="Sort agents">
                 <option value="recent_desc">Last active (newest first)</option>
+                <option value="heartbeat_age_desc">Heartbeat age (stale first)</option>
                 <option value="agent_id_asc">Agent id (A-Z)</option>
               </select>
             </label>
+            <div class="agents-field agents-heatmap-controls">
+              <span class="agents-label">Heartbeat</span>
+              <div class="agents-heatmap-actions">
+                <label class="agents-toggle">
+                  <input id="agentsHeatmapToggle" type="checkbox" />
+                  <span>Heatmap</span>
+                </label>
+                <button id="agentsHeartbeatSortBtn" type="button" class="agents-chip" title="Sort stale agents first (Cmd/Ctrl+Shift+H)">Stale first</button>
+                <button id="agentsSortResetBtn" type="button" class="agents-chip">Reset sort</button>
+              </div>
+              <div id="agentsSortIndicator" class="agents-sort-indicator" aria-live="polite"></div>
+            </div>
             <label class="agents-field">
               <span class="agents-label">Active window (min)</span>
               <input id="agentsActiveMinutes" type="number" min="1" step="1" value="10" aria-label="Active within minutes" />

--- a/styles.css
+++ b/styles.css
@@ -1418,6 +1418,36 @@ button.send-btn .btn-icon {
   gap: 8px;
 }
 
+.agents-heatmap-controls {
+  min-width: 280px;
+}
+
+.agents-heatmap-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.agents-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 30px;
+  color: var(--text);
+  font-size: 12px;
+}
+
+.agents-toggle input {
+  accent-color: #4dc4ff;
+}
+
+.agents-sort-indicator {
+  min-height: 15px;
+  font-size: 11px;
+  color: var(--muted);
+}
+
 .agents-chip {
   border: 1px solid rgba(255, 255, 255, 0.16);
   background: rgba(255, 255, 255, 0.03);
@@ -1432,6 +1462,11 @@ button.send-btn .btn-icon {
 .agents-chip[aria-pressed="true"] {
   border-color: rgba(77, 196, 255, 0.6);
   background: rgba(77, 196, 255, 0.16);
+}
+
+.agents-chip:disabled {
+  cursor: default;
+  opacity: 0.48;
 }
 
 .agents-list {
@@ -1493,6 +1528,30 @@ button.agents-section-title:hover {
   background: rgba(255, 255, 255, 0.02);
 }
 
+.agents-row-heatmap {
+  border-left-width: 4px;
+}
+
+.agents-row-heatmap[data-heartbeat-bucket="fresh"] {
+  border-color: rgba(86, 211, 100, 0.36);
+  background: linear-gradient(90deg, rgba(86, 211, 100, 0.13), rgba(255, 255, 255, 0.025) 46%);
+}
+
+.agents-row-heatmap[data-heartbeat-bucket="warning"] {
+  border-color: rgba(255, 199, 70, 0.45);
+  background: linear-gradient(90deg, rgba(255, 199, 70, 0.18), rgba(255, 255, 255, 0.026) 50%);
+}
+
+.agents-row-heatmap[data-heartbeat-bucket="stale"] {
+  border-color: rgba(255, 138, 76, 0.55);
+  background: linear-gradient(90deg, rgba(255, 138, 76, 0.24), rgba(255, 255, 255, 0.028) 56%);
+}
+
+.agents-row-heatmap[data-heartbeat-bucket="critical"] {
+  border-color: rgba(255, 93, 116, 0.66);
+  background: linear-gradient(90deg, rgba(255, 93, 116, 0.3), rgba(255, 255, 255, 0.03) 62%);
+}
+
 .agents-pin {
   width: 36px;
   height: 36px;
@@ -1526,6 +1585,22 @@ button.agents-section-title:hover {
   border-radius: 999px;
   padding: 1px 8px;
   color: var(--text);
+}
+
+.agents-age-chip[data-heartbeat-bucket="fresh"] {
+  border-color: rgba(86, 211, 100, 0.45);
+}
+
+.agents-age-chip[data-heartbeat-bucket="warning"] {
+  border-color: rgba(255, 199, 70, 0.5);
+}
+
+.agents-age-chip[data-heartbeat-bucket="stale"] {
+  border-color: rgba(255, 138, 76, 0.58);
+}
+
+.agents-age-chip[data-heartbeat-bucket="critical"] {
+  border-color: rgba(255, 93, 116, 0.66);
 }
 
 .agents-status-snippet {

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -99,6 +99,51 @@ test('fleet attention mode sections healthy agents and keeps filters while expan
   await expect(page.locator('#agentsList .agents-row:visible')).toHaveCount(1);
 });
 
+test('agents modal heartbeat heatmap and stale-first sort are toggleable and resettable', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  const agents = ['fresh-agent', 'warning-agent', 'stale-agent', 'critical-agent']
+    .map((id) => ({ id, name: id, displayName: id }));
+
+  await clawnsole.gotoAndLoginAdmin(page);
+  await page.route(/\/agents(?:\?|$)/, async (route) => {
+    await route.fulfill({ json: { agents } });
+  });
+  await page.evaluate(() => {
+    const now = Date.now();
+    localStorage.setItem('clawnsole.admin.agentLastSeenAtMs', JSON.stringify({
+      'fresh-agent': now,
+      'warning-agent': now - 15 * 60 * 1000,
+      'stale-agent': now - 70 * 60 * 1000
+    }));
+    localStorage.removeItem('clawnsole.admin.agents.heartbeatHeatmap');
+    localStorage.removeItem('clawnsole.admin.agents.sort');
+    localStorage.removeItem('clawnsole.admin.agents.preHeartbeatSort');
+  });
+  await page.getByRole('button', { name: 'Refresh agent list' }).click();
+
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsModal')).toHaveClass(/open/);
+  await expect(page.locator('#agentsHeatmapToggle')).not.toBeChecked();
+  await expect(page.locator('#agentsList .agents-row-heatmap')).toHaveCount(0);
+
+  await page.locator('#agentsHeatmapToggle').check();
+  await expect(page.locator('#agentsList .agents-row-heatmap')).toHaveCount(4);
+  await expect(page.locator('#agentsList .agents-row[data-heartbeat-bucket="critical"]')).toContainText('critical-agent');
+  await expect(page.locator('#agentsList .agents-row[data-heartbeat-bucket="stale"]')).toContainText('stale-agent');
+  await expect(page.locator('#agentsList .agents-row[data-heartbeat-bucket="warning"]')).toContainText('warning-agent');
+  await expect(page.locator('#agentsList .agents-row[data-heartbeat-bucket="fresh"]')).toContainText('fresh-agent');
+
+  await page.getByRole('button', { name: 'Stale first' }).click();
+  await expect(page.locator('#agentsSort')).toHaveValue('heartbeat_age_desc');
+  await expect(page.locator('#agentsSortIndicator')).toContainText('Sorted by heartbeat age');
+  await expect(page.locator('#agentsList .agents-row:visible').first()).toContainText('critical-agent');
+
+  await page.getByRole('button', { name: 'Reset sort' }).click();
+  await expect(page.locator('#agentsSort')).toHaveValue('recent_desc');
+  await expect(page.locator('#agentsSortIndicator')).toHaveText('');
+});
+
 test('agents modal quick actions open/reuse chat, timeline, and workqueue context', async ({ page, clawnsole }) => {
   if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
 


### PR DESCRIPTION
## Summary
- add a persisted off-by-default heartbeat heatmap mode to the Agents/Fleet modal
- add heartbeat age buckets and stale-first sorting with reset-to-previous/default behavior
- add Cmd/Ctrl+Shift+H and modal H shortcut support plus UI coverage

Fixes #389

## Tests
- npm test
- npx playwright test tests/ui/agents-modal.spec.js --workers=1