### PR TITLE
Add pane grid label regression test

### DIFF
--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -47,6 +47,30 @@ test('workqueue pane: renders + has queue dropdown + does not show chat composer
   await expect(wqPane.locator('[data-pane-input]')).toBeHidden();
 });
 
+test('workqueue pane: pane grid label switches from chat-only to generic panes', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'clawnsole.admin.panes.v1',
+      JSON.stringify([{ key: 'ptestchat', kind: 'chat', agentId: 'main' }])
+    );
+  });
+
+  await loginAdmin(page, env.serverPort);
+
+  const grid = page.getByTestId('pane-grid');
+  await expect(grid).toHaveAttribute('aria-label', 'Chat panes');
+
+  await addPane(page, 'Workqueue pane');
+
+  await expect(page.locator('[data-pane-kind="workqueue"]').last()).toBeVisible();
+  await expect(grid).toHaveAttribute('aria-label', 'Panes');
+});
+
 test('workqueue pane: queue target supports search + recent persistence', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);


### PR DESCRIPTION
## Summary
- Add a focused UI regression for issue #263 covering chat-only layout -> add Workqueue pane.
- Verifies the pane grid label remains `Chat panes` for all-chat layouts and switches to `Panes` once a non-chat pane is visible.

Fixes #263

## Tests
- `npx playwright test tests/ui/workqueue-pane.spec.js -g "pane grid label"`