### PR TITLE
Show feedback when global shortcuts are blocked

### DIFF
--- a/app.js
+++ b/app.js
@@ -8077,6 +8077,26 @@ globalElements.wqEnqueueBtn?.addEventListener('click', () => workqueueEnqueueFro
 globalElements.wqClaimBtn?.addEventListener('click', () => workqueueClaimNextFromUi());
 
 let shortcutState = { lastGAtMs: 0 };
+const shortcutDebug = {
+  cooldownMs: 5000,
+  lastShownAtByReason: new Map(),
+  messages: {
+    typing: 'Shortcut paused while typing',
+    overlay: 'Close modal to use this shortcut',
+    layout: 'Use Cmd/Ctrl+1..9 on this keyboard layout'
+  },
+  report(reason) {
+    const key = String(reason || '').trim();
+    const message = this.messages[key];
+    if (!message) return false;
+    const now = Date.now();
+    const lastShownAt = Number(this.lastShownAtByReason.get(key) || 0);
+    if (lastShownAt && now - lastShownAt < this.cooldownMs) return true;
+    this.lastShownAtByReason.set(key, now);
+    showToast(message, { kind: 'info', timeoutMs: 2200, testId: 'shortcut-blocked-toast' });
+    return true;
+  }
+};
 
 function isTypingContext(target) {
   const el = target || document.activeElement;
@@ -8104,6 +8124,62 @@ function isAnyOverlayOpen() {
     isOverlayElementOpen(globalElements.loginOverlay) ||
     paneManager?._addPaneMenuState?.open
   );
+}
+
+function isTypingShortcutExempt(event) {
+  const key = String(event?.key || '').toLowerCase();
+  if (key === 'escape') return true;
+  if ((event?.metaKey || event?.ctrlKey) && !event?.shiftKey && !event?.altKey && (key === 'k' || key === 'p')) return true;
+  return false;
+}
+
+function isPaneNumberShortcut(event) {
+  const key = String(event?.key || '');
+  if (event?.altKey && !event?.metaKey && !event?.ctrlKey && !event?.shiftKey) {
+    const n = Number.parseInt(key, 10);
+    return Number.isFinite(n) && n >= 1 && n <= 9;
+  }
+  if ((event?.metaKey || event?.ctrlKey) && !event?.shiftKey && !event?.altKey) {
+    const n = Number.parseInt(key, 10);
+    return Number.isFinite(n) && n >= 1 && n <= 9;
+  }
+  return false;
+}
+
+function isLayoutMismatchedPaneNumberShortcut(event) {
+  if (!(event?.metaKey || event?.ctrlKey) || event?.shiftKey || event?.altKey) return false;
+  const code = String(event?.code || '');
+  const digit = code.match(/^Digit([1-9])$/);
+  if (!digit) return false;
+  const key = String(event?.key || '');
+  return Number.parseInt(key, 10) !== Number(digit[1]);
+}
+
+function isAddPaneShortcut(event) {
+  if (!(event?.metaKey || event?.ctrlKey) || !event?.shiftKey) return false;
+  const key = String(event?.key || '').toLowerCase();
+  return key === 'c' || key === 'w' || key === 'r' || key === 't';
+}
+
+function isNonTrivialGlobalShortcut(event) {
+  const key = String(event?.key || '');
+  const lowerKey = key.toLowerCase();
+  if (isAddPaneShortcut(event) || isPaneNumberShortcut(event) || isLayoutMismatchedPaneNumberShortcut(event)) return true;
+  if ((event?.metaKey || event?.ctrlKey) && event?.shiftKey && !event?.altKey) {
+    return lowerKey === 'k' || lowerKey === 'j' || lowerKey === 'n' || lowerKey === 'f' || lowerKey === 'h' ||
+      key === ']' || key === '}' || key === '[' || key === '{';
+  }
+  if ((event?.metaKey || event?.ctrlKey) && !event?.shiftKey && !event?.altKey && lowerKey === 'r') return true;
+  if (event?.ctrlKey && !event?.metaKey && !event?.altKey && key === 'Tab') return true;
+  if (!event?.metaKey && !event?.ctrlKey && !event?.shiftKey && !event?.altKey) {
+    return lowerKey === 'g' || ((lowerKey === 'c' || lowerKey === 'w') && shortcutState.lastGAtMs && Date.now() - shortcutState.lastGAtMs < 1000);
+  }
+  return false;
+}
+
+function reportBlockedGlobalShortcut(event, reason) {
+  if (!isNonTrivialGlobalShortcut(event)) return false;
+  return shortcutDebug.report(reason);
 }
 
 function closeTopmostOverlay() {
@@ -8336,9 +8412,25 @@ window.addEventListener('keydown', (event) => {
   }
 
   // Never steal focus / override browser shortcuts while typing.
-  if (isTypingContext(event.target)) return;
+  if (isTypingContext(event.target)) {
+    if (!isTypingShortcutExempt(event)) reportBlockedGlobalShortcut(event, 'typing');
+    return;
+  }
 
   const key = String(event.key || '');
+
+  if (isLayoutMismatchedPaneNumberShortcut(event)) {
+    event.preventDefault();
+    reportBlockedGlobalShortcut(event, 'layout');
+    return;
+  }
+
+  if (isAnyOverlayOpen()) {
+    if (reportBlockedGlobalShortcut(event, 'overlay')) {
+      event.preventDefault();
+      return;
+    }
+  }
 
   // Ctrl+Tab walks panes in most-recently-used order; Shift reverses the traversal.
   if (event.ctrlKey && !event.metaKey && !event.altKey && key === 'Tab') {

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -102,6 +102,57 @@ test('pane-add shortcuts are scoped to workspace and blocked by overlays', async
   await expect(panes).toHaveCount(initialCount + 1);
 });
 
+test('blocked global shortcuts explain typing and modal guards', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const panes = page.locator('[data-pane]');
+  const blockedToasts = page.getByTestId('shortcut-blocked-toast');
+  const fireAddChatShortcut = async () => {
+    await page.evaluate(() => {
+      const event = new KeyboardEvent('keydown', {
+        key: 'C',
+        ctrlKey: true,
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true
+      });
+      (document.activeElement || window).dispatchEvent(event);
+    });
+  };
+
+  await expect(panes).toHaveCount(2);
+
+  const input = page.locator('[data-pane][data-pane-kind="chat"] [data-pane-input]').first();
+  await input.focus();
+  await expect(input).toBeFocused();
+  await fireAddChatShortcut();
+  await expect(panes).toHaveCount(2);
+  await expect(blockedToasts.last()).toContainText('Shortcut paused while typing');
+
+  await page.click('#connectionStatus');
+  await page.keyboard.press('Shift+/');
+  await expect(page.locator('#shortcutsModal')).toHaveAttribute('aria-hidden', 'false');
+  await fireAddChatShortcut();
+  await expect(panes).toHaveCount(2);
+  await expect(blockedToasts.last()).toContainText('Close modal to use this shortcut');
+
+  await page.keyboard.press('Escape');
+  await expect(page.locator('#shortcutsModal')).toHaveAttribute('aria-hidden', 'true');
+  const blockedCountBeforeUnblocked = await blockedToasts.count();
+
+  await fireAddChatShortcut();
+  await expect(panes).toHaveCount(3);
+  expect(await blockedToasts.count()).toBe(blockedCountBeforeUnblocked);
+});
+
 test('shortcuts modal restores prior focus on close', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!app?.skipReason, app?.skipReason);


### PR DESCRIPTION
## Summary
- add centralized blocked-shortcut feedback with per-reason 5s rate limiting
- report typing, modal/overlay, and keyboard-layout shortcut blocks with subtle toasts
- cover typing-blocked, modal-blocked, and unblocked shortcut behavior in Playwright

Closes #272

## Tests
- npm test
- npx playwright test tests/pane.shortcuts.e2e.spec.js --workers=1