### PR TITLE
Normalize issue-backed Workqueue titles

### DIFF
--- a/app.js
+++ b/app.js
@@ -114,6 +114,7 @@ const fmtRemaining = __appCore.fmtRemaining || ((msUntil) => {
   if (min > 0) return `${min}m ${sec % 60}s`;
   return `${sec}s`;
 });
+const formatWorkqueueIssueTitle = __appCore.formatWorkqueueIssueTitle || ((item) => String(item?.title || ''));
 const sortWorkqueueItems = __appCore.sortWorkqueueItems || ((items, opts) => (Array.isArray(items) ? items.slice() : []));
 const inferPaneCols = __appCore.inferPaneCols || ((count) => {
   const n = Number(count);
@@ -3576,7 +3577,7 @@ function renderWorkqueueItems() {
       const next = String(it.lastNote || '').trim();
 
       card.innerHTML = `
-        <div class="wq-card-title">${escapeHtml(String(it.title || ''))}</div>
+        <div class="wq-card-title">${escapeHtml(formatWorkqueueIssueTitle(it))}</div>
         <div class="wq-card-meta">
           <span class="wq-badge wq-badge-${escapeHtml(status)}">${escapeHtml(status)}</span>
           ${age ? `<span class="wq-card-chip mono">age ${escapeHtml(age)}</span>` : ''}
@@ -3626,7 +3627,7 @@ function renderWorkqueueInspect(item) {
     </div>
     <div class="wq-inspect-block">
       <div class="wq-inspect-label">Title</div>
-      <div class="wq-inspect-pre">${escapeHtml(String(item.title || ''))}</div>
+      <div class="wq-inspect-pre">${escapeHtml(formatWorkqueueIssueTitle(item))}</div>
     </div>
     <div class="wq-inspect-block">
       <div class="wq-inspect-label">Instructions</div>
@@ -4178,7 +4179,7 @@ function renderWorkqueuePaneItems(pane) {
     const status = String(it.status || '');
 
     row.innerHTML = `
-      <div class="wq-col title">${escapeHtml(String(it.title || ''))}</div>
+      <div class="wq-col title">${escapeHtml(formatWorkqueueIssueTitle(it))}</div>
       <div class="wq-col status"><span class="wq-badge wq-badge-${escapeHtml(status)}">${escapeHtml(status)}</span></div>
       <div class="wq-col prio mono">${escapeHtml(String(it.priority ?? ''))}</div>
       <div class="wq-col attempts mono">${escapeHtml(String(it.attempts ?? ''))}</div>
@@ -4239,7 +4240,7 @@ function renderWorkqueuePaneInspect(pane, item) {
     </div>
     <div class="wq-inspect-block">
       <div class="wq-inspect-label">Title</div>
-      <div class="wq-inspect-pre">${escapeHtml(String(item.title || ''))}</div>
+      <div class="wq-inspect-pre">${escapeHtml(formatWorkqueueIssueTitle(item))}</div>
     </div>
     <div class="wq-inspect-block">
       <div class="wq-inspect-label">Instructions</div>

--- a/lib/app-core.js
+++ b/lib/app-core.js
@@ -109,8 +109,8 @@
         }
 
         if (sortKey === 'title') {
-          const av = String(A.title || '');
-          const bv = String(B.title || '');
+          const av = formatWorkqueueIssueTitle(A);
+          const bv = formatWorkqueueIssueTitle(B);
           const r = av.localeCompare(bv);
           if (r) return r * dir;
         }
@@ -119,6 +119,94 @@
         return a.idx - b.idx;
       })
       .map((x) => x.it);
+  }
+
+  function normalizeWorkqueueIssueRepo(value) {
+    const s = String(value || '').trim().toLowerCase();
+    if (!s || !/^[a-z0-9_.-]+\/[a-z0-9_.-]+$/.test(s)) return '';
+    return s;
+  }
+
+  function normalizeWorkqueueIssueNumber(value) {
+    const s = String(value || '').trim().replace(/^#/, '');
+    return /^\d+$/.test(s) ? s : '';
+  }
+
+  function parseWorkqueueIssueRef(value) {
+    const src = String(value || '');
+    if (!src) return null;
+
+    const metaUrl = src.match(/github\.com\/([a-z0-9_.-]+\/[a-z0-9_.-]+)\/issues\/(\d+)/i);
+    if (metaUrl) {
+      const repo = normalizeWorkqueueIssueRepo(metaUrl[1]);
+      const issueNumber = normalizeWorkqueueIssueNumber(metaUrl[2]);
+      if (repo && issueNumber) return { repo, issueNumber };
+    }
+
+    const repoRefPattern = String.raw`([a-z0-9_.-]+)\s*\/\s*([a-z0-9_.-]+)`;
+    const fullRef = src.match(new RegExp(String.raw`(?:^|[\s[(])(?:issue:)?${repoRefPattern}\s*#\s*(\d+)\b`, 'i'));
+    if (fullRef) {
+      const repo = normalizeWorkqueueIssueRepo(`${fullRef[1]}/${fullRef[2]}`);
+      const issueNumber = normalizeWorkqueueIssueNumber(fullRef[3]);
+      if (repo && issueNumber) return { repo, issueNumber };
+    }
+
+    const repoLine = src.match(new RegExp(String.raw`\brepo\s*:\s*${repoRefPattern}\b`, 'i'));
+    const issueLine = src.match(/\b(?:issue|issueNumber)\s*:\s*#?\s*(\d+)\b/i);
+    if (repoLine && issueLine) {
+      const repo = normalizeWorkqueueIssueRepo(`${repoLine[1]}/${repoLine[2]}`);
+      const issueNumber = normalizeWorkqueueIssueNumber(issueLine[1]);
+      if (repo && issueNumber) return { repo, issueNumber };
+    }
+
+    return null;
+  }
+
+  function getWorkqueueIssueRef(item) {
+    const meta = item?.meta && typeof item.meta === 'object' ? item.meta : {};
+    const explicitRepo = normalizeWorkqueueIssueRepo(meta.repo || item?.repo);
+    const explicitIssue = normalizeWorkqueueIssueNumber(meta.issueNumber || meta.issue || item?.issueNumber || item?.issue);
+    if (explicitRepo && explicitIssue) return { repo: explicitRepo, issueNumber: explicitIssue };
+
+    return (
+      parseWorkqueueIssueRef(item?.dedupeKey) ||
+      parseWorkqueueIssueRef(meta.dedupeKey) ||
+      parseWorkqueueIssueRef(meta.url) ||
+      parseWorkqueueIssueRef(item?.instructions) ||
+      parseWorkqueueIssueRef(item?.title)
+    );
+  }
+
+  function stripWorkqueueIssueTitlePrefix(title, ref) {
+    let text = String(title || '').trim();
+    if (!text) return '';
+
+    text = text
+      .replace(/^\s*\[(?:issue|open issue|issue coverage)\]\s*/i, '')
+      .replace(/^\s*(?:open\s+issue|issue\s+coverage|issue)\s*:\s*/i, '')
+      .trim();
+
+    if (ref?.repo && ref?.issueNumber) {
+      const escapedRepo = ref.repo.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace('/', String.raw`\s*\/\s*`);
+      const refPattern = new RegExp(String.raw`^\s*${escapedRepo}\s*#\s*${ref.issueNumber}\b\s*(?:[-:|]+)?\s*`, 'i');
+      text = text.replace(refPattern, '').trim();
+    }
+
+    text = text
+      .replace(/^[-:|]+\s*/, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+
+    return text;
+  }
+
+  function formatWorkqueueIssueTitle(item) {
+    const rawTitle = String(item?.title || '').trim();
+    const ref = getWorkqueueIssueRef(item);
+    if (!ref?.repo || !ref?.issueNumber) return rawTitle;
+
+    const displayTitle = stripWorkqueueIssueTitlePrefix(rawTitle, ref);
+    return `[ISSUE] ${ref.repo}#${ref.issueNumber}${displayTitle ? ` - ${displayTitle}` : ''}`;
   }
 
   function inferPaneCols(count) {
@@ -362,6 +450,7 @@
   const AppCore = {
     escapeHtml,
     fmtRemaining,
+    formatWorkqueueIssueTitle,
     sortWorkqueueItems,
     inferPaneCols,
     normalizePaneKind,

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -75,6 +75,41 @@ function seedLegacyDuplicateWorkqueueItems(queue) {
   fs.writeFileSync(path.join(dir, 'work-queues.json'), JSON.stringify(data, null, 2));
 }
 
+function seedLegacyIssueTitleVariants(queue) {
+  const dir = path.join(env.tempHome, '.openclaw', 'clawnsole');
+  fs.mkdirSync(dir, { recursive: true });
+  const now = new Date();
+  const iso = (offsetMs) => new Date(now.getTime() + offsetMs).toISOString();
+  const mkItem = (id, title, offsetMs) => ({
+    id,
+    queue,
+    title,
+    instructions: 'Repo: rmdmattingly/clawnsole\nIssue: #280',
+    priority: 10,
+    status: 'ready',
+    claimedBy: '',
+    claimedAt: '',
+    leaseUntil: 0,
+    attempts: 0,
+    lastError: '',
+    createdAt: iso(offsetMs),
+    updatedAt: iso(offsetMs),
+    dedupeKey: `legacy-title-variant-${id}`
+  });
+
+  const data = {
+    version: 1,
+    queues: { [queue]: { name: queue, createdAt: iso(-120000) } },
+    assignments: {},
+    items: [
+      mkItem('legacy-title-a', '[issue] rmdmattingly/clawnsole#280 Normalize row titles', -30000),
+      mkItem('legacy-title-b', 'Open issue: Normalize row titles', -20000),
+      mkItem('legacy-title-c', 'Issue coverage: Normalize row titles', -10000)
+    ]
+  };
+  fs.writeFileSync(path.join(dir, 'work-queues.json'), JSON.stringify(data, null, 2));
+}
+
 test('workqueue pane: renders + has queue dropdown + does not show chat composer', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);
@@ -317,6 +352,30 @@ test('workqueue pane: source chips + clawnsole preset filter items without reloa
   await pane.locator('[data-wq-preset-clawnsole]').click();
   await expect(pane.locator('.wq-row')).toHaveCount(1);
   await expect(pane.locator('.wq-row .wq-col.title')).toContainText(/clawnsole issue item/i);
+});
+
+test('workqueue pane: normalizes mixed legacy issue title prefixes', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  const queue = `title-normalize-${Date.now()}`;
+  seedLegacyIssueTitleVariants(queue);
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  const pane = page.locator('[data-pane]').last();
+  await pane.locator('[data-wq-queue-select]').selectOption('__custom__');
+  await pane.locator('[data-wq-queue-custom]').fill(queue);
+  await pane.locator('[data-wq-queue-custom]').press('Enter');
+
+  await expect(pane.locator('.wq-row')).toHaveCount(3);
+  await expect(pane.locator('.wq-row .wq-col.title')).toHaveText([
+    '[ISSUE] rmdmattingly/clawnsole#280 - Normalize row titles',
+    '[ISSUE] rmdmattingly/clawnsole#280 - Normalize row titles',
+    '[ISSUE] rmdmattingly/clawnsole#280 - Normalize row titles'
+  ]);
 });
 
 test('workqueue pane: duplicate health summary cleans legacy issue duplicates', async ({ page }) => {

--- a/tests/unit/app-core.test.js
+++ b/tests/unit/app-core.test.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict');
 const {
   escapeHtml,
   fmtRemaining,
+  formatWorkqueueIssueTitle,
   sortWorkqueueItems,
   inferPaneCols,
   normalizePaneKind,
@@ -84,6 +85,53 @@ test('sortWorkqueueItems supports explicit sort keys and stable ordering fallbac
   // For ties without timestamps, preserve input order.
   const byPrio = sortWorkqueueItems(items, { sortKey: 'priority', sortDir: 'desc' });
   assert.deepEqual(byPrio.map((it) => it.id), ['a', 'b', 'c']);
+});
+
+test('formatWorkqueueIssueTitle normalizes mixed legacy issue prefixes', () => {
+  const base = {
+    queue: 'dev-team',
+    instructions: 'Repo: rmdmattingly/clawnsole\nIssue: #280'
+  };
+
+  assert.equal(
+    formatWorkqueueIssueTitle({
+      ...base,
+      title: '[issue] rmdmattingly/clawnsole#280 UX: Normalize issue-backed Workqueue row titles'
+    }),
+    '[ISSUE] rmdmattingly/clawnsole#280 - UX: Normalize issue-backed Workqueue row titles'
+  );
+  assert.equal(
+    formatWorkqueueIssueTitle({
+      ...base,
+      title: 'Open issue: UX: Normalize issue-backed Workqueue row titles'
+    }),
+    '[ISSUE] rmdmattingly/clawnsole#280 - UX: Normalize issue-backed Workqueue row titles'
+  );
+  assert.equal(
+    formatWorkqueueIssueTitle({
+      ...base,
+      title: 'Issue coverage: UX: Normalize issue-backed Workqueue row titles'
+    }),
+    '[ISSUE] rmdmattingly/clawnsole#280 - UX: Normalize issue-backed Workqueue row titles'
+  );
+});
+
+test('sortWorkqueueItems title sort uses normalized issue display titles', () => {
+  const items = [
+    {
+      id: 'b',
+      title: 'Open issue: Beta',
+      instructions: 'Repo: rmdmattingly/clawnsole\nIssue: #281'
+    },
+    {
+      id: 'a',
+      title: '[issue] rmdmattingly/clawnsole#280 Alpha',
+      instructions: 'Repo: rmdmattingly/clawnsole\nIssue: #280'
+    }
+  ];
+
+  const sorted = sortWorkqueueItems(items, { sortKey: 'title', sortDir: 'asc' });
+  assert.deepEqual(sorted.map((it) => it.id), ['a', 'b']);
 });
 
 test('sortWorkqueueItems priority sort uses updatedAt desc tie-breaker', () => {


### PR DESCRIPTION
## Summary
- Normalize issue-backed Workqueue display titles to `[ISSUE] owner/repo#number - title` in modal cards, pane rows, and inspect views.
- Use normalized titles for explicit title sorting so mixed legacy prefixes sort consistently.
- Add unit and UI regressions for `[issue]`, `Open issue:`, and `Issue coverage:` legacy rows.

Closes #280

## Tests
- npm run test:syntax
- npm run test:unit
- npx playwright test tests/ui/workqueue-pane.spec.js -g "normalizes mixed legacy issue title prefixes" --workers=1