### PR TITLE
Harden recurring prompt Python worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,10 @@ node scripts/recurring-prompts-scheduler.js --loopSeconds 60
 # Python worker wrapper (retry/backoff; suitable for launchd/systemd/cron)
 python3 scripts/recurring-prompts-worker.py --once
 python3 scripts/recurring-prompts-worker.py --loopSeconds 60
+
+# Python API worker (polls Clawnsole API and triggers due prompts with idempotency)
+python3 scripts/recurring_prompts_worker.py --once --admin-password "$CLAWNSOLE_ADMIN_PASSWORD"
+python3 scripts/recurring_prompts_worker.py --loop-seconds 60 --device-label launchd-admin-prompts
 ```
 
 Prompts are stored in `~/.openclaw/clawnsole-recurring-prompts*.json` (instance-aware).

--- a/scripts/recurring_prompts_worker.py
+++ b/scripts/recurring_prompts_worker.py
@@ -39,6 +39,10 @@ def _json_request(base_url: str, method: str, path: str, *, data=None, headers=N
         except json.JSONDecodeError:
             payload = {"error": raw or str(err)}
         return err.code, payload, err.headers
+    except urllib.error.URLError as err:
+        return 0, {"error": str(getattr(err, "reason", err))}, {}
+    except (TimeoutError, OSError) as err:
+        return 0, {"error": str(err) or "request failed"}, {}
 
 
 def _login(base_url: str, password: str, timeout: int) -> str:
@@ -76,7 +80,7 @@ def _load_prompts(base_url: str, cookie: str, timeout: int):
     return prompts if isinstance(prompts, list) else []
 
 
-def _trigger_prompt(base_url: str, cookie: str, prompt: dict, now_ms: int, timeout: int, dry_run: bool):
+def _trigger_prompt(base_url: str, cookie: str, prompt: dict, now_ms: int, timeout: int, dry_run: bool, device_label: str):
     prompt_id = str(prompt.get("id") or "").strip()
     if not prompt_id:
         return {"ok": False, "error": "missing prompt id"}
@@ -93,7 +97,7 @@ def _trigger_prompt(base_url: str, cookie: str, prompt: dict, now_ms: int, timeo
         data={
             "scheduledAt": scheduled_at,
             "idempotencyKey": idempotency_key,
-            "deviceLabel": "python-worker",
+            "deviceLabel": device_label,
             "dryRun": dry_run,
         },
         headers={"Cookie": cookie, "Idempotency-Key": idempotency_key},
@@ -136,7 +140,15 @@ def run_once(args) -> dict:
     for prompt in due:
         last_error = None
         for attempt in range(args.retries + 1):
-            result = _trigger_prompt(args.base_url, cookie, prompt, now_ms, args.timeout, args.dry_run)
+            result = _trigger_prompt(
+                args.base_url,
+                cookie,
+                prompt,
+                now_ms,
+                args.timeout,
+                args.dry_run,
+                args.device_label,
+            )
             if result.get("ok"):
                 delivered += 1
                 if result.get("duplicate"):
@@ -168,6 +180,7 @@ def parse_args(argv):
     parser.add_argument("--retries", type=int, default=2)
     parser.add_argument("--backoff", type=float, default=1.0)
     parser.add_argument("--max-backoff", type=float, default=10.0)
+    parser.add_argument("--device-label", default=os.environ.get("CLAWNSOLE_WORKER_DEVICE_LABEL", "python-worker"))
     parser.add_argument("--dry-run", action="store_true")
     return parser.parse_args(argv)
 

--- a/tests/unit/recurring-prompts-worker.test.js
+++ b/tests/unit/recurring-prompts-worker.test.js
@@ -2,11 +2,12 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { spawnSync } = require('node:child_process');
+const { spawn, spawnSync } = require('node:child_process');
 const { test } = require('node:test');
 
 const ROOT = path.resolve(__dirname, '..', '..');
 const WORKER = path.join(ROOT, 'scripts', 'recurring-prompts-worker.py');
+const API_WORKER = path.join(ROOT, 'scripts', 'recurring_prompts_worker.py');
 
 function runWorker(args) {
   return spawnSync('python3', [WORKER, ...args], {
@@ -21,6 +22,24 @@ function parseJsonLines(stdout) {
     .split(/\n+/)
     .filter(Boolean)
     .map((line) => JSON.parse(line));
+}
+
+function waitForFile(file, timeoutMs = 5000) {
+  const start = Date.now();
+  return new Promise((resolve, reject) => {
+    const tick = () => {
+      if (fs.existsSync(file)) {
+        resolve();
+        return;
+      }
+      if (Date.now() - start > timeoutMs) {
+        reject(new Error(`timed out waiting for ${file}`));
+        return;
+      }
+      setTimeout(tick, 25);
+    };
+    tick();
+  });
 }
 
 test('recurring prompts worker exits with config error when scheduler is missing', () => {
@@ -76,4 +95,98 @@ console.log('scheduler ok');
   assert.match(events[0].output, /temporary scheduler failure/);
   assert.equal(events[1].attempt, 1);
   assert.match(events[1].output, /scheduler ok/);
+});
+
+test('recurring prompts API worker polls due prompts and retries trigger with idempotency key', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'clawnsole-recurring-api-worker-'));
+  const portPath = path.join(dir, 'port.txt');
+  const requestsPath = path.join(dir, 'requests.json');
+  const serverPath = path.join(dir, 'server.js');
+  const promptId = 'prompt-1';
+  const scheduledAt = Date.now() - 60_000;
+
+  fs.writeFileSync(
+    serverPath,
+    `
+const http = require('http');
+const fs = require('fs');
+let triggerAttempts = 0;
+const requests = [];
+const requestsPath = ${JSON.stringify(requestsPath)};
+const server = http.createServer((req, res) => {
+  let raw = '';
+  req.on('data', (chunk) => { raw += chunk; });
+  req.on('end', () => {
+    requests.push({ method: req.method, url: req.url, cookie: req.headers.cookie || '', idempotencyKey: req.headers['idempotency-key'] || '', body: raw });
+    fs.writeFileSync(requestsPath, JSON.stringify(requests, null, 2));
+    if (req.method === 'POST' && req.url === '/auth/login') {
+      res.writeHead(200, { 'Content-Type': 'application/json', 'Set-Cookie': 'clawnsole_admin=ok; Path=/; HttpOnly' });
+      res.end(JSON.stringify({ ok: true }));
+      return;
+    }
+    if (req.method === 'GET' && req.url === '/api/recurring-prompts') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ prompts: [{ id: ${JSON.stringify(promptId)}, enabled: true, nextRunAt: ${scheduledAt}, title: 'Due', message: 'Ship status' }] }));
+      return;
+    }
+    if (req.method === 'POST' && req.url === '/api/recurring-prompts/${promptId}/trigger') {
+      triggerAttempts += 1;
+      res.writeHead(triggerAttempts === 1 ? 503 : 200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(triggerAttempts === 1 ? { ok: false, error: 'temporary gateway error' } : { ok: true, duplicate: false }));
+      return;
+    }
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'not_found' }));
+  });
+});
+server.listen(0, '127.0.0.1', () => {
+  fs.writeFileSync(${JSON.stringify(portPath)}, String(server.address().port));
+});
+process.on('SIGTERM', () => server.close(() => process.exit(0)));
+`,
+    'utf8'
+  );
+
+  const server = spawn(process.execPath, [serverPath], { cwd: dir, stdio: ['ignore', 'pipe', 'pipe'] });
+  try {
+    await waitForFile(portPath);
+    const baseUrl = `http://127.0.0.1:${fs.readFileSync(portPath, 'utf8')}`;
+    const result = spawnSync('python3', [
+      API_WORKER,
+      '--once',
+      '--base-url',
+      baseUrl,
+      '--admin-password',
+      'admin',
+      '--retries',
+      '1',
+      '--backoff',
+      '0',
+      '--max-backoff',
+      '0',
+      '--device-label',
+      'unit-worker'
+    ], {
+      cwd: ROOT,
+      encoding: 'utf8'
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.deepEqual(JSON.parse(result.stdout), {
+      ok: true,
+      due: 1,
+      delivered: 1,
+      duplicates: 0,
+      errors: []
+    });
+
+    const requests = JSON.parse(fs.readFileSync(requestsPath, 'utf8'));
+    const triggerRequests = requests.filter((req) => req.url.endsWith('/trigger'));
+    assert.equal(triggerRequests.length, 2);
+    assert.equal(triggerRequests[0].idempotencyKey, `${promptId}:${scheduledAt}`);
+    assert.equal(triggerRequests[1].idempotencyKey, `${promptId}:${scheduledAt}`);
+    assert.match(triggerRequests[0].body, /"deviceLabel": "unit-worker"/);
+  } finally {
+    server.kill('SIGTERM');
+  }
 });


### PR DESCRIPTION
## Summary
- catch Python worker transport failures as retryable trigger errors
- add configurable worker device labels for prompt run history
- document Python worker usage alongside the existing scheduler command
- add a unit test that runs the Python worker against a local HTTP server and verifies due filtering, retry, idempotency, and trigger payloads

Fixes #208

## Tests
- python3 -m py_compile scripts/recurring_prompts_worker.py
- node --test tests/unit/recurring-prompts-worker.test.js
- npm run test:syntax
- npm run test:unit