### PR TITLE
Humanize workqueue table headers

### DIFF
--- a/app.js
+++ b/app.js
@@ -3227,6 +3227,14 @@ function renderAgentsModalList() {
 const WORKQUEUE_STATUSES = ['ready', 'pending', 'claimed', 'in_progress', 'done', 'failed'];
 const WORKQUEUE_PANE_INITIAL_RENDER_LIMIT = 100;
 const WORKQUEUE_PANE_RENDER_CHUNK_SIZE = 100;
+const WORKQUEUE_HEADER_META = {
+  title: { label: 'Task', tooltip: 'Sort by task title.' },
+  status: { label: 'Status', tooltip: 'Sort by queue status.' },
+  priority: { label: 'Priority', tooltip: 'Sort by priority. Higher values are handled first by default.' },
+  attempts: { label: 'Attempts', tooltip: 'Sort by how many times this task has been claimed.' },
+  claimedBy: { label: 'Claimed by', tooltip: 'Sort by the agent currently assigned to the task.' },
+  leaseUntil: { label: 'Lease expires', tooltip: 'Sort by when the current claim expires.' }
+};
 
 function formatWorkqueueStatusLabel(status) {
   const s = String(status || '').trim().toLowerCase();
@@ -3315,10 +3323,13 @@ function ensureWorkqueueModalSorting() {
   const updateUi = () => {
     btns.forEach((btn) => {
       const key = btn.getAttribute('data-wq-modal-sort') || '';
+      const meta = WORKQUEUE_HEADER_META[key];
       const active = key && key === workqueueState.sortKey;
       btn.classList.toggle('active', active);
       btn.setAttribute('aria-pressed', active ? 'true' : 'false');
-      btn.title = active ? (workqueueState.sortDir === 'asc' ? 'Sorted ascending' : 'Sorted descending') : '';
+      if (meta) btn.textContent = meta.label;
+      const sortState = active ? ` Currently sorted ${workqueueState.sortDir === 'asc' ? 'ascending' : 'descending'}.` : '';
+      btn.title = `${meta?.tooltip || 'Sort workqueue items.'}${sortState}`;
     });
   };
 
@@ -6432,12 +6443,12 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       <div class="wq-layout">
         <section class="wq-list" aria-label="Workqueue items">
           <div class="wq-list-header">
-            <button type="button" class="wq-list-sort" data-wq-sort="title">title</button>
-            <button type="button" class="wq-list-sort" data-wq-sort="status">status</button>
-            <button type="button" class="wq-list-sort" data-wq-sort="priority">prio</button>
-            <button type="button" class="wq-list-sort" data-wq-sort="attempts">attempts</button>
-            <button type="button" class="wq-list-sort" data-wq-sort="claimedBy">claimedBy</button>
-            <div>lease</div>
+            <button type="button" class="wq-list-sort" data-wq-sort="title">Task</button>
+            <button type="button" class="wq-list-sort" data-wq-sort="status">Status</button>
+            <button type="button" class="wq-list-sort" data-wq-sort="priority">Priority</button>
+            <button type="button" class="wq-list-sort" data-wq-sort="attempts">Attempts</button>
+            <button type="button" class="wq-list-sort" data-wq-sort="claimedBy">Claimed by</button>
+            <button type="button" class="wq-list-sort" data-wq-sort="leaseUntil">Lease expires</button>
           </div>
           <div class="wq-list-body" data-wq-list-body></div>
           <div data-wq-empty class="hint" style="padding: 10px 12px;" hidden>No items.</div>
@@ -6809,10 +6820,13 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     const updateSortUi = () => {
       sortBtns.forEach((btn) => {
         const key = btn.getAttribute('data-wq-sort') || '';
+        const meta = WORKQUEUE_HEADER_META[key];
         const active = key && key === pane.workqueue.sortKey;
         btn.classList.toggle('active', active);
         btn.setAttribute('aria-pressed', active ? 'true' : 'false');
-        btn.title = active ? (pane.workqueue.sortDir === 'asc' ? 'Sorted ascending' : 'Sorted descending') : '';
+        if (meta) btn.textContent = meta.label;
+        const sortState = active ? ` Currently sorted ${pane.workqueue.sortDir === 'asc' ? 'ascending' : 'descending'}.` : '';
+        btn.title = `${meta?.tooltip || 'Sort workqueue items.'}${sortState}`;
       });
     };
 

--- a/index.html
+++ b/index.html
@@ -382,12 +382,12 @@
           <div class="wq-layout">
             <div class="wq-list" aria-label="Workqueue items">
               <div class="wq-list-header" role="group" aria-label="Sort workqueue items">
-                <button type="button" class="wq-list-sort" data-wq-modal-sort="title">Title</button>
+                <button type="button" class="wq-list-sort" data-wq-modal-sort="title">Task</button>
                 <button type="button" class="wq-list-sort" data-wq-modal-sort="status">Status</button>
-                <button type="button" class="wq-list-sort" data-wq-modal-sort="priority">Prio</button>
-                <button type="button" class="wq-list-sort" data-wq-modal-sort="attempts">Att</button>
-                <button type="button" class="wq-list-sort" data-wq-modal-sort="claimedBy">Claimed By</button>
-                <button type="button" class="wq-list-sort" data-wq-modal-sort="leaseUntil">Lease</button>
+                <button type="button" class="wq-list-sort" data-wq-modal-sort="priority">Priority</button>
+                <button type="button" class="wq-list-sort" data-wq-modal-sort="attempts">Attempts</button>
+                <button type="button" class="wq-list-sort" data-wq-modal-sort="claimedBy">Claimed by</button>
+                <button type="button" class="wq-list-sort" data-wq-modal-sort="leaseUntil">Lease expires</button>
               </div>
               <div id="wqListBody" class="wq-list-body"></div>
               <div id="wqListEmpty" class="hint" hidden>No items match.</div>

--- a/tests/pane.workqueue.e2e.spec.js
+++ b/tests/pane.workqueue.e2e.spec.js
@@ -46,6 +46,21 @@ test('pane: workqueue renders + core controls visible', async ({ page }) => {
   await expect(wqPane.locator('[data-wq-refresh]')).toBeVisible();
   await expect(wqPane.locator('[data-wq-queue-select]')).toBeVisible();
   await expect(wqPane.locator('[data-wq-status]')).toBeVisible();
+  const listHeader = wqPane.locator('.wq-list-header');
+  await expect(listHeader.locator('[data-wq-sort="title"]')).toHaveText('Task');
+  await expect(listHeader.locator('[data-wq-sort="status"]')).toHaveText('Status');
+  await expect(listHeader.locator('[data-wq-sort="priority"]')).toHaveText('Priority');
+  await expect(listHeader.locator('[data-wq-sort="attempts"]')).toHaveText('Attempts');
+  await expect(listHeader.locator('[data-wq-sort="claimedBy"]')).toHaveText('Claimed by');
+  await expect(listHeader.locator('[data-wq-sort="leaseUntil"]')).toHaveText('Lease expires');
+  await expect(listHeader.locator('[data-wq-sort="attempts"]')).toHaveAttribute(
+    'title',
+    /how many times this task has been claimed/
+  );
+  await expect(listHeader.locator('[data-wq-sort="leaseUntil"]')).toHaveAttribute(
+    'title',
+    /when the current claim expires/
+  );
 
   // Layout regression: toolbar + list should consume full thread height (no dead space below).
   const thread = wqPane.locator('[data-pane-thread]');

--- a/tests/ui/workqueue-modal.spec.js
+++ b/tests/ui/workqueue-modal.spec.js
@@ -46,6 +46,20 @@ test('workqueue modal: status filters use human labels and queue-scoped counts',
   await page.evaluate(() => window.openWorkqueue?.());
   await expect(page.locator('#workqueueModal')).toHaveClass(/open/);
 
+  await expect(page.locator('[data-wq-modal-sort="title"]')).toHaveText('Task');
+  await expect(page.locator('[data-wq-modal-sort="priority"]')).toHaveText('Priority');
+  await expect(page.locator('[data-wq-modal-sort="attempts"]')).toHaveText('Attempts');
+  await expect(page.locator('[data-wq-modal-sort="claimedBy"]')).toHaveText('Claimed by');
+  await expect(page.locator('[data-wq-modal-sort="leaseUntil"]')).toHaveText('Lease expires');
+  await expect(page.locator('[data-wq-modal-sort="attempts"]')).toHaveAttribute(
+    'title',
+    /how many times this task has been claimed/
+  );
+  await expect(page.locator('[data-wq-modal-sort="leaseUntil"]')).toHaveAttribute(
+    'title',
+    /when the current claim expires/
+  );
+
   // Humanized labels (no raw snake_case token in display text).
   await expect(page.locator('#wqStatusFilters .wq-status-chip', { hasText: 'In progress (' })).toHaveCount(1);
   await expect(page.locator('#wqStatusFilters .wq-status-chip', { hasText: 'in_progress' })).toHaveCount(0);


### PR DESCRIPTION
## Summary
- Rename Workqueue list headers from internal field names to human labels in the modal and pane.
- Add explanatory header tooltips for ambiguous columns, including Attempts and Lease expires.
- Make the pane Lease expires header a sortable control using the existing leaseUntil sort key.

Fixes #292

## Tests
- npm test
- npx playwright test tests/ui/workqueue-modal.spec.js tests/pane.workqueue.e2e.spec.js --workers=1