### PR TITLE
Guard chat pane close with draft warning

### DIFF
--- a/app.js
+++ b/app.js
@@ -2000,9 +2000,8 @@ function renderPaneManager() {
           paneManagerUiState.selectedIndex = selectedVisible;
           if (action === 'close') {
             try {
-              paneManager.removePane(pane.key);
+              paneManager.removePane(pane.key).then(() => renderPaneManager());
             } catch {}
-            renderPaneManager();
             return;
           }
           if (action === 'move-up') {
@@ -4971,6 +4970,91 @@ function panePumpOutbox(pane) {
     });
 }
 
+function paneCloseGuardState(pane) {
+  if (!pane || pane.kind !== 'chat') return { needsConfirm: false, hasDraft: false, hasActiveRun: false };
+  const hasDraft = Boolean(String(pane.elements?.input?.value || '').trim());
+  const hasActiveRun = Boolean(pane.pendingSend || paneIsAbortable(pane));
+  return { needsConfirm: hasDraft || hasActiveRun, hasDraft, hasActiveRun };
+}
+
+function confirmPaneCloseGuard(pane) {
+  const state = paneCloseGuardState(pane);
+  if (!state.needsConfirm) return Promise.resolve(true);
+
+  return new Promise((resolve) => {
+    const priorFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const overlay = document.createElement('div');
+    overlay.className = 'pane-close-guard-backdrop';
+    overlay.setAttribute('role', 'presentation');
+    overlay.setAttribute('data-testid', 'pane-close-guard');
+
+    const dialog = document.createElement('div');
+    dialog.className = 'pane-close-guard-dialog';
+    dialog.setAttribute('role', 'dialog');
+    dialog.setAttribute('aria-modal', 'true');
+    dialog.setAttribute('aria-labelledby', 'paneCloseGuardTitle');
+    dialog.setAttribute('aria-describedby', 'paneCloseGuardDesc');
+
+    const warnings = [];
+    if (state.hasActiveRun) warnings.push('an active run in progress');
+    if (state.hasDraft) warnings.push('unsent draft text');
+
+    dialog.innerHTML = `
+      <h2 id="paneCloseGuardTitle">Close this pane?</h2>
+      <p id="paneCloseGuardDesc">${escapeHtml(state.hasActiveRun ? 'Closing now may interrupt work or discard context.' : 'This pane has unsent text.')}</p>
+      <ul>${warnings.map((warning) => `<li>${escapeHtml(warning)}</li>`).join('')}</ul>
+      <div class="pane-close-guard-actions">
+        <button class="secondary" type="button" data-pane-close-cancel>Cancel</button>
+        <button class="danger" type="button" data-pane-close-confirm>Close anyway</button>
+      </div>
+    `;
+
+    overlay.appendChild(dialog);
+    document.body.appendChild(overlay);
+
+    const cancelBtn = dialog.querySelector('[data-pane-close-cancel]');
+    const confirmBtn = dialog.querySelector('[data-pane-close-confirm]');
+    const focusable = () => Array.from(dialog.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'))
+      .filter((el) => !el.disabled && el.offsetParent !== null);
+
+    const finish = (ok) => {
+      document.removeEventListener('keydown', onKeyDown, true);
+      try {
+        overlay.remove();
+      } catch {}
+      try {
+        priorFocus?.focus?.();
+      } catch {}
+      resolve(Boolean(ok));
+    };
+
+    function onKeyDown(event) {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        finish(false);
+        return;
+      }
+      if (event.key !== 'Tab') return;
+      const nodes = focusable();
+      if (nodes.length === 0) return;
+      const first = nodes[0];
+      const last = nodes[nodes.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+
+    cancelBtn?.addEventListener('click', () => finish(false));
+    confirmBtn?.addEventListener('click', () => finish(true));
+    document.addEventListener('keydown', onKeyDown, true);
+    cancelBtn?.focus?.();
+  });
+}
+
 
 async function paneSendChat(pane) {
   const raw = pane.elements.input.value.trim();
@@ -7398,11 +7482,13 @@ const paneManager = {
       } catch {}
     }
   },
-  removePane(key) {
-    if (roleState.role !== 'admin') return;
-    if (this.panes.length <= 1) return;
+  async removePane(key) {
+    if (roleState.role !== 'admin') return false;
+    if (this.panes.length <= 1) return false;
     const idx = this.panes.findIndex((pane) => pane.key === key);
-    if (idx < 0) return;
+    if (idx < 0) return false;
+    const targetPane = this.panes[idx];
+    if (!(await confirmPaneCloseGuard(targetPane))) return false;
     const [pane] = this.panes.splice(idx, 1);
     forgetFocusedPaneKey(pane?.key || key);
     try {
@@ -7418,6 +7504,7 @@ const paneManager = {
     this.persistAdminPanes();
     updateGlobalStatus();
     updateConnectionControls();
+    return true;
   },
   movePane(key, delta = 0) {
     if (roleState.role !== 'admin') return false;

--- a/styles.css
+++ b/styles.css
@@ -675,6 +675,50 @@ body::before {
   color: var(--muted);
 }
 
+.pane-close-guard-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 18px;
+  background: rgba(0, 0, 0, 0.55);
+}
+
+.pane-close-guard-dialog {
+  width: min(420px, calc(100vw - 36px));
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 12px;
+  background: rgba(11, 14, 18, 0.98);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.52);
+  padding: 18px;
+}
+
+.pane-close-guard-dialog h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.pane-close-guard-dialog p {
+  margin: 10px 0 0;
+  color: var(--muted);
+}
+
+.pane-close-guard-dialog ul {
+  margin: 12px 0 0;
+  padding-left: 18px;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.pane-close-guard-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 16px;
+  flex-wrap: wrap;
+}
+
 .pane-header-right {
   display: inline-flex;
   align-items: center;

--- a/tests/ui/chat-pane.spec.js
+++ b/tests/ui/chat-pane.spec.js
@@ -78,6 +78,58 @@ test('chat pane: stop button can cancel a running response', async ({ page }) =>
   await expect(pane.locator('.chat-bubble.assistant')).not.toContainText('mock-reply: please stream this', { timeout: 3000 });
 });
 
+test('chat pane: close guard covers empty, draft, and active run states', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Chat pane');
+
+  const panes = page.locator('[data-pane][data-pane-kind="chat"]');
+  await expect(panes).toHaveCount(2);
+
+  const emptyPane = panes.last();
+  await emptyPane.locator('[data-pane-close]').click();
+  await expect(page.getByTestId('pane-close-guard')).toHaveCount(0);
+  await expect(panes).toHaveCount(1);
+
+  await addPane(page, 'Chat pane');
+  const draftPane = panes.last();
+  await draftPane.locator('[data-pane-input]').fill('keep this draft');
+  await draftPane.locator('[data-pane-close]').click();
+
+  const draftGuard = page.getByTestId('pane-close-guard');
+  await expect(draftGuard).toBeVisible();
+  await expect(draftGuard).toContainText('unsent draft text');
+  await expect(draftGuard.getByRole('dialog', { name: 'Close this pane?' })).toBeVisible();
+  await expect(draftGuard.locator('[data-pane-close-cancel]')).toBeFocused();
+  await draftGuard.locator('[data-pane-close-cancel]').click();
+  await expect(draftGuard).toHaveCount(0);
+  await expect(panes).toHaveCount(2);
+
+  await draftPane.locator('[data-pane-close]').click();
+  await page.getByTestId('pane-close-guard').locator('[data-pane-close-confirm]').click();
+  await expect(panes).toHaveCount(1);
+
+  const activePane = panes.first();
+  await activePane.locator('[data-pane-input]').fill('please stream close guard');
+  await activePane.locator('[data-pane-send]').click();
+  await expect(activePane.locator('[data-pane-stop]')).toBeVisible();
+
+  await activePane.locator('[data-pane-close]').click();
+  const activeGuard = page.getByTestId('pane-close-guard');
+  await expect(activeGuard).toBeVisible();
+  await expect(activeGuard).toContainText('an active run in progress');
+  await page.keyboard.press('Escape');
+  await expect(activeGuard).toHaveCount(0);
+  await expect(panes).toHaveCount(1);
+
+  await activePane.locator('[data-pane-stop]').click();
+  await expect(activePane.locator('.chat-bubble.assistant').last()).toContainText('(canceled)', { ignoreCase: true, timeout: 5000 });
+});
+
 test('chat pane: unread badge appears on inactive pane and clears on focus', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);


### PR DESCRIPTION
## Summary\n- add a chat-pane close confirmation when unsent draft text or an active run would be lost\n- wire the guard through header and pane-manager close actions\n- add focused Playwright coverage for empty, draft, and active-run close flows\n\nFixes #253\n\n## Tests\n- npm test\n- npm run test:ui -- tests/ui/chat-pane.spec.js