### PR TITLE
Improve workqueue table title readability

### DIFF
--- a/app.js
+++ b/app.js
@@ -4189,9 +4189,12 @@ function renderWorkqueuePaneItems(pane) {
 
   const now = Date.now();
   for (const it of visibleItems) {
+    const displayTitle = formatWorkqueueIssueTitle(it);
     const row = document.createElement('button');
     row.type = 'button';
     row.className = 'wq-row';
+    row.title = displayTitle;
+    row.setAttribute('aria-label', `Open workqueue item: ${displayTitle}`);
     if (it.id && it.id === pane.workqueue.selectedItemId) row.classList.add('selected');
 
     const leaseMs = it.leaseUntil ? Number(it.leaseUntil) - now : NaN;
@@ -4199,7 +4202,7 @@ function renderWorkqueuePaneItems(pane) {
     const status = String(it.status || '');
 
     row.innerHTML = `
-      <div class="wq-col title">${escapeHtml(formatWorkqueueIssueTitle(it))}</div>
+      <div class="wq-col title" title="${escapeHtml(displayTitle)}" aria-label="${escapeHtml(displayTitle)}" data-wq-title>${escapeHtml(displayTitle)}</div>
       <div class="wq-col status"><span class="wq-badge wq-badge-${escapeHtml(status)}">${escapeHtml(status)}</span></div>
       <div class="wq-col prio mono">${escapeHtml(String(it.priority ?? ''))}</div>
       <div class="wq-col attempts mono">${escapeHtml(String(it.attempts ?? ''))}</div>

--- a/styles.css
+++ b/styles.css
@@ -2327,7 +2327,7 @@ kbd {
 .wq-list-header,
 .wq-row {
   display: grid;
-  grid-template-columns: 1.4fr 0.6fr 0.25fr 0.25fr 0.6fr 0.45fr;
+  grid-template-columns: minmax(32ch, 1fr) minmax(8ch, 12ch) 5ch 5ch minmax(9ch, 12ch) 8ch;
   gap: 10px;
   align-items: center;
 }

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -110,6 +110,37 @@ function seedLegacyIssueTitleVariants(queue) {
   fs.writeFileSync(path.join(dir, 'work-queues.json'), JSON.stringify(data, null, 2));
 }
 
+function seedLongTitleWorkqueueItem(queue, title) {
+  const dir = path.join(env.tempHome, '.openclaw', 'clawnsole');
+  fs.mkdirSync(dir, { recursive: true });
+  const now = new Date();
+  const iso = now.toISOString();
+  const data = {
+    version: 1,
+    queues: { [queue]: { name: queue, createdAt: iso } },
+    assignments: {},
+    items: [
+      {
+        id: 'long-title-affordance',
+        queue,
+        title,
+        instructions: 'Long title affordance coverage',
+        priority: 42,
+        status: 'ready',
+        claimedBy: '',
+        claimedAt: '',
+        leaseUntil: 0,
+        attempts: 0,
+        lastError: '',
+        createdAt: iso,
+        updatedAt: iso,
+        dedupeKey: 'long-title-affordance'
+      }
+    ]
+  };
+  fs.writeFileSync(path.join(dir, 'work-queues.json'), JSON.stringify(data, null, 2));
+}
+
 test('workqueue pane: renders + has queue dropdown + does not show chat composer', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);
@@ -376,6 +407,40 @@ test('workqueue pane: normalizes mixed legacy issue title prefixes', async ({ pa
     '[ISSUE] rmdmattingly/clawnsole#280 - Normalize row titles',
     '[ISSUE] rmdmattingly/clawnsole#280 - Normalize row titles'
   ]);
+});
+
+test('workqueue pane: long table titles keep full-title hover and focus affordance', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  const queue = `long-title-${Date.now()}`;
+  const longTitle = '[issue] rmdmattingly/clawnsole#297 UX: Workqueue table readability pass with a deliberately very long synthetic title that should truncate in the row while remaining fully discoverable';
+  const displayTitle = '[ISSUE] rmdmattingly/clawnsole#297 - UX: Workqueue table readability pass with a deliberately very long synthetic title that should truncate in the row while remaining fully discoverable';
+  seedLongTitleWorkqueueItem(queue, longTitle);
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  const pane = page.locator('[data-pane]').last();
+  await pane.locator('[data-wq-queue-select]').selectOption('__custom__');
+  await pane.locator('[data-wq-queue-custom]').fill(queue);
+  await pane.locator('[data-wq-queue-custom]').press('Enter');
+
+  const row = pane.locator('.wq-row').first();
+  const title = row.locator('[data-wq-title]');
+  await expect(row).toBeVisible();
+  await expect(title).toContainText('Workqueue table readability pass');
+  await expect(row).toHaveAttribute('title', displayTitle);
+  await expect(row).toHaveAttribute('aria-label', `Open workqueue item: ${displayTitle}`);
+  await expect(title).toHaveAttribute('title', displayTitle);
+  await expect(title).toHaveAttribute('aria-label', displayTitle);
+
+  await row.focus();
+  await expect(row).toBeFocused();
+  await expect(row).toHaveAttribute('aria-label', `Open workqueue item: ${displayTitle}`);
+  expect(await title.evaluate((el) => el.scrollWidth > el.clientWidth)).toBeTruthy();
 });
 
 test('workqueue pane: duplicate health summary cleans legacy issue duplicates', async ({ page }) => {


### PR DESCRIPTION
## Summary
- reserve the workqueue table title column as the primary flexible column while capping dense metadata columns
- add full-title hover/focus affordances on workqueue rows and title cells
- add Playwright coverage for long synthetic titles remaining visible, truncated, and discoverable

Fixes #297

## Tests
- npm run test:syntax
- npm run test:unit -- --test-name-pattern formatWorkqueueIssueTitle
- npx playwright test tests/ui/workqueue-pane.spec.js --grep "long table titles" --workers=1
- npx playwright test tests/ui/workqueue-pane.spec.js --workers=1