### PR TITLE
Add Workqueue control focus shortcuts

### DIFF
--- a/app.js
+++ b/app.js
@@ -3536,10 +3536,29 @@ function getWorkqueueItemSource(item) {
 function applyWorkqueueQuickFilters(items, quickFilters) {
   const sourceSet = new Set(Array.isArray(quickFilters?.sources) ? quickFilters.sources.map((x) => String(x || '').trim()).filter(Boolean) : []);
   const repoSet = new Set(Array.isArray(quickFilters?.repos) ? quickFilters.repos.map((x) => String(x || '').trim()).filter(Boolean) : []);
+  const itemQuery = String(quickFilters?.itemSearch || '').trim().toLowerCase();
 
   return (Array.isArray(items) ? items : []).filter((it) => {
     if (sourceSet.size && !sourceSet.has(getWorkqueueItemSource(it))) return false;
     if (repoSet.size && !repoSet.has(getWorkqueueItemRepo(it))) return false;
+    if (itemQuery) {
+      const haystack = [
+        it?.id,
+        it?.title,
+        it?.status,
+        it?.claimedBy,
+        it?.assignee,
+        it?.assignedTo,
+        it?.agentId,
+        it?.instructions,
+        it?.lastNote,
+        it?.lastError,
+        it?.meta?.repo,
+        it?.meta?.source,
+        it?.meta?.kind
+      ].map((v) => String(v || '').toLowerCase()).join(' ');
+      if (!haystack.includes(itemQuery)) return false;
+    }
     return true;
   });
 }
@@ -5594,7 +5613,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       scopeFilter: normalizeWorkqueueScope(scopeFilter ?? getDefaultWorkqueueScope()),
       quickFilters: {
         sources: Array.isArray(quickFilters?.sources) ? quickFilters.sources.map((s) => String(s || '').trim()).filter(Boolean) : [],
-        repos: Array.isArray(quickFilters?.repos) ? quickFilters.repos.map((s) => String(s || '').trim()).filter(Boolean) : []
+        repos: Array.isArray(quickFilters?.repos) ? quickFilters.repos.map((s) => String(s || '').trim()).filter(Boolean) : [],
+        itemSearch: typeof quickFilters?.itemSearch === 'string' ? quickFilters.itemSearch.trim() : ''
       },
       items: [],
       selectedItemId: null,
@@ -5658,6 +5678,9 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
             lines: ['Shows queued work items, grouped by status.', 'Drag cards between columns to change status.', 'Use Refresh when another worker updates the queue.'],
             shortcuts: [
               ['g w', 'open Workqueue modal'],
+              ['w q', 'focus queue search'],
+              ['w i', 'focus item search'],
+              ['w s', 'focus status filter'],
               ['Cmd/Ctrl+K', 'cycle focus between panes']
             ]
           };
@@ -5811,6 +5834,11 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
             <div class="wq-scope" data-wq-repo-chips></div>
           </div>
 
+          <label class="wq-field">
+            <span class="wq-label">Item search</span>
+            <input data-wq-item-search type="search" placeholder="Search items" aria-label="Search workqueue items" autocomplete="off" />
+          </label>
+
           <button data-wq-preset-clawnsole class="secondary" type="button">Clawnsole only</button>
           <button data-wq-clear-quick class="secondary" type="button">Clear filters</button>
           <button data-wq-refresh class="secondary" type="button">Refresh</button>
@@ -5915,6 +5943,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     const statusClearBtn = elements.thread.querySelector('[data-wq-status-clear]');
     const sourceBtns = Array.from(elements.thread.querySelectorAll('[data-wq-source]'));
     const repoChipsEl = elements.thread.querySelector('[data-wq-repo-chips]');
+    const itemSearchEl = elements.thread.querySelector('[data-wq-item-search]');
     const clawnsoleOnlyBtn = elements.thread.querySelector('[data-wq-preset-clawnsole]');
     const clearQuickBtn = elements.thread.querySelector('[data-wq-clear-quick]');
     const refreshBtn = elements.thread.querySelector('[data-wq-refresh]');
@@ -5936,9 +5965,15 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     const initQuick = pane.workqueue?.quickFilters || {};
     const sourceSet = new Set(Array.isArray(initQuick.sources) ? initQuick.sources.map((x) => String(x || '').trim()).filter(Boolean) : []);
     const repoSet = new Set(Array.isArray(initQuick.repos) ? initQuick.repos.map((x) => String(x || '').trim()).filter(Boolean) : []);
+    const initialItemSearch = typeof initQuick.itemSearch === 'string' ? initQuick.itemSearch.trim() : '';
+    if (itemSearchEl) itemSearchEl.value = initialItemSearch;
 
     const persistQuickFilters = () => {
-      pane.workqueue.quickFilters = { sources: Array.from(sourceSet), repos: Array.from(repoSet) };
+      pane.workqueue.quickFilters = {
+        sources: Array.from(sourceSet),
+        repos: Array.from(repoSet),
+        itemSearch: String(itemSearchEl?.value || '').trim()
+      };
       paneManager.persistAdminPanes();
     };
 
@@ -6211,6 +6246,19 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       });
     });
 
+    itemSearchEl?.addEventListener('input', () => {
+      persistQuickFilters();
+      renderWorkqueuePaneItems(pane);
+    });
+    itemSearchEl?.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && itemSearchEl.value) {
+        e.preventDefault();
+        itemSearchEl.value = '';
+        persistQuickFilters();
+        renderWorkqueuePaneItems(pane);
+      }
+    });
+
     clawnsoleOnlyBtn?.addEventListener('click', () => {
       sourceSet.clear();
       repoSet.clear();
@@ -6223,6 +6271,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     clearQuickBtn?.addEventListener('click', () => {
       sourceSet.clear();
       repoSet.clear();
+      if (itemSearchEl) itemSearchEl.value = '';
       persistQuickFilters();
       updateQuickFilterUi();
       renderWorkqueuePaneItems(pane);
@@ -7045,7 +7094,8 @@ const paneManager = {
           const scopeFilter = normalizeWorkqueueScope(item.scopeFilter ?? getDefaultWorkqueueScope());
           const quickFilters = {
             sources: Array.isArray(item?.quickFilters?.sources) ? item.quickFilters.sources.map((s) => String(s || '').trim()).filter(Boolean) : [],
-            repos: Array.isArray(item?.quickFilters?.repos) ? item.quickFilters.repos.map((s) => String(s || '').trim()).filter(Boolean) : []
+            repos: Array.isArray(item?.quickFilters?.repos) ? item.quickFilters.repos.map((s) => String(s || '').trim()).filter(Boolean) : [],
+            itemSearch: typeof item?.quickFilters?.itemSearch === 'string' ? item.quickFilters.itemSearch.trim() : ''
           };
           const sortKey = typeof item.sortKey === 'string' ? item.sortKey : 'priority';
           const sortDir = item.sortDir === 'asc' ? 'asc' : 'desc';
@@ -7093,7 +7143,8 @@ const paneManager = {
           scopeFilter: pane.workqueue?.scopeFilter || 'all',
           quickFilters: {
             sources: Array.isArray(pane.workqueue?.quickFilters?.sources) ? pane.workqueue.quickFilters.sources : [],
-            repos: Array.isArray(pane.workqueue?.quickFilters?.repos) ? pane.workqueue.quickFilters.repos : []
+            repos: Array.isArray(pane.workqueue?.quickFilters?.repos) ? pane.workqueue.quickFilters.repos : [],
+            itemSearch: typeof pane.workqueue?.quickFilters?.itemSearch === 'string' ? pane.workqueue.quickFilters.itemSearch : ''
           },
           sortKey: pane.workqueue?.sortKey || 'priority',
           sortDir: pane.workqueue?.sortDir || 'desc'
@@ -7707,7 +7758,7 @@ globalElements.wqRefreshBtn?.addEventListener('click', () => {
 globalElements.wqEnqueueBtn?.addEventListener('click', () => workqueueEnqueueFromUi());
 globalElements.wqClaimBtn?.addEventListener('click', () => workqueueClaimNextFromUi());
 
-let shortcutState = { lastGAtMs: 0 };
+let shortcutState = { lastGAtMs: 0, lastWAtMs: 0 };
 
 function isTypingContext(target) {
   const el = target || document.activeElement;
@@ -7845,6 +7896,71 @@ function cycleUnreadPaneFocus(direction = 1) {
   const next = Number.isInteger(pick) ? pick : ordered[0];
   focusPaneIndex(next);
   return true;
+}
+
+function activeWorkqueuePane() {
+  const active = document.activeElement;
+  const panes = paneManager?.panes || [];
+  const focused = panes.find((pane) => {
+    const root = pane?.elements?.root;
+    return pane?.kind === 'workqueue' && root && active && (root === active || root.contains(active));
+  });
+  if (focused) return focused;
+
+  const key = focusedPaneKey();
+  return panes.find((pane) => pane?.kind === 'workqueue' && pane.key === key) || null;
+}
+
+function canFocusShortcutTarget(el) {
+  if (!el || typeof el.focus !== 'function') return false;
+  try {
+    if (el.disabled || el.hidden) return false;
+    if (el.closest?.('[hidden]')) return false;
+    if (el.getClientRects && el.getClientRects().length === 0) return false;
+  } catch {
+    return false;
+  }
+  return true;
+}
+
+function focusWorkqueueControl(target) {
+  const pane = activeWorkqueuePane();
+  if (!pane) {
+    showToast('Open or focus a Workqueue pane first.', { kind: 'info', timeoutMs: 2200 });
+    return false;
+  }
+
+  const root = pane.elements?.thread;
+  const selectors = {
+    queue: '[data-wq-queue-search]',
+    item: '[data-wq-item-search]',
+    status: '[data-wq-status-details] summary'
+  };
+  const labels = {
+    queue: 'queue search',
+    item: 'item search',
+    status: 'status filter'
+  };
+  const el = root?.querySelector?.(selectors[target]);
+  if (!canFocusShortcutTarget(el)) {
+    showToast(`Workqueue ${labels[target] || 'control'} is hidden or disabled.`, { kind: 'info', timeoutMs: 2400 });
+    return false;
+  }
+
+  try {
+    pane.elements?.root?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
+    el.focus();
+    if (target === 'status') {
+      root?.querySelector?.('[data-wq-status-details]')?.setAttribute('open', '');
+    } else if (typeof el.select === 'function') {
+      el.select();
+    }
+    notePaneFocused(pane);
+    return true;
+  } catch {
+    showToast(`Unable to focus Workqueue ${labels[target] || 'control'}.`, { kind: 'error', timeoutMs: 2600 });
+    return false;
+  }
 }
 
 window.addEventListener('keydown', (event) => {
@@ -7996,17 +8112,32 @@ window.addEventListener('keydown', (event) => {
   // 'g' chords jump between common triage surfaces.
   const now = Date.now();
   if (!event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey) {
+    const hasPendingGChord = shortcutState.lastGAtMs && now - shortcutState.lastGAtMs < 1000;
+    if (key.toLowerCase() === 'w' && activeWorkqueuePane() && !hasPendingGChord) {
+      shortcutState.lastWAtMs = now;
+      return;
+    }
+    if (shortcutState.lastWAtMs && now - shortcutState.lastWAtMs < 1000) {
+      const workqueueFocusMap = { q: 'queue', i: 'item', s: 'status' };
+      const target = workqueueFocusMap[key.toLowerCase()];
+      if (target) {
+        shortcutState.lastWAtMs = 0;
+        event.preventDefault();
+        focusWorkqueueControl(target);
+        return;
+      }
+    }
     if (key.toLowerCase() === 'g') {
       shortcutState.lastGAtMs = now;
       return;
     }
-    if (key.toLowerCase() === 'c' && shortcutState.lastGAtMs && now - shortcutState.lastGAtMs < 1000) {
+    if (key.toLowerCase() === 'c' && hasPendingGChord) {
       shortcutState.lastGAtMs = 0;
       event.preventDefault();
       returnToLastActiveChatPane();
       return;
     }
-    if (key.toLowerCase() === 'w' && shortcutState.lastGAtMs && now - shortcutState.lastGAtMs < 1000) {
+    if (key.toLowerCase() === 'w' && hasPendingGChord) {
       shortcutState.lastGAtMs = 0;
       event.preventDefault();
       openTopbarWorkqueueAction();

--- a/index.html
+++ b/index.html
@@ -272,6 +272,9 @@
           <div class="shortcut-group">
             <h3 class="shortcut-group-title">Workqueue actions</h3>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>g</kbd> <kbd>w</kbd></div><div class="shortcut-desc">Open Workqueue modal</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>w</kbd> <kbd>q</kbd></div><div class="shortcut-desc">Focus Workqueue queue search</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>w</kbd> <kbd>i</kbd></div><div class="shortcut-desc">Focus Workqueue item search</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>w</kbd> <kbd>s</kbd></div><div class="shortcut-desc">Focus Workqueue status filter</div></div>
           </div>
         </div>
       </div>

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -36,6 +36,9 @@ test('shortcuts overlay: ? opens, Esc closes, content renders', async ({ page })
   await expect(modal).toContainText('Pane focus/navigation');
   await expect(modal).toContainText('Pane actions');
   await expect(modal).toContainText('Workqueue actions');
+  await expect(modal).toContainText('Focus Workqueue queue search');
+  await expect(modal).toContainText('Focus Workqueue item search');
+  await expect(modal).toContainText('Focus Workqueue status filter');
   await expect(modal).toContainText('disabled while typing');
 
   await page.keyboard.press('Escape');

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -50,6 +50,7 @@ test('workqueue pane: renders + has queue dropdown + does not show chat composer
   await expect(wqPane.locator('.wq-pane')).toHaveCount(1);
   await expect(wqPane.locator('[data-wq-queue-search]')).toBeVisible();
   await expect(wqPane.locator('[data-wq-queue-select]')).toBeVisible();
+  await expect(wqPane.locator('[data-wq-item-search]')).toBeVisible();
 
   // Header target should describe queue context (not agent).
   await expect(wqPane.locator('[data-pane-target-label]')).toHaveText('Queue');
@@ -229,6 +230,78 @@ test('workqueue pane: source chips + clawnsole preset filter items without reloa
   await pane.locator('[data-wq-preset-clawnsole]').click();
   await expect(pane.locator('.wq-row')).toHaveCount(1);
   await expect(pane.locator('.wq-row .wq-col.title')).toContainText(/clawnsole issue item/i);
+});
+
+test('workqueue pane: item search and control focus shortcuts are guarded', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  const pane = page.locator('[data-pane]').last();
+  const queue = `shortcut-focus-${Date.now()}`;
+
+  const enqueue = async (title) => {
+    await page.evaluate(async ({ queue, title }) => {
+      await fetch('/api/workqueue/enqueue', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ queue, title, instructions: 'shortcut coverage', priority: 50 })
+      });
+    }, { queue, title });
+  };
+
+  await enqueue('shortcut alpha item');
+  await enqueue('shortcut beta item');
+
+  await pane.locator('[data-wq-queue-select]').selectOption('__custom__');
+  await pane.locator('[data-wq-queue-custom]').fill(queue);
+  await pane.locator('[data-wq-queue-custom]').press('Enter');
+  await pane.locator('[data-wq-refresh]').click();
+  await expect(pane.locator('.wq-row')).toHaveCount(2);
+
+  const itemSearch = pane.locator('[data-wq-item-search]');
+  await itemSearch.fill('alpha');
+  await expect(pane.locator('.wq-row')).toHaveCount(1);
+  await expect(pane.locator('.wq-row .wq-col.title')).toContainText('shortcut alpha item');
+  await itemSearch.press('Escape');
+  await expect(pane.locator('.wq-row')).toHaveCount(2);
+
+  const trigger = pane.locator('[data-wq-refresh]');
+  await trigger.focus();
+  await expect(trigger).toBeFocused();
+
+  await page.keyboard.press('w');
+  await page.keyboard.press('q');
+  await expect(pane.locator('[data-wq-queue-search]')).toBeFocused();
+
+  await trigger.focus();
+  await page.keyboard.press('w');
+  await page.keyboard.press('i');
+  await expect(itemSearch).toBeFocused();
+
+  await trigger.focus();
+  await page.keyboard.press('w');
+  await page.keyboard.press('s');
+  await expect(pane.locator('[data-wq-status-details] summary')).toBeFocused();
+  await expect(pane.locator('[data-wq-status-details]')).toHaveAttribute('open', '');
+
+  await itemSearch.focus();
+  await page.keyboard.press('w');
+  await page.keyboard.press('q');
+  await expect(itemSearch).toBeFocused();
+
+  await trigger.focus();
+  await pane.locator('[data-wq-item-search]').evaluate((el) => {
+    el.setAttribute('hidden', '');
+  });
+  await page.keyboard.press('w');
+  await page.keyboard.press('i');
+  await expect(page.getByTestId('toast').filter({ hasText: 'hidden or disabled' })).toBeVisible();
 });
 
 test('workqueue pane: controls toolbar is sticky and list scrolls independently', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Add Workqueue item search filtering and persist it with pane quick filters.
- Add Workqueue-scoped focus shortcuts: w q for queue search, w i for item search, and w s for status filter.
- Surface shortcuts in the help modal and inline Workqueue pane help; blocked targets show non-disruptive toasts.

## Tests
- npm test
- npx playwright test tests/ui/workqueue-pane.spec.js tests/pane.shortcuts.e2e.spec.js --workers=1

Closes #379