### PR TITLE
feat(fleet): add agent triage row action

### DIFF
--- a/app.js
+++ b/app.js
@@ -2920,10 +2920,12 @@ function openAgentChatFromFleet(agentId) {
   const target = normalizeAgentId(agentId || 'main');
   const pane =
     findExistingPane('chat', (p) => normalizeAgentId(p.agentId || 'main') === target) ||
+    findExistingPane('chat') ||
     paneManager.addPane('chat');
-  if (!pane) return;
+  if (!pane) return null;
   paneSetAgent(pane, target);
   paneManager.focusPanePrimary(pane);
+  return pane;
 }
 
 function openAgentTimelineFromFleet(agentId) {
@@ -2976,7 +2978,7 @@ function openAgentWorkqueueFromFleet(agentId) {
     findExistingPane('workqueue', (p) => String(p.workqueue?.queue || '').trim() === preferredQueue) ||
     findExistingPane('workqueue') ||
     paneManager.addPane('workqueue', { queue: preferredQueue, agentId: target });
-  if (!pane) return;
+  if (!pane) return null;
 
   pane.agentId = target;
   try {
@@ -2989,6 +2991,15 @@ function openAgentWorkqueueFromFleet(agentId) {
   } catch {}
   paneManager.persistAdminPanes();
   paneManager.focusPanePrimary(pane);
+  return pane;
+}
+
+function openAgentTriageFromFleet(agentId) {
+  const target = normalizeAgentId(agentId || 'main');
+  const chatPane = openAgentChatFromFleet(target);
+  openAgentWorkqueueFromFleet(target);
+  closeAgentsModal();
+  if (chatPane) paneManager.focusPanePrimary(chatPane);
 }
 
 function findActivePaneFromFocus() {
@@ -3155,13 +3166,15 @@ function renderAgentsModalList() {
           <div class="agents-row-meta">${escapeHtml(id)} · ${escapeHtml(bucketLabel)} · <span class="agents-age-chip" data-heartbeat-bucket="${escapeHtml(triage.ageBucket)}">${escapeHtml(heartbeatAge)} · ${escapeHtml(heatBucketLabel)}</span>${statusSnippetHtml}</div>
         </div>
         <div class="agents-row-actions agents-row-actions-inline" role="group" aria-label="Quick actions for ${escapeHtml(label)}">
+          <button type="button" class="secondary agents-action-btn agents-action-primary" data-agent-action="triage" data-agent-id="${escapeHtml(id)}" title="Triage agent" aria-label="Triage ${escapeHtml(label)}">Triage</button>
           <button type="button" class="secondary agents-action-btn" data-agent-action="open-chat" data-agent-id="${escapeHtml(id)}" title="Open Chat" aria-label="Open Chat for ${escapeHtml(label)}">Chat</button>
-          <button type="button" class="secondary agents-action-btn" data-agent-action="open-timeline" data-agent-id="${escapeHtml(id)}" title="Open Timeline" aria-label="Open Timeline for ${escapeHtml(label)}">Timeline</button>
           <button type="button" class="secondary agents-action-btn" data-agent-action="open-workqueue" data-agent-id="${escapeHtml(id)}" title="Open Workqueue" aria-label="Open Workqueue">Workqueue</button>
+          <button type="button" class="secondary agents-action-btn" data-agent-action="open-timeline" data-agent-id="${escapeHtml(id)}" title="Open Timeline" aria-label="Open Timeline for ${escapeHtml(label)}">Timeline</button>
         </div>
         <details class="agents-row-actions-overflow">
           <summary class="secondary" aria-label="More actions for ${escapeHtml(label)}" title="More actions">⋯</summary>
           <div class="agents-row-actions-menu" role="group" aria-label="Quick actions for ${escapeHtml(label)}">
+            <button type="button" class="secondary agents-action-btn agents-action-primary" data-agent-action="triage" data-agent-id="${escapeHtml(id)}" title="Triage agent" aria-label="Triage ${escapeHtml(label)}">Triage agent</button>
             <button type="button" class="secondary agents-action-btn" data-agent-action="open-chat" data-agent-id="${escapeHtml(id)}" title="Open Chat" aria-label="Open Chat for ${escapeHtml(label)}">Open Chat</button>
             <button type="button" class="secondary agents-action-btn" data-agent-action="open-timeline" data-agent-id="${escapeHtml(id)}" title="Open Timeline" aria-label="Open Timeline for ${escapeHtml(label)}">Open Timeline</button>
             <button type="button" class="secondary agents-action-btn" data-agent-action="open-workqueue" data-agent-id="${escapeHtml(id)}" title="Open Workqueue" aria-label="Open Workqueue">Open Workqueue</button>
@@ -3185,7 +3198,8 @@ function renderAgentsModalList() {
           e.preventDefault();
           e.stopPropagation();
           const action = String(btn.getAttribute('data-agent-action') || '').trim();
-          if (action === 'open-chat') openAgentChatFromFleet(id);
+          if (action === 'triage') openAgentTriageFromFleet(id);
+          else if (action === 'open-chat') openAgentChatFromFleet(id);
           else if (action === 'open-timeline') openAgentTimelineFromFleet(id);
           else if (action === 'open-workqueue') openAgentWorkqueueFromFleet(id);
         });

--- a/styles.css
+++ b/styles.css
@@ -1717,6 +1717,11 @@ button.agents-section-title:hover {
   border-radius: 10px;
 }
 
+.agents-action-primary {
+  border-color: rgba(77, 196, 255, 0.46);
+  background: rgba(77, 196, 255, 0.13);
+}
+
 .agents-list.compact .agents-action-btn {
   padding: 2px 6px;
   min-height: 24px;

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -191,6 +191,7 @@ test('agents modal quick actions open/reuse chat, timeline, and workqueue contex
   await expect(page.locator('#agentsModal')).toHaveClass(/open/);
 
   const firstRow = page.locator('#agentsList .agents-row').first();
+  await expect(firstRow.locator('[data-agent-action="triage"]').first()).toBeVisible();
   await expect(firstRow.locator('[data-agent-action="open-chat"]').first()).toBeVisible();
   await expect(firstRow.locator('[data-agent-action="open-timeline"]').first()).toBeVisible();
   await expect(firstRow.locator('[data-agent-action="open-workqueue"]').first()).toBeVisible();
@@ -208,6 +209,64 @@ test('agents modal quick actions open/reuse chat, timeline, and workqueue contex
   await firstRow.locator('[data-agent-action="open-workqueue"]').first().click();
   await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
   await expect(page.locator('[data-pane][data-pane-kind="workqueue"] [data-wq-claim-agent]')).toHaveValue(agentId || 'main');
+});
+
+test('agents modal triage action opens chat and workqueue from empty layout', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  await page.route(/\/agents(?:\?|$)/, async (route) => {
+    await route.fulfill({ json: { agents: [{ id: 'alpha', name: 'Alpha', displayName: 'Alpha' }] } });
+  });
+
+  await clawnsole.gotoAndLoginAdmin(page);
+  await page.evaluate(() => localStorage.setItem('clawnsole.admin.layoutMode', 'custom'));
+
+  await page.evaluate(() => {
+    if (typeof paneManager !== 'undefined') {
+      paneManager.panes.splice(0);
+      paneManager.persistAdminPanes();
+      paneManager.updatePaneLabels();
+      paneManager.updateCloseButtons();
+      paneManager.applyInferredLayout();
+    }
+    document.querySelectorAll('[data-pane]').forEach((pane) => pane.remove());
+  });
+  await expect(page.locator('[data-pane]')).toHaveCount(0);
+
+  await page.getByRole('button', { name: 'Refresh agent list' }).click();
+  await page.getByRole('button', { name: 'Open agents' }).click();
+
+  await page.locator('#agentsList .agents-row').filter({ hasText: 'Alpha (alpha)' }).locator('[data-agent-action="triage"]').first().click();
+
+  await expect(page.locator('#agentsModal')).not.toHaveClass(/open/);
+  await expect(page.locator('[data-pane][data-pane-kind="chat"]')).toHaveCount(1);
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"] [data-wq-claim-agent]')).toHaveValue('alpha');
+  await expect(page.locator('[data-pane][data-pane-kind="chat"] [data-pane-input]')).toBeFocused();
+});
+
+test('agents modal triage action reuses existing matching panes', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  await page.route(/\/agents(?:\?|$)/, async (route) => {
+    await route.fulfill({ json: { agents: [{ id: 'beta', name: 'Beta', displayName: 'Beta' }] } });
+  });
+
+  await clawnsole.gotoAndLoginAdmin(page);
+  await page.getByRole('button', { name: 'Refresh agent list' }).click();
+
+  const chatPane = page.locator('[data-pane][data-pane-kind="chat"]').first();
+  const workqueuePane = page.locator('[data-pane][data-pane-kind="workqueue"]').first();
+  await expect(chatPane).toBeVisible();
+  await expect(workqueuePane).toBeVisible();
+
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await page.locator('#agentsList .agents-row').filter({ hasText: 'Beta (beta)' }).locator('[data-agent-action="triage"]').first().click();
+
+  await expect(page.locator('[data-pane][data-pane-kind="chat"]')).toHaveCount(1);
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
+  await expect(workqueuePane.locator('[data-wq-claim-agent]')).toHaveValue('beta');
+  await expect(chatPane.locator('[data-pane-input]')).toBeFocused();
 });
 
 test('agents modal compact density tightens rows and persists', async ({ page, clawnsole }) => {


### PR DESCRIPTION
## Summary
- add a visible Fleet row Triage action that opens/reuses Chat and Workqueue panes for the selected agent
- reuse existing chat/workqueue panes where possible, close the Agents modal, and focus the chat input for immediate triage
- cover empty-layout and existing-pane triage flows in agents modal Playwright tests

Fixes #288

## Tests
- npm test
- npx playwright test tests/ui/agents-modal.spec.js --workers=1