### PR TITLE
Add active pane breadcrumb

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,6 +20,9 @@ const globalElements = {
   recurringPromptHistoryEmpty: document.getElementById('recurringPromptHistoryEmpty'),
   status: document.getElementById('connectionStatus'),
   paneManagerBtn: document.getElementById('paneManagerBtn'),
+  activePaneBreadcrumb: document.getElementById('activePaneBreadcrumb'),
+  activePaneBreadcrumbType: document.querySelector('[data-active-pane-breadcrumb-type]'),
+  activePaneBreadcrumbTarget: document.querySelector('[data-active-pane-breadcrumb-target]'),
   pulseCanvas: document.getElementById('pulseCanvas'),
   workqueueBtn: document.getElementById('workqueueBtn'),
   fleetBtn: document.getElementById('fleetBtn'),
@@ -854,6 +857,7 @@ function setAuthState(authed) {
   updateGlobalStatus();
   updateConnectionControls();
   paneManager.refreshChatEnabled();
+  updateActivePaneBreadcrumb();
 
   if (authUi.startAgentAutoRefresh) {
     startAgentAutoRefresh();
@@ -1390,6 +1394,29 @@ function focusedPaneKey() {
   return pane?.key || '';
 }
 
+function activePane() {
+  const key = focusedPaneKey();
+  const panes = paneManager?.panes || [];
+  return panes.find((pane) => pane.key === key) || panes[0] || null;
+}
+
+function updateActivePaneBreadcrumb() {
+  const button = globalElements.activePaneBreadcrumb;
+  if (!button) return;
+
+  const pane = roleState.role === 'admin' && uiState.authed ? activePane() : null;
+  button.hidden = !pane;
+  if (!pane) return;
+
+  const identity = paneIdentityLabel(pane, { includeUnread: false });
+  const typeText = `${paneHeaderLetter(pane)} ${paneLabel(pane)}`;
+  const targetText = paneTargetLabel(pane);
+  if (globalElements.activePaneBreadcrumbType) globalElements.activePaneBreadcrumbType.textContent = typeText;
+  if (globalElements.activePaneBreadcrumbTarget) globalElements.activePaneBreadcrumbTarget.textContent = targetText ? `· ${targetText}` : '';
+  button.dataset.paneKey = String(pane.key || '');
+  button.title = `Open Pane Manager: ${identity}`;
+}
+
 function paneUnreadCount(pane) {
   return Math.max(0, Number(pane?.unreadCount || 0));
 }
@@ -1399,6 +1426,7 @@ function clearPaneUnread(pane) {
   if (!pane.unreadCount) return;
   pane.unreadCount = 0;
   renderPaneIdentity(pane);
+  updateActivePaneBreadcrumb();
   if (isPaneManagerOpen()) renderPaneManager();
 }
 
@@ -1409,6 +1437,7 @@ function markPaneUnread(pane, increment = 1) {
   const next = paneUnreadCount(pane) + Math.max(1, Number(increment || 1));
   pane.unreadCount = next;
   renderPaneIdentity(pane);
+  updateActivePaneBreadcrumb();
   if (isPaneManagerOpen()) renderPaneManager();
 }
 
@@ -1606,7 +1635,7 @@ function renderPaneManager() {
   });
 }
 
-function openPaneManager() {
+function openPaneManager({ paneKey = '' } = {}) {
   if (roleState.role !== 'admin') return;
   if (!uiState.authed) {
     showLogin('Please sign in to continue.');
@@ -1615,13 +1644,20 @@ function openPaneManager() {
   if (!globalElements.paneManagerModal) return;
 
   paneManagerUiState.open = true;
-  paneManagerUiState.selectedIndex = 0;
   paneManagerUiState.query = String(globalElements.paneManagerSearch?.value || '').trim();
   paneManagerUiState.unreadOnly = !!globalElements.paneManagerUnreadOnly?.checked;
+  const selectedKey = paneKey || activePane()?.key || '';
+  const selectedIndex = (paneManager?.panes || []).findIndex((pane) => pane.key === selectedKey);
+  paneManagerUiState.selectedIndex = selectedIndex >= 0 ? selectedIndex : 0;
 
   globalElements.paneManagerModal.classList.add('open');
   globalElements.paneManagerModal.setAttribute('aria-hidden', 'false');
   renderPaneManager();
+
+  const selectedRow = globalElements.paneManagerList?.querySelector?.('.pane-manager-row[aria-selected="true"]');
+  try {
+    selectedRow?.scrollIntoView?.({ block: 'nearest' });
+  } catch {}
 
   // Focus quick-find for immediate filtering.
   try {
@@ -4521,6 +4557,7 @@ function paneHeaderLetter(pane) {
 function renderPaneIdentity(pane) {
   if (!pane?.elements?.name) return;
   pane.elements.name.textContent = paneIdentityLabel(pane, { includeUnread: true });
+  updateActivePaneBreadcrumb();
 }
 
 function paneSetHeaderTarget(pane, { label, value, ariaLabel, onClick } = {}) {
@@ -6872,6 +6909,7 @@ function focusPaneIndex(idx) {
   const pane = paneManager.panes[idx];
   if (!pane) return;
   clearPaneUnread(pane);
+  updateActivePaneBreadcrumb();
 
   try {
     pane.elements?.root?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
@@ -7109,6 +7147,19 @@ globalElements.resetLayoutBtn?.addEventListener('click', () => {
 globalElements.paneManagerBtn?.addEventListener('click', (event) => {
   event?.preventDefault?.();
   openPaneManager();
+});
+
+globalElements.activePaneBreadcrumb?.addEventListener('click', (event) => {
+  event?.preventDefault?.();
+  const paneKey = globalElements.activePaneBreadcrumb?.dataset?.paneKey || activePane()?.key || '';
+  openPaneManager({ paneKey });
+});
+
+document.addEventListener('focusin', (event) => {
+  const target = event?.target;
+  if (!(target instanceof Element)) return;
+  if (!target.closest?.('[data-pane]')) return;
+  updateActivePaneBreadcrumb();
 });
 
 globalElements.paneManagerCloseBtn?.addEventListener('click', () => closePaneManager());

--- a/index.html
+++ b/index.html
@@ -40,6 +40,17 @@
               data-testid="panes-indicator"
             ></button>
           </div>
+          <button
+            id="activePaneBreadcrumb"
+            class="active-pane-breadcrumb"
+            type="button"
+            aria-label="Open pane manager for active pane"
+            data-testid="active-pane-breadcrumb"
+            hidden
+          >
+            <span class="active-pane-breadcrumb__type" data-active-pane-breadcrumb-type>Pane</span>
+            <span class="active-pane-breadcrumb__target" data-active-pane-breadcrumb-target></span>
+          </button>
           <div id="paneControls" class="pane-controls" hidden>
             <div class="pane-add-wrap">
               <button id="addPaneBtn" class="icon-btn" type="button" aria-haspopup="menu" aria-expanded="false" aria-label="Add pane" data-testid="add-pane-btn">

--- a/styles.css
+++ b/styles.css
@@ -146,6 +146,43 @@ body::before {
   display: flex;
   align-items: center;
   gap: 10px;
+  min-width: 0;
+}
+
+.active-pane-breadcrumb {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  max-width: min(34vw, 360px);
+  min-height: 32px;
+  padding: 6px 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(9, 12, 16, 0.42);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.active-pane-breadcrumb:hover {
+  border-color: rgba(127, 209, 185, 0.45);
+  background: rgba(127, 209, 185, 0.08);
+}
+
+.active-pane-breadcrumb__type {
+  flex: 0 0 auto;
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.active-pane-breadcrumb__target {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--muted);
+  font-size: 12px;
 }
 
 .agent-switch {
@@ -2645,6 +2682,10 @@ kbd {
     flex-wrap: wrap;
     justify-content: flex-end;
     margin-left: auto;
+  }
+
+  .active-pane-breadcrumb {
+    max-width: min(52vw, 260px);
   }
 
   .chat-page {

--- a/tests/pane.manager.e2e.spec.js
+++ b/tests/pane.manager.e2e.spec.js
@@ -85,6 +85,33 @@ test('pane header: identity line uses "[Letter] [Type] · [Target]" across pane 
   await expect(page.locator('.pane-manager-row .pane-manager-pane-id').first()).toHaveText(/^[a-zA-Z0-9]+$/);
 });
 
+test('active pane breadcrumb updates and opens manager on the active row', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const breadcrumb = page.getByTestId('active-pane-breadcrumb');
+  await expect(breadcrumb).toBeVisible();
+  await expect(breadcrumb).toContainText('A Chat');
+
+  const workqueuePane = page.locator('[data-pane][data-pane-kind="workqueue"]').first();
+  await workqueuePane.locator('[data-wq-queue-select]').focus();
+  await expect(breadcrumb).toContainText('B Workqueue');
+
+  await breadcrumb.click();
+  const modal = page.locator('#paneManagerModal');
+  await expect(modal).toHaveAttribute('aria-hidden', 'false');
+
+  const selectedRow = page.locator('.pane-manager-row[aria-selected="true"]');
+  await expect(selectedRow).toContainText('B Workqueue');
+});
+
 test('pane manager: quick-find filters and groups by kind', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!app?.skipReason, app?.skipReason);


### PR DESCRIPTION
## Summary
- add a persistent active-pane breadcrumb to the admin header
- keep the pane type visible while truncating long targets safely
- open Pane Manager from the breadcrumb with the active pane row selected

## Tests
- npm run test:syntax
- NODE_PATH=/Users/raysopenclaw/.openclaw/workspace-dev-deploy/repos/clawnsole/node_modules /Users/raysopenclaw/.openclaw/workspace-dev-deploy/repos/clawnsole/node_modules/.bin/playwright test tests/pane.manager.e2e.spec.js --workers=1

Closes #274

Note: stacked on #417 / dev/issue-255-typing-shortcut-guard to keep this diff isolated from existing local work.