### PR TITLE
Improve workqueue title readability

### DIFF
--- a/app.js
+++ b/app.js
@@ -4197,9 +4197,12 @@ function renderWorkqueuePaneItems(pane) {
     const leaseMs = it.leaseUntil ? Number(it.leaseUntil) - now : NaN;
     const leaseLabel = it.leaseUntil ? fmtRemaining(leaseMs) : '';
     const status = String(it.status || '');
+    const title = formatWorkqueueIssueTitle(it);
+    row.title = title;
+    row.setAttribute('aria-label', `Workqueue item: ${title}`);
 
     row.innerHTML = `
-      <div class="wq-col title">${escapeHtml(formatWorkqueueIssueTitle(it))}</div>
+      <div class="wq-col title"><span class="wq-title-text" title="${escapeHtml(title)}">${escapeHtml(title)}</span></div>
       <div class="wq-col status"><span class="wq-badge wq-badge-${escapeHtml(status)}">${escapeHtml(status)}</span></div>
       <div class="wq-col prio mono">${escapeHtml(String(it.priority ?? ''))}</div>
       <div class="wq-col attempts mono">${escapeHtml(String(it.attempts ?? ''))}</div>

--- a/styles.css
+++ b/styles.css
@@ -2327,7 +2327,7 @@ kbd {
 .wq-list-header,
 .wq-row {
   display: grid;
-  grid-template-columns: 1.4fr 0.6fr 0.25fr 0.25fr 0.6fr 0.45fr;
+  grid-template-columns: minmax(32ch, 1fr) minmax(7rem, max-content) 4ch 5ch minmax(7ch, 10ch) minmax(6ch, 8ch);
   gap: 10px;
   align-items: center;
 }
@@ -2506,6 +2506,18 @@ kbd {
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 13px;
+}
+
+.wq-col.title {
+  font-weight: 600;
+}
+
+.wq-title-text {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .wq-col.mono {

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -378,6 +378,76 @@ test('workqueue pane: normalizes mixed legacy issue title prefixes', async ({ pa
   ]);
 });
 
+test('workqueue pane: long table titles stay discoverable on hover and focus', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  const queue = `long-title-${Date.now()}`;
+  const title = '[ISSUE] rmdmattingly/clawnsole#297 - Workqueue title readability affordance with a very long synthetic title that should truncate visually while remaining fully available to pointer and keyboard users';
+  const stateDir = path.join(env.tempHome, '.openclaw', 'clawnsole');
+  fs.mkdirSync(stateDir, { recursive: true });
+  const now = new Date().toISOString();
+  fs.writeFileSync(
+    path.join(stateDir, 'work-queues.json'),
+    JSON.stringify({
+      version: 1,
+      queues: { [queue]: { name: queue, createdAt: now } },
+      assignments: {},
+      items: [{
+        id: 'long-title-item',
+        queue,
+        title,
+        instructions: 'fixture item',
+        priority: 100,
+        status: 'ready',
+        claimedBy: '',
+        claimedAt: '',
+        leaseUntil: 0,
+        attempts: 3,
+        lastError: '',
+        createdAt: now,
+        updatedAt: now,
+        meta: { repo: 'rmdmattingly/clawnsole' }
+      }]
+    }, null, 2)
+  );
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  const pane = page.locator('[data-pane]').last();
+  await pane.locator('[data-wq-queue-select]').selectOption('__custom__');
+  await pane.locator('[data-wq-queue-custom]').fill(queue);
+  await pane.locator('[data-wq-queue-custom]').press('Enter');
+
+  const row = pane.locator('.wq-row').first();
+  const titleText = row.locator('.wq-title-text');
+  await expect(row).toBeVisible();
+  await expect(titleText).toHaveAttribute('title', title);
+  await expect(row).toHaveAttribute('title', title);
+  await expect(row).toHaveAttribute('aria-label', `Workqueue item: ${title}`);
+  await row.focus();
+  await expect(row).toBeFocused();
+
+  const titleLayout = await titleText.evaluate((el) => {
+    const cs = window.getComputedStyle(el);
+    return {
+      overflow: cs.overflow,
+      textOverflow: cs.textOverflow,
+      whiteSpace: cs.whiteSpace,
+      clipped: el.scrollWidth > el.clientWidth
+    };
+  });
+  expect(titleLayout).toMatchObject({
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    clipped: true
+  });
+});
+
 test('workqueue pane: duplicate health summary cleans legacy issue duplicates', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);


### PR DESCRIPTION
## Summary
- make the Workqueue table title column the primary flexible column with fixed-width metadata columns
- expose full row title through native title attributes and the row aria-label for hover/focus discovery
- add a Playwright regression covering a long synthetic title and ellipsis behavior

Fixes #297

## Tests
- npm run test:syntax
- npx playwright test tests/ui/workqueue-pane.spec.js -g "long table titles" --workers=1