### PR TITLE
Add Fleet compact density mode

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,6 +30,7 @@ const globalElements = {
   agentsCloseBtn: document.getElementById('agentsCloseBtn'),
   agentsSearch: document.getElementById('agentsSearch'),
   agentsFilterButtons: Array.from(document.querySelectorAll('[data-agents-filter]')),
+  agentsDensityButtons: Array.from(document.querySelectorAll('[data-agents-density]')),
   agentsSort: document.getElementById('agentsSort'),
   agentsActiveMinutes: document.getElementById('agentsActiveMinutes'),
   agentsLastRefreshed: document.getElementById('agentsLastRefreshed'),
@@ -241,6 +242,7 @@ const ADMIN_AGENT_LAST_SEEN_KEY = 'clawnsole.admin.agentLastSeenAtMs';
 const ADMIN_AGENT_FILTER_KEY = 'clawnsole.admin.agents.filter';
 const ADMIN_AGENT_SORT_KEY = 'clawnsole.admin.agents.sort';
 const ADMIN_AGENT_ACTIVE_MINUTES_KEY = 'clawnsole.admin.agents.activeMinutes';
+const ADMIN_AGENT_DENSITY_KEY = 'clawnsole.admin.agents.density';
 const ADMIN_AGENT_HEALTHY_COLLAPSED_KEY = 'clawnsole.admin.agents.healthyCollapsed';
 const ADMIN_AGENT_HEALTHY_COLLAPSE_THRESHOLD = 10;
 const ADMIN_AUTH_DESTINATION_KEY = 'clawnsole.admin.authDestination.v1';
@@ -450,6 +452,23 @@ function getFleetSort() {
   const raw = String(storage.get(ADMIN_AGENT_SORT_KEY, 'recent_desc') || 'recent_desc').trim();
   const allowed = new Set(['recent_desc', 'agent_id_asc']);
   return allowed.has(raw) ? raw : 'recent_desc';
+}
+
+function getFleetDensity() {
+  return String(storage.get(ADMIN_AGENT_DENSITY_KEY, 'comfortable') || 'comfortable') === 'compact' ? 'compact' : 'comfortable';
+}
+
+function syncFleetDensityControl() {
+  const density = getFleetDensity();
+  if (globalElements.agentsList) {
+    globalElements.agentsList.dataset.density = density;
+    globalElements.agentsList.classList.toggle('compact', density === 'compact');
+  }
+  globalElements.agentsDensityButtons.forEach((btn) => {
+    const active = String(btn.getAttribute('data-agents-density') || '') === density;
+    btn.classList.toggle('active', active);
+    btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+  });
 }
 
 function getAgentPaneStateMap() {
@@ -2637,6 +2656,7 @@ function openAgentsModal() {
     const minutes = Number(storage.get(ADMIN_AGENT_ACTIVE_MINUTES_KEY, '10')) || 10;
     globalElements.agentsActiveMinutes.value = String(Math.max(1, minutes));
   }
+  syncFleetDensityControl();
 
   renderAgentsModalList();
   renderAgentsLastRefreshed();
@@ -2791,6 +2811,7 @@ function renderAgentsModalList() {
   const withinMinutes = Math.max(1, Number(globalElements.agentsActiveMinutes?.value) || 10);
   const filterMode = getFleetFilter();
   const sortMode = getFleetSort();
+  syncFleetDensityControl();
 
   const pins = getPinnedAgentIds();
   const lastSeenMap = getAgentLastSeenMap();
@@ -7646,6 +7667,14 @@ globalElements.agentsFilterButtons.forEach((btn) => {
       chip.setAttribute('aria-pressed', active ? 'true' : 'false');
     });
     renderAgentsModalList();
+  });
+});
+
+globalElements.agentsDensityButtons.forEach((btn) => {
+  btn.addEventListener('click', () => {
+    const density = String(btn.getAttribute('data-agents-density') || 'comfortable') === 'compact' ? 'compact' : 'comfortable';
+    storage.set(ADMIN_AGENT_DENSITY_KEY, density);
+    syncFleetDensityControl();
   });
 });
 

--- a/index.html
+++ b/index.html
@@ -438,6 +438,13 @@
               <span class="agents-label">Active window (min)</span>
               <input id="agentsActiveMinutes" type="number" min="1" step="1" value="10" aria-label="Active within minutes" />
             </label>
+            <div class="agents-field agents-density">
+              <span class="agents-label">Density</span>
+              <div class="agents-density-toggle" role="group" aria-label="Fleet density">
+                <button type="button" class="agents-chip" data-agents-density="comfortable" aria-pressed="true">Comfortable</button>
+                <button type="button" class="agents-chip" data-agents-density="compact" aria-pressed="false">Compact</button>
+              </div>
+            </div>
           </div>
 
           <div id="agentsList" class="agents-list" aria-label="Agent list"></div>

--- a/styles.css
+++ b/styles.css
@@ -1407,7 +1407,7 @@ button.send-btn .btn-icon {
 
 .agents-toolbar {
   display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: minmax(220px, 1fr) auto auto auto;
   gap: 12px;
   align-items: end;
   margin-bottom: 14px;
@@ -1438,6 +1438,12 @@ button.send-btn .btn-icon {
   gap: 8px;
 }
 
+.agents-density-toggle {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+}
+
 .agents-chip {
   border: 1px solid rgba(255, 255, 255, 0.16);
   background: rgba(255, 255, 255, 0.03);
@@ -1458,6 +1464,10 @@ button.send-btn .btn-icon {
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
+
+.agents-list.compact {
+  gap: 6px;
 }
 
 .agents-section-title {
@@ -1498,6 +1508,10 @@ button.agents-section-title:hover {
   gap: 8px;
 }
 
+.agents-list.compact .agents-rows {
+  gap: 4px;
+}
+
 .agents-rows[hidden] {
   display: none;
 }
@@ -1513,6 +1527,13 @@ button.agents-section-title:hover {
   background: rgba(255, 255, 255, 0.02);
 }
 
+.agents-list.compact .agents-row {
+  grid-template-columns: 32px minmax(0, 1fr) auto;
+  gap: 8px;
+  border-radius: 10px;
+  padding: 3px 8px;
+}
+
 .agents-pin {
   width: 36px;
   height: 36px;
@@ -1521,6 +1542,14 @@ button.agents-section-title:hover {
   background: rgba(9, 12, 16, 0.35);
   color: var(--text);
   cursor: pointer;
+}
+
+.agents-list.compact .agents-pin {
+  width: 24px;
+  height: 24px;
+  min-height: 24px;
+  padding: 0;
+  border-radius: 9px;
 }
 
 .agents-pin[aria-pressed="true"] {
@@ -1534,10 +1563,24 @@ button.agents-section-title:hover {
   color: var(--text);
 }
 
+.agents-list.compact .agents-row-title {
+  font-size: 13px;
+  line-height: 1.05;
+}
+
 .agents-row-meta {
   margin-top: 2px;
   font-size: 12px;
   color: var(--muted);
+}
+
+.agents-list.compact .agents-row-meta {
+  margin-top: 0;
+  font-size: 11px;
+  line-height: 1.05;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .agents-age-chip {
@@ -1562,6 +1605,13 @@ button.agents-section-title:hover {
   padding: 5px 9px;
   font-size: 12px;
   border-radius: 10px;
+}
+
+.agents-list.compact .agents-action-btn {
+  padding: 2px 6px;
+  min-height: 24px;
+  line-height: 1;
+  border-radius: 8px;
 }
 
 .agents-row-actions-overflow {

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -126,3 +126,50 @@ test('agents modal quick actions open/reuse chat, timeline, and workqueue contex
   await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
   await expect(page.locator('[data-pane][data-pane-kind="workqueue"] [data-wq-claim-agent]')).toHaveValue(agentId || 'main');
 });
+
+test('agents modal compact density tightens rows and persists', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  const agents = Array.from({ length: 5 }, (_, index) => {
+    const id = `density-agent-${index + 1}`;
+    return { id, name: id, displayName: id };
+  });
+
+  await clawnsole.gotoAndLoginAdmin(page);
+  await page.route(/\/agents(?:\?|$)/, async (route) => {
+    await route.fulfill({ json: { agents } });
+  });
+  await page.evaluate(() => {
+    const now = Date.now();
+    const lastSeen = {};
+    for (let index = 1; index <= 5; index += 1) {
+      lastSeen[`density-agent-${index}`] = now;
+    }
+    localStorage.setItem('clawnsole.admin.agentLastSeenAtMs', JSON.stringify(lastSeen));
+  });
+  await page.getByRole('button', { name: 'Refresh agent list' }).click();
+
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsModal')).toHaveClass(/open/);
+
+  const rows = page.locator('#agentsList .agents-row:visible');
+  await expect(rows).toHaveCount(5);
+  const firstRow = rows.first();
+  const comfortableHeight = await firstRow.evaluate((el) => el.getBoundingClientRect().height);
+
+  await page.getByRole('button', { name: 'Compact' }).click();
+  await expect(page.locator('#agentsList')).toHaveClass(/compact/);
+  await expect(page.getByRole('button', { name: 'Compact' })).toHaveAttribute('aria-pressed', 'true');
+  const compactHeight = await firstRow.evaluate((el) => el.getBoundingClientRect().height);
+
+  expect(compactHeight).toBeLessThan(comfortableHeight * 0.7);
+  await expect(firstRow.locator('[data-agent-action="open-chat"]').first()).toBeVisible();
+  await expect(firstRow.locator('[data-agent-action="open-timeline"]').first()).toBeVisible();
+  await expect(firstRow.locator('[data-agent-action="open-workqueue"]').first()).toBeVisible();
+
+  await page.reload();
+  await clawnsole.waitForAdminUiReady(page);
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsList')).toHaveClass(/compact/);
+  await expect(page.getByRole('button', { name: 'Compact' })).toHaveAttribute('aria-pressed', 'true');
+});


### PR DESCRIPTION
## Summary
- Add a persisted Comfortable/Compact density toggle to the Fleet/Agents modal.
- Apply compact row spacing, text, pin, and quick-action sizing while keeping Chat/Timeline/Workqueue controls visible.
- Cover density persistence and row-height reduction in the Agents modal UI spec.

Closes #264.

## Tests
- npm run test:syntax
- npx playwright test tests/ui/agents-modal.spec.js --workers=1
