### PR TITLE
Add Fleet triage return shortcut

### DIFF
--- a/app.js
+++ b/app.js
@@ -11592,6 +11592,11 @@ window.addEventListener('keydown', (event) => {
   // Ctrl/Cmd+Shift+T → focus matching timeline target (Alt/Option adds anyway)
   const isAccel = (event.metaKey || event.ctrlKey) && event.shiftKey;
   if (isAccel && roleState.role === 'admin' && !isAnyOverlayOpen()) {
+    if (matchesKeybind(event, 'workqueue.openForActiveChat')) {
+      event.preventDefault();
+      openWorkqueueForActiveChatAgent();
+      return;
+    }
     if (matchesKeybindWithOptionalAlt(event, 'triage.return') && !event.altKey) {
       event.preventDefault();
       paneManager.closeAddPaneMenu();
@@ -11634,13 +11639,6 @@ window.addEventListener('keydown', (event) => {
   if (matchesKeybind(event, 'chat.composer')) {
     event.preventDefault();
     focusChatComposer();
-    return;
-  }
-
-  // Cmd/Ctrl+Shift+G targets the focused chat pane, so allow it from the chat input.
-  if (matchesKeybind(event, 'workqueue.openForActiveChat') && roleState.role === 'admin') {
-    event.preventDefault();
-    openWorkqueueForActiveChatAgent();
     return;
   }
 

--- a/app.js
+++ b/app.js
@@ -4244,7 +4244,6 @@ function openCommandPalette() {
 }
 
 // Agents (admin-only)
-
 function openAgentsModal() {
   if (roleState.role !== 'admin') return;
   globalElements.agentsModal?.classList.add('open');
@@ -11592,7 +11591,14 @@ window.addEventListener('keydown', (event) => {
   // Ctrl/Cmd+Shift+R → focus matching cron target (Alt/Option adds anyway)
   // Ctrl/Cmd+Shift+T → focus matching timeline target (Alt/Option adds anyway)
   const isAccel = (event.metaKey || event.ctrlKey) && event.shiftKey;
-  if (isAccel && roleState.role === 'admin' && !isTypingContext(event.target) && !isAnyOverlayOpen()) {
+  if (isAccel && roleState.role === 'admin' && !isAnyOverlayOpen()) {
+    if (matchesKeybindWithOptionalAlt(event, 'triage.return') && !event.altKey) {
+      event.preventDefault();
+      paneManager.closeAddPaneMenu();
+      returnToTriageSource();
+      return;
+    }
+    if (isTypingContext(event.target)) return;
     const addPaneShortcuts = [
       ['pane.addChat', 'chat'],
       ['pane.addWorkqueue', 'workqueue'],


### PR DESCRIPTION
Fixes #405.\n\n## Summary\n- store a Fleet/Agents triage return anchor when opening Chat or Workqueue from the Agents modal\n- add Return to previous triage context via command palette and Ctrl/Cmd+Shift+B\n- restore the previous Fleet row selection, scroll position, and keyboard focus\n\n## Tests\n- npm test\n- npx playwright test tests/ui/agents-modal.spec.js\n