### PR TITLE
Guard chat pane close with drafts or active runs

### DIFF
--- a/app.js
+++ b/app.js
@@ -5458,6 +5458,27 @@ function paneHasDraftChanges(pane) {
   return Boolean(draftText || hasAttachments);
 }
 
+function paneHasActiveRun(pane) {
+  if (!pane) return false;
+  return Boolean(pane.thinking?.active || (pane.chat?.runs && pane.chat.runs.size > 0) || (pane.abortState && pane.abortState.active));
+}
+
+function paneCloseGuardPrompt(pane) {
+  if (!pane || pane.kind !== 'chat') return true;
+
+  const hasDraft = paneHasDraftChanges(pane);
+  const hasActiveRun = paneHasActiveRun(pane);
+  if (!hasDraft && !hasActiveRun) return true;
+
+  const warnings = [];
+  if (hasDraft) warnings.push('- unsent draft text or attachments');
+  if (hasActiveRun) warnings.push('- active run in progress');
+
+  return window.confirm(
+    `Close this chat pane?\n\nThis pane has:\n${warnings.join('\n')}\n\nClosing it will discard this pane context.`
+  );
+}
+
 function paneSetDestinationStrip(pane) {
   const strip = pane?.elements?.destinationStrip;
   const valueEl = pane?.elements?.destinationValue;
@@ -7403,6 +7424,8 @@ const paneManager = {
     if (this.panes.length <= 1) return;
     const idx = this.panes.findIndex((pane) => pane.key === key);
     if (idx < 0) return;
+    const closingPane = this.panes[idx];
+    if (!paneCloseGuardPrompt(closingPane)) return;
     const [pane] = this.panes.splice(idx, 1);
     forgetFocusedPaneKey(pane?.key || key);
     try {

--- a/tests/ui/chat-pane.spec.js
+++ b/tests/ui/chat-pane.spec.js
@@ -106,6 +106,74 @@ test('chat pane: unread badge appears on inactive pane and clears on focus', asy
   await expect(firstBadge).toBeHidden();
 });
 
+test('chat pane: close with empty composer does not prompt', async ({ page }) => {
+  test.setTimeout(120000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+
+  let sawDialog = false;
+  page.once('dialog', async (dialog) => {
+    sawDialog = true;
+    await dialog.dismiss();
+  });
+
+  await page.locator('[data-pane][data-pane-kind="chat"]').first().locator('[data-pane-close]').click();
+  await expect(page.locator('[data-pane][data-pane-kind="chat"]')).toHaveCount(0);
+  expect(sawDialog).toBe(false);
+});
+
+test('chat pane: close with unsent draft prompts before removing pane', async ({ page }) => {
+  test.setTimeout(120000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+
+  const chatPane = page.locator('[data-pane][data-pane-kind="chat"]').first();
+  await chatPane.locator('[data-pane-input]').fill('keep this draft');
+
+  page.once('dialog', async (dialog) => {
+    expect(dialog.message()).toMatch(/unsent draft/i);
+    await dialog.dismiss();
+  });
+  await chatPane.locator('[data-pane-close]').click();
+  await expect(page.locator('[data-pane][data-pane-kind="chat"]')).toHaveCount(1);
+  await expect(chatPane.locator('[data-pane-input]')).toHaveValue('keep this draft');
+
+  page.once('dialog', async (dialog) => {
+    expect(dialog.message()).toMatch(/unsent draft/i);
+    await dialog.accept();
+  });
+  await chatPane.locator('[data-pane-close]').click();
+  await expect(page.locator('[data-pane][data-pane-kind="chat"]')).toHaveCount(0);
+});
+
+test('chat pane: close with active run prompts with explicit warning', async ({ page }) => {
+  test.setTimeout(120000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+
+  const chatPane = page.locator('[data-pane][data-pane-kind="chat"]').first();
+  await chatPane.locator('[data-pane-input]').fill('stream while closing');
+  await chatPane.locator('[data-pane-send]').click();
+  await expect(chatPane.locator('.chat-bubble.assistant', { hasText: 'mock-stream: stream while clo' })).toBeVisible();
+
+  page.once('dialog', async (dialog) => {
+    expect(dialog.message()).toMatch(/active run in progress/i);
+    await dialog.dismiss();
+  });
+  await chatPane.locator('[data-pane-close]').click();
+  await expect(page.locator('[data-pane][data-pane-kind="chat"]')).toHaveCount(1);
+  await expect(chatPane.locator('[data-pane-stop]')).toBeVisible();
+});
+
 test('topbar workqueue action reuses paired pane for active chat target and falls back to modal', async ({ page }) => {
   test.setTimeout(120000);
   test.skip(!!env?.skipReason, env?.skipReason);


### PR DESCRIPTION
## Summary
- add a shared chat-pane close guard for unsent drafts/attachments and active runs
- keep empty chat pane close behavior unchanged
- add Playwright coverage for empty close, draft cancel/confirm, and active-run warning

## Tests
- npm test
- npx playwright test tests/ui/chat-pane.spec.js

Closes #253