### PR TITLE
UX: add Agents modal keyboard triage loop

### DIFF
--- a/app.js
+++ b/app.js
@@ -533,6 +533,7 @@ let agentAutoRefreshInterval = null;
 let agentsModalAutoRefreshInterval = null;
 let agentsModalFreshnessTicker = null;
 let agentsLastRefreshedAtMs = 0;
+let agentsModalSelectedAgentId = '';
 
 function startAgentAutoRefresh() {
   if (roleState.role !== 'admin') return;
@@ -2611,9 +2612,9 @@ function openAgentsModal() {
   startAgentsModalAutoRefresh();
   startAgentsModalFreshnessTicker();
 
-  // Focus search by default for fast filtering.
   try {
-    globalElements.agentsSearch?.focus?.();
+    const selected = getAgentsModalSelectedRow();
+    (selected || globalElements.agentsList)?.focus?.({ preventScroll: true });
   } catch {}
 }
 
@@ -2622,6 +2623,63 @@ function closeAgentsModal() {
   globalElements.agentsModal?.setAttribute('aria-hidden', 'true');
   stopAgentsModalAutoRefresh();
   stopAgentsModalFreshnessTicker();
+}
+
+function isAgentsModalShortcutTarget(target) {
+  const el = target instanceof Element ? target : null;
+  if (!el) return true;
+  if (el.isContentEditable) return false;
+  const tag = String(el.tagName || '').toLowerCase();
+  if (tag === 'input' || tag === 'textarea' || tag === 'select') return false;
+  if (el.closest('input, textarea, select, [contenteditable="true"]')) return false;
+  return true;
+}
+
+function getAgentsModalRows() {
+  return Array.from(globalElements.agentsList?.querySelectorAll?.('.agents-row[data-agent-id]') || []).filter((row) => !row.closest('[hidden]'));
+}
+
+function getAgentsModalSelectedRow() {
+  return getAgentsModalRows().find((row) => row.classList.contains('selected')) || null;
+}
+
+function syncAgentsModalSelection({ scroll = false } = {}) {
+  const rows = getAgentsModalRows();
+  if (rows.length === 0) {
+    agentsModalSelectedAgentId = '';
+    return;
+  }
+
+  const hasSelected = rows.some((row) => String(row.getAttribute('data-agent-id') || '') === agentsModalSelectedAgentId);
+  if (!hasSelected) agentsModalSelectedAgentId = String(rows[0].getAttribute('data-agent-id') || '');
+
+  rows.forEach((row) => {
+    const selected = String(row.getAttribute('data-agent-id') || '') === agentsModalSelectedAgentId;
+    row.classList.toggle('selected', selected);
+    row.setAttribute('aria-selected', selected ? 'true' : 'false');
+    row.tabIndex = selected ? 0 : -1;
+    if (selected && scroll) row.scrollIntoView({ block: 'nearest' });
+  });
+}
+
+function moveAgentsModalSelection(delta) {
+  const rows = getAgentsModalRows();
+  if (rows.length === 0) return;
+  const current = Math.max(
+    0,
+    rows.findIndex((row) => String(row.getAttribute('data-agent-id') || '') === agentsModalSelectedAgentId)
+  );
+  const next = Math.min(rows.length - 1, Math.max(0, current + delta));
+  agentsModalSelectedAgentId = String(rows[next].getAttribute('data-agent-id') || '');
+  syncAgentsModalSelection({ scroll: true });
+  rows[next].focus?.({ preventScroll: true });
+}
+
+function openAgentsModalSelection(kind) {
+  const id = String(getAgentsModalSelectedRow()?.getAttribute('data-agent-id') || agentsModalSelectedAgentId || '').trim();
+  if (!id) return;
+  if (kind === 'workqueue') openAgentWorkqueueFromFleet(id);
+  else openAgentChatFromFleet(id);
 }
 
 function findExistingPane(kind, predicate = null) {
@@ -2794,6 +2852,10 @@ function renderAgentsModalList() {
       const id = String(agent?.id || '').trim();
       const row = document.createElement('div');
       row.className = 'agents-row';
+      row.setAttribute('data-agent-id', id);
+      row.setAttribute('role', 'option');
+      row.setAttribute('aria-selected', 'false');
+      row.tabIndex = -1;
 
       const label = formatAgentLabel(agent, { includeId: true });
       const pinnedNow = pins.has(id);
@@ -2835,6 +2897,12 @@ function renderAgentsModalList() {
         renderAgentsModalList();
       });
 
+      row.addEventListener('click', () => {
+        agentsModalSelectedAgentId = id;
+        syncAgentsModalSelection();
+        row.focus?.({ preventScroll: true });
+      });
+
       const actionButtons = Array.from(row.querySelectorAll('[data-agent-action]'));
       actionButtons.forEach((btn) => {
         btn.addEventListener('click', (e) => {
@@ -2859,6 +2927,7 @@ function renderAgentsModalList() {
 
   const empty = ordered.length === 0;
   if (globalElements.agentsEmpty) globalElements.agentsEmpty.hidden = !empty;
+  syncAgentsModalSelection();
 }
 
 // Workqueue (admin-only)
@@ -7530,6 +7599,26 @@ globalElements.agentsBtn?.addEventListener('click', () => openAgentsModal());
 globalElements.agentsCloseBtn?.addEventListener('click', () => closeAgentsModal());
 globalElements.agentsModal?.addEventListener('click', (event) => {
   if (event.target === globalElements.agentsModal) closeAgentsModal();
+});
+document.addEventListener('keydown', (event) => {
+  if (!globalElements.agentsModal?.classList?.contains('open')) return;
+  const target = event.target instanceof Element ? event.target : null;
+  if (target && target !== document.body && !globalElements.agentsModal?.contains(target)) return;
+  if (!isAgentsModalShortcutTarget(event.target)) return;
+  if (event.key === 'j' || event.key === 'ArrowDown') {
+    event.preventDefault();
+    moveAgentsModalSelection(1);
+    return;
+  }
+  if (event.key === 'k' || event.key === 'ArrowUp') {
+    event.preventDefault();
+    moveAgentsModalSelection(-1);
+    return;
+  }
+  if (event.key === 'Enter') {
+    event.preventDefault();
+    openAgentsModalSelection(event.shiftKey ? 'workqueue' : 'chat');
+  }
 });
 
 globalElements.agentsSearch?.addEventListener('input', () => renderAgentsModalList());

--- a/index.html
+++ b/index.html
@@ -439,7 +439,7 @@
             </label>
           </div>
 
-          <div id="agentsList" class="agents-list" aria-label="Agent list"></div>
+          <div id="agentsList" class="agents-list" role="listbox" aria-label="Agent list"></div>
           <div id="agentsEmpty" class="hint" hidden>No agents match.</div>
         </div>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -1493,6 +1493,17 @@ button.agents-section-title:hover {
   background: rgba(255, 255, 255, 0.02);
 }
 
+.agents-row.selected {
+  border-color: rgba(82, 168, 255, 0.75);
+  background: rgba(82, 168, 255, 0.12);
+  box-shadow: 0 0 0 2px rgba(82, 168, 255, 0.18);
+}
+
+.agents-row:focus-visible {
+  outline: 2px solid rgba(82, 168, 255, 0.85);
+  outline-offset: 2px;
+}
+
 .agents-pin {
   width: 36px;
   height: 36px;

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -126,3 +126,46 @@ test('agents modal quick actions open/reuse chat, timeline, and workqueue contex
   await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
   await expect(page.locator('[data-pane][data-pane-kind="workqueue"] [data-wq-claim-agent]')).toHaveValue(agentId || 'main');
 });
+
+test('agents modal keyboard triage selects rows and opens chat or workqueue', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  const agents = [
+    { id: 'alpha-agent', name: 'alpha-agent', displayName: 'Alpha Agent' },
+    { id: 'bravo-agent', name: 'bravo-agent', displayName: 'Bravo Agent' },
+    { id: 'charlie-agent', name: 'charlie-agent', displayName: 'Charlie Agent' }
+  ];
+
+  await clawnsole.gotoAndLoginAdmin(page);
+  await page.route(/\/agents(?:\?|$)/, async (route) => {
+    await route.fulfill({ json: { agents } });
+  });
+  await page.getByRole('button', { name: 'Refresh agent list' }).click();
+
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsModal')).toHaveClass(/open/);
+
+  const rows = page.locator('#agentsList .agents-row');
+  await expect(rows).toHaveCount(3);
+  await expect(rows.nth(0)).toHaveClass(/selected/);
+
+  await page.locator('#agentsSearch').focus();
+  await page.keyboard.press('ArrowDown');
+  await expect(rows.nth(0)).toHaveClass(/selected/);
+
+  await rows.nth(0).click();
+  await page.keyboard.press('j');
+  await expect(rows.nth(1)).toHaveClass(/selected/);
+
+  await page.keyboard.press('Enter');
+  await expect.poll(async () => {
+    return page.locator('[data-pane][data-pane-kind="chat"] [data-pane-agent-select]').evaluateAll((nodes) => nodes.map((node) => node.value));
+  }).toContain('bravo-agent');
+
+  await page.keyboard.press('Shift+Enter');
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"] [data-wq-claim-agent]')).toHaveValue('bravo-agent');
+
+  await page.keyboard.press('ArrowUp');
+  await expect(rows.nth(0)).toHaveClass(/selected/);
+});


### PR DESCRIPTION
## Summary\n- add selected-row state to the Agents modal with visible highlight and listbox semantics\n- wire j/k and arrow navigation plus Enter for Chat and Shift+Enter for Workqueue\n- preserve shortcut suppression while typing in the search input\n\n## Tests\n- npm test\n- npm run test:syntax\n- npx playwright test tests/ui/agents-modal.spec.js\n\nCloses #383