### PR TITLE
Add Fleet health summary chips

### DIFF
--- a/app.js
+++ b/app.js
@@ -38,6 +38,7 @@ const globalElements = {
   agentsSortIndicator: document.getElementById('agentsSortIndicator'),
   agentsActiveMinutes: document.getElementById('agentsActiveMinutes'),
   agentsLastRefreshed: document.getElementById('agentsLastRefreshed'),
+  agentsHealthSummary: document.getElementById('agentsHealthSummary'),
   agentsList: document.getElementById('agentsList'),
   agentsEmpty: document.getElementById('agentsEmpty'),
   toastHost: document.getElementById('toastHost'),
@@ -492,6 +493,10 @@ function syncFleetDensityControl() {
   if (globalElements.agentsList) {
     globalElements.agentsList.dataset.density = density;
     globalElements.agentsList.classList.toggle('compact', density === 'compact');
+  }
+  if (globalElements.agentsHealthSummary) {
+    globalElements.agentsHealthSummary.dataset.density = density;
+    globalElements.agentsHealthSummary.classList.toggle('compact', density === 'compact');
   }
   globalElements.agentsDensityButtons.forEach((btn) => {
     const active = String(btn.getAttribute('data-agents-density') || '') === density;
@@ -3108,10 +3113,33 @@ function renderAgentsModalList() {
   const ordered = [...pinned, ...rest];
   const needsAttention = rest.filter((agent) => classify(agent?.id).bucket !== 'active');
   const healthy = rest.filter((agent) => classify(agent?.id).bucket === 'active');
+  const healthSummary = baseAgents.reduce((acc, agent) => {
+    const { bucket } = classify(agent?.id);
+    if (bucket === 'active') acc.healthy += 1;
+    else acc.needsTriage += 1;
+    if (bucket === 'offline_error') acc.disconnected += 1;
+    return acc;
+  }, { needsTriage: 0, healthy: 0, disconnected: 0 });
   const healthyCollapseDefault = baseAgents.length > ADMIN_AGENT_HEALTHY_COLLAPSE_THRESHOLD;
   const healthyCollapsed = String(storage.get(ADMIN_AGENT_HEALTHY_COLLAPSED_KEY, healthyCollapseDefault ? '1' : '0')) === '1';
 
   root.innerHTML = '';
+  if (globalElements.agentsHealthSummary) {
+    globalElements.agentsHealthSummary.innerHTML = `
+      <div class="agents-health-chip" title="Agents with stale, offline, error, or unknown heartbeat state">
+        <span class="agents-health-chip-label">Needs triage</span>
+        <strong>${healthSummary.needsTriage}</strong>
+      </div>
+      <div class="agents-health-chip" title="Agents active within the configured active window">
+        <span class="agents-health-chip-label">Healthy</span>
+        <strong>${healthSummary.healthy}</strong>
+      </div>
+      <div class="agents-health-chip" title="Agents currently offline, errored, or never seen">
+        <span class="agents-health-chip-label">Disconnected</span>
+        <strong>${healthSummary.disconnected}</strong>
+      </div>
+    `;
+  }
 
   const renderSection = (title, agents, { collapsible = false, collapsed = false } = {}) => {
     const section = document.createElement('div');

--- a/index.html
+++ b/index.html
@@ -461,6 +461,7 @@
             </div>
           </div>
 
+          <div id="agentsHealthSummary" class="agents-health-summary" aria-label="Fleet health summary"></div>
           <div id="agentsList" class="agents-list" aria-label="Agent list"></div>
           <div id="agentsEmpty" class="hint" hidden>No agents match.</div>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -1530,6 +1530,53 @@ button.send-btn .btn-icon {
   opacity: 0.48;
 }
 
+.agents-health-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin: 0 0 12px;
+}
+
+.agents-health-chip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-width: 0;
+  padding: 10px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.agents-health-chip-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.agents-health-chip strong {
+  color: var(--text);
+  font-size: 18px;
+  line-height: 1;
+}
+
+.agents-health-summary.compact {
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.agents-health-summary.compact .agents-health-chip {
+  padding: 6px 8px;
+}
+
+.agents-health-summary.compact .agents-health-chip strong {
+  font-size: 15px;
+}
+
 .agents-list {
   display: flex;
   flex-direction: column;

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -121,10 +121,21 @@ test('fleet attention mode sections healthy agents and keeps filters while expan
   await page.getByRole('button', { name: 'Open agents' }).click();
   await expect(page.locator('#agentsModal')).toHaveClass(/open/);
 
+  const summary = page.locator('#agentsHealthSummary');
+  await expect(summary.locator('.agents-health-chip').filter({ hasText: 'Needs triage' }).locator('strong')).toHaveText('1');
+  await expect(summary.locator('.agents-health-chip').filter({ hasText: 'Healthy' }).locator('strong')).toHaveText('11');
+  await expect(summary.locator('.agents-health-chip').filter({ hasText: 'Disconnected' }).locator('strong')).toHaveText('1');
+
   await expect(page.locator('#agentsList .agents-section-title').first()).toContainText('Needs attention (1)');
   const healthyToggle = page.getByRole('button', { name: /Healthy \(11\) Show/ });
   await expect(healthyToggle).toHaveAttribute('aria-expanded', 'false');
   await expect(page.locator('#agentsList .agents-row:visible')).toHaveCount(1);
+
+  await page.locator('#agentsSearch').fill('agent-12');
+  await expect(page.getByRole('button', { name: /Healthy \(1\) Show/ })).toBeVisible();
+  await expect(summary.locator('.agents-health-chip').filter({ hasText: 'Needs triage' }).locator('strong')).toHaveText('1');
+  await expect(summary.locator('.agents-health-chip').filter({ hasText: 'Healthy' }).locator('strong')).toHaveText('11');
+  await page.locator('#agentsSearch').fill('');
 
   await healthyToggle.click();
   await expect(page.getByRole('button', { name: /Healthy \(11\) Hide/ })).toHaveAttribute('aria-expanded', 'true');
@@ -307,6 +318,7 @@ test('agents modal compact density tightens rows and persists', async ({ page, c
 
   await page.getByRole('button', { name: 'Compact' }).click();
   await expect(page.locator('#agentsList')).toHaveClass(/compact/);
+  await expect(page.locator('#agentsHealthSummary')).toHaveClass(/compact/);
   await expect(page.getByRole('button', { name: 'Compact' })).toHaveAttribute('aria-pressed', 'true');
   const compactHeight = await firstRow.evaluate((el) => el.getBoundingClientRect().height);
 
@@ -319,5 +331,6 @@ test('agents modal compact density tightens rows and persists', async ({ page, c
   await clawnsole.waitForAdminUiReady(page);
   await page.getByRole('button', { name: 'Open agents' }).click();
   await expect(page.locator('#agentsList')).toHaveClass(/compact/);
+  await expect(page.locator('#agentsHealthSummary')).toHaveClass(/compact/);
   await expect(page.getByRole('button', { name: 'Compact' })).toHaveAttribute('aria-pressed', 'true');
 });


### PR DESCRIPTION
## Summary
- Add Fleet health summary chips for Needs triage, Healthy, and Disconnected counts above the agent list.
- Keep summary counts based on the full Fleet source list before search/status filters narrow visible rows.
- Apply compact density styling to the summary strip and cover it with a Playwright regression test.

## Tests
- npm test
- npx playwright test tests/ui/agents-modal.spec.js --workers=1

Closes #294