### PR TITLE
Guard recommended layout reset when drafts exist

### DIFF
--- a/app.js
+++ b/app.js
@@ -5529,6 +5529,10 @@ function paneHasDraftChanges(pane) {
   return Boolean(draftText || hasAttachments);
 }
 
+function anyPaneHasDraftChanges(panes) {
+  return (Array.isArray(panes) ? panes : []).some((pane) => pane?.kind === 'chat' && paneHasDraftChanges(pane));
+}
+
 function paneSetDestinationStrip(pane) {
   const strip = pane?.elements?.destinationStrip;
   const valueEl = pane?.elements?.destinationValue;
@@ -7193,7 +7197,11 @@ const paneManager = {
   resetAdminLayoutToDefault({ confirm = true } = {}) {
     if (roleState.role !== 'admin') return;
     if (confirm) {
-      const ok = window.confirm('Reset layout to default (Chat + Workqueue)?');
+      const hasDraft = anyPaneHasDraftChanges(this.panes);
+      const message = hasDraft
+        ? 'Reset to recommended layout (Chat + Workqueue)?\n\nYou have unsent draft text or attachments. Resetting will clear the current panes and discard those drafts.'
+        : 'Reset to recommended layout (Chat + Workqueue)?';
+      const ok = window.confirm(message);
       if (!ok) return;
     }
 

--- a/index.html
+++ b/index.html
@@ -476,7 +476,7 @@
           </label>
           <div class="button-row">
             <button id="disconnectBtn">Disconnect</button>
-            <button id="resetLayoutBtn" type="button" class="secondary">Reset layout</button>
+            <button id="resetLayoutBtn" type="button" class="secondary">Reset to recommended layout</button>
           </div>
           <div class="hint">
             Auto-connecting with the gateway token from your local OpenClaw config.

--- a/tests/pane.layout.e2e.spec.js
+++ b/tests/pane.layout.e2e.spec.js
@@ -64,3 +64,35 @@ test('layout: reset layout restores default (Chat + Workqueue)', async ({ page }
   await expect(panes).toHaveCount(2);
   await expect(panes.nth(1)).toHaveAttribute('data-pane-kind', 'workqueue');
 });
+
+test('layout: reset warns and preserves panes when a draft would be discarded', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  await page.getByRole('button', { name: 'Add pane' }).click();
+  await page.getByRole('button', { name: 'Cron pane' }).click();
+  await expect(page.locator('[data-pane]')).toHaveCount(3);
+
+  const chatPane = page.locator('[data-pane]').first();
+  await chatPane.getByTestId('pane-input').fill('draft before reset');
+
+  await page.getByRole('button', { name: 'Open settings' }).click();
+
+  let sawDraftWarning = false;
+  page.once('dialog', async (dialog) => {
+    sawDraftWarning = /unsent draft text or attachments/i.test(dialog.message());
+    await dialog.dismiss();
+  });
+  await page.click('#resetLayoutBtn');
+
+  await expect.poll(() => sawDraftWarning).toBe(true);
+  await expect(page.locator('[data-pane]')).toHaveCount(3);
+  await expect(chatPane.getByTestId('pane-input')).toHaveValue('draft before reset');
+});


### PR DESCRIPTION
## Summary
- rename the settings reset action to “Reset to recommended layout”
- add a draft-aware reset confirmation that warns drafts/attachments will be discarded
- add Playwright coverage that dismissing the warning preserves panes and draft text

Fixes #258

## Tests
- npm test -- tests/pane.layout.e2e.spec.js
- npx playwright test tests/pane.layout.e2e.spec.js --workers=1