### PR TITLE
Guard recommended layout reset with draft confirmation

### DIFF
--- a/app.js
+++ b/app.js
@@ -2323,8 +2323,8 @@ function buildCommandPaletteItems() {
     withShortcut(
       {
         id: 'cmd:reset-layout',
-        label: 'Layout: Reset panes',
-        detail: 'Reset admin layout to default',
+        label: 'Layout: Reset to recommended layout',
+        detail: 'Restore Chat + Workqueue panes',
         run: () => paneManager.resetAdminLayoutToDefault({ confirm: true })
       },
       ''
@@ -7190,10 +7190,16 @@ const paneManager = {
     });
     storage.set(ADMIN_PANES_KEY, JSON.stringify(payload));
   },
+  hasUnsentDrafts() {
+    return this.panes.some((pane) => {
+      if (pane.kind !== 'chat') return false;
+      return String(pane.elements?.input?.value || '').trim().length > 0;
+    });
+  },
   resetAdminLayoutToDefault({ confirm = true } = {}) {
     if (roleState.role !== 'admin') return;
-    if (confirm) {
-      const ok = window.confirm('Reset layout to default (Chat + Workqueue)?');
+    if (confirm && this.hasUnsentDrafts()) {
+      const ok = window.confirm('Reset to recommended layout? Unsent draft text will be discarded.');
       if (!ok) return;
     }
 
@@ -8155,6 +8161,10 @@ globalElements.disconnectBtn?.addEventListener('click', () => {
   });
   paneManager.connectAll();
 });
+
+if (globalElements.resetLayoutBtn) {
+  globalElements.resetLayoutBtn.textContent = 'Reset to recommended layout';
+}
 
 globalElements.resetLayoutBtn?.addEventListener('click', () => {
   paneManager.resetAdminLayoutToDefault({ confirm: true });

--- a/tests/pane.layout.e2e.spec.js
+++ b/tests/pane.layout.e2e.spec.js
@@ -64,3 +64,44 @@ test('layout: reset layout restores default (Chat + Workqueue)', async ({ page }
   await expect(panes).toHaveCount(2);
   await expect(panes.nth(1)).toHaveAttribute('data-pane-kind', 'workqueue');
 });
+
+test('layout: reset requires confirmation before discarding a chat draft', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const input = page.locator('[data-pane][data-pane-kind="chat"]').first().locator('[data-pane-input]');
+  await input.fill('hold this thought');
+
+  await page.getByRole('button', { name: 'Add pane' }).click();
+  await page.getByRole('button', { name: 'Cron pane' }).click();
+  await expect(page.locator('[data-pane]')).toHaveCount(3);
+
+  await page.getByRole('button', { name: 'Open settings' }).click();
+
+  page.once('dialog', async (dialog) => {
+    expect(dialog.message()).toContain('Unsent draft text will be discarded');
+    await dialog.dismiss();
+  });
+  await page.click('#resetLayoutBtn');
+  await expect(page.locator('[data-pane]')).toHaveCount(3);
+  await expect(input).toHaveValue('hold this thought');
+
+  page.once('dialog', async (dialog) => {
+    expect(dialog.message()).toContain('Unsent draft text will be discarded');
+    await dialog.accept();
+  });
+  await page.click('#resetLayoutBtn');
+
+  const panes = page.locator('[data-pane]');
+  await expect(panes).toHaveCount(2);
+  await expect(panes.first()).toHaveAttribute('data-pane-kind', 'chat');
+  await expect(panes.nth(1)).toHaveAttribute('data-pane-kind', 'workqueue');
+  await expect(panes.first().locator('[data-pane-input]')).toHaveValue('');
+});


### PR DESCRIPTION
## Summary
- Rename the reset action to the recommended Chat + Workqueue layout
- Make reset one-click unless a chat pane has unsent draft text
- Add Playwright coverage for cancel/accept draft-discard confirmation

Fixes #258

## Tests
- npm run test:syntax
- NODE_PATH=/Users/raysopenclaw/.openclaw/workspace-dev-deploy/repos/clawnsole/node_modules npm test
- NODE_PATH=/Users/raysopenclaw/.openclaw/workspace-dev-deploy/repos/clawnsole/node_modules ../clawnsole/node_modules/.bin/playwright test tests/pane.layout.e2e.spec.js --workers=1