### PR TITLE
Group repetitive workqueue rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ See also:
 Clawnsole's workqueue supports assigning agents to queues, and letting `claim-next`
 resolve queues automatically when you omit them.
 
+The workqueue pane groups similar routine rows by default when the visible list has
+more than 20 items. Grouping prefers stable dedupe-key prefixes and falls back to
+normalized title prefixes; use the "Group similar" checkbox in the pane toolbar to
+show every row individually.
+
 ### Defaults
 
 - `CLAWNSOLE_DEFAULT_QUEUES` (comma-separated, default: `dev-team`)

--- a/app.js
+++ b/app.js
@@ -109,6 +109,8 @@ const fmtRemaining = __appCore.fmtRemaining || ((msUntil) => {
   return `${sec}s`;
 });
 const sortWorkqueueItems = __appCore.sortWorkqueueItems || ((items, opts) => (Array.isArray(items) ? items.slice() : []));
+const DEFAULT_WORKQUEUE_GROUP_THRESHOLD = __appCore.DEFAULT_WORKQUEUE_GROUP_THRESHOLD || 20;
+const buildWorkqueueGroupRows = __appCore.buildWorkqueueGroupRows || ((items) => (Array.isArray(items) ? items.map((item) => ({ type: 'item', item })) : []));
 const inferPaneCols = __appCore.inferPaneCols || ((count) => {
   const n = Number(count);
   if (!Number.isFinite(n) || n <= 1) return 1;
@@ -3601,6 +3603,12 @@ function renderWorkqueuePaneItems(pane) {
   });
   const filteredItems = applyWorkqueueQuickFilters(scopedItems, pane.workqueue?.quickFilters);
   const items = sortWorkqueueItems(filteredItems, { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
+  const rows = buildWorkqueueGroupRows(items, {
+    enabled: pane.workqueue?.groupingEnabled !== false,
+    threshold: DEFAULT_WORKQUEUE_GROUP_THRESHOLD,
+    expandedKeys: pane.workqueue?.expandedGroupKeys,
+    now: Date.now()
+  });
 
   if (empty) {
     const hasItems = items.length > 0;
@@ -3636,10 +3644,12 @@ function renderWorkqueuePaneItems(pane) {
   }
 
   const now = Date.now();
-  for (const it of items) {
+  const expandedGroups = new Set(Array.isArray(pane.workqueue?.expandedGroupKeys) ? pane.workqueue.expandedGroupKeys.map(String) : []);
+  const renderItemRow = (it, { groupChild = false } = {}) => {
     const row = document.createElement('button');
     row.type = 'button';
     row.className = 'wq-row';
+    if (groupChild) row.classList.add('wq-row-group-child');
     if (it.id && it.id === pane.workqueue.selectedItemId) row.classList.add('selected');
 
     const leaseMs = it.leaseUntil ? Number(it.leaseUntil) - now : NaN;
@@ -3659,6 +3669,44 @@ function renderWorkqueuePaneItems(pane) {
       pane.workqueue.selectedItemId = it.id || null;
       renderWorkqueuePaneItems(pane);
       renderWorkqueuePaneInspect(pane, it);
+    });
+
+    body.appendChild(row);
+  };
+
+  for (const rowData of rows) {
+    if (rowData?.type !== 'group') {
+      renderItemRow(rowData?.item || rowData, { groupChild: !!rowData?.groupKey });
+      continue;
+    }
+
+    const group = rowData;
+    const row = document.createElement('button');
+    row.type = 'button';
+    row.className = 'wq-row wq-row-group';
+    row.setAttribute('data-wq-group-row', group.key);
+    row.setAttribute('aria-expanded', group.expanded ? 'true' : 'false');
+
+    const leaseMs = group.leaseUntil ? Number(group.leaseUntil) - now : NaN;
+    const leaseLabel = group.leaseUntil ? fmtRemaining(leaseMs) : '';
+    const status = String(group.status || 'mixed');
+    const statusText = `${status} / ${group.count}`;
+
+    row.innerHTML = `
+      <div class="wq-col title"><span class="wq-group-caret">${group.expanded ? '▾' : '▸'}</span>${escapeHtml(group.title)} <span class="wq-count-badge mono">×${escapeHtml(String(group.count))}</span></div>
+      <div class="wq-col status"><span class="wq-badge wq-badge-${escapeHtml(status)}">${escapeHtml(statusText)}</span></div>
+      <div class="wq-col prio mono">${escapeHtml(String(group.priority ?? ''))}</div>
+      <div class="wq-col attempts mono">${escapeHtml(String(group.attempts ?? ''))}</div>
+      <div class="wq-col claimedBy">${escapeHtml(String(group.claimedBy || ''))}</div>
+      <div class="wq-col lease mono" data-lease-until="${escapeHtml(String(group.leaseUntil || ''))}">${escapeHtml(leaseLabel)}</div>
+    `;
+
+    row.addEventListener('click', () => {
+      if (expandedGroups.has(group.key)) expandedGroups.delete(group.key);
+      else expandedGroups.add(group.key);
+      pane.workqueue.expandedGroupKeys = Array.from(expandedGroups);
+      renderWorkqueuePaneItems(pane);
+      paneManager.persistAdminPanes();
     });
 
     body.appendChild(row);
@@ -5543,7 +5591,7 @@ function renderAgentOptions(selectEl, agentId) {
   selectEl.value = normalizeAgentId(agentId || 'main');
 }
 
-function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, scopeFilter, quickFilters, sortKey, sortDir, cronAgentId, closable = true } = {}) {
+function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, scopeFilter, quickFilters, sortKey, sortDir, groupingEnabled, expandedGroupKeys, cronAgentId, closable = true } = {}) {
   const template = globalElements.paneTemplate;
   const root = template.content.firstElementChild.cloneNode(true);
   const elements = {
@@ -5599,7 +5647,9 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       items: [],
       selectedItemId: null,
       sortKey: typeof sortKey === 'string' && sortKey.trim() ? sortKey.trim() : 'priority',
-      sortDir: sortDir === 'asc' ? 'asc' : 'desc'
+      sortDir: sortDir === 'asc' ? 'asc' : 'desc',
+      groupingEnabled: groupingEnabled !== false,
+      expandedGroupKeys: Array.isArray(expandedGroupKeys) ? expandedGroupKeys.map(String).filter(Boolean) : []
     },
     cronAgentId: typeof cronAgentId === 'string' ? cronAgentId.trim() : '',
     connected: false,
@@ -5822,6 +5872,11 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
             <button type="button" class="wq-sort-btn" data-wq-sort="updatedAt">Updated</button>
             <button type="button" class="wq-sort-btn" data-wq-sort="createdAt">Created</button>
           </div>
+
+          <label class="wq-group-toggle">
+            <input data-wq-group-toggle type="checkbox" ${pane.workqueue.groupingEnabled !== false ? 'checked' : ''} />
+            <span>Group similar</span>
+          </label>
         </div>
 
         <details class="wq-enqueue">
@@ -5918,6 +5973,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     const clawnsoleOnlyBtn = elements.thread.querySelector('[data-wq-preset-clawnsole]');
     const clearQuickBtn = elements.thread.querySelector('[data-wq-clear-quick]');
     const refreshBtn = elements.thread.querySelector('[data-wq-refresh]');
+    const groupToggleEl = elements.thread.querySelector('[data-wq-group-toggle]');
 
     const DEFAULT_STATUSES = ['ready', 'pending', 'claimed', 'in_progress'];
 
@@ -6259,6 +6315,13 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       btn.addEventListener('click', () => setSort(btn.getAttribute('data-wq-sort')));
     });
     updateSortUi();
+
+    groupToggleEl?.addEventListener('change', () => {
+      pane.workqueue.groupingEnabled = !!groupToggleEl.checked;
+      if (!pane.workqueue.groupingEnabled) pane.workqueue.expandedGroupKeys = [];
+      renderWorkqueuePaneItems(pane);
+      paneManager.persistAdminPanes();
+    });
 
     // Enqueue assignment target picker (searchable + recent targets).
     const claimAgentPicker = elements.thread.querySelector('[data-wq-claim-agent-picker]');
@@ -7049,7 +7112,9 @@ const paneManager = {
           };
           const sortKey = typeof item.sortKey === 'string' ? item.sortKey : 'priority';
           const sortDir = item.sortDir === 'asc' ? 'asc' : 'desc';
-          return { key, kind, agentId, queue, statusFilter, scopeFilter, quickFilters, sortKey, sortDir };
+          const groupingEnabled = item.groupingEnabled !== false;
+          const expandedGroupKeys = Array.isArray(item.expandedGroupKeys) ? item.expandedGroupKeys.map((s) => String(s || '').trim()).filter(Boolean) : [];
+          return { key, kind, agentId, queue, statusFilter, scopeFilter, quickFilters, sortKey, sortDir, groupingEnabled, expandedGroupKeys };
         }
         if (kind === 'cron' || kind === 'timeline') {
           return { key, kind };
@@ -7096,7 +7161,9 @@ const paneManager = {
             repos: Array.isArray(pane.workqueue?.quickFilters?.repos) ? pane.workqueue.quickFilters.repos : []
           },
           sortKey: pane.workqueue?.sortKey || 'priority',
-          sortDir: pane.workqueue?.sortDir || 'desc'
+          sortDir: pane.workqueue?.sortDir || 'desc',
+          groupingEnabled: pane.workqueue?.groupingEnabled !== false,
+          expandedGroupKeys: Array.isArray(pane.workqueue?.expandedGroupKeys) ? pane.workqueue.expandedGroupKeys : []
         };
       }
       if (pane.kind === 'cron' || pane.kind === 'timeline') {

--- a/lib/app-core.js
+++ b/lib/app-core.js
@@ -121,6 +121,118 @@
       .map((x) => x.it);
   }
 
+  const DEFAULT_WORKQUEUE_GROUP_THRESHOLD = 20;
+
+  function normalizeWorkqueueGroupText(value) {
+    return String(value || '')
+      .toLowerCase()
+      .replace(/\[[^\]]+\]/g, ' ')
+      .replace(/https?:\/\/\S+/g, ' ')
+      .replace(/\b\d{4}-\d{2}-\d{2}(?:[t ][0-9:.+-z]*)?\b/gi, ' ')
+      .replace(/\b\d{1,2}:\d{2}(?::\d{2})?\b/g, ' ')
+      .replace(/\b\d+\b/g, ' ')
+      .replace(/\b(?:mon|tue|wed|thu|fri|sat|sun)\w*\b/g, ' ')
+      .replace(/\b(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\w*\b/g, ' ')
+      .replace(/[^\w#/-]+/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  function workqueueGroupSignature(item) {
+    const dedupeKey = normalizeWorkqueueGroupText(item?.dedupeKey || item?.meta?.dedupeKey || '');
+    if (dedupeKey) {
+      const stableDedupe = dedupeKey
+        .replace(/[:/_-]?\b\d{4}\b.*$/, '')
+        .replace(/[:/_-]?\b\d{8,}\b.*$/, '')
+        .replace(/\s+/g, ' ')
+        .trim();
+      if (stableDedupe) return `dedupe:${stableDedupe}`;
+      return `dedupe:${dedupeKey}`;
+    }
+
+    const normalizedTitle = normalizeWorkqueueGroupText(item?.title || '');
+    if (!normalizedTitle) return '';
+    const prefix = normalizedTitle.split(/\s+/).slice(0, 6).join(' ');
+    return prefix ? `title:${prefix}` : '';
+  }
+
+  function buildWorkqueueGroupRows(items, { enabled = false, threshold = DEFAULT_WORKQUEUE_GROUP_THRESHOLD, expandedKeys = [], now = Date.now() } = {}) {
+    const sourceItems = Array.isArray(items) ? items : [];
+    const expanded = new Set(Array.isArray(expandedKeys) ? expandedKeys.map(String) : []);
+    const shouldGroup = !!enabled && sourceItems.length > Number(threshold || 0);
+    if (!shouldGroup) return sourceItems.map((item) => ({ type: 'item', item }));
+
+    const buckets = new Map();
+    const order = [];
+    for (const item of sourceItems) {
+      const signature = workqueueGroupSignature(item);
+      if (!signature) {
+        order.push({ type: 'item', item });
+        continue;
+      }
+      if (!buckets.has(signature)) {
+        buckets.set(signature, []);
+        order.push({ type: 'bucket', signature });
+      }
+      buckets.get(signature).push(item);
+    }
+
+    const numOr0 = (v) => (Number.isFinite(Number(v)) ? Number(v) : 0);
+    const timeOr0 = (v) => {
+      const n = Date.parse(String(v || ''));
+      return Number.isFinite(n) ? n : 0;
+    };
+    const signalRank = (item) => {
+      const lease = Number(item?.leaseUntil || 0);
+      if (lease > 0 && lease <= now) return 0;
+      const status = String(item?.status || '');
+      if (status === 'in_progress') return 1;
+      if (status === 'claimed') return 2;
+      if (status === 'failed') return 3;
+      if (status === 'ready') return 4;
+      if (status === 'pending') return 5;
+      if (status === 'done') return 6;
+      return 7;
+    };
+    const signalLabel = (item) => {
+      const lease = Number(item?.leaseUntil || 0);
+      if (lease > 0 && lease <= now) return 'expired';
+      return String(item?.status || '');
+    };
+
+    return order.flatMap((entry) => {
+      if (entry.type === 'item') return [{ type: 'item', item: entry.item }];
+      const bucketItems = buckets.get(entry.signature) || [];
+      if (bucketItems.length <= 1) return bucketItems.map((item) => ({ type: 'item', item }));
+
+      const sortedBySignal = bucketItems.slice().sort((a, b) => (
+        signalRank(a) - signalRank(b) ||
+        numOr0(b.priority) - numOr0(a.priority) ||
+        timeOr0(b.updatedAt || b.createdAt) - timeOr0(a.updatedAt || a.createdAt)
+      ));
+      const newest = bucketItems.reduce((best, item) => (
+        timeOr0(item?.updatedAt || item?.createdAt) > timeOr0(best?.updatedAt || best?.createdAt) ? item : best
+      ), bucketItems[0]);
+      const representative = sortedBySignal[0] || bucketItems[0];
+      const group = {
+        type: 'group',
+        key: entry.signature,
+        expanded: expanded.has(entry.signature),
+        items: bucketItems,
+        count: bucketItems.length,
+        title: String(representative?.title || 'Grouped workqueue items'),
+        status: signalLabel(representative),
+        priority: Math.max(...bucketItems.map((item) => numOr0(item?.priority))),
+        attempts: bucketItems.reduce((sum, item) => sum + numOr0(item?.attempts), 0),
+        claimedBy: Array.from(new Set(bucketItems.map((item) => String(item?.claimedBy || '').trim()).filter(Boolean))).join(', '),
+        leaseUntil: representative?.leaseUntil || '',
+        updatedAt: newest?.updatedAt || newest?.createdAt || '',
+        representative
+      };
+      return group.expanded ? [group, ...bucketItems.map((item) => ({ type: 'item', item, groupKey: entry.signature }))] : [group];
+    });
+  }
+
   function inferPaneCols(count) {
     const n = Number(count);
     if (!Number.isFinite(n) || n <= 1) return 1;
@@ -363,6 +475,10 @@
     escapeHtml,
     fmtRemaining,
     sortWorkqueueItems,
+    DEFAULT_WORKQUEUE_GROUP_THRESHOLD,
+    normalizeWorkqueueGroupText,
+    workqueueGroupSignature,
+    buildWorkqueueGroupRows,
     inferPaneCols,
     normalizePaneKind,
     normalizeAdminDestination,

--- a/styles.css
+++ b/styles.css
@@ -1846,8 +1846,20 @@ kbd {
 .wq-pane .wq-field,
 .wq-pane .wq-scope,
 .wq-pane .wq-sort,
+.wq-pane .wq-group-toggle,
 .wq-pane .wq-toolbar-row > button {
   flex: 0 0 auto;
+}
+
+.wq-group-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 34px;
+  padding: 0 10px;
+  color: var(--muted);
+  font-size: 12px;
+  white-space: nowrap;
 }
 
 .wq-status-field {
@@ -2308,6 +2320,34 @@ kbd {
 
 .wq-row.selected {
   background: rgba(127, 209, 185, 0.12);
+}
+
+.wq-row-group {
+  background: rgba(127, 209, 185, 0.07);
+  border-left: 3px solid rgba(127, 209, 185, 0.55);
+  font-weight: 600;
+}
+
+.wq-row-group-child {
+  padding-left: 24px;
+  background: rgba(255, 255, 255, 0.015);
+}
+
+.wq-group-caret {
+  display: inline-flex;
+  width: 16px;
+  color: var(--muted);
+}
+
+.wq-count-badge {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 6px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: rgba(127, 209, 185, 0.16);
+  color: var(--text);
+  font-size: 11px;
 }
 
 .wq-col {

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -231,6 +231,56 @@ test('workqueue pane: source chips + clawnsole preset filter items without reloa
   await expect(pane.locator('.wq-row .wq-col.title')).toContainText(/clawnsole issue item/i);
 });
 
+test('workqueue pane: groups repetitive routine rows and expands in place', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  const queue = `routine-group-${Date.now()}`;
+  await page.evaluate(async ({ queue }) => {
+    for (let idx = 0; idx < 21; idx += 1) {
+      const res = await fetch('/api/workqueue/enqueue', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          queue,
+          title: `PR review sweep ${idx}`,
+          instructions: 'routine check',
+          priority: idx === 10 ? 50 : 1,
+          dedupeKey: `pr-review:2026-06-${String(idx + 1).padStart(2, '0')}T00`
+        })
+      });
+      if (!res.ok) throw new Error(`enqueue failed ${res.status}`);
+    }
+  }, { queue });
+
+  const pane = page.locator('[data-pane]').last();
+  await pane.locator('[data-wq-scope="all"]').click();
+  await pane.locator('[data-wq-queue-select]').selectOption('__custom__');
+  await pane.locator('[data-wq-queue-custom]').fill(queue);
+  await pane.locator('[data-wq-queue-custom]').press('Enter');
+  await pane.locator('[data-wq-refresh]').click();
+
+  const rows = pane.locator('[data-wq-list-body] .wq-row');
+  await expect(pane.locator('[data-wq-group-row]')).toHaveCount(1);
+  await expect(rows).toHaveCount(1);
+  await expect(pane.locator('[data-wq-group-row] .wq-count-badge')).toHaveText('×21');
+
+  await pane.locator('[data-wq-group-row]').click();
+  await expect(pane.locator('[data-wq-group-row]')).toHaveAttribute('aria-expanded', 'true');
+  await expect(rows).toHaveCount(22);
+  await expect(pane.locator('.wq-row-group-child')).toHaveCount(21);
+
+  await pane.locator('[data-wq-group-toggle]').uncheck();
+  await expect(pane.locator('[data-wq-group-row]')).toHaveCount(0);
+  await expect(rows).toHaveCount(21);
+});
+
 test('workqueue pane: controls toolbar is sticky and list scrolls independently', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);

--- a/tests/unit/app-core.test.js
+++ b/tests/unit/app-core.test.js
@@ -5,6 +5,8 @@ const {
   escapeHtml,
   fmtRemaining,
   sortWorkqueueItems,
+  buildWorkqueueGroupRows,
+  DEFAULT_WORKQUEUE_GROUP_THRESHOLD,
   inferPaneCols,
   normalizePaneKind,
   normalizeAdminDestination,
@@ -95,6 +97,41 @@ test('sortWorkqueueItems priority sort uses updatedAt desc tie-breaker', () => {
 
   const sorted = sortWorkqueueItems(items, { sortKey: 'priority', sortDir: 'desc' });
   assert.deepEqual(sorted.map((it) => it.id), ['c', 'b', 'a']);
+});
+
+test('buildWorkqueueGroupRows collapses repetitive rows only past the documented threshold', () => {
+  const items = Array.from({ length: DEFAULT_WORKQUEUE_GROUP_THRESHOLD + 1 }, (_, idx) => ({
+    id: `routine-${idx}`,
+    title: `PR review sweep ${idx}`,
+    dedupeKey: `pr-review:2026-06-${String(idx + 1).padStart(2, '0')}T00`,
+    status: idx === 2 ? 'claimed' : 'ready',
+    priority: idx === 5 ? 99 : idx,
+    updatedAt: `2026-06-${String((idx % 9) + 1).padStart(2, '0')}T00:00:00Z`
+  }));
+
+  const belowThreshold = buildWorkqueueGroupRows(items.slice(0, DEFAULT_WORKQUEUE_GROUP_THRESHOLD), { enabled: true });
+  assert.equal(belowThreshold.length, DEFAULT_WORKQUEUE_GROUP_THRESHOLD);
+  assert.equal(belowThreshold.some((row) => row.type === 'group'), false);
+
+  const grouped = buildWorkqueueGroupRows(items, { enabled: true, now: Date.parse('2026-07-01T00:00:00Z') });
+  assert.equal(grouped.length, 1);
+  assert.equal(grouped[0].type, 'group');
+  assert.equal(grouped[0].count, DEFAULT_WORKQUEUE_GROUP_THRESHOLD + 1);
+  assert.equal(grouped[0].priority, 99);
+  assert.equal(grouped[0].status, 'claimed');
+
+  const expanded = buildWorkqueueGroupRows(items, { enabled: true, expandedKeys: [grouped[0].key] });
+  assert.equal(expanded[0].type, 'group');
+  assert.equal(expanded[0].expanded, true);
+  assert.equal(expanded.length, DEFAULT_WORKQUEUE_GROUP_THRESHOLD + 2);
+
+  const titleFallback = buildWorkqueueGroupRows(
+    items.map(({ dedupeKey, ...item }) => item),
+    { enabled: true }
+  );
+  assert.equal(titleFallback.length, 1);
+  assert.equal(titleFallback[0].type, 'group');
+  assert.equal(titleFallback[0].count, DEFAULT_WORKQUEUE_GROUP_THRESHOLD + 1);
 });
 
 test('inferPaneCols maps pane counts to sensible layout widths', () => {


### PR DESCRIPTION
## Summary
- Add pure workqueue row grouping by stable dedupe prefix or normalized title prefix, enabled by default above 20 visible rows.
- Add pane UI toggle, expandable group rows, persisted group state, and styling.
- Document the grouping threshold in README.

Closes #206

## Tests
- npm run test:syntax
- node --test tests/unit/app-core.test.js
- NODE_PATH=/Users/raysopenclaw/src/clawnsole/node_modules /Users/raysopenclaw/src/clawnsole/node_modules/.bin/playwright test tests/ui/workqueue-pane.spec.js --workers=1