### PR TITLE
Scope pane-add shortcuts to workspace

### DIFF
--- a/app.js
+++ b/app.js
@@ -7847,6 +7847,19 @@ function cycleUnreadPaneFocus(direction = 1) {
   return true;
 }
 
+function isBlockingOverlayOpenForPaneShortcuts() {
+  const blockers = [
+    globalElements.loginOverlay,
+    globalElements.settingsModal,
+    globalElements.shortcutsModal,
+    globalElements.commandPaletteModal,
+    globalElements.paneManagerModal,
+    globalElements.workqueueModal,
+    globalElements.agentsModal
+  ];
+  return blockers.some((el) => !!el?.classList?.contains('open')) || !!paneManager?._addPaneMenuState?.open;
+}
+
 window.addEventListener('keydown', (event) => {
   const isEditableTarget = (() => {
     const el = event.target;
@@ -7871,6 +7884,7 @@ window.addEventListener('keydown', (event) => {
     const kind = map[key];
     if (kind) {
       // Don't hijack add-pane shortcuts while typing in inputs/editors.
+      if (isBlockingOverlayOpenForPaneShortcuts()) return;
       event.preventDefault();
       paneManager.closeAddPaneMenu();
       paneManager.addPane(kind, { forceNew: !!event.altKey });

--- a/index.html
+++ b/index.html
@@ -265,6 +265,7 @@
             <h3 class="shortcut-group-title">Pane actions</h3>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Open command palette</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd></div><div class="shortcut-desc">Add pane</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>C/W/R/T</kbd></div><div class="shortcut-desc">Add Chat/Workqueue/Cron/Timeline pane (workspace only)</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd></div><div class="shortcut-desc">Open/focus Fleet pane</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>R</kbd></div><div class="shortcut-desc">Refresh agent list</div></div>
           </div>

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -37,9 +37,69 @@ test('shortcuts overlay: ? opens, Esc closes, content renders', async ({ page })
   await expect(modal).toContainText('Pane actions');
   await expect(modal).toContainText('Workqueue actions');
   await expect(modal).toContainText('disabled while typing');
+  await expect(modal).toContainText('workspace only');
 
   await page.keyboard.press('Escape');
   await expect(modal).toHaveAttribute('aria-hidden', 'true');
+});
+
+test('pane-add shortcuts are scoped to workspace and blocked by overlays', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const panes = page.locator('[data-pane]');
+  const paneCount = async () => panes.count();
+  const triggerChatPaneShortcut = async () => page.evaluate(() => {
+    window.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'C',
+      ctrlKey: true,
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true
+    }));
+  });
+
+  const initialCount = await paneCount();
+  await page.click('#connectionStatus');
+
+  await page.keyboard.press('Shift+/');
+  await expect(page.locator('#shortcutsModal')).toHaveAttribute('aria-hidden', 'false');
+  await triggerChatPaneShortcut();
+  await expect(panes).toHaveCount(initialCount);
+  await page.keyboard.press('Escape');
+  await expect(page.locator('#shortcutsModal')).toHaveAttribute('aria-hidden', 'true');
+
+  await page.locator('#settingsBtn').click();
+  await expect(page.locator('#settingsModal')).toHaveClass(/open/);
+  await triggerChatPaneShortcut();
+  await expect(panes).toHaveCount(initialCount);
+  await page.keyboard.press('Escape');
+  await expect(page.locator('#settingsModal')).not.toHaveClass(/open/);
+
+  await page.evaluate(() => window.openWorkqueue?.());
+  await expect(page.locator('#workqueueModal')).toHaveClass(/open/);
+  await triggerChatPaneShortcut();
+  await expect(panes).toHaveCount(initialCount);
+  await page.keyboard.press('Escape');
+  await expect(page.locator('#workqueueModal')).not.toHaveClass(/open/);
+
+  await page.getByTestId('add-pane-btn').click();
+  await expect(page.getByTestId('pane-add-menu')).toBeVisible();
+  await triggerChatPaneShortcut();
+  await expect(panes).toHaveCount(initialCount);
+  await page.keyboard.press('Escape');
+  await expect(page.getByTestId('pane-add-menu')).toBeHidden();
+
+  await page.click('#connectionStatus');
+  await triggerChatPaneShortcut();
+  await expect(panes).toHaveCount(initialCount + 1);
 });
 
 test('shortcuts modal restores prior focus on close', async ({ page }) => {


### PR DESCRIPTION
## Summary
- suppress pane-add accelerators while modal/overlay UI or the add-pane menu is open
- document the pane-add accelerator scope in shortcut help
- add regression coverage for shortcuts/settings/workqueue/add-pane overlays and post-close shortcut behavior

Fixes #254.

## Tests
- npm ci
- npx playwright test tests/pane.shortcuts.e2e.spec.js -g "shortcuts overlay|pane-add shortcuts are scoped"