### PR TITLE
Fix idle Stop generating control

### DIFF
--- a/app.js
+++ b/app.js
@@ -4830,7 +4830,7 @@ function paneRenderStopControl(pane) {
   btn.hidden = !visible;
 
   const isCanceling = Boolean(pane.abortState && pane.abortState.active);
-  btn.disabled = !uiState.authed || !pane.connected || isCanceling;
+  btn.disabled = !visible || isCanceling;
   btn.setAttribute('aria-label', isCanceling ? 'Canceling…' : 'Stop generating');
 }
 

--- a/styles.css
+++ b/styles.css
@@ -2844,6 +2844,10 @@ kbd {
   color: rgba(255, 120, 120, 0.95);
 }
 
+.chat-actions .stop-btn[hidden] {
+  display: none;
+}
+
 .chat-actions .stop-btn:hover {
   background: rgba(255, 70, 70, 0.12);
 }

--- a/tests/ui/chat-pane.spec.js
+++ b/tests/ui/chat-pane.spec.js
@@ -61,18 +61,28 @@ test('chat pane: stop button can cancel a running response', async ({ page }) =>
   const pane = page.locator('[data-pane][data-pane-kind="chat"]').last();
   await expect(pane.locator('[data-pane-send]')).toBeEnabled({ timeout: 90000 });
 
+  const stopBtn = pane.locator('[data-pane-stop]');
+  await expect(stopBtn).toBeHidden();
+  await expect(stopBtn).toBeDisabled();
+
+  await pane.locator('[data-pane-input]').focus();
+  await page.keyboard.press('Tab');
+  await expect(pane.locator('[data-pane-send]')).toBeFocused();
+
   await pane.locator('[data-pane-input]').fill('please stream this');
   await pane.locator('[data-pane-send]').click();
 
   // Streaming begins immediately in mock gateway.
   await expect(pane.locator('.chat-bubble.assistant', { hasText: 'mock-stream: please stream' })).toBeVisible();
 
-  const stopBtn = pane.locator('[data-pane-stop]');
   await expect(stopBtn).toBeVisible();
+  await expect(stopBtn).toBeEnabled();
   await stopBtn.click();
 
   await expect(stopBtn).toHaveAttribute('aria-label', 'Canceling…');
   await expect(pane.locator('.chat-bubble.assistant').last()).toContainText('(canceled)', { ignoreCase: true, timeout: 5000 });
+  await expect(stopBtn).toBeHidden();
+  await expect(stopBtn).toBeDisabled();
 
   // Cancel should not still emit a completed reply after stream is stopped.
   await expect(pane.locator('.chat-bubble.assistant')).not.toContainText('mock-reply: please stream this', { timeout: 3000 });


### PR DESCRIPTION
## Summary
- keep the chat Stop generating control disabled whenever it is hidden/idle
- restore native hidden behavior for the stop button despite the component display styling
- extend chat-pane regression coverage for idle -> running -> idle state and keyboard tab order

Fixes #359.

## Tests
- npm run test:syntax
- npx playwright test tests/ui/chat-pane.spec.js -g "stop button" --workers=1

No prod deploy.