### PR TITLE
Add workqueue all-scope guardrail

### DIFF
--- a/app.js
+++ b/app.js
@@ -3324,6 +3324,7 @@ async function fetchAndRenderWorkqueueItemsForPane(pane) {
 function renderWorkqueuePaneItems(pane) {
   const body = pane.elements?.thread?.querySelector('[data-wq-list-body]');
   const empty = pane.elements?.thread?.querySelector('[data-wq-empty]');
+  const allScopeGuardrail = pane.elements?.thread?.querySelector('[data-wq-all-scope-guardrail]');
   if (!body) return;
   body.innerHTML = '';
 
@@ -3339,6 +3340,10 @@ function renderWorkqueuePaneItems(pane) {
   });
   const filteredItems = applyWorkqueueQuickFilters(scopedItems, pane.workqueue?.quickFilters);
   const items = sortWorkqueueItems(filteredItems, { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
+  renderWorkqueueAllScopeGuardrail(pane, allScopeGuardrail, {
+    visibleCount: items.length,
+    threshold: getWorkqueueAllScopeGuardrailThreshold()
+  });
 
   if (empty) {
     const hasItems = items.length > 0;
@@ -3407,6 +3412,65 @@ function renderWorkqueuePaneItems(pane) {
     pane.workqueue.selectedItemId = null;
     renderWorkqueuePaneInspect(pane, null);
   }
+}
+
+function renderWorkqueueAllScopeGuardrail(pane, root, { visibleCount, threshold }) {
+  if (!root) return;
+  const scope = pane.workqueue?.scopeFilter || 'all';
+  const dismissed = pane.workqueue?.allScopeGuardrailDismissed === true;
+  const shouldShow = scope === 'all' && !dismissed && visibleCount > threshold;
+
+  root.hidden = !shouldShow;
+  root.innerHTML = '';
+  if (!shouldShow) return;
+
+  const queue = String(pane.workqueue?.queue || '').trim() || 'dev-team';
+  const shownKey = `${queue}:${visibleCount}:${threshold}`;
+  if (pane.workqueue.allScopeGuardrailShownKey !== shownKey) {
+    pane.workqueue.allScopeGuardrailShownKey = shownKey;
+    logWorkqueueGuardrailEvent('shown', { queue, visibleCount, threshold });
+  }
+
+  const text = document.createElement('span');
+  text.className = 'wq-all-scope-guardrail-text';
+  text.textContent = `Viewing all items (${visibleCount}). Narrow scope?`;
+  root.appendChild(text);
+
+  const makeButton = (label, nextScope) => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'wq-scope-btn';
+    btn.textContent = label;
+    btn.addEventListener('click', () => {
+      pane.workqueue.scopeFilter = normalizeWorkqueueScope(nextScope);
+      storage.set(WORKQUEUE_SCOPE_PREF_KEY, pane.workqueue.scopeFilter);
+      logWorkqueueGuardrailEvent('action', { queue, action: nextScope, visibleCount, threshold });
+      pane.elements?.thread?.querySelectorAll('[data-wq-scope]')?.forEach((scopeBtn) => {
+        const key = scopeBtn.getAttribute('data-wq-scope') || '';
+        const active = key === pane.workqueue.scopeFilter;
+        scopeBtn.classList.toggle('active', active);
+        scopeBtn.setAttribute('aria-pressed', active ? 'true' : 'false');
+      });
+      renderWorkqueuePaneItems(pane);
+      paneManager.persistAdminPanes();
+    });
+    return btn;
+  };
+
+  root.appendChild(makeButton('Assigned to active target', 'assigned'));
+  root.appendChild(makeButton('Unassigned', 'unassigned'));
+
+  const dismiss = document.createElement('button');
+  dismiss.type = 'button';
+  dismiss.className = 'wq-guardrail-dismiss';
+  dismiss.setAttribute('aria-label', 'Dismiss all scope guardrail');
+  dismiss.textContent = 'Dismiss';
+  dismiss.addEventListener('click', () => {
+    pane.workqueue.allScopeGuardrailDismissed = true;
+    logWorkqueueGuardrailEvent('dismissed', { queue, visibleCount, threshold });
+    renderWorkqueuePaneItems(pane);
+  });
+  root.appendChild(dismiss);
 }
 
 function renderWorkqueuePaneInspect(pane, item) {
@@ -3910,6 +3974,8 @@ const ADMIN_PANES_KEY = 'clawnsole.admin.panes.v1';
 // Layout is inferred from pane count; no manual layout toggle.
 const ADMIN_DEFAULT_AGENT_KEY = 'clawnsole.admin.agentId';
 const WORKQUEUE_SCOPE_PREF_KEY = 'clawnsole.admin.workqueue.scope.v1';
+const WORKQUEUE_ALL_SCOPE_GUARDRAIL_THRESHOLD_KEY = 'clawnsole.admin.workqueue.allScopeGuardrailThreshold';
+const WORKQUEUE_ALL_SCOPE_GUARDRAIL_DEFAULT_THRESHOLD = 200;
 
 function normalizeWorkqueueScope(scope) {
   return scope === 'assigned' || scope === 'unassigned' ? scope : 'all';
@@ -3918,6 +3984,34 @@ function normalizeWorkqueueScope(scope) {
 function getDefaultWorkqueueScope() {
   // Low-noise triage default: focus on unassigned work first.
   return normalizeWorkqueueScope(storage.get(WORKQUEUE_SCOPE_PREF_KEY, 'unassigned'));
+}
+
+function getWorkqueueAllScopeGuardrailThreshold() {
+  const raw = storage.get(WORKQUEUE_ALL_SCOPE_GUARDRAIL_THRESHOLD_KEY, '');
+  if (raw === '') return WORKQUEUE_ALL_SCOPE_GUARDRAIL_DEFAULT_THRESHOLD;
+  const configured = Number(raw);
+  return Number.isFinite(configured) && configured >= 0 ? configured : WORKQUEUE_ALL_SCOPE_GUARDRAIL_DEFAULT_THRESHOLD;
+}
+
+function logWorkqueueGuardrailEvent(type, detail = {}) {
+  const event = {
+    type,
+    detail,
+    at: new Date().toISOString()
+  };
+  try {
+    window.__debug = window.__debug || {};
+    window.__debug.workqueueGuardrailEvents = Array.isArray(window.__debug.workqueueGuardrailEvents)
+      ? window.__debug.workqueueGuardrailEvents
+      : [];
+    window.__debug.workqueueGuardrailEvents.push(event);
+  } catch {}
+  try {
+    window.dispatchEvent(new CustomEvent('clawnsole:workqueue-guardrail', { detail: event }));
+  } catch {}
+  try {
+    console.info('[workqueue.guardrail]', type, detail);
+  } catch {}
 }
 
 function computeBaseDeviceLabel() {
@@ -5526,6 +5620,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
             <button type="button" class="wq-scope-btn" data-wq-scope="unassigned">Unassigned</button>
             <button type="button" class="wq-scope-btn" data-wq-scope="all">All</button>
           </div>
+          <div class="wq-all-scope-guardrail" data-wq-all-scope-guardrail role="status" hidden></div>
 
           <div class="wq-field" data-wq-source-group role="group" aria-label="Filter by source">
             <span class="wq-label">Source</span>

--- a/styles.css
+++ b/styles.css
@@ -1947,6 +1947,42 @@ kbd {
   background: rgba(127, 209, 185, 0.12);
 }
 
+.wq-all-scope-guardrail {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  flex: 0 0 auto;
+  max-width: min(100%, 640px);
+  padding: 6px 8px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 179, 71, 0.32);
+  background: rgba(255, 179, 71, 0.1);
+  color: var(--text);
+}
+
+.wq-all-scope-guardrail[hidden] {
+  display: none;
+}
+
+.wq-all-scope-guardrail-text {
+  font-size: 12px;
+  color: var(--text);
+}
+
+.wq-guardrail-dismiss {
+  font-size: 11px;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 4px 6px;
+}
+
+.wq-guardrail-dismiss:hover {
+  color: var(--text);
+}
+
 .wq-enqueue {
   margin-top: 10px;
 }

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -120,6 +120,105 @@ test('workqueue pane: scope filter toggles assigned/unassigned/all deterministic
   await expect(rows).toHaveCount(2);
 });
 
+test('workqueue pane: all-scope guardrail appears above threshold and downscopes in one click', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await page.evaluate(() => {
+    localStorage.setItem('clawnsole.admin.workqueue.allScopeGuardrailThreshold', '2');
+  });
+  await addPane(page, 'Workqueue pane');
+
+  const queue = `all-scope-guardrail-${Date.now()}`;
+  await page.evaluate(async ({ queue }) => {
+    const post = async (url, body) => {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(body)
+      });
+      if (!res.ok) throw new Error(`${url} failed: ${res.status}`);
+      const data = await res.json();
+      if (!data?.ok) throw new Error(`${url} failed: ${data?.error || 'not ok'}`);
+      return data;
+    };
+
+    await post('/api/workqueue/enqueue', { queue, title: 'guardrail a', instructions: 'x', priority: 1 });
+    await post('/api/workqueue/enqueue', { queue, title: 'guardrail b', instructions: 'x', priority: 1 });
+    await post('/api/workqueue/enqueue', { queue, title: 'guardrail c', instructions: 'x', priority: 1 });
+    await post('/api/workqueue/claim-next', { agentId: 'main', queues: [queue], leaseMs: 900000 });
+  }, { queue });
+
+  const pane = page.locator('[data-pane]').last();
+  await pane.locator('[data-wq-queue-select]').selectOption('__custom__');
+  await pane.locator('[data-wq-queue-custom]').fill(queue);
+  await pane.locator('[data-wq-queue-custom]').press('Enter');
+  await pane.locator('[data-wq-refresh]').click();
+  await pane.locator('[data-wq-scope="all"]').click();
+
+  const guardrail = pane.locator('[data-wq-all-scope-guardrail]');
+  await expect(guardrail).toBeVisible();
+  await expect(guardrail).toContainText('Viewing all items (3). Narrow scope?');
+
+  await guardrail.getByRole('button', { name: 'Assigned to active target' }).click();
+  await expect(pane.locator('[data-wq-list-body] .wq-row')).toHaveCount(1);
+  await expect(guardrail).toBeHidden();
+
+  const events = await page.evaluate(() => window.__debug?.workqueueGuardrailEvents || []);
+  expect(events.map((event) => event.type)).toEqual(expect.arrayContaining(['shown', 'action']));
+});
+
+test('workqueue pane: all-scope guardrail stays hidden below threshold and after session dismiss', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await page.evaluate(() => {
+    localStorage.setItem('clawnsole.admin.workqueue.allScopeGuardrailThreshold', '10');
+  });
+  await addPane(page, 'Workqueue pane');
+
+  const queue = `all-scope-guardrail-hidden-${Date.now()}`;
+  await page.evaluate(async ({ queue }) => {
+    for (const title of ['hidden a', 'hidden b', 'hidden c']) {
+      const res = await fetch('/api/workqueue/enqueue', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ queue, title, instructions: 'x', priority: 1 })
+      });
+      if (!res.ok) throw new Error(`enqueue failed: ${res.status}`);
+    }
+  }, { queue });
+
+  const pane = page.locator('[data-pane]').last();
+  await pane.locator('[data-wq-queue-select]').selectOption('__custom__');
+  await pane.locator('[data-wq-queue-custom]').fill(queue);
+  await pane.locator('[data-wq-queue-custom]').press('Enter');
+  await pane.locator('[data-wq-refresh]').click();
+  await pane.locator('[data-wq-scope="all"]').click();
+
+  const guardrail = pane.locator('[data-wq-all-scope-guardrail]');
+  await expect(pane.locator('[data-wq-list-body] .wq-row')).toHaveCount(3);
+  await expect(guardrail).toBeHidden();
+
+  await page.evaluate(() => {
+    localStorage.setItem('clawnsole.admin.workqueue.allScopeGuardrailThreshold', '2');
+  });
+  await pane.locator('[data-wq-refresh]').click();
+  await expect(guardrail).toBeVisible();
+  await guardrail.getByRole('button', { name: 'Dismiss' }).click();
+  await expect(guardrail).toBeHidden();
+  await pane.locator('[data-wq-refresh]').click();
+  await expect(guardrail).toBeHidden();
+});
+
 test('workqueue pane: source chips + clawnsole preset filter items without reload', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);


### PR DESCRIPTION
## Summary\n- Add a high-volume guardrail when the workqueue pane is in All scope and visible rows exceed the configurable threshold (default 200).\n- Provide one-click downscope actions for assigned-to-active-target and unassigned rows, plus session-scoped dismissal.\n- Emit lightweight guardrail events for shown/action/dismissed tuning.\n\nFixes #408\n\n## Tests\n- npm run test:syntax\n- npx playwright test tests/ui/workqueue-pane.spec.js --workers=1\n\n🚢