### PR TITLE
Fix Fleet pinned agents top section

### DIFF
--- a/app.js
+++ b/app.js
@@ -3076,8 +3076,8 @@ function renderAgentsModalList() {
   const pinned = sortAgents(filtered.filter((a) => pins.has(String(a?.id || '').trim())));
   const rest = sortAgents(filtered.filter((a) => !pins.has(String(a?.id || '').trim())));
   const ordered = [...pinned, ...rest];
-  const needsAttention = ordered.filter((agent) => classify(agent?.id).bucket !== 'active');
-  const healthy = ordered.filter((agent) => classify(agent?.id).bucket === 'active');
+  const needsAttention = rest.filter((agent) => classify(agent?.id).bucket !== 'active');
+  const healthy = rest.filter((agent) => classify(agent?.id).bucket === 'active');
   const healthyCollapseDefault = baseAgents.length > ADMIN_AGENT_HEALTHY_COLLAPSE_THRESHOLD;
   const healthyCollapsed = String(storage.get(ADMIN_AGENT_HEALTHY_COLLAPSED_KEY, healthyCollapseDefault ? '1' : '0')) === '1';
 
@@ -3175,6 +3175,7 @@ function renderAgentsModalList() {
     root.appendChild(section);
   };
 
+  if (pinned.length > 0) renderSection('Pinned', pinned);
   renderSection('Needs attention', needsAttention);
   renderSection('Healthy', healthy, { collapsible: true, collapsed: healthyCollapsed });
 

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -24,6 +24,44 @@ test('agents modal supports pinning agents and persists to localStorage', async 
   await expect(firstPinAfter).toHaveAttribute('aria-pressed', 'true');
 });
 
+test('agents modal renders pinned agents in a dedicated top section after reload', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  const agents = [
+    { id: 'alpha', name: 'Alpha', displayName: 'Alpha' },
+    { id: 'beta', name: 'Beta', displayName: 'Beta' },
+    { id: 'gamma', name: 'Gamma', displayName: 'Gamma' }
+  ];
+  await page.route(/\/agents(?:\?|$)/, async (route) => {
+    await route.fulfill({ json: { agents } });
+  });
+
+  await clawnsole.gotoAndLoginAdmin(page);
+  await page.evaluate(() => {
+    const now = Date.now();
+    localStorage.setItem('clawnsole.admin.agentLastSeenAtMs', JSON.stringify({ alpha: now, gamma: now }));
+  });
+  await page.getByRole('button', { name: 'Refresh agent list' }).click();
+
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsModal')).toHaveClass(/open/);
+
+  await page.locator('#agentsList .agents-row').filter({ hasText: 'Beta (beta)' }).locator('.agents-pin').click();
+  await expect(page.locator('#agentsList .agents-section-title').nth(0)).toContainText('Pinned (1)');
+  await expect(page.locator('#agentsList .agents-section').nth(0).locator('.agents-row')).toContainText('Beta (beta)');
+  await expect(page.locator('#agentsList .agents-section-title').nth(1)).toContainText('Needs attention (0)');
+  await expect(page.locator('#agentsList .agents-section-title').nth(2)).toContainText('Healthy (2)');
+
+  await page.reload();
+  await clawnsole.waitForAdminUiReady(page);
+  await page.getByRole('button', { name: 'Open agents' }).click();
+
+  await expect(page.locator('#agentsList .agents-section-title').nth(0)).toContainText('Pinned (1)');
+  await expect(page.locator('#agentsList .agents-section').nth(0).locator('.agents-row')).toContainText('Beta (beta)');
+  await expect(page.locator('#agentsList .agents-section-title').nth(1)).toContainText('Needs attention (0)');
+  await expect(page.locator('#agentsList .agents-section-title').nth(2)).toContainText('Healthy (2)');
+});
+
 test('agents modal shows live refresh freshness indicators', async ({ page, clawnsole }) => {
   if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
 


### PR DESCRIPTION
## Summary
- render pinned Fleet agents in a dedicated top Pinned section
- keep pinned agents out of Needs attention/Healthy duplicate sections
- add Playwright coverage for pin, reload persistence, and top-section ordering

## Tests
- npm run test:syntax
- npx playwright test tests/ui/agents-modal.spec.js --grep "pinned agents in a dedicated top section" --workers=1

Closes #278