### PR TITLE
Add recurring prompt external worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,12 +169,15 @@ Clawnsole can store recurring prompts targeted at individual agents. Delivery is
 
 1) In Clawnsole (Admin) open **Gateway Link** → **Recurring Agent Prompts** and create prompts.
 
-2) Run the scheduler (example: once per minute):
+2) Run an external worker (example: once):
 
 ```bash
-node scripts/recurring-prompts-scheduler.js --once
-# or loop
-node scripts/recurring-prompts-scheduler.js --loopSeconds 60
+python3 scripts/recurring_prompts_worker.py \
+  --base-url http://127.0.0.1:5173 \
+  --admin-password "$CLAWNSOLE_ADMIN_PASSWORD" \
+  --once
 ```
 
-Prompts are stored in `~/.openclaw/clawnsole-recurring-prompts*.json` (instance-aware).
+Loop mode is default (`--loop-seconds 60`).
+
+See full worker docs + launchd/systemd examples: [`docs/RECURRING_PROMPTS_WORKER.md`](./docs/RECURRING_PROMPTS_WORKER.md)

--- a/docs/RECURRING_PROMPTS_WORKER.md
+++ b/docs/RECURRING_PROMPTS_WORKER.md
@@ -1,0 +1,98 @@
+# Recurring Prompts External Worker (Python)
+
+This worker runs outside OpenClaw Gateway scheduling. It logs into Clawnsole, polls recurring prompts, filters due slots, and asks Clawnsole to trigger each delivery with a deterministic idempotency key per slot.
+
+## API contract expected
+
+- `POST /auth/login`
+  - Body: `{ password }`
+  - Returns the admin auth cookie used by later calls
+- `GET /api/recurring-prompts`
+  - Returns `{ ok: true, prompts: [{ id, agentId, message, nextRunAt, enabled? }, ...] }`
+- `POST /api/recurring-prompts/:id/trigger`
+  - Body: `{ scheduledAt, idempotencyKey, deviceLabel, dryRun? }`
+  - Returns `{ ok: true, ... }`
+
+## Run manually
+
+```bash
+python3 scripts/recurring_prompts_worker.py \
+  --base-url http://127.0.0.1:5173 \
+  --admin-password "$CLAWNSOLE_ADMIN_PASSWORD" \
+  --once
+```
+
+If a caller already has an admin cookie, pass `--cookie "$CLAWNSOLE_ADMIN_COOKIE"` instead of `--admin-password`.
+
+Loop mode (default) runs every `--loop-seconds` (default 60s).
+
+## Flags / env
+
+- `--base-url` / `CLAWNSOLE_BASE_URL`
+- `--admin-password` / `CLAWNSOLE_ADMIN_PASSWORD`
+- `--cookie` / `CLAWNSOLE_ADMIN_COOKIE`
+- `--loop-seconds`
+- `--timeout`
+- `--retries`
+- `--backoff`
+- `--max-backoff`
+- `--once`
+- `--dry-run`
+
+## systemd example
+
+`/etc/systemd/system/clawnsole-recurring-worker.service`
+
+```ini
+[Unit]
+Description=Clawnsole recurring prompts worker
+After=network-online.target
+
+[Service]
+Type=simple
+Environment=CLAWNSOLE_BASE_URL=http://127.0.0.1:5173
+Environment=CLAWNSOLE_ADMIN_PASSWORD=replace-with-admin-password
+WorkingDirectory=/opt/clawnsole
+ExecStart=/usr/bin/python3 /opt/clawnsole/scripts/recurring_prompts_worker.py --loop-seconds 60
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## launchd (macOS) example
+
+`~/Library/LaunchAgents/com.clawnsole.recurring-worker.plist`
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key><string>com.clawnsole.recurring-worker</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>/usr/bin/python3</string>
+      <string>/Users/you/src/dev/clawnsole/scripts/recurring_prompts_worker.py</string>
+      <string>--loop-seconds</string><string>60</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>CLAWNSOLE_BASE_URL</key><string>http://127.0.0.1:5173</string>
+      <key>CLAWNSOLE_ADMIN_PASSWORD</key><string>replace-with-admin-password</string>
+    </dict>
+    <key>RunAtLoad</key><true/>
+    <key>KeepAlive</key><true/>
+    <key>StandardOutPath</key><string>/tmp/clawnsole-recurring-worker.log</string>
+    <key>StandardErrorPath</key><string>/tmp/clawnsole-recurring-worker.err.log</string>
+  </dict>
+</plist>
+```
+
+Load:
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.clawnsole.recurring-worker.plist 2>/dev/null || true
+launchctl load ~/Library/LaunchAgents/com.clawnsole.recurring-worker.plist
+```

--- a/tests/unit/test_recurring_prompts_worker.py
+++ b/tests/unit/test_recurring_prompts_worker.py
@@ -1,0 +1,91 @@
+import importlib.util
+import pathlib
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+MODULE_PATH = pathlib.Path(__file__).resolve().parents[2] / "scripts" / "recurring_prompts_worker.py"
+spec = importlib.util.spec_from_file_location("recurring_prompts_worker", MODULE_PATH)
+worker = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = worker
+spec.loader.exec_module(worker)
+
+
+def args(**overrides):
+    values = {
+        "base_url": "http://127.0.0.1:5173",
+        "admin_password": "",
+        "cookie": "clawnsole_auth=test",
+        "timeout": 15,
+        "retries": 2,
+        "backoff": 1.0,
+        "max_backoff": 10.0,
+        "dry_run": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+class RecurringPromptsWorkerTests(unittest.TestCase):
+    def test_trigger_prompt_uses_stable_idempotency_key_for_scheduled_slot(self):
+        calls = []
+
+        def fake_request(base_url, method, path, *, data=None, headers=None, timeout=15):
+            calls.append((base_url, method, path, data, headers, timeout))
+            return 200, {"ok": True}, {}
+
+        prompt = {"id": "p1", "nextRunAt": 1234}
+        with mock.patch.object(worker, "_json_request", side_effect=fake_request):
+            result = worker._trigger_prompt("http://clawnsole", "cookie=1", prompt, 9999, 15, True)
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(calls[0][2], "/api/recurring-prompts/p1/trigger")
+        self.assertEqual(calls[0][3]["scheduledAt"], 1234)
+        self.assertEqual(calls[0][3]["idempotencyKey"], "p1:1234")
+        self.assertEqual(calls[0][3]["dryRun"], True)
+        self.assertEqual(calls[0][4]["Idempotency-Key"], "p1:1234")
+
+    def test_run_once_filters_due_prompts_and_skips_future_disabled(self):
+        prompts = [
+            {"id": "due", "enabled": True, "nextRunAt": 1_700_000_000_000},
+            {"id": "future", "enabled": True, "nextRunAt": 1_700_000_060_000},
+            {"id": "disabled", "enabled": False, "nextRunAt": 1_700_000_000_000},
+        ]
+        triggered = []
+
+        def fake_trigger(base_url, cookie, prompt, now_ms, timeout, dry_run):
+            triggered.append(prompt["id"])
+            return {"ok": True, "duplicate": False}
+
+        with (
+            mock.patch.object(worker.time, "time", return_value=1_700_000_030),
+            mock.patch.object(worker, "_load_prompts", return_value=prompts),
+            mock.patch.object(worker, "_trigger_prompt", side_effect=fake_trigger),
+        ):
+            result = worker.run_once(args())
+
+        self.assertEqual(result["ok"], True)
+        self.assertEqual(result["due"], 1)
+        self.assertEqual(result["delivered"], 1)
+        self.assertEqual(triggered, ["due"])
+
+    def test_run_once_retries_failed_trigger_then_succeeds(self):
+        outcomes = [{"ok": False, "error": "bad gateway", "status": 502}, {"ok": True, "duplicate": True}]
+
+        with (
+            mock.patch.object(worker, "_load_prompts", return_value=[{"id": "due", "nextRunAt": 1}]),
+            mock.patch.object(worker, "_trigger_prompt", side_effect=lambda *a: outcomes.pop(0)),
+            mock.patch.object(worker.time, "sleep") as sleep_mock,
+        ):
+            result = worker.run_once(args(retries=1, backoff=0.25))
+
+        self.assertEqual(result["ok"], True)
+        self.assertEqual(result["delivered"], 1)
+        self.assertEqual(result["duplicates"], 1)
+        sleep_mock.assert_called_once_with(0.25)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- document the external recurring prompt worker runbook, auth options, and launchd/systemd examples
- add Python unit coverage for stable per-slot idempotency keys, due-prompt filtering, and retry behavior
- link the README recurring prompt section to the detailed worker docs

Completes follow-up coverage for #208 after the upstream worker/trigger implementation landed on main.

## Tests
- npm test
- python3 -m unittest tests/unit/test_recurring_prompts_worker.py
