### PR TITLE
Cap Workqueue pane initial row render

### DIFF
--- a/app.js
+++ b/app.js
@@ -3512,6 +3512,9 @@ async function renderWorkqueuePane(rootEl, { queue = '' } = {}) {
 window.__debug = window.__debug || {};
 window.__debug.renderWorkqueuePane = renderWorkqueuePane;
 
+const WORKQUEUE_PANE_INITIAL_RENDER_LIMIT = 100;
+const WORKQUEUE_PANE_RENDER_INCREMENT = 100;
+
 function getWorkqueueItemRepo(item) {
   const repo = String(item?.meta?.repo || '').trim();
   if (repo) return repo;
@@ -3544,6 +3547,11 @@ function applyWorkqueueQuickFilters(items, quickFilters) {
   });
 }
 
+function resetWorkqueuePaneRenderLimit(pane) {
+  if (!pane?.workqueue) return;
+  pane.workqueue.renderLimit = WORKQUEUE_PANE_INITIAL_RENDER_LIMIT;
+}
+
 async function fetchAndRenderWorkqueueItemsForPane(pane) {
   if (!pane || pane.kind !== 'workqueue') return;
   const body = pane.elements?.thread?.querySelector('[data-wq-list-body]');
@@ -3573,6 +3581,7 @@ async function fetchAndRenderWorkqueueItemsForPane(pane) {
     ]));
     pane.workqueue.items = items;
     pane.workqueue.itemsSignature = nextSignature;
+    resetWorkqueuePaneRenderLimit(pane);
     if (previousSignature && previousSignature !== nextSignature) {
       markPaneUnread(pane, 1, 'workqueue');
     }
@@ -3586,6 +3595,8 @@ async function fetchAndRenderWorkqueueItemsForPane(pane) {
 function renderWorkqueuePaneItems(pane) {
   const body = pane.elements?.thread?.querySelector('[data-wq-list-body]');
   const empty = pane.elements?.thread?.querySelector('[data-wq-empty]');
+  const renderSummary = pane.elements?.thread?.querySelector('[data-wq-render-summary]');
+  const loadMore = pane.elements?.thread?.querySelector('[data-wq-render-more]');
   if (!body) return;
   body.innerHTML = '';
 
@@ -3601,6 +3612,10 @@ function renderWorkqueuePaneItems(pane) {
   });
   const filteredItems = applyWorkqueueQuickFilters(scopedItems, pane.workqueue?.quickFilters);
   const items = sortWorkqueueItems(filteredItems, { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
+  const rawLimit = Number(pane.workqueue?.renderLimit);
+  const renderLimit = Number.isFinite(rawLimit) && rawLimit > 0 ? Math.floor(rawLimit) : WORKQUEUE_PANE_INITIAL_RENDER_LIMIT;
+  pane.workqueue.renderLimit = renderLimit;
+  const visibleItems = items.slice(0, renderLimit);
 
   if (empty) {
     const hasItems = items.length > 0;
@@ -3635,8 +3650,23 @@ function renderWorkqueuePaneItems(pane) {
     }
   }
 
+  if (renderSummary) {
+    renderSummary.textContent = items.length > visibleItems.length
+      ? `Showing ${visibleItems.length} of ${items.length} matching items`
+      : `${items.length} matching item(s)`;
+  }
+
+  if (loadMore) {
+    loadMore.hidden = visibleItems.length >= items.length;
+    loadMore.textContent = `Load ${Math.min(WORKQUEUE_PANE_RENDER_INCREMENT, Math.max(0, items.length - visibleItems.length))} more`;
+    loadMore.onclick = () => {
+      pane.workqueue.renderLimit = Math.min(items.length, visibleItems.length + WORKQUEUE_PANE_RENDER_INCREMENT);
+      renderWorkqueuePaneItems(pane);
+    };
+  }
+
   const now = Date.now();
-  for (const it of items) {
+  for (const it of visibleItems) {
     const row = document.createElement('button');
     row.type = 'button';
     row.className = 'wq-row';
@@ -5882,6 +5912,10 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
             <div>lease</div>
           </div>
           <div class="wq-list-body" data-wq-list-body></div>
+          <div class="wq-render-controls">
+            <span class="hint" data-wq-render-summary></span>
+            <button type="button" class="secondary" data-wq-render-more hidden>Load more</button>
+          </div>
           <div data-wq-empty class="hint" style="padding: 10px 12px;" hidden>No items.</div>
         </section>
 
@@ -5965,6 +5999,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
           btn.addEventListener('click', () => {
             if (repoSet.has(repo)) repoSet.delete(repo);
             else repoSet.add(repo);
+            resetWorkqueuePaneRenderLimit(pane);
             persistQuickFilters();
             updateQuickFilterUi();
             renderWorkqueuePaneItems(pane);
@@ -6189,6 +6224,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     };
     const setScope = (scope) => {
       pane.workqueue.scopeFilter = normalizeWorkqueueScope(scope);
+      resetWorkqueuePaneRenderLimit(pane);
       storage.set(WORKQUEUE_SCOPE_PREF_KEY, pane.workqueue.scopeFilter);
       updateScopeUi();
       renderWorkqueuePaneItems(pane);
@@ -6205,6 +6241,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         if (!key) return;
         if (sourceSet.has(key)) sourceSet.delete(key);
         else sourceSet.add(key);
+        resetWorkqueuePaneRenderLimit(pane);
         persistQuickFilters();
         updateQuickFilterUi();
         renderWorkqueuePaneItems(pane);
@@ -6215,6 +6252,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       sourceSet.clear();
       repoSet.clear();
       repoSet.add('rmdmattingly/clawnsole');
+      resetWorkqueuePaneRenderLimit(pane);
       persistQuickFilters();
       updateQuickFilterUi();
       renderWorkqueuePaneItems(pane);
@@ -6223,6 +6261,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     clearQuickBtn?.addEventListener('click', () => {
       sourceSet.clear();
       repoSet.clear();
+      resetWorkqueuePaneRenderLimit(pane);
       persistQuickFilters();
       updateQuickFilterUi();
       renderWorkqueuePaneItems(pane);
@@ -6250,6 +6289,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         pane.workqueue.sortKey = nextKey;
         pane.workqueue.sortDir = nextKey === 'claimedBy' || nextKey === 'title' || nextKey === 'status' ? 'asc' : 'desc';
       }
+      resetWorkqueuePaneRenderLimit(pane);
       updateSortUi();
       renderWorkqueuePaneItems(pane);
       paneManager.persistAdminPanes();

--- a/styles.css
+++ b/styles.css
@@ -2159,6 +2159,20 @@ kbd {
   scrollbar-gutter: stable both-edges;
 }
 
+.wq-render-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 8px 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(0, 0, 0, 0.14);
+}
+
+.wq-render-controls [data-wq-render-more][hidden] {
+  display: none;
+}
+
 /* Kanban-style board for Workqueue (Issue #89) */
 .wq-list-kanban {
   overflow: hidden;

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -34,6 +34,38 @@ function seedAgentsForWorkqueuePicker() {
   fs.writeFileSync(configPath, JSON.stringify(cfg, null, 2));
 }
 
+function seedWorkqueueState({ queue, count }) {
+  const dir = path.join(env.tempHome, '.openclaw', 'clawnsole');
+  fs.mkdirSync(dir, { recursive: true });
+  const base = Date.now() - count * 1000;
+  const items = Array.from({ length: count }, (_, i) => {
+    const isHighPriority = i === 0;
+    return {
+      id: `large-${i}`,
+      queue,
+      title: isHighPriority ? 'zz high priority hidden until sorted' : `large item ${String(i).padStart(3, '0')}`,
+      instructions: 'large list fixture',
+      priority: isHighPriority ? 999 : 1,
+      status: 'ready',
+      claimedBy: '',
+      claimedAt: '',
+      leaseUntil: 0,
+      attempts: 0,
+      lastError: '',
+      createdAt: new Date(base + i * 1000).toISOString(),
+      updatedAt: new Date(base + i * 1000).toISOString(),
+      meta: { repo: 'rmdmattingly/clawnsole', kind: 'issue' }
+    };
+  });
+  const state = {
+    version: 1,
+    queues: { [queue]: { name: queue, createdAt: new Date(base).toISOString() } },
+    items,
+    assignments: {}
+  };
+  fs.writeFileSync(path.join(dir, 'work-queues.json'), JSON.stringify(state, null, 2));
+}
+
 test('workqueue pane: renders + has queue dropdown + does not show chat composer', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);
@@ -271,4 +303,37 @@ test('workqueue pane: controls toolbar is sticky and list scrolls independently'
     return { overflowY: cs.overflowY };
   });
   expect(['auto', 'scroll']).toContain(listStyles.overflowY);
+});
+
+test('workqueue pane: caps large initial render but sorts the full fetched list', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  const queue = `large-render-${Date.now()}`;
+  seedWorkqueueState({ queue, count: 520 });
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  const wqPane = page.locator('[data-pane]').last();
+  await wqPane.locator('[data-wq-queue-select]').selectOption('__custom__');
+  await wqPane.locator('[data-wq-queue-custom]').fill(queue);
+  const itemsResP = page.waitForResponse((res) => res.url().includes('/api/workqueue/items') && res.ok(), { timeout: 15000 });
+  await wqPane.locator('[data-wq-queue-custom]').press('Enter');
+  await itemsResP;
+
+  const rows = wqPane.locator('[data-wq-list-body] .wq-row');
+  await expect(rows).toHaveCount(100);
+  await expect(wqPane.locator('[data-wq-render-summary]')).toHaveText('Showing 100 of 520 matching items');
+  await expect(wqPane.locator('[data-wq-render-more]')).toBeVisible();
+
+  await wqPane.locator('[data-wq-sort="createdAt"]').first().click();
+  await expect(rows.first().locator('.wq-col.title')).toHaveText('large item 519');
+
+  await wqPane.locator('[data-wq-sort="priority"]').first().click();
+  await expect(rows.first().locator('.wq-col.title')).toHaveText('zz high priority hidden until sorted');
+
+  await wqPane.locator('[data-wq-render-more]').click();
+  await expect(rows).toHaveCount(200);
 });


### PR DESCRIPTION
## Summary
- cap Workqueue pane DOM rows to the first 100 matching items on initial render
- add a load-more control that expands in 100-row increments
- keep sorting/filtering against the full fetched dataset before applying the render cap

## Tests
- npm test
- npx playwright test tests/ui/workqueue-pane.spec.js --workers=1

Closes #261