### PR TITLE
Add active pane chip and highlight

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,6 +19,7 @@ const globalElements = {
   recurringPromptHistoryRows: document.getElementById('recurringPromptHistoryRows'),
   recurringPromptHistoryEmpty: document.getElementById('recurringPromptHistoryEmpty'),
   status: document.getElementById('connectionStatus'),
+  activePaneChip: document.getElementById('activePaneChip'),
   paneManagerBtn: document.getElementById('paneManagerBtn'),
   pulseCanvas: document.getElementById('pulseCanvas'),
   workqueueBtn: document.getElementById('workqueueBtn'),
@@ -2069,7 +2070,9 @@ function focusedPaneKey() {
     const root = entry?.elements?.root;
     return !!(root && active && (root === active || root.contains(active)));
   });
-  return pane?.key || '';
+  if (pane?.key) return pane.key;
+  const stored = String(storage.get(ADMIN_ACTIVE_PANE_KEY, '') || '');
+  return panes.some((entry) => String(entry?.key || '') === stored) ? stored : '';
 }
 
 let paneFocusMruKeys = [];
@@ -2093,20 +2096,57 @@ function notePaneFocused(pane) {
   if (!key) return;
   const panes = paneManager?.panes || [];
   if (!panes.some((entry) => String(entry?.key || '') === key)) return;
+  storage.set(ADMIN_ACTIVE_PANE_KEY, key);
   paneMruTraversal = null;
   paneMruOrder();
   paneFocusMruKeys = [key, ...paneFocusMruKeys.filter((entry) => entry !== key)];
   updateBrowserTitle(pane);
+  syncActivePaneState();
 }
 
 function forgetFocusedPaneKey(paneKey) {
   const key = String(paneKey || '');
   if (!key) return;
   paneFocusMruKeys = paneFocusMruKeys.filter((entry) => entry !== key);
+  if (String(storage.get(ADMIN_ACTIVE_PANE_KEY, '') || '') === key) storage.remove(ADMIN_ACTIVE_PANE_KEY);
   if (paneMruTraversal?.order) {
     paneMruTraversal.order = paneMruTraversal.order.filter((entry) => entry !== key);
     if (paneMruTraversal.order.length < 2) paneMruTraversal = null;
   }
+  syncActivePaneState();
+}
+
+function activePaneFromStoredKey() {
+  const panes = paneManager?.panes || [];
+  const key = String(storage.get(ADMIN_ACTIVE_PANE_KEY, '') || '');
+  return panes.find((pane) => String(pane?.key || '') === key) || panes[0] || null;
+}
+
+function syncActivePaneState() {
+  const panes = paneManager?.panes || [];
+  const active = activePaneFromStoredKey();
+  const activeKey = String(active?.key || '');
+
+  panes.forEach((pane) => {
+    try {
+      pane.elements.root.dataset.paneActive = activeKey && String(pane.key || '') === activeKey ? 'true' : 'false';
+    } catch {}
+  });
+
+  const chip = globalElements.activePaneChip;
+  if (!chip) return;
+  if (!active) {
+    chip.hidden = true;
+    chip.textContent = 'Active: —';
+    chip.removeAttribute('data-active-kind');
+    return;
+  }
+
+  const label = paneIdentityLabel(active);
+  chip.hidden = roleState.role !== 'admin';
+  chip.textContent = `Active: ${label}`;
+  chip.dataset.activeKind = String(active.kind || 'chat');
+  chip.title = `Active pane: ${label}`;
 }
 
 function paneIndexByKey(key) {
@@ -2174,6 +2214,7 @@ function clearPaneUnread(pane) {
   pane.unreadKind = '';
   renderPaneIdentity(pane);
   renderPaneActivityBadge(pane);
+  syncActivePaneState();
   if (isPaneManagerOpen()) renderPaneManager();
 }
 
@@ -2214,6 +2255,7 @@ function markPaneUnread(pane, increment = 1, kind = 'chat') {
   pane.unreadKind = String(kind || 'activity');
   renderPaneIdentity(pane);
   renderPaneActivityBadge(pane);
+  syncActivePaneState();
   if (isPaneManagerOpen()) renderPaneManager();
 }
 
@@ -5865,6 +5907,7 @@ renderPulse();
 
 const ADMIN_PANES_KEY = 'clawnsole.admin.panes.v1';
 const ADMIN_LAYOUT_LOCK_KEY = 'clawnsole.admin.layout.lock.v1';
+const ADMIN_ACTIVE_PANE_KEY = 'clawnsole.admin.activePaneKey.v1';
 // Layout is inferred from pane count; no manual layout toggle.
 const ADMIN_LAYOUT_MODE_KEY = 'clawnsole.admin.layoutMode';
 const ADMIN_DEFAULT_AGENT_KEY = 'clawnsole.admin.agentId';
@@ -8916,7 +8959,10 @@ const paneManager = {
     this.updatePaneLabels();
     this.updateCloseButtons();
     this.applyInferredLayout();
-    updateBrowserTitle(this.panes[0] || null);
+    const active = activePaneFromStoredKey();
+    if (active?.key) storage.set(ADMIN_ACTIVE_PANE_KEY, active.key);
+    updateBrowserTitle(active || this.panes[0] || null);
+    syncActivePaneState();
   },
   isLayoutLocked() {
     return !!this.layoutLocked;
@@ -8952,6 +8998,7 @@ const paneManager = {
       } catch {}
     });
     this.panes = [];
+    syncActivePaneState();
   },
   loadAdminPanes() {
     const storedDefault = storage.get(ADMIN_DEFAULT_AGENT_KEY, 'main');
@@ -9539,12 +9586,14 @@ const paneManager = {
 
     this.updatePaneLabels();
     this.persistAdminPanes();
+    syncActivePaneState();
     updateGlobalStatus();
     return true;
   },
   updatePaneLabels() {
     this.panes.forEach((pane) => renderPaneIdentity(pane));
     this.updatePaneGridLabel();
+    syncActivePaneState();
   },
   updatePaneGridLabel() {
     const grid = globalElements.paneGrid;
@@ -10002,7 +10051,11 @@ function focusPaneIndex(idx, { trackMru = true, showHud = false } = {}) {
   if (!pane) return;
   clearPaneUnread(pane);
   if (trackMru) notePaneFocused(pane);
-  else updateBrowserTitle(pane);
+  else {
+    storage.set(ADMIN_ACTIVE_PANE_KEY, pane.key);
+    updateBrowserTitle(pane);
+    syncActivePaneState();
+  }
   if (showHud) showPaneSwitchHud(pane);
 
   try {
@@ -10467,6 +10520,16 @@ globalElements.paneManagerBtn?.addEventListener('click', (event) => {
   openPaneManager();
 });
 
+globalElements.activePaneChip?.addEventListener('click', (event) => {
+  event?.preventDefault?.();
+  const active = activePaneFromStoredKey();
+  if (active) {
+    const idx = paneManager.panes.findIndex((pane) => pane.key === active.key);
+    paneManagerUiState.selectedIndex = Math.max(0, idx);
+  }
+  openPaneManager();
+});
+
 globalElements.paneManagerCloseBtn?.addEventListener('click', () => closePaneManager());
 
 globalElements.paneManagerSearch?.addEventListener('input', () => {
@@ -10600,8 +10663,8 @@ window.addEventListener('load', () => {
 
       const isTouch = window.matchMedia && window.matchMedia('(hover: none) and (pointer: coarse)').matches;
       if (!isTouch) {
-        const firstPane = paneManager.panes[0];
-        firstPane?.elements.input?.focus();
+        const activePane = activePaneFromStoredKey();
+        if (activePane) paneManager.focusPanePrimary(activePane);
       }
     })
     .catch(() => {

--- a/index.html
+++ b/index.html
@@ -30,6 +30,17 @@
           </div>
         </div>
         <div class="topbar-actions">
+          <button
+            id="activePaneChip"
+            class="active-pane-chip"
+            type="button"
+            aria-label="Open active pane in pane manager"
+            title="Active pane"
+            data-testid="active-pane-chip"
+            hidden
+          >
+            Active: —
+          </button>
           <div class="status compact">
             <div class="status-pill" id="connectionStatus" data-testid="connection-status">disconnected</div>
             <button

--- a/styles.css
+++ b/styles.css
@@ -155,6 +155,44 @@ body::before {
   gap: 10px;
 }
 
+.active-pane-chip {
+  display: inline-flex;
+  align-items: center;
+  max-width: min(34vw, 360px);
+  min-height: 32px;
+  padding: 0 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(var(--pane-accent-rgb, var(--pane-accent-chat-rgb)), 0.58);
+  background: rgba(var(--pane-accent-rgb, var(--pane-accent-chat-rgb)), 0.14);
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 650;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+}
+
+.active-pane-chip[hidden] {
+  display: none;
+}
+
+.active-pane-chip[data-active-kind="chat"] {
+  --pane-accent-rgb: var(--pane-accent-chat-rgb);
+}
+
+.active-pane-chip[data-active-kind="workqueue"] {
+  --pane-accent-rgb: var(--pane-accent-workqueue-rgb);
+}
+
+.active-pane-chip[data-active-kind="cron"] {
+  --pane-accent-rgb: var(--pane-accent-cron-rgb);
+}
+
+.active-pane-chip[data-active-kind="timeline"] {
+  --pane-accent-rgb: var(--pane-accent-timeline-rgb);
+}
+
 .agent-switch {
   display: inline-flex;
   align-items: center;
@@ -538,6 +576,20 @@ body::before {
 
 .pane-type-pill {
   flex: 0 0 auto;
+}
+
+.chat-panel.pane[data-pane-active="true"] {
+  border-color: rgba(var(--pane-accent-rgb), 0.92);
+  box-shadow:
+    0 0 0 2px rgba(var(--pane-accent-rgb), 0.46),
+    0 0 0 6px rgba(var(--pane-accent-rgb), 0.12),
+    0 28px 80px rgba(0, 0, 0, 0.34);
+}
+
+.chat-panel.pane[data-pane-active="true"] .pane-header {
+  background: linear-gradient(90deg, rgba(var(--pane-accent-rgb), 0.24), rgba(9, 12, 16, 0.14));
+  border-color: rgba(var(--pane-accent-rgb), 0.7);
+  border-left-color: rgba(var(--pane-accent-rgb), 1);
 }
 
 /* Per-pane subtle treatment */

--- a/tests/pane.manager.e2e.spec.js
+++ b/tests/pane.manager.e2e.spec.js
@@ -50,6 +50,52 @@ test('pane manager: lists panes + focuses via keyboard', async ({ page }) => {
   expect(focusedPaneIndex).toBe(1);
 });
 
+test('active pane chip and visual state follow keyboard pane cycling', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const panes = page.locator('[data-pane]');
+  const chip = page.getByTestId('active-pane-chip');
+  const triggerNextPaneShortcut = async () => page.evaluate(() => {
+    const event = new KeyboardEvent('keydown', {
+      key: 'K',
+      ctrlKey: true,
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true
+    });
+    window.dispatchEvent(event);
+  });
+
+  await expect(panes).toHaveCount(2);
+  await expect(chip).toBeVisible();
+  await expect(chip).toHaveText(/^Active: A Chat · .+/);
+  await expect(chip).toHaveAttribute('data-active-kind', 'chat');
+  await expect(panes.nth(0)).toHaveAttribute('data-pane-active', 'true');
+  await expect(page.locator('[data-pane][data-pane-active="true"]')).toHaveCount(1);
+
+  await triggerNextPaneShortcut();
+  await expect(chip).toHaveText(/^Active: B Workqueue · .+/);
+  await expect(chip).toHaveAttribute('data-active-kind', 'workqueue');
+  await expect(panes.nth(1)).toHaveAttribute('data-pane-active', 'true');
+  await expect(panes.nth(0)).toHaveAttribute('data-pane-active', 'false');
+  await expect(page.locator('[data-pane][data-pane-active="true"]')).toHaveCount(1);
+
+  await triggerNextPaneShortcut();
+  await expect(chip).toHaveText(/^Active: A Chat · .+/);
+  await expect(chip).toHaveAttribute('data-active-kind', 'chat');
+  await expect(panes.nth(0)).toHaveAttribute('data-pane-active', 'true');
+  await expect(panes.nth(1)).toHaveAttribute('data-pane-active', 'false');
+  await expect(page.locator('[data-pane][data-pane-active="true"]')).toHaveCount(1);
+});
+
 test('pane header: identity line uses "[Letter] [Type] · [Target]" across pane kinds', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!app?.skipReason, app?.skipReason);


### PR DESCRIPTION
## Summary
- add a persistent topbar Active chip showing the focused pane identity
- mark exactly one pane with data-pane-active and stronger active styling
- persist/restore active pane selection across reloads and pane layout changes
- add Playwright coverage for keyboard pane cycling updating chip + visual state

## Testing
- npm run test:syntax
- NODE_PATH=/Users/raysopenclaw/.openclaw/workspace-dev/clawnsole/node_modules /Users/raysopenclaw/.openclaw/workspace-dev/clawnsole/node_modules/.bin/playwright test tests/pane.manager.e2e.spec.js --workers=1
- NODE_PATH=/Users/raysopenclaw/.openclaw/workspace-dev/clawnsole/node_modules /Users/raysopenclaw/.openclaw/workspace-dev/clawnsole/node_modules/.bin/playwright test tests/pane.shortcuts.e2e.spec.js --workers=1

Closes #407