### PR TITLE
Add pane activity badges

### DIFF
--- a/app.js
+++ b/app.js
@@ -1803,17 +1803,49 @@ function clearPaneUnread(pane) {
   if (!pane) return;
   if (!pane.unreadCount) return;
   pane.unreadCount = 0;
+  pane.unreadKind = '';
   renderPaneIdentity(pane);
+  renderPaneActivityBadge(pane);
   if (isPaneManagerOpen()) renderPaneManager();
 }
 
-function markPaneUnread(pane, increment = 1) {
+function unreadKindLabel(kind) {
+  const k = String(kind || '').trim().toLowerCase();
+  if (k === 'workqueue') return 'workqueue update';
+  if (k === 'activity') return 'activity update';
+  return 'chat message';
+}
+
+function renderPaneActivityBadge(pane) {
+  const badge = pane?.elements?.activityBadge;
+  if (!badge) return;
+
+  const count = paneUnreadCount(pane);
+  if (count <= 0) {
+    badge.hidden = true;
+    badge.textContent = '•';
+    badge.setAttribute('aria-label', 'No unread activity');
+    badge.title = 'No unread activity';
+    return;
+  }
+
+  const kindLabel = unreadKindLabel(pane?.unreadKind);
+  const countLabel = `${count} unread ${kindLabel}${count === 1 ? '' : 's'}`;
+  badge.hidden = false;
+  badge.textContent = count > 99 ? '99+' : String(count);
+  badge.setAttribute('aria-label', countLabel);
+  badge.title = countLabel;
+}
+
+function markPaneUnread(pane, increment = 1, kind = 'chat') {
   if (!pane) return;
   const activeKey = focusedPaneKey();
   if (activeKey && activeKey === pane.key) return;
   const next = paneUnreadCount(pane) + Math.max(1, Number(increment || 1));
   pane.unreadCount = next;
+  pane.unreadKind = String(kind || 'activity');
   renderPaneIdentity(pane);
+  renderPaneActivityBadge(pane);
   if (isPaneManagerOpen()) renderPaneManager();
 }
 
@@ -3532,7 +3564,18 @@ async function fetchAndRenderWorkqueueItemsForPane(pane) {
     if (!res.ok) throw new Error(String(res.status));
     const data = await res.json();
     const items = Array.isArray(data.items) ? data.items : [];
+    const previousSignature = pane.workqueue.itemsSignature || '';
+    const nextSignature = JSON.stringify(items.map((it) => [
+      it?.id || '',
+      it?.status || '',
+      it?.updatedAt || '',
+      it?.title || ''
+    ]));
     pane.workqueue.items = items;
+    pane.workqueue.itemsSignature = nextSignature;
+    if (previousSignature && previousSignature !== nextSignature) {
+      markPaneUnread(pane, 1, 'workqueue');
+    }
     if (statusLine) statusLine.textContent = `${items.length} item(s)`;
     renderWorkqueuePaneItems(pane);
   } catch (err) {
@@ -4445,8 +4488,8 @@ function paneAddChatMessage(pane, { role, text, runId, streaming = false, persis
   }
 
   pane.elements.thread.appendChild(bubble);
-  if (role === 'assistant') {
-    markPaneUnread(pane, 1);
+  if (role === 'assistant' && !streaming) {
+    markPaneUnread(pane, 1, 'chat');
   }
   pane.scroll.pinned = shouldPin;
   scrollToBottom(pane);
@@ -4476,7 +4519,7 @@ function paneUpdateChatRun(pane, runId, text, done) {
     return;
   }
   if (done) {
-    markPaneUnread(pane, 1);
+    markPaneUnread(pane, 1, 'chat');
   }
   const shouldPin = pane.scroll.pinned || isNearBottom(pane.elements.thread);
   entry.pendingText = text || '';
@@ -5516,6 +5559,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     agentLabel: root.querySelector('[data-pane-agent-label]'),
     agentWarning: root.querySelector('[data-pane-agent-warning]'),
     status: root.querySelector('[data-pane-status]'),
+    activityBadge: root.querySelector('[data-pane-activity-badge]'),
     helpDetails: root.querySelector('[data-pane-help]'),
     helpPopover: root.querySelector('[data-pane-help-popover]'),
     closeBtn: root.querySelector('[data-pane-close]'),
@@ -5564,6 +5608,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     elements,
     chat: { runs: new Map(), history: [] },
     unreadCount: 0,
+    unreadKind: '',
     scroll: { pinned: true },
     thinking: { active: false, timer: null, dotsTimer: null, bubble: null },
     activeRunId: null,
@@ -5693,6 +5738,11 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     notePaneFocused(pane);
     clearPaneUnread(pane);
   });
+  elements.root?.addEventListener('pointerdown', () => {
+    notePaneFocused(pane);
+    clearPaneUnread(pane);
+  });
+  renderPaneActivityBadge(pane);
 
   // WORKQUEUE PANE
   if (pane.role === 'admin' && pane.kind === 'workqueue') {

--- a/index.html
+++ b/index.html
@@ -114,6 +114,7 @@
                   <div class="pane-help-popover" data-pane-help-popover></div>
                 </details>
 
+                <div class="pane-activity-badge" data-pane-activity-badge data-testid="pane-activity-badge" hidden aria-live="polite" aria-label="No unread activity">•</div>
                 <div class="status-pill pane-status" data-pane-status data-testid="pane-connection-status">disconnected</div>
                 <button class="icon-btn pane-close" data-pane-close type="button" aria-label="Close pane" data-testid="pane-close">
                   ✕

--- a/styles.css
+++ b/styles.css
@@ -681,6 +681,26 @@ body::before {
   gap: 10px;
 }
 
+.pane-activity-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 7px;
+  border-radius: 999px;
+  border: 1px solid rgba(239, 68, 68, 0.45);
+  background: rgba(239, 68, 68, 0.14);
+  color: #fecaca;
+  font-size: 11px;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.pane-activity-badge[hidden] {
+  display: none !important;
+}
+
 .pane-help {
   position: relative;
 }

--- a/tests/ui/chat-pane.spec.js
+++ b/tests/ui/chat-pane.spec.js
@@ -78,6 +78,34 @@ test('chat pane: stop button can cancel a running response', async ({ page }) =>
   await expect(pane.locator('.chat-bubble.assistant')).not.toContainText('mock-reply: please stream this', { timeout: 3000 });
 });
 
+test('chat pane: unread badge appears on inactive pane and clears on focus', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Chat pane');
+
+  const panes = page.locator('[data-pane][data-pane-kind="chat"]');
+  const firstPane = panes.first();
+  const secondPane = panes.nth(1);
+
+  await firstPane.locator('[data-pane-input]').fill('badge check');
+  await firstPane.locator('[data-pane-send]').click();
+
+  await secondPane.locator('[data-pane-input]').focus();
+  await expect(firstPane.locator('[data-chat-role="assistant"]').last()).toContainText('mock-reply: badge check', { timeout: 10000 });
+
+  const firstBadge = firstPane.locator('[data-pane-activity-badge]');
+  await expect(firstBadge).toBeVisible();
+  await expect(firstBadge).toHaveText('1');
+  await expect(firstBadge).toHaveAttribute('aria-label', /unread chat message/);
+
+  await firstPane.locator('[data-pane-input]').focus();
+  await expect(firstBadge).toBeHidden();
+});
+
 test('topbar workqueue action reuses paired pane for active chat target and falls back to modal', async ({ page }) => {
   test.setTimeout(120000);
   test.skip(!!env?.skipReason, env?.skipReason);


### PR DESCRIPTION
Fixes #193.\n\n## Summary\n- Add visible per-pane activity badges in pane headers backed by existing unread pane state.\n- Keep Pane Manager unread counts in sync while making badge labels type-aware for chat and workqueue updates.\n- Clear unread indicators on focus or direct pane interaction.\n\n## Verification\n- npm test\n- npx playwright test tests/ui/chat-pane.spec.js -g "unread badge" --workers=1\n\n🚢