### PR TITLE
Add Fleet keyboard triage shortcuts

### DIFF
--- a/app.js
+++ b/app.js
@@ -533,6 +533,7 @@ let agentAutoRefreshInterval = null;
 let agentsModalAutoRefreshInterval = null;
 let agentsModalFreshnessTicker = null;
 let agentsLastRefreshedAtMs = 0;
+let agentsSelectedId = '';
 
 function startAgentAutoRefresh() {
   if (roleState.role !== 'admin') return;
@@ -2740,6 +2741,52 @@ function openAgentWorkqueueFromFleet(agentId) {
   paneManager.focusPanePrimary(pane);
 }
 
+function getFleetRows() {
+  return Array.from(globalElements.agentsList?.querySelectorAll?.('.agents-row[data-agent-id]') || []);
+}
+
+function getSelectedFleetRow() {
+  return getFleetRows().find((row) => String(row.getAttribute('data-agent-id') || '') === agentsSelectedId) || null;
+}
+
+function setSelectedFleetAgent(agentId, { focus = false } = {}) {
+  const nextId = String(agentId || '').trim();
+  if (!nextId) return;
+  agentsSelectedId = nextId;
+
+  for (const row of getFleetRows()) {
+    const active = String(row.getAttribute('data-agent-id') || '') === nextId;
+    row.classList.toggle('selected', active);
+    row.setAttribute('aria-current', active ? 'true' : 'false');
+    row.tabIndex = active ? 0 : -1;
+    if (active && focus) {
+      try {
+        row.focus({ preventScroll: true });
+        row.scrollIntoView({ block: 'nearest' });
+      } catch {}
+    }
+  }
+}
+
+function moveSelectedFleetAgent(delta) {
+  const rows = getFleetRows();
+  if (!rows.length) return;
+
+  const currentIdx = Math.max(0, rows.findIndex((row) => String(row.getAttribute('data-agent-id') || '') === agentsSelectedId));
+  const nextIdx = Math.min(rows.length - 1, Math.max(0, currentIdx + delta));
+  setSelectedFleetAgent(rows[nextIdx].getAttribute('data-agent-id'), { focus: true });
+}
+
+function activateSelectedFleetAgent(action) {
+  const row = getSelectedFleetRow();
+  const target = String(row?.getAttribute('data-agent-id') || agentsSelectedId || '').trim();
+  if (!target) return;
+
+  if (action === 'chat') openAgentChatFromFleet(target);
+  else if (action === 'timeline') openAgentTimelineFromFleet(target);
+  else if (action === 'workqueue') openAgentWorkqueueFromFleet(target);
+}
+
 function findActivePaneFromFocus() {
   const active = document.activeElement;
   if (!active) return null;
@@ -2786,6 +2833,7 @@ function openTopbarWorkqueueAction() {
 function renderAgentsModalList() {
   const root = globalElements.agentsList;
   if (!root) return;
+  root.setAttribute('aria-label', 'Fleet agents');
 
   const search = String(globalElements.agentsSearch?.value || '').trim().toLowerCase();
   const withinMinutes = Math.max(1, Number(globalElements.agentsActiveMinutes?.value) || 10);
@@ -2869,6 +2917,7 @@ function renderAgentsModalList() {
       const id = String(agent?.id || '').trim();
       const row = document.createElement('div');
       row.className = 'agents-row';
+      row.setAttribute('data-agent-id', id);
 
       const label = formatAgentLabel(agent, { includeId: true });
       const pinnedNow = pins.has(id);
@@ -2901,6 +2950,9 @@ function renderAgentsModalList() {
       `;
 
       const pinBtn = row.querySelector('[data-agent-pin]');
+      row.addEventListener('click', () => setSelectedFleetAgent(id));
+      row.addEventListener('focus', () => setSelectedFleetAgent(id));
+
       pinBtn?.addEventListener('click', (e) => {
         e.preventDefault();
         e.stopPropagation();
@@ -2933,6 +2985,14 @@ function renderAgentsModalList() {
   renderSection('Healthy', healthy, { collapsible: true, collapsed: healthyCollapsed });
 
   const empty = ordered.length === 0;
+  const rows = getFleetRows();
+  if (rows.length) {
+    const selectedStillVisible = rows.some((row) => String(row.getAttribute('data-agent-id') || '') === agentsSelectedId);
+    const nextSelected = selectedStillVisible ? agentsSelectedId : rows[0].getAttribute('data-agent-id');
+    setSelectedFleetAgent(nextSelected);
+  } else {
+    agentsSelectedId = '';
+  }
   if (globalElements.agentsEmpty) globalElements.agentsEmpty.hidden = !empty;
 }
 
@@ -7624,6 +7684,32 @@ globalElements.agentsBtn?.addEventListener('click', () => openAgentsModal());
 globalElements.agentsCloseBtn?.addEventListener('click', () => closeAgentsModal());
 globalElements.agentsModal?.addEventListener('click', (event) => {
   if (event.target === globalElements.agentsModal) closeAgentsModal();
+});
+globalElements.agentsModal?.addEventListener('keydown', (event) => {
+  if (!globalElements.agentsModal?.classList?.contains('open')) return;
+  if (isTypingContext(event.target)) return;
+  if (!globalElements.agentsModal.contains(event.target)) return;
+
+  const key = String(event.key || '');
+  if (key.toLowerCase() === 'j') {
+    event.preventDefault();
+    moveSelectedFleetAgent(1);
+    return;
+  }
+  if (key.toLowerCase() === 'k') {
+    event.preventDefault();
+    moveSelectedFleetAgent(-1);
+    return;
+  }
+  if (key === 'Enter') {
+    event.preventDefault();
+    activateSelectedFleetAgent(event.shiftKey ? 'workqueue' : 'chat');
+    return;
+  }
+  if (key === '.' && !event.shiftKey) {
+    event.preventDefault();
+    activateSelectedFleetAgent('timeline');
+  }
 });
 
 globalElements.agentsSearch?.addEventListener('input', () => renderAgentsModalList());

--- a/index.html
+++ b/index.html
@@ -273,6 +273,14 @@
             <h3 class="shortcut-group-title">Workqueue actions</h3>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>g</kbd> <kbd>w</kbd></div><div class="shortcut-desc">Open Workqueue modal</div></div>
           </div>
+
+          <div class="shortcut-group">
+            <h3 class="shortcut-group-title">Fleet triage</h3>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>j</kbd>/<kbd>k</kbd></div><div class="shortcut-desc">Select next / previous Fleet row</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Enter</kbd></div><div class="shortcut-desc">Open Chat for selected Fleet agent</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Shift</kbd>+<kbd>Enter</kbd></div><div class="shortcut-desc">Open Workqueue for selected Fleet agent</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>.</kbd></div><div class="shortcut-desc">Open Timeline for selected Fleet agent</div></div>
+          </div>
         </div>
       </div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -1513,6 +1513,17 @@ button.agents-section-title:hover {
   background: rgba(255, 255, 255, 0.02);
 }
 
+.agents-row.selected,
+.agents-row[aria-current="true"] {
+  border-color: rgba(77, 196, 255, 0.72);
+  background: rgba(77, 196, 255, 0.1);
+}
+
+.agents-row:focus-visible {
+  outline: 2px solid rgba(77, 196, 255, 0.9);
+  outline-offset: 2px;
+}
+
 .agents-pin {
   width: 36px;
   height: 36px;

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -126,3 +126,53 @@ test('agents modal quick actions open/reuse chat, timeline, and workqueue contex
   await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
   await expect(page.locator('[data-pane][data-pane-kind="workqueue"] [data-wq-claim-agent]')).toHaveValue(agentId || 'main');
 });
+
+test('fleet keyboard triage selects rows and opens selected agent panes', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  const agents = [
+    { id: 'dev', name: 'dev', displayName: 'dev' },
+    { id: 'main', name: 'main', displayName: 'main' }
+  ];
+  await page.route(/\/agents(?:\?|$)/, async (route) => {
+    await route.fulfill({ json: { agents } });
+  });
+
+  await clawnsole.gotoAndLoginAdmin(page);
+
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsModal')).toHaveClass(/open/);
+
+  const rows = page.locator('#agentsList .agents-row');
+  await expect(rows).toHaveCount(2);
+  const firstRow = rows.nth(0);
+  const secondRow = rows.nth(1);
+  await expect(firstRow).toHaveAttribute('aria-current', 'true');
+
+  await page.locator('#agentsSearch').focus();
+  await page.keyboard.press('j');
+  await expect(firstRow).toHaveAttribute('aria-current', 'true');
+  await page.locator('#agentsSearch').fill('');
+  await expect(rows).toHaveCount(2);
+
+  await firstRow.focus();
+  await page.keyboard.press('j');
+  await expect(secondRow).toHaveAttribute('aria-current', 'true');
+  await page.keyboard.press('k');
+  await expect(firstRow).toHaveAttribute('aria-current', 'true');
+  await page.keyboard.press('j');
+
+  const agentId = (await secondRow.getAttribute('data-agent-id')) || 'main';
+  await page.keyboard.press('Enter');
+  await expect(page.locator('[data-pane][data-pane-kind="chat"]')).toHaveCount(1);
+  await expect(page.locator('[data-pane][data-pane-kind="chat"] [data-pane-agent-select]').first()).toHaveValue(agentId);
+
+  await secondRow.focus();
+  await page.keyboard.press('Shift+Enter');
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"] [data-wq-claim-agent]')).toHaveValue(agentId);
+
+  await secondRow.focus();
+  await page.keyboard.press('.');
+  await expect(page.locator('[data-pane][data-pane-kind="timeline"]')).toHaveCount(1);
+});


### PR DESCRIPTION
## Summary
- Add Fleet row keyboard selection with j/k and visible selected-row treatment.
- Reuse existing Fleet quick actions for Enter (Chat), Shift+Enter (Workqueue), and . (Timeline).
- Document the shortcuts in the keyboard shortcuts modal.

Fixes #259

## Tests
- npm run test:syntax
- NODE_PATH=/Users/raysopenclaw/src/clawnsole/node_modules /Users/raysopenclaw/src/clawnsole/node_modules/.bin/playwright test tests/ui/agents-modal.spec.js --workers=1