### PR TITLE
Canonicalize issue workqueue dedupe variants

### DIFF
--- a/lib/workqueue.js
+++ b/lib/workqueue.js
@@ -177,6 +177,10 @@ function normalizeIssueRepoName(repo) {
   return String(repo || '').trim().toLowerCase().replace(/\s+/g, '');
 }
 
+function normalizeIssueRepoParts(owner, name) {
+  return normalizeIssueRepoName(`${owner || ''}/${name || ''}`);
+}
+
 function normalizeIssueNumber(raw) {
   const n = Number.parseInt(String(raw || '').trim(), 10);
   return Number.isFinite(n) && n > 0 ? String(n) : '';
@@ -193,17 +197,27 @@ function parseIssueRef(text) {
     if (repo && issueNumber) return { repo, issueNumber };
   }
 
-  const fromFullRef = src.match(/(?:^|[\s[(])(?:issue:)?([a-z0-9_.-]+\/[a-z0-9_.-]+)\s*#\s*(\d+)\b/i);
+  const repoRefPattern = String.raw`([a-z0-9_.-]+)\s*\/\s*([a-z0-9_.-]+)`;
+
+  const fromFullRef = src.match(new RegExp(String.raw`(?:^|[\s[(])(?:issue:)?${repoRefPattern}\s*#\s*(\d+)\b`, 'i'));
   if (fromFullRef) {
-    const repo = normalizeIssueRepoName(fromFullRef[1]);
-    const issueNumber = normalizeIssueNumber(fromFullRef[2]);
+    const repo = normalizeIssueRepoParts(fromFullRef[1], fromFullRef[2]);
+    const issueNumber = normalizeIssueNumber(fromFullRef[3]);
     if (repo && issueNumber) return { repo, issueNumber };
   }
 
-  const fromColonRef = src.match(/(?:^|[\s[(])(?:issue:)?([a-z0-9_.-]+\/[a-z0-9_.-]+)\s*:\s*(\d+)\b/i);
+  const fromColonRef = src.match(new RegExp(String.raw`(?:^|[\s[(])(?:issue:)?${repoRefPattern}\s*:\s*(\d+)\b`, 'i'));
   if (fromColonRef) {
-    const repo = normalizeIssueRepoName(fromColonRef[1]);
-    const issueNumber = normalizeIssueNumber(fromColonRef[2]);
+    const repo = normalizeIssueRepoParts(fromColonRef[1], fromColonRef[2]);
+    const issueNumber = normalizeIssueNumber(fromColonRef[3]);
+    if (repo && issueNumber) return { repo, issueNumber };
+  }
+
+  const repoLine = src.match(new RegExp(String.raw`\brepo\s*:\s*${repoRefPattern}\b`, 'i'));
+  const issueLine = src.match(/\b(?:issue|issueNumber)\s*:\s*#?\s*(\d+)\b/i);
+  if (repoLine && issueLine) {
+    const repo = normalizeIssueRepoParts(repoLine[1], repoLine[2]);
+    const issueNumber = normalizeIssueNumber(issueLine[1]);
     if (repo && issueNumber) return { repo, issueNumber };
   }
 
@@ -216,7 +230,7 @@ function canonicalizeIssueDedupeKey({ repo, issueNumber, dedupeKey, title, instr
   const explicitIssue = normalizeIssueNumber(issueNumber ?? metaObj.issueNumber ?? metaObj.issue);
   if (explicitRepo && explicitIssue) return `${explicitRepo}#${explicitIssue}`;
 
-  const parsed = parseIssueRef(dedupeKey) || parseIssueRef(metaObj.dedupeKey) || parseIssueRef(instructions) || parseIssueRef(title);
+  const parsed = parseIssueRef(dedupeKey) || parseIssueRef(metaObj.dedupeKey) || parseIssueRef(metaObj.url) || parseIssueRef(instructions) || parseIssueRef(title);
   if (parsed) return `${parsed.repo}#${parsed.issueNumber}`;
 
   return String(dedupeKey || '').trim();

--- a/tests/unit/workqueue.test.js
+++ b/tests/unit/workqueue.test.js
@@ -311,14 +311,30 @@ test('workqueue: issue-backed enqueue canonicalizes producer dedupe variants', (
       meta: { dedupeKey: 'rmdmattingly/clawnsole:392', source: 'coverage' }
     },
     {
+      title: 'Open issue triage: RMDMATTINGLY / CLAWNSOLE #392',
+      instructions: 'Ship queued issue',
+      priority: 4
+    },
+    {
+      title: 'Split fields producer',
+      instructions: 'Repo: RMDMATTINGLY / CLAWNSOLE\nIssue: #392\nShip queued issue',
+      priority: 5
+    },
+    {
+      title: 'Meta URL producer',
+      instructions: 'Ship queued issue',
+      priority: 6,
+      meta: { url: 'https://github.com/rmdmattingly/clawnsole/issues/392', source: 'follow-up' }
+    },
+    {
       title: 'URL producer',
       instructions: 'Ship https://github.com/rmdmattingly/clawnsole/issues/392',
-      priority: 4
+      priority: 7
     },
     {
       title: 'Explicit issue producer',
       instructions: 'Ship queued issue',
-      priority: 5,
+      priority: 8,
       repo: 'rmdmattingly/clawnsole',
       issueNumber: 392
     }
@@ -331,12 +347,42 @@ test('workqueue: issue-backed enqueue canonicalizes producer dedupe variants', (
   assert.equal(latest._deduped, true);
   assert.equal(latest.dedupeKey, 'rmdmattingly/clawnsole#392');
   assert.equal(latest.title, 'Explicit issue producer');
-  assert.equal(latest.priority, 5);
+  assert.equal(latest.priority, 8);
 
   const state = loadState(root);
   assert.equal(state.items.length, 1);
   assert.equal(state.items[0].dedupeKey, 'rmdmattingly/clawnsole#392');
   assert.equal(state.items[0].title, 'Explicit issue producer');
+});
+
+test('workqueue: issue-backed canonical dedupe keeps distinct issues separate', () => {
+  const root = tempRoot();
+
+  enqueueItem(root, {
+    queue: 'dev-team',
+    title: 'Issue coverage',
+    instructions: 'Ship https://github.com/rmdmattingly/clawnsole/issues/392',
+    priority: 1
+  });
+  enqueueItem(root, {
+    queue: 'dev-team',
+    title: 'Issue coverage',
+    instructions: 'Ship https://github.com/rmdmattingly/clawnsole/issues/393',
+    priority: 1
+  });
+  enqueueItem(root, {
+    queue: 'dev-team',
+    title: 'Issue coverage',
+    instructions: 'Ship https://github.com/example/clawnsole/issues/392',
+    priority: 1
+  });
+
+  const state = loadState(root);
+  assert.equal(state.items.length, 3);
+  assert.deepEqual(
+    state.items.map((it) => it.dedupeKey).sort(),
+    ['example/clawnsole#392', 'rmdmattingly/clawnsole#392', 'rmdmattingly/clawnsole#393']
+  );
 });
 
 test('workqueue: issue-backed enqueue creates new row when only terminal matches exist', () => {


### PR DESCRIPTION
## Summary
- extend issue workqueue dedupe parsing to tolerate spaced repo refs, split `Repo:`/`Issue:` fields, and `meta.url` issue links
- keep canonical issue keys in `owner/repo#number` form across producer variants
- add collision coverage so different repos/issues stay separate

Fixes #262

## Tests
- `node --test tests/unit/workqueue.test.js`
- `npm test`

Note: `npm ci` was needed in the fresh worktree before the full suite because `ws` was not installed locally.