### PR TITLE
UX/Auth: polish admin unlock form

### DIFF
--- a/app.js
+++ b/app.js
@@ -474,6 +474,7 @@ const uiState = {
   agents: []
 };
 
+let loginInFlight = false;
 let toastSeq = 0;
 function showToast(message, { kind = 'info', timeoutMs = 2600 } = {}) {
   if (!globalElements.toastHost) return;
@@ -1045,12 +1046,37 @@ function setRole(role) {
   }
 }
 
-function showLogin(message = '') {
+function setLoginSubmitting(submitting) {
+  loginInFlight = !!submitting;
+  if (globalElements.loginBtn) {
+    globalElements.loginBtn.disabled = loginInFlight;
+    globalElements.loginBtn.textContent = loginInFlight ? 'Unlocking...' : 'Unlock';
+    globalElements.loginBtn.setAttribute('aria-busy', loginInFlight ? 'true' : 'false');
+  }
+  if (globalElements.loginPassword) {
+    globalElements.loginPassword.disabled = loginInFlight;
+  }
+}
+
+function focusLoginPassword() {
+  try {
+    globalElements.loginPassword?.focus({ preventScroll: true });
+    requestAnimationFrame(() => {
+      try { globalElements.loginPassword?.focus({ preventScroll: true }); } catch {}
+    });
+    setTimeout(() => {
+      try { globalElements.loginPassword?.focus({ preventScroll: true }); } catch {}
+    }, 50);
+  } catch {}
+}
+
+function showLogin(message = '', { clearPassword = true } = {}) {
+  setLoginSubmitting(false);
   captureAdminAuthDestination();
   globalElements.loginOverlay.classList.add('open');
   globalElements.loginOverlay.setAttribute('aria-hidden', 'false');
   globalElements.loginError.textContent = message;
-  globalElements.loginPassword.value = '';
+  if (clearPassword) globalElements.loginPassword.value = '';
 
   // Guest role selection removed.
 
@@ -1066,25 +1092,25 @@ function showLogin(message = '') {
   globalElements.fleetBtn?.setAttribute('disabled', 'disabled');
   if (globalElements.fleetBtn) globalElements.fleetBtn.style.opacity = '0.5';
 
-  const isTouch = window.matchMedia && window.matchMedia('(hover: none) and (pointer: coarse)').matches;
-  if (!isTouch) {
-    globalElements.loginPassword.focus();
-  }
+  focusLoginPassword();
 }
 
 function hideLogin() {
   globalElements.loginOverlay.classList.remove('open');
   globalElements.loginOverlay.setAttribute('aria-hidden', 'true');
   globalElements.loginError.textContent = '';
+  setLoginSubmitting(false);
   setAuthState(true);
 }
 
 async function attemptLogin() {
+  if (loginInFlight) return;
   const password = globalElements.loginPassword.value.trim();
   if (!password) {
-    showLogin('Password required.');
+    showLogin('Password required.', { clearPassword: false });
     return;
   }
+  setLoginSubmitting(true);
   try {
     const res = await fetch('/auth/login', {
       method: 'POST',
@@ -1093,7 +1119,7 @@ async function attemptLogin() {
       credentials: 'include'
     });
     if (!res.ok) {
-      showLogin('Invalid password. Try again.');
+      showLogin('Invalid password. Try again.', { clearPassword: false });
       return;
     }
     await res.json();
@@ -1111,7 +1137,9 @@ async function attemptLogin() {
     }
     window.location.replace(nextHref);
   } catch {
-    showLogin('Login failed. Please retry.');
+    showLogin('Login failed. Please retry.', { clearPassword: false });
+  } finally {
+    setLoginSubmitting(false);
   }
 }
 

--- a/tests/ui/auth-lifecycle.spec.js
+++ b/tests/ui/auth-lifecycle.spec.js
@@ -10,6 +10,63 @@ test('visiting /admin without auth shows login overlay', async ({ page, clawnsol
   await expect(page.getByTestId('role-pill')).toContainText('signed out');
 });
 
+test('unlock form autofocuses password and submits with Enter', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  await page.goto(clawnsole.adminUrl);
+
+  const password = page.getByTestId('login-password');
+  await expect(page.getByTestId('login-overlay')).toHaveClass(/open/);
+  await expect(password).toBeFocused();
+
+  await password.fill('admin');
+  await password.press('Enter');
+
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+  await expect(page.getByTestId('login-overlay')).not.toHaveClass(/open/);
+});
+
+test('unlock form shows in-flight state and prevents duplicate submits', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  let loginRequests = 0;
+  let releaseLogin;
+  const loginPending = new Promise((resolve) => {
+    releaseLogin = resolve;
+  });
+
+  await page.route('**/auth/login', async (route) => {
+    loginRequests += 1;
+    await loginPending;
+    await route.fulfill({
+      status: 401,
+      contentType: 'application/json',
+      body: JSON.stringify({ error: 'invalid password' })
+    });
+  });
+
+  await page.goto(clawnsole.adminUrl);
+
+  const password = page.getByTestId('login-password');
+  const unlock = page.getByTestId('login-button');
+  await password.fill('wrong-password');
+  await password.press('Enter');
+
+  await expect(unlock).toBeDisabled();
+  await expect(unlock).toHaveAttribute('aria-busy', 'true');
+  await expect(unlock).toContainText('Unlocking');
+
+  await password.dispatchEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
+  await unlock.dispatchEvent('click');
+  expect(loginRequests).toBe(1);
+
+  releaseLogin();
+  await expect(page.getByTestId('login-error')).toContainText('Invalid password');
+  await expect(password).toBeFocused();
+  await expect(password).toBeEnabled();
+  expect(loginRequests).toBe(1);
+});
+
 test('admin login restores the intended in-app destination', async ({ page, clawnsole }) => {
   if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
 


### PR DESCRIPTION
## Summary
- autofocus the admin unlock password field with a deferred refocus when the login card opens
- add in-flight unlock state that disables controls, shows loading text, and ignores duplicate submits
- keep failed-password text focused and ready for immediate retry

## Tests
- npm run test:syntax
- npx playwright test tests/ui/auth-lifecycle.spec.js --workers=1

Closes #316