### PR TITLE
Fix last-chat return no-op toast

### DIFF
--- a/app.js
+++ b/app.js
@@ -7800,7 +7800,7 @@ function returnToLastActiveChatPane() {
     return true;
   }
 
-  toast('No previous chat pane.', 'info');
+  showToast('No previous chat pane.', { kind: 'info' });
   return false;
 }
 

--- a/tests/ui/command-palette.spec.js
+++ b/tests/ui/command-palette.spec.js
@@ -97,6 +97,7 @@ test('pane navigation: returns to the last active chat pane from shortcut and co
   const chatInput = page.locator('[data-pane][data-pane-kind="chat"]').first().locator('[data-pane-input]');
   const workqueuePane = page.locator('[data-pane][data-pane-kind="workqueue"]').first();
   const queueSelect = workqueuePane.locator('[data-wq-queue-select]');
+  const fleetBtn = page.locator('#fleetBtn');
 
   await expect(chatInput).toBeVisible();
   await chatInput.click();
@@ -105,6 +106,11 @@ test('pane navigation: returns to the last active chat pane from shortcut and co
   await expect(queueSelect).toBeVisible();
   await queueSelect.focus();
   await expect(queueSelect).toBeFocused();
+
+  await fleetBtn.click();
+  const fleetPane = page.locator('[data-pane][data-pane-kind="timeline"]').first();
+  await expect(fleetPane).toBeVisible();
+  await expect.poll(async () => page.evaluate(() => document.activeElement?.closest?.('[data-pane]')?.dataset?.paneKind || '')).toBe('timeline');
 
   await page.evaluate(() => document.activeElement?.blur?.());
   await page.keyboard.press('g');
@@ -121,4 +127,23 @@ test('pane navigation: returns to the last active chat pane from shortcut and co
   await page.keyboard.press('Enter');
 
   await expect(chatInput).toBeFocused();
+});
+
+test('pane navigation: return to last active chat safely no-ops when no chat pane exists', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+  await loginAdmin(page, env.serverPort);
+
+  await page.locator('[data-pane][data-pane-kind="chat"] [data-pane-close]').first().click();
+  await expect(page.locator('[data-pane][data-pane-kind="chat"]')).toHaveCount(0);
+
+  await page.evaluate(() => document.activeElement?.blur?.());
+  await page.keyboard.press('g');
+  await page.keyboard.press('c');
+
+  await expect(page.getByTestId('toast').last()).toContainText('No previous chat pane.');
+  await expect(page.locator('[data-pane]')).toHaveCount(1);
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
 });


### PR DESCRIPTION
## Summary
- Fix the no-chat fallback in Return to last active Chat pane to use the existing showToast helper.
- Expand regression coverage for Chat -> Workqueue -> Fleet -> return and for the no-chat safe no-op path.

## Tests
- npx playwright test tests/ui/command-palette.spec.js --grep "pane navigation"

Refs #257