### PR TITLE
Guard admin launch shortcuts while typing

### DIFF
--- a/app.js
+++ b/app.js
@@ -7784,20 +7784,6 @@ window.addEventListener('keydown', (event) => {
     }
   }
 
-  // Cmd/Ctrl+P opens Pane Manager (even while typing).
-  if ((event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey && String(event.key || '').toLowerCase() === 'p') {
-    event.preventDefault();
-    openPaneManager();
-    return;
-  }
-
-  // Cmd/Ctrl+K opens command palette (even while typing).
-  if ((event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey && String(event.key || '').toLowerCase() === 'k') {
-    event.preventDefault();
-    openCommandPalette();
-    return;
-  }
-
   if (event.key === 'Escape') {
     closeCommandPalette();
     closePaneManager();
@@ -7815,6 +7801,20 @@ window.addEventListener('keydown', (event) => {
   if (isTypingContext(event.target)) return;
 
   const key = String(event.key || '');
+
+  // Cmd/Ctrl+P opens Pane Manager.
+  if ((event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey && key.toLowerCase() === 'p') {
+    event.preventDefault();
+    openPaneManager();
+    return;
+  }
+
+  // Cmd/Ctrl+K opens command palette.
+  if ((event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey && key.toLowerCase() === 'k') {
+    event.preventDefault();
+    openCommandPalette();
+    return;
+  }
 
   // Ctrl+Tab walks panes in most-recently-used order; Shift reverses the traversal.
   if (event.ctrlKey && !event.metaKey && !event.altKey && key === 'Tab') {

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -229,6 +229,39 @@ test('add-pane shortcuts do not fire while typing in chat input', async ({ page 
   await expect(panes).toHaveCount(2);
 });
 
+test('admin launch shortcuts do not fire while typing in chat input', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const input = page.locator('[data-pane][data-pane-kind="chat"] [data-pane-input]').first();
+  const shortcutsModal = page.locator('#shortcutsModal');
+  const workqueueModal = page.locator('#workqueueModal');
+  const commandPaletteModal = page.getByTestId('command-palette-modal');
+  const paneManagerModal = page.getByTestId('pane-manager-modal');
+
+  await input.focus();
+  await input.fill('typing');
+  await expect(input).toBeFocused();
+
+  await page.keyboard.press('Shift+/');
+  await page.keyboard.press('g');
+  await page.keyboard.press('w');
+  await page.keyboard.press('ControlOrMeta+K');
+  await page.keyboard.press('ControlOrMeta+P');
+
+  await expect(shortcutsModal).toHaveAttribute('aria-hidden', 'true');
+  await expect(workqueueModal).toHaveAttribute('aria-hidden', 'true');
+  await expect(commandPaletteModal).toHaveAttribute('aria-hidden', 'true');
+  await expect(paneManagerModal).toHaveAttribute('aria-hidden', 'true');
+});
+
 test('fleet quick action button + keyboard shortcut focus existing timeline pane without duplicates', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!app?.skipReason, app?.skipReason);


### PR DESCRIPTION
## Summary
- keep Cmd/Ctrl+K and Cmd/Ctrl+P behind the typing-context guard
- add Playwright coverage for ?, g w, Cmd/Ctrl+K, and Cmd/Ctrl+P while focused in a chat input

## Tests
- npx playwright test tests/pane.shortcuts.e2e.spec.js -g "admin launch shortcuts do not fire|add-pane shortcuts do not fire|shortcuts overlay"

Closes #167