### PR TITLE
Preserve fleet modal context across refresh

### DIFF
--- a/app.js
+++ b/app.js
@@ -630,6 +630,10 @@ let agentAutoRefreshInterval = null;
 let agentsModalAutoRefreshInterval = null;
 let agentsModalFreshnessTicker = null;
 let agentsLastRefreshedAtMs = 0;
+const fleetModalState = {
+  selectedAgentId: '',
+  notice: ''
+};
 
 function startAgentAutoRefresh() {
   if (roleState.role !== 'admin') return;
@@ -2980,6 +2984,117 @@ function closeAgentsModal() {
   stopAgentsModalFreshnessTicker();
 }
 
+function getFleetScrollContainer() {
+  return globalElements.agentsList?.closest?.('.modal-body') || globalElements.agentsList || null;
+}
+
+function cssEscape(value) {
+  if (window.CSS?.escape) return window.CSS.escape(String(value || ''));
+  return String(value || '').replace(/["\\]/g, '\\$&');
+}
+
+function getVisibleFleetRows() {
+  return Array.from(globalElements.agentsList?.querySelectorAll?.('.agents-row[data-agent-id]') || [])
+    .filter((row) => row.getClientRects().length > 0);
+}
+
+function captureFleetListViewport() {
+  const scroller = getFleetScrollContainer();
+  const scrollerTop = scroller?.getBoundingClientRect?.().top || 0;
+  const rows = getVisibleFleetRows();
+  const anchor = rows.find((row) => row.getBoundingClientRect().bottom >= scrollerTop + 1) || rows[0] || null;
+  return {
+    scrollTop: scroller ? scroller.scrollTop : 0,
+    anchorId: anchor?.dataset?.agentId || '',
+    anchorIndex: anchor ? rows.indexOf(anchor) : -1,
+    rowIds: rows.map((row) => row.dataset?.agentId || '').filter(Boolean),
+    anchorOffset: anchor ? anchor.getBoundingClientRect().top - scrollerTop : 0,
+    activeId: document.activeElement?.closest?.('.agents-row[data-agent-id]')?.dataset?.agentId || ''
+  };
+}
+
+function restoreFleetListViewport(snapshot) {
+  const scroller = getFleetScrollContainer();
+  if (!scroller || !snapshot) return;
+  const restore = () => {
+    const findRow = (id) => id
+      ? globalElements.agentsList?.querySelector?.(`.agents-row[data-agent-id="${cssEscape(id)}"]`)
+      : null;
+    let anchor = findRow(snapshot.anchorId);
+    if (!anchor && Array.isArray(snapshot.rowIds) && snapshot.anchorIndex >= 0) {
+      const candidates = snapshot.rowIds.slice(Math.max(0, snapshot.anchorIndex))
+        .concat(snapshot.rowIds.slice(0, Math.max(0, snapshot.anchorIndex)).reverse());
+      anchor = candidates.map((id) => findRow(id)).find(Boolean) || null;
+    }
+    if (anchor && anchor.getClientRects().length > 0) {
+      const scrollerTop = scroller.getBoundingClientRect().top || 0;
+      scroller.scrollTop += anchor.getBoundingClientRect().top - scrollerTop - snapshot.anchorOffset;
+    } else {
+      scroller.scrollTop = snapshot.scrollTop || 0;
+    }
+    if (snapshot.activeId) {
+      globalElements.agentsList
+        ?.querySelector?.(`.agents-row[data-agent-id="${cssEscape(snapshot.activeId)}"]`)
+        ?.focus?.({ preventScroll: true });
+    }
+  };
+  requestAnimationFrame(restore);
+}
+
+function setFleetSelectedAgent(agentId, { focus = false, scroll = false } = {}) {
+  const id = String(agentId || '').trim();
+  if (!id) return;
+  fleetModalState.selectedAgentId = id;
+  globalElements.agentsList?.querySelectorAll?.('.agents-row[data-agent-id]')?.forEach((row) => {
+    const selected = row.dataset.agentId === id;
+    row.classList.toggle('selected', selected);
+    row.setAttribute('aria-selected', selected ? 'true' : 'false');
+    row.tabIndex = selected ? 0 : -1;
+  });
+  const row = globalElements.agentsList?.querySelector?.(`.agents-row[data-agent-id="${cssEscape(id)}"]`);
+  if (row && focus) row.focus({ preventScroll: !scroll });
+  if (row && scroll) row.scrollIntoView({ block: 'nearest' });
+}
+
+function moveFleetSelection(delta) {
+  const rows = getVisibleFleetRows();
+  if (rows.length === 0) return;
+  const current = fleetModalState.selectedAgentId;
+  const currentIndex = rows.findIndex((row) => row.dataset.agentId === current);
+  const nextIndex = currentIndex === -1
+    ? (delta > 0 ? 0 : rows.length - 1)
+    : Math.max(0, Math.min(rows.length - 1, currentIndex + delta));
+  setFleetSelectedAgent(rows[nextIndex].dataset.agentId, { focus: true, scroll: true });
+}
+
+function handleFleetModalKeydown(event) {
+  if (isTypingContext(event.target)) return false;
+  const key = String(event.key || '').toLowerCase();
+  if (!event.metaKey && !event.ctrlKey && !event.altKey && (key === 'j' || key === 'arrowdown')) {
+    event.preventDefault();
+    moveFleetSelection(1);
+    return true;
+  }
+  if (!event.metaKey && !event.ctrlKey && !event.altKey && (key === 'k' || key === 'arrowup')) {
+    event.preventDefault();
+    moveFleetSelection(-1);
+    return true;
+  }
+  if (!event.metaKey && !event.ctrlKey && !event.altKey && key === 'enter') {
+    const id = fleetModalState.selectedAgentId;
+    if (id) {
+      event.preventDefault();
+      openAgentTriageFromFleet(id);
+      return true;
+    }
+  }
+  if (key !== 'h' || event.metaKey || event.ctrlKey || event.altKey) return false;
+  event.preventDefault();
+  if (event.shiftKey || getFleetSort() !== 'heartbeat_age_desc') setFleetHeartbeatSort();
+  else resetFleetSort();
+  return true;
+}
+
 function findExistingPane(kind, predicate = null) {
   const list = Array.isArray(paneManager?.panes) ? paneManager.panes : [];
   for (const pane of list) {
@@ -3116,6 +3231,7 @@ function openTopbarWorkqueueAction() {
 function renderAgentsModalList() {
   const root = globalElements.agentsList;
   if (!root) return;
+  const viewportSnapshot = captureFleetListViewport();
 
   const search = String(globalElements.agentsSearch?.value || '').trim().toLowerCase();
   const withinMinutes = Math.max(1, Number(globalElements.agentsActiveMinutes?.value) || 10);
@@ -3189,6 +3305,20 @@ function renderAgentsModalList() {
   }, { needsTriage: 0, healthy: 0, disconnected: 0 });
   const healthyCollapseDefault = baseAgents.length > ADMIN_AGENT_HEALTHY_COLLAPSE_THRESHOLD;
   const healthyCollapsed = String(storage.get(ADMIN_AGENT_HEALTHY_COLLAPSED_KEY, healthyCollapseDefault ? '1' : '0')) === '1';
+  const previousSelection = fleetModalState.selectedAgentId;
+  const orderedIds = ordered.map((agent) => String(agent?.id || '').trim()).filter(Boolean);
+  if (orderedIds.length === 0) {
+    fleetModalState.selectedAgentId = '';
+  } else if (!fleetModalState.selectedAgentId) {
+    fleetModalState.selectedAgentId = orderedIds[0];
+  } else if (!orderedIds.includes(fleetModalState.selectedAgentId)) {
+    fleetModalState.selectedAgentId = orderedIds[0];
+    fleetModalState.notice = previousSelection
+      ? `Selected agent ${previousSelection} is no longer in the current filter.`
+      : '';
+  } else {
+    fleetModalState.notice = '';
+  }
 
   root.innerHTML = '';
 
@@ -3232,6 +3362,16 @@ function renderAgentsModalList() {
     root.appendChild(summary);
   };
 
+  const renderNotice = () => {
+    if (!fleetModalState.notice) return;
+    const notice = document.createElement('div');
+    notice.className = 'agents-selection-notice';
+    notice.setAttribute('role', 'status');
+    notice.setAttribute('aria-live', 'polite');
+    notice.textContent = fleetModalState.notice;
+    root.appendChild(notice);
+  };
+
   const renderSection = (title, agents, { collapsible = false, collapsed = false } = {}) => {
     const section = document.createElement('div');
     section.className = 'agents-section';
@@ -3261,6 +3401,8 @@ function renderAgentsModalList() {
       const id = String(agent?.id || '').trim();
       const row = document.createElement('div');
       row.className = 'agents-row';
+      row.dataset.agentId = id;
+      row.setAttribute('role', 'option');
 
       const label = formatAgentLabel(agent, { includeId: true });
       const pinnedNow = pins.has(id);
@@ -3297,6 +3439,11 @@ function renderAgentsModalList() {
         </details>
       `;
 
+      row.addEventListener('click', (e) => {
+        if (e.target?.closest?.('button, summary, details, a, input, select, textarea')) return;
+        setFleetSelectedAgent(id, { focus: true });
+      });
+
       const pinBtn = row.querySelector('[data-agent-pin]');
       pinBtn?.addEventListener('click', (e) => {
         e.preventDefault();
@@ -3328,9 +3475,12 @@ function renderAgentsModalList() {
   };
 
   renderSummary();
+  renderNotice();
   if (pinned.length > 0) renderSection('Pinned', pinned);
   renderSection('Needs attention', needsAttention);
   renderSection('Healthy', healthy, { collapsible: true, collapsed: healthyCollapsed });
+  setFleetSelectedAgent(fleetModalState.selectedAgentId);
+  restoreFleetListViewport(viewportSnapshot);
 
   if (globalElements.agentsHeatmapToggle) globalElements.agentsHeatmapToggle.checked = heatmapEnabled;
   if (globalElements.agentsHeartbeatSortBtn) {
@@ -8407,12 +8557,13 @@ globalElements.agentsModal?.addEventListener('click', (event) => {
   if (event.target === globalElements.agentsModal) closeAgentsModal();
 });
 globalElements.agentsModal?.addEventListener('keydown', (event) => {
-  if (isTypingContext(event.target)) return;
-  if (String(event.key || '').toLowerCase() !== 'h' || event.metaKey || event.ctrlKey || event.altKey) return;
-  event.preventDefault();
-  if (event.shiftKey || getFleetSort() !== 'heartbeat_age_desc') setFleetHeartbeatSort();
-  else resetFleetSort();
-});
+  handleFleetModalKeydown(event);
+}, true);
+window.addEventListener('keydown', (event) => {
+  if (!globalElements.agentsModal?.classList?.contains('open')) return;
+  if (globalElements.agentsModal.contains(event.target)) return;
+  handleFleetModalKeydown(event);
+}, true);
 
 globalElements.agentsSearch?.addEventListener('input', () => renderAgentsModalList());
 globalElements.agentsSearch?.addEventListener('keydown', (event) => {

--- a/index.html
+++ b/index.html
@@ -462,7 +462,7 @@
             </div>
           </div>
 
-          <div id="agentsList" class="agents-list" aria-label="Agent list"></div>
+          <div id="agentsList" class="agents-list" role="listbox" aria-label="Agent list"></div>
           <div id="agentsEmpty" class="hint" hidden>No agents match.</div>
         </div>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -1658,6 +1658,26 @@ button.agents-section-title:hover {
   background: rgba(255, 255, 255, 0.02);
 }
 
+.agents-row.selected,
+.agents-row[aria-selected="true"] {
+  border-color: rgba(103, 179, 255, 0.6);
+  background: rgba(103, 179, 255, 0.08);
+}
+
+.agents-row:focus-visible {
+  outline: 2px solid rgba(103, 179, 255, 0.72);
+  outline-offset: 2px;
+}
+
+.agents-selection-notice {
+  border: 1px solid rgba(255, 203, 107, 0.28);
+  border-radius: 8px;
+  padding: 8px 10px;
+  background: rgba(255, 203, 107, 0.08);
+  color: var(--muted);
+  font-size: 12px;
+}
+
 .agents-row-heatmap {
   border-left-width: 4px;
 }

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -138,6 +138,82 @@ test('agents modal quick filter narrows list and Esc clears it', async ({ page, 
   await expect(rows).toHaveCount(initialCount);
 });
 
+test('agents modal preserves selected row and keyboard triage across refresh', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  let agents = ['alpha', 'beta', 'gamma'].map((id) => ({ id, name: id, displayName: id }));
+  await page.route(/\/agents(?:\?|$)/, async (route) => {
+    await route.fulfill({ json: { agents } });
+  });
+
+  await clawnsole.gotoAndLoginAdmin(page);
+  await page.getByRole('button', { name: 'Refresh agent list' }).click();
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsModal')).toHaveClass(/open/);
+
+  const beta = page.locator('#agentsList .agents-row[data-agent-id="beta"]');
+  await beta.click();
+  await expect(beta).toHaveAttribute('aria-selected', 'true');
+
+  agents = ['alpha', 'beta', 'gamma', 'zeta'].map((id) => ({ id, name: id, displayName: id }));
+  await page.evaluate(() => refreshAgents({ reason: 'test' }));
+  await expect(beta).toHaveAttribute('aria-selected', 'true');
+
+  await beta.focus();
+  await page.keyboard.press('j');
+  const gamma = page.locator('#agentsList .agents-row[data-agent-id="gamma"]');
+  await expect(gamma).toHaveAttribute('aria-selected', 'true');
+
+  await page.keyboard.press('Enter');
+  await expect(page.locator('[data-pane][data-pane-kind="chat"] [data-pane-agent-select]').last()).toHaveValue('gamma');
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"] [data-wq-claim-agent]').last()).toHaveValue('gamma');
+});
+
+test('agents modal keeps scroll anchor and falls back when selected agent disappears', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  let agents = Array.from({ length: 45 }, (_, index) => {
+    const id = `agent-${String(index + 1).padStart(2, '0')}`;
+    return { id, name: id, displayName: id };
+  });
+  await page.route(/\/agents(?:\?|$)/, async (route) => {
+    await route.fulfill({ json: { agents } });
+  });
+
+  await clawnsole.gotoAndLoginAdmin(page);
+  await page.getByRole('button', { name: 'Refresh agent list' }).click();
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsModal')).toHaveClass(/open/);
+
+  const body = page.locator('#agentsModal .modal-body');
+  await body.evaluate((el) => { el.scrollTop = 620; });
+  const selected = page.locator('#agentsList .agents-row[data-agent-id="agent-18"]');
+  await selected.click();
+  await expect(selected).toHaveAttribute('aria-selected', 'true');
+  const firstVisibleBefore = await page.evaluate(() => {
+    const bodyEl = document.querySelector('#agentsModal .modal-body');
+    const top = bodyEl.getBoundingClientRect().top;
+    return Array.from(document.querySelectorAll('#agentsList .agents-row'))
+      .find((row) => row.getBoundingClientRect().bottom >= top + 1)?.dataset.agentId;
+  });
+  expect(firstVisibleBefore).toBeTruthy();
+
+  agents = agents.filter((agent) => agent.id !== 'agent-18');
+  await page.evaluate(() => refreshAgents({ reason: 'test' }));
+
+  await expect(page.locator('#agentsList .agents-selection-notice')).toContainText('agent-18');
+  await expect(page.locator('#agentsList .agents-row[aria-selected="true"]')).toHaveCount(1);
+  await expect(page.locator('#agentsList .agents-row[data-agent-id="agent-18"]')).toHaveCount(0);
+  await page.waitForFunction((expected) => {
+    const bodyEl = document.querySelector('#agentsModal .modal-body');
+    const top = bodyEl.getBoundingClientRect().top;
+    const visibleIds = Array.from(document.querySelectorAll('#agentsList .agents-row'))
+      .filter((row) => row.getBoundingClientRect().bottom >= top + 1 && row.getBoundingClientRect().top <= bodyEl.getBoundingClientRect().bottom - 1)
+      .map((row) => row.dataset.agentId);
+    return visibleIds.includes(expected) || visibleIds.includes('agent-17') || visibleIds.includes('agent-19');
+  }, firstVisibleBefore);
+});
+
 test('fleet attention mode sections healthy agents and keeps filters while expanding', async ({ page, clawnsole }) => {
   if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
 


### PR DESCRIPTION
## Summary
- Preserve selected Fleet row across refreshes and restore a stable visible scroll anchor.
- Add graceful fallback selection plus a subtle status notice when the previously selected agent leaves the current filter/list.
- Add keyboard j/k and Enter continuity tests for the refreshed Fleet modal workflow.

Fixes #293

## Tests
- npm run test:syntax
- npx playwright test tests/ui/agents-modal.spec.js --workers=1