### PR TITLE
Default Workqueue UI to priority sort

### DIFF
--- a/app.js
+++ b/app.js
@@ -109,6 +109,7 @@ const fmtRemaining = __appCore.fmtRemaining || ((msUntil) => {
   return `${sec}s`;
 });
 const sortWorkqueueItems = __appCore.sortWorkqueueItems || ((items, opts) => (Array.isArray(items) ? items.slice() : []));
+const defaultWorkqueueSort = __appCore.defaultWorkqueueSort || { sortKey: 'priority', sortDir: 'desc' };
 const inferPaneCols = __appCore.inferPaneCols || ((count) => {
   const n = Number(count);
   if (!Number.isFinite(n) || n <= 1) return 1;
@@ -330,8 +331,8 @@ function buildDefaultAdminPanes(defaultAgent = 'main') {
       queue: 'dev-team',
       statusFilter: ['ready', 'pending', 'claimed', 'in_progress'],
       scopeFilter: getDefaultWorkqueueScope(),
-      sortKey: 'priority',
-      sortDir: 'desc'
+      sortKey: defaultWorkqueueSort.sortKey,
+      sortDir: defaultWorkqueueSort.sortDir
     }
   ];
 }
@@ -2695,8 +2696,8 @@ const workqueueState = {
   statusFilter: new Set(['ready', 'pending', 'claimed', 'in_progress']),
   items: [],
   selectedItemId: null,
-  sortKey: 'default',
-  sortDir: 'desc',
+  sortKey: defaultWorkqueueSort.sortKey,
+  sortDir: defaultWorkqueueSort.sortDir,
   leaseTicker: null,
   autoRefreshEnabled: true,
   autoRefreshIntervalMs: 15000,
@@ -5335,8 +5336,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       },
       items: [],
       selectedItemId: null,
-      sortKey: typeof sortKey === 'string' && sortKey.trim() ? sortKey.trim() : 'priority',
-      sortDir: sortDir === 'asc' ? 'asc' : 'desc'
+      sortKey: typeof sortKey === 'string' && sortKey.trim() ? sortKey.trim() : defaultWorkqueueSort.sortKey,
+      sortDir: sortDir === 'asc' ? 'asc' : defaultWorkqueueSort.sortDir
     },
     cronAgentId: typeof cronAgentId === 'string' ? cronAgentId.trim() : '',
     connected: false,
@@ -6788,8 +6789,8 @@ const paneManager = {
             sources: Array.isArray(item?.quickFilters?.sources) ? item.quickFilters.sources.map((s) => String(s || '').trim()).filter(Boolean) : [],
             repos: Array.isArray(item?.quickFilters?.repos) ? item.quickFilters.repos.map((s) => String(s || '').trim()).filter(Boolean) : []
           };
-          const sortKey = typeof item.sortKey === 'string' ? item.sortKey : 'priority';
-          const sortDir = item.sortDir === 'asc' ? 'asc' : 'desc';
+          const sortKey = typeof item.sortKey === 'string' ? item.sortKey : defaultWorkqueueSort.sortKey;
+          const sortDir = item.sortDir === 'asc' ? 'asc' : defaultWorkqueueSort.sortDir;
           return { key, kind, agentId, queue, statusFilter, scopeFilter, quickFilters, sortKey, sortDir };
         }
         if (kind === 'cron' || kind === 'timeline') {
@@ -6836,8 +6837,8 @@ const paneManager = {
             sources: Array.isArray(pane.workqueue?.quickFilters?.sources) ? pane.workqueue.quickFilters.sources : [],
             repos: Array.isArray(pane.workqueue?.quickFilters?.repos) ? pane.workqueue.quickFilters.repos : []
           },
-          sortKey: pane.workqueue?.sortKey || 'priority',
-          sortDir: pane.workqueue?.sortDir || 'desc'
+          sortKey: pane.workqueue?.sortKey || defaultWorkqueueSort.sortKey,
+          sortDir: pane.workqueue?.sortDir || defaultWorkqueueSort.sortDir
         };
       }
       if (pane.kind === 'cron' || pane.kind === 'timeline') {

--- a/lib/app-core.js
+++ b/lib/app-core.js
@@ -25,6 +25,8 @@
     return `${sec}s`;
   }
 
+  const defaultWorkqueueSort = Object.freeze({ sortKey: 'priority', sortDir: 'desc' });
+
   function sortWorkqueueItems(items, { sortKey = 'default', sortDir = 'desc' } = {}) {
     const dir = sortDir === 'asc' ? 1 : -1;
     const statusRank = (s) => {
@@ -362,6 +364,7 @@
   const AppCore = {
     escapeHtml,
     fmtRemaining,
+    defaultWorkqueueSort,
     sortWorkqueueItems,
     inferPaneCols,
     normalizePaneKind,

--- a/tests/unit/app-core.test.js
+++ b/tests/unit/app-core.test.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict');
 const {
   escapeHtml,
   fmtRemaining,
+  defaultWorkqueueSort,
   sortWorkqueueItems,
   inferPaneCols,
   normalizePaneKind,
@@ -56,6 +57,10 @@ test('normalizeAdminDestination accepts only fresh same-origin admin destination
     normalizeAdminDestination({ href: '/admin', createdAt: now - 700_000 }, { origin, now, ttlMs: 600_000 }).reason,
     'stale'
   );
+});
+
+test('defaultWorkqueueSort surfaces priority descending as the initial UI sort', () => {
+  assert.deepEqual(defaultWorkqueueSort, { sortKey: 'priority', sortDir: 'desc' });
 });
 
 test('sortWorkqueueItems default groups by status then priority then timestamps', () => {


### PR DESCRIPTION
## Summary
- Add a shared default Workqueue sort of priority desc.
- Use that default for the Workqueue modal, default admin pane layout, new panes, and pane persistence fallbacks.
- Add unit coverage for the exported default sort value; existing priority sort test covers updatedAt desc tiebreaking.

## Tests
- npm test

Closes #178