### PR TITLE
Add pane-switch HUD for keyboard navigation

### DIFF
--- a/app.js
+++ b/app.js
@@ -72,6 +72,7 @@ const globalElements = {
   settingsBtn: document.getElementById('settingsBtn'),
   settingsModal: document.getElementById('settingsModal'),
   settingsCloseBtn: document.getElementById('settingsCloseBtn'),
+  showPaneSwitchHud: document.getElementById('showPaneSwitchHud'),
   rolePill: document.getElementById('rolePill'),
   loginOverlay: document.getElementById('loginOverlay'),
   loginPassword: document.getElementById('loginPassword'),
@@ -246,6 +247,7 @@ const ADMIN_AGENT_HEALTHY_COLLAPSE_THRESHOLD = 10;
 const ADMIN_AUTH_DESTINATION_KEY = 'clawnsole.admin.authDestination.v1';
 const ADMIN_AUTH_RESTORE_PENDING_KEY = 'clawnsole.admin.authRestorePending.v1';
 const ADMIN_AUTH_RESTORE_NOTICE_KEY = 'clawnsole.admin.authRestoreNotice.v1';
+const PANE_SWITCH_HUD_PREF_KEY = 'clawnsole.admin.showPaneSwitchHud.v1';
 const ADMIN_AUTH_DESTINATION_TTL_MS = 10 * 60 * 1000;
 const WQ_RECENT_TARGETS_KEY = 'clawnsole.wq.recentTargets';
 const WQ_RECENT_ENQUEUE_AGENTS_KEY = 'clawnsole.wq.recentEnqueueAgents';
@@ -1293,6 +1295,10 @@ function openSettings() {
   globalElements.settingsModal.classList.add('open');
   globalElements.settingsModal.setAttribute('aria-hidden', 'false');
 
+  if (globalElements.showPaneSwitchHud) {
+    globalElements.showPaneSwitchHud.checked = storage.get(PANE_SWITCH_HUD_PREF_KEY, true) !== false;
+  }
+
   // Guest mode removed.
 
   loadRecurringPromptAgents();
@@ -1302,6 +1308,45 @@ function openSettings() {
 function closeSettings() {
   globalElements.settingsModal.classList.remove('open');
   globalElements.settingsModal.setAttribute('aria-hidden', 'true');
+}
+
+let paneSwitchHudEl = null;
+let paneSwitchHudTimer = null;
+
+function paneSwitchHudEnabled() {
+  return storage.get(PANE_SWITCH_HUD_PREF_KEY, true) !== false;
+}
+
+function ensurePaneSwitchHud() {
+  if (paneSwitchHudEl) return paneSwitchHudEl;
+  const el = document.createElement('div');
+  el.className = 'pane-switch-hud';
+  el.dataset.testid = 'pane-switch-hud';
+  el.setAttribute('aria-hidden', 'true');
+  document.body.appendChild(el);
+  paneSwitchHudEl = el;
+  return el;
+}
+
+function showPaneSwitchHud(pane, { source = '' } = {}) {
+  if (source !== 'keyboard') return;
+  if (!paneSwitchHudEnabled()) return;
+  if (!pane) return;
+
+  const el = ensurePaneSwitchHud();
+  const letter = paneHeaderLetter(pane);
+  const type = paneLabel(pane);
+  const target = paneTargetLabel(pane);
+  el.innerHTML = `
+    <div class="pane-switch-hud__identity">${escapeHtml(letter)} ${escapeHtml(type)} <span aria-hidden="true">·</span> ${escapeHtml(target)}</div>
+    <div class="pane-switch-hud__actions">${escapeHtml(pane.kind === 'chat' ? 'Type to send · Ctrl/Cmd+K commands' : 'Tab for controls · Ctrl/Cmd+K commands')}</div>
+  `;
+
+  window.clearTimeout(paneSwitchHudTimer);
+  el.classList.add('open');
+  paneSwitchHudTimer = window.setTimeout(() => {
+    el.classList.remove('open');
+  }, 900);
 }
 
 const recurringPromptState = {
@@ -1789,9 +1834,7 @@ function switchPaneByMru(direction = 1) {
   traversal.updatedAt = now;
   paneMruTraversal = traversal;
 
-  focusPaneIndex(paneIdx, { trackMru: false });
-  const pane = panes[paneIdx];
-  if (pane) showToast(`Switched to ${paneIdentityLabel(pane)}`, { kind: 'info', timeoutMs: 1400 });
+  focusPaneIndex(paneIdx, { trackMru: false, source: 'keyboard' });
   return true;
 }
 
@@ -7508,6 +7551,9 @@ globalElements.settingsCloseBtn?.addEventListener('click', () => closeSettings()
 globalElements.settingsModal?.addEventListener('click', (event) => {
   if (event.target === globalElements.settingsModal) closeSettings();
 });
+globalElements.showPaneSwitchHud?.addEventListener('change', () => {
+  storage.set(PANE_SWITCH_HUD_PREF_KEY, !!globalElements.showPaneSwitchHud.checked);
+});
 
 globalElements.shortcutsBtn?.addEventListener('click', () => openShortcuts());
 globalElements.shortcutsCloseBtn?.addEventListener('click', () => closeShortcuts());
@@ -7718,11 +7764,12 @@ function isTypingContext(target) {
   return false;
 }
 
-function focusPaneIndex(idx, { trackMru = true } = {}) {
+function focusPaneIndex(idx, { trackMru = true, source = '' } = {}) {
   const pane = paneManager.panes[idx];
   if (!pane) return;
   clearPaneUnread(pane);
   if (trackMru) notePaneFocused(pane);
+  showPaneSwitchHud(pane, { source });
 
   try {
     pane.elements?.root?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
@@ -7789,14 +7836,14 @@ function returnToLastActiveChatPane() {
     if (!key || key === activeKey) continue;
     const idx = panes.findIndex((pane) => pane.key === key && pane.kind === 'chat');
     if (idx >= 0) {
-      focusPaneIndex(idx);
+      focusPaneIndex(idx, { source: 'keyboard' });
       return true;
     }
   }
 
   const fallbackIdx = panes.findIndex((pane) => pane.kind === 'chat' && pane.key !== activeKey);
   if (fallbackIdx >= 0) {
-    focusPaneIndex(fallbackIdx);
+    focusPaneIndex(fallbackIdx, { source: 'keyboard' });
     return true;
   }
 
@@ -7811,7 +7858,7 @@ function cyclePaneFocus() {
   const active = document.activeElement;
   const idx = panes.findIndex((p) => p.elements?.root && (p.elements.root === active || p.elements.root.contains(active)));
   const next = idx >= 0 ? (idx + 1) % panes.length : 0;
-  focusPaneIndex(next);
+  focusPaneIndex(next, { source: 'keyboard' });
 }
 
 function cyclePaneFocusBackward() {
@@ -7821,7 +7868,7 @@ function cyclePaneFocusBackward() {
   const active = document.activeElement;
   const idx = panes.findIndex((p) => p.elements?.root && (p.elements.root === active || p.elements.root.contains(active)));
   const next = idx >= 0 ? (idx - 1 + panes.length) % panes.length : panes.length - 1;
-  focusPaneIndex(next);
+  focusPaneIndex(next, { source: 'keyboard' });
 }
 
 function cycleUnreadPaneFocus(direction = 1) {
@@ -7843,7 +7890,7 @@ function cycleUnreadPaneFocus(direction = 1) {
   const ordered = dir > 0 ? unreadIndexes : unreadIndexes.slice().reverse();
   const pick = ordered.find((idx) => dir > 0 ? idx > currentIdx : idx < currentIdx);
   const next = Number.isInteger(pick) ? pick : ordered[0];
-  focusPaneIndex(next);
+  focusPaneIndex(next, { source: 'keyboard' });
   return true;
 }
 
@@ -7930,7 +7977,7 @@ window.addEventListener('keydown', (event) => {
     const n = Number.parseInt(key, 10);
     if (Number.isFinite(n) && n >= 1 && n <= 9) {
       event.preventDefault();
-      focusPaneIndex(n - 1);
+      focusPaneIndex(n - 1, { source: 'keyboard' });
       return;
     }
   }
@@ -7940,7 +7987,7 @@ window.addEventListener('keydown', (event) => {
     const n = Number.parseInt(key, 10);
     if (Number.isFinite(n) && n >= 1 && n <= 9) {
       event.preventDefault();
-      focusPaneIndex(n - 1);
+      focusPaneIndex(n - 1, { source: 'keyboard' });
       return;
     }
   }

--- a/index.html
+++ b/index.html
@@ -475,6 +475,14 @@
             Auto-connecting with the gateway token from your local OpenClaw config.
           </div>
 
+          <section class="settings-section" aria-label="Pane switching">
+            <h3>Pane switching</h3>
+            <label class="inline-checkbox">
+              <input id="showPaneSwitchHud" type="checkbox" checked />
+              Show pane-switch HUD
+            </label>
+          </section>
+
           <section class="settings-section" aria-label="Recurring admin prompts">
             <h3>Recurring admin/system prompts</h3>
             <p class="hint">These run as admin/system prompts via <code>/api/recurring-prompts</code>.</p>

--- a/styles.css
+++ b/styles.css
@@ -3155,6 +3155,52 @@ kbd {
   color: rgba(255, 230, 230, 0.95);
 }
 
+.pane-switch-hud {
+  position: fixed;
+  z-index: 9998;
+  left: 50%;
+  bottom: 28px;
+  max-width: min(460px, calc(100vw - 32px));
+  padding: 12px 16px;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(10, 15, 23, 0.92);
+  color: rgba(248, 250, 252, 0.96);
+  box-shadow: 0 18px 55px rgba(0, 0, 0, 0.48);
+  pointer-events: none;
+  transform: translate(-50%, 10px);
+  opacity: 0;
+  transition: opacity 140ms ease, transform 140ms ease;
+}
+
+.pane-switch-hud.open {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.pane-switch-hud__identity {
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.25;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.pane-switch-hud__actions {
+  margin-top: 3px;
+  color: rgba(203, 213, 225, 0.78);
+  font-size: 12px;
+  line-height: 1.25;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pane-switch-hud {
+    transition: none;
+    transform: translate(-50%, 0);
+  }
+}
+
 /* Cron + Timeline */
 .cron-list {
   display: flex;

--- a/tests/ui/pane-switch-hud.spec.js
+++ b/tests/ui/pane-switch-hud.spec.js
@@ -1,0 +1,53 @@
+const { test, expect } = require('@playwright/test');
+
+const { startTestEnv, loginAdmin, attachConsoleErrorAsserts, addPane } = require('./_helpers');
+
+let env;
+
+test.beforeAll(async () => {
+  env = await startTestEnv();
+});
+
+test.afterAll(() => {
+  env?.stop?.();
+});
+
+test.afterEach(async ({ page }) => {
+  if (page.__consoleAsserts) {
+    page.__consoleAsserts.assertNoErrors();
+  }
+});
+
+test('pane switch HUD appears for keyboard pane changes and honors setting', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  const hud = page.getByTestId('pane-switch-hud');
+  await expect(hud).toHaveCount(0);
+
+  await page.locator('[data-testid="pane"][data-pane-kind="workqueue"]').last().click();
+  await expect(hud).toHaveCount(0);
+
+  await page.evaluate(() => document.activeElement?.blur?.());
+  await page.keyboard.press('Alt+1');
+  await expect(hud).toBeVisible();
+  await expect(hud).toContainText(/A Chat · main/);
+  await expect(page.locator('[data-testid="pane"][data-pane-kind="chat"]').first().locator('[data-pane-input]')).toBeFocused();
+
+  await page.getByRole('button', { name: 'Open settings' }).click();
+  await expect(page.locator('#settingsModal')).toHaveAttribute('aria-hidden', 'false');
+  await page.locator('#showPaneSwitchHud').uncheck();
+  await page.keyboard.press('Escape');
+  await expect(page.locator('#settingsModal')).toHaveAttribute('aria-hidden', 'true');
+
+  await page.waitForTimeout(950);
+  await expect(hud).not.toHaveClass(/open/);
+  await page.evaluate(() => document.activeElement?.blur?.());
+  await page.keyboard.press('Alt+2');
+  await expect(hud).not.toHaveClass(/open/);
+});


### PR DESCRIPTION
Fixes #265.\n\n## Summary\n- Add a keyboard-only pane-switch HUD showing pane letter, type, target, and context actions\n- Add a Settings toggle for the HUD, default on\n- Cover keyboard display, mouse suppression, focus preservation, and setting disablement with a UI spec\n\n## Tests\n- npm test\n- npx playwright test tests/ui/pane-switch-hud.spec.js