### PR TITLE
Add baseline pane restore affordance

### DIFF
--- a/app.js
+++ b/app.js
@@ -490,18 +490,33 @@ const uiState = {
 };
 
 let toastSeq = 0;
-function showToast(message, { kind = 'info', timeoutMs = 2600 } = {}) {
+function showToast(message, { kind = 'info', timeoutMs = 2600, actionLabel = '', onAction = null, testId = 'toast' } = {}) {
   if (!globalElements.toastHost) return;
   const text = typeof message === 'string' ? message.trim() : String(message || '').trim();
   if (!text) return;
 
   const el = document.createElement('div');
   el.className = `toast ${kind === 'error' ? 'toast-error' : 'toast-info'}`;
-  el.textContent = text;
   const id = ++toastSeq;
   el.dataset.toastId = String(id);
-  el.setAttribute('data-testid', 'toast');
+  el.setAttribute('data-testid', testId || 'toast');
   el.dataset.toastKind = kind;
+
+  const messageEl = document.createElement('span');
+  messageEl.className = 'toast-message';
+  messageEl.textContent = text;
+  el.appendChild(messageEl);
+
+  const hasAction = actionLabel && typeof onAction === 'function';
+  let actionBtn = null;
+  if (hasAction) {
+    actionBtn = document.createElement('button');
+    actionBtn.type = 'button';
+    actionBtn.className = 'toast-action';
+    actionBtn.textContent = String(actionLabel);
+    actionBtn.dataset.testid = 'toast-action';
+    el.appendChild(actionBtn);
+  }
 
   globalElements.toastHost.appendChild(el);
 
@@ -521,7 +536,18 @@ function showToast(message, { kind = 'info', timeoutMs = 2600 } = {}) {
   };
 
   const timer = setTimeout(remove, Math.max(800, Number(timeoutMs) || 2600));
+  actionBtn?.addEventListener('click', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    clearTimeout(timer);
+    try {
+      onAction?.();
+    } catch {}
+    remove();
+  });
+
   el.addEventListener('click', () => {
+    if (hasAction) return;
     clearTimeout(timer);
     remove();
   });
@@ -4193,6 +4219,7 @@ renderPulse();
 
 const ADMIN_PANES_KEY = 'clawnsole.admin.panes.v1';
 // Layout is inferred from pane count; no manual layout toggle.
+const ADMIN_LAYOUT_MODE_KEY = 'clawnsole.admin.layoutMode';
 const ADMIN_DEFAULT_AGENT_KEY = 'clawnsole.admin.agentId';
 const WORKQUEUE_SCOPE_PREF_KEY = 'clawnsole.admin.workqueue.scope.v1';
 
@@ -7199,8 +7226,10 @@ const paneManager = {
         kind: 'workqueue',
         agentId: nextAgentId,
         queue: nextQueue,
-        statusFilter: ['ready', 'pending', 'claimed', 'in_progress'],
-        scopeFilter: getDefaultWorkqueueScope(),
+        statusFilter: Array.isArray(options?.statusFilter) && options.statusFilter.length
+          ? options.statusFilter
+          : ['ready', 'pending', 'claimed', 'in_progress'],
+        scopeFilter: normalizeWorkqueueScope(options?.scopeFilter ?? getDefaultWorkqueueScope()),
         closable: true
       });
       this.panes.push(pane);
@@ -7281,6 +7310,38 @@ const paneManager = {
         }
       } catch {}
     }, 0);
+  },
+  baselineGuardEnabled() {
+    if (roleState.role !== 'admin') return false;
+    return String(storage.get(ADMIN_LAYOUT_MODE_KEY, 'default') || 'default') !== 'custom';
+  },
+  maybeOfferBaselineRestore(removedPane) {
+    if (!this.baselineGuardEnabled()) return;
+    const kind = removedPane?.kind;
+    if (kind !== 'chat' && kind !== 'workqueue') return;
+    if (this.panes.some((pane) => pane?.kind === kind)) return;
+
+    const labelKind = kind === 'workqueue' ? 'Workqueue' : 'Chat';
+    const agentId = normalizeAgentId(removedPane.agentId || storage.get(ADMIN_DEFAULT_AGENT_KEY, 'main') || 'main');
+    const restoreOptions =
+      kind === 'workqueue'
+        ? {
+            forceNew: true,
+            agentId,
+            queue: removedPane.workqueue?.queue || 'dev-team',
+            statusFilter: Array.isArray(removedPane.workqueue?.statusFilter)
+              ? removedPane.workqueue.statusFilter.slice()
+              : undefined,
+            scopeFilter: removedPane.workqueue?.scopeFilter || getDefaultWorkqueueScope()
+          }
+        : { agentId };
+
+    showToast(`${labelKind} pane closed.`, {
+      timeoutMs: 10000,
+      actionLabel: `Restore ${labelKind} pane`,
+      testId: `restore-${kind}-toast`,
+      onAction: () => this.addPane(kind, restoreOptions)
+    });
   },
   openAddPaneMenu(anchorEl) {
     if (roleState.role !== 'admin') return;
@@ -7452,6 +7513,7 @@ const paneManager = {
     this.updateCloseButtons();
     this.applyInferredLayout();
     this.persistAdminPanes();
+    this.maybeOfferBaselineRestore(pane);
     updateGlobalStatus();
     updateConnectionControls();
   },

--- a/app.js
+++ b/app.js
@@ -7263,7 +7263,7 @@ const paneManager = {
       return pane;
     }
 
-    const agentId = normalizeAgentId(storage.get(ADMIN_DEFAULT_AGENT_KEY, 'main'));
+    const agentId = normalizeAgentId(options?.agentId || storage.get(ADMIN_DEFAULT_AGENT_KEY, 'main'));
     const pane = createPane({ key: `p${randomId().slice(0, 8)}`, role: 'admin', kind: 'chat', agentId, closable: true });
     this.panes.push(pane);
     globalElements.paneGrid.appendChild(pane.elements.root);

--- a/styles.css
+++ b/styles.css
@@ -3127,6 +3127,9 @@ kbd {
 
 .toast {
   pointer-events: auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
   padding: 10px 12px;
   border-radius: 12px;
   font-size: 14px;
@@ -3137,6 +3140,26 @@ kbd {
   transform: translateY(10px);
   opacity: 0;
   transition: opacity 160ms ease, transform 160ms ease;
+}
+
+.toast-message {
+  min-width: 0;
+}
+
+.toast-action {
+  flex: 0 0 auto;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.1);
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  padding: 6px 8px;
+}
+
+.toast-action:hover {
+  background: rgba(255, 255, 255, 0.16);
 }
 
 .toast.open {

--- a/tests/ui/pane-baseline-restore.spec.js
+++ b/tests/ui/pane-baseline-restore.spec.js
@@ -1,4 +1,6 @@
 const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
 
 const { startTestEnv, waitForAdminUiReady, attachConsoleErrorAsserts } = require('./_helpers');
 
@@ -18,17 +20,35 @@ test.afterEach(async ({ page }) => {
   }
 });
 
-async function loginAdminWithBaselinePanes(page, serverPort) {
+async function loginAdminWithBaselinePanes(page, serverPort, { chatAgentId = 'main' } = {}) {
+  if (chatAgentId !== 'main' && env?.tempHome) {
+    const configPath = path.join(env.tempHome, '.openclaw', 'openclaw.json');
+    const cfg = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    cfg.agents = {
+      list: [
+        { id: 'main', name: 'main' },
+        { id: chatAgentId, name: chatAgentId }
+      ]
+    };
+    fs.writeFileSync(configPath, JSON.stringify(cfg, null, 2));
+  }
+
   await page.goto(`http://127.0.0.1:${serverPort}/`);
-  await page.evaluate(() => {
+  await page.evaluate((nextChatAgentId) => {
     localStorage.removeItem('clawnsole.admin.authDestination.v1');
     localStorage.removeItem('clawnsole.admin.authRestorePending.v1');
     localStorage.removeItem('clawnsole.admin.authRestoreNotice.v1');
+    if (nextChatAgentId !== 'main') {
+      localStorage.setItem(
+        'clawnsole.admin.authDestination.v1',
+        JSON.stringify({ href: '/admin', createdAt: Date.now(), activePaneKey: 'ptestchat' })
+      );
+    }
     localStorage.setItem('clawnsole.admin.agentId', 'main');
     localStorage.setItem(
       'clawnsole.admin.panes.v1',
       JSON.stringify([
-        { key: 'ptestchat', kind: 'chat', agentId: 'main' },
+        { key: 'ptestchat', kind: 'chat', agentId: nextChatAgentId },
         {
           key: 'ptestwq',
           kind: 'workqueue',
@@ -41,7 +61,7 @@ async function loginAdminWithBaselinePanes(page, serverPort) {
         }
       ])
     );
-  });
+  }, chatAgentId);
   await page.fill('#loginPassword', 'admin');
   await page.click('#loginBtn');
   await waitForAdminUiReady(page);
@@ -79,6 +99,50 @@ test('baseline restore: close and restore final chat and workqueue panes', async
 
   await expect(workqueuePanes).toHaveCount(1);
   await expect(workqueuePanes.first().locator('[data-wq-queue-select]')).toBeFocused();
+});
+
+test('baseline restore: restored chat keeps original agent', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdminWithBaselinePanes(page, env.serverPort, { chatAgentId: 'dev' });
+  await expect
+    .poll(async () =>
+      page.evaluate(async () => {
+        const res = await fetch('/agents', { credentials: 'include', cache: 'no-store' });
+        const data = await res.json();
+        return (data.agents || []).map((agent) => agent.id).join(',');
+      })
+    )
+    .toContain('dev');
+
+  const chatPanes = page.locator('[data-pane][data-pane-kind="chat"]');
+  await expect(chatPanes).toHaveCount(1);
+  await expect
+    .poll(async () =>
+      page.evaluate(() => {
+        const panes = JSON.parse(localStorage.getItem('clawnsole.admin.panes.v1') || '[]');
+        return panes.find((pane) => pane.kind === 'chat')?.agentId || '';
+      })
+    )
+    .toBe('dev');
+  await chatPanes.first().getByTestId('pane-close').click();
+
+  const restoreChatToast = page.getByTestId('restore-chat-toast');
+  await expect(restoreChatToast).toBeVisible();
+  await restoreChatToast.getByTestId('toast-action').click();
+
+  await expect(chatPanes).toHaveCount(1);
+  await expect
+    .poll(async () =>
+      page.evaluate(() => {
+        const panes = JSON.parse(localStorage.getItem('clawnsole.admin.panes.v1') || '[]');
+        return panes.find((pane) => pane.kind === 'chat')?.agentId || '';
+      })
+    )
+    .toBe('dev');
 });
 
 test('baseline restore: custom layout mode disables restore affordance', async ({ page }) => {

--- a/tests/ui/pane-baseline-restore.spec.js
+++ b/tests/ui/pane-baseline-restore.spec.js
@@ -1,0 +1,97 @@
+const { test, expect } = require('@playwright/test');
+
+const { startTestEnv, waitForAdminUiReady, attachConsoleErrorAsserts } = require('./_helpers');
+
+let env;
+
+test.beforeAll(async () => {
+  env = await startTestEnv();
+});
+
+test.afterAll(() => {
+  env?.stop?.();
+});
+
+test.afterEach(async ({ page }) => {
+  if (page.__consoleAsserts) {
+    page.__consoleAsserts.assertNoErrors();
+  }
+});
+
+async function loginAdminWithBaselinePanes(page, serverPort) {
+  await page.goto(`http://127.0.0.1:${serverPort}/`);
+  await page.evaluate(() => {
+    localStorage.removeItem('clawnsole.admin.authDestination.v1');
+    localStorage.removeItem('clawnsole.admin.authRestorePending.v1');
+    localStorage.removeItem('clawnsole.admin.authRestoreNotice.v1');
+    localStorage.setItem('clawnsole.admin.agentId', 'main');
+    localStorage.setItem(
+      'clawnsole.admin.panes.v1',
+      JSON.stringify([
+        { key: 'ptestchat', kind: 'chat', agentId: 'main' },
+        {
+          key: 'ptestwq',
+          kind: 'workqueue',
+          agentId: 'main',
+          queue: 'dev-team',
+          statusFilter: ['ready', 'pending', 'claimed', 'in_progress'],
+          scopeFilter: 'all',
+          sortKey: 'priority',
+          sortDir: 'desc'
+        }
+      ])
+    );
+  });
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await waitForAdminUiReady(page);
+}
+
+test('baseline restore: close and restore final chat and workqueue panes', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdminWithBaselinePanes(page, env.serverPort);
+
+  const chatPanes = page.locator('[data-pane][data-pane-kind="chat"]');
+  const workqueuePanes = page.locator('[data-pane][data-pane-kind="workqueue"]');
+
+  await expect(chatPanes).toHaveCount(1);
+  await expect(workqueuePanes).toHaveCount(1);
+  await chatPanes.first().getByTestId('pane-close').click();
+
+  const restoreChatToast = page.getByTestId('restore-chat-toast');
+  await expect(restoreChatToast).toBeVisible();
+  await expect(restoreChatToast.getByTestId('toast-action')).toHaveText('Restore Chat pane');
+  await restoreChatToast.getByTestId('toast-action').click();
+
+  await expect(chatPanes).toHaveCount(1);
+  await expect(chatPanes.first().locator('[data-pane-input]')).toBeFocused();
+
+  await workqueuePanes.first().getByTestId('pane-close').click();
+
+  const restoreWorkqueueToast = page.getByTestId('restore-workqueue-toast');
+  await expect(restoreWorkqueueToast).toBeVisible();
+  await expect(restoreWorkqueueToast.getByTestId('toast-action')).toHaveText('Restore Workqueue pane');
+  await restoreWorkqueueToast.getByTestId('toast-action').click();
+
+  await expect(workqueuePanes).toHaveCount(1);
+  await expect(workqueuePanes.first().locator('[data-wq-queue-select]')).toBeFocused();
+});
+
+test('baseline restore: custom layout mode disables restore affordance', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdminWithBaselinePanes(page, env.serverPort);
+  await page.evaluate(() => localStorage.setItem('clawnsole.admin.layoutMode', 'custom'));
+
+  await page.locator('[data-pane][data-pane-kind="chat"]').first().getByTestId('pane-close').click();
+
+  await expect(page.getByTestId('restore-chat-toast')).toHaveCount(0);
+  await expect(page.locator('[data-pane][data-pane-kind="chat"]')).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary
- add action-capable toast support for one-click pane restore
- offer restore actions when the last Chat or Workqueue pane is closed in default admin layout mode
- preserve Workqueue restore options and cover custom layout opt-out

## Tests
- npm test
- npx playwright test tests/ui/pane-baseline-restore.spec.js

Fixes #266