### PR TITLE
Add workqueue duplicate collapse command

### DIFF
--- a/app.js
+++ b/app.js
@@ -2545,6 +2545,10 @@ function buildCommandPaletteItems() {
       'g c'
     ),
     withShortcut(
+      { id: 'cmd:focus-chat-composer', label: 'Chat: Focus composer', detail: 'Jump to the active or most recent Chat composer', run: () => focusChatComposer() },
+      '⌘/Ctrl+L'
+    ),
+    withShortcut(
       { id: 'cmd:pane-mru-next', label: 'Panes: Switch to previous MRU pane', detail: 'Move through panes by most-recent focus order', run: () => switchPaneByMru(1) },
       'Ctrl+Tab'
     ),
@@ -6236,6 +6240,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
             lines: ['Shows queued work items, grouped by status.', 'Drag cards between columns to change status.', 'Use Refresh when another worker updates the queue.'],
             shortcuts: [
               ['g w', 'open Workqueue modal'],
+              ['Cmd/Ctrl+L', 'focus Chat composer'],
               ['Cmd/Ctrl+K', 'cycle focus between panes']
             ]
           };
@@ -6246,6 +6251,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
             lines: ['Shows scheduled jobs in the Gateway cron scheduler.', 'Use filters to find failing/disabled jobs.', 'Use Run/Edit/Disable for quick ops.'],
             shortcuts: [
               ['?', 'keyboard shortcuts overlay'],
+              ['Cmd/Ctrl+L', 'focus Chat composer'],
               ['Cmd/Ctrl+K', 'cycle focus between panes']
             ]
           };
@@ -6256,6 +6262,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
             lines: ['Shows recent cron run history (best-effort).', 'Adjust range/status/search to find events.', 'Click View to inspect the underlying job.'],
             shortcuts: [
               ['?', 'keyboard shortcuts overlay'],
+              ['Cmd/Ctrl+L', 'focus Chat composer'],
               ['Cmd/Ctrl+K', 'cycle focus between panes']
             ]
           };
@@ -6266,6 +6273,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
           shortcuts: [
             ['Alt/Option+1..9', 'focus panes 1-9 by visible order'],
             ['Cmd/Ctrl+1..9', 'focus panes 1-9 by visible order'],
+            ['Cmd/Ctrl+L', 'focus Chat composer'],
             ['Cmd/Ctrl+Shift+K', 'focus next pane'],
             ['Cmd/Ctrl+Shift+J', 'focus previous pane']
           ]
@@ -8443,7 +8451,7 @@ function hasPaneNumberLayoutMismatch(event) {
 
 function isTypingShortcutExempt(event) {
   const key = String(event?.key || '').toLowerCase();
-  return (event?.metaKey || event?.ctrlKey) && !event.shiftKey && !event.altKey && (key === 'p' || key === 'k');
+  return (event?.metaKey || event?.ctrlKey) && !event.shiftKey && !event.altKey && (key === 'p' || key === 'k' || key === 'l');
 }
 
 function isNonTrivialGlobalShortcut(event) {
@@ -8455,6 +8463,7 @@ function isNonTrivialGlobalShortcut(event) {
   if (isAccel && ['c', 'w', 'r', 't', 'k', 'j', 'n', 'f', 'h'].includes(lower)) return true;
   if (isAccel && (key === ']' || key === '}' || key === '[' || key === '{')) return true;
   if (hasMetaCtrl && !event.shiftKey && !event.altKey && ['p', 'k', 'r'].includes(lower)) return true;
+  if (hasMetaCtrl && !event.shiftKey && !event.altKey && lower === 'l') return true;
   if (event.ctrlKey && !event.metaKey && !event.altKey && key === 'Tab') return true;
   if ((key === '?' || (key === '/' && event.shiftKey)) && !event.metaKey && !event.ctrlKey && !event.altKey) return true;
   if (event.altKey && !event.metaKey && !event.ctrlKey && !event.shiftKey) {
@@ -8592,6 +8601,40 @@ function returnToLastActiveChatPane() {
   return false;
 }
 
+function focusChatComposer() {
+  const panes = paneManager?.panes || [];
+  if (!panes.length) {
+    paneManager?.addPane?.('chat');
+    return true;
+  }
+
+  const activeKey = focusedPaneKey();
+  const activeIdx = panes.findIndex((pane) => pane.key === activeKey && pane.kind === 'chat');
+  if (activeIdx >= 0) {
+    focusPaneIndex(activeIdx);
+    return true;
+  }
+
+  for (const key of paneMruOrder()) {
+    const idx = panes.findIndex((pane) => pane.key === key && pane.kind === 'chat');
+    if (idx >= 0) {
+      focusPaneIndex(idx);
+      return true;
+    }
+  }
+
+  const fallbackIdx = panes.findIndex((pane) => pane.kind === 'chat');
+  if (fallbackIdx >= 0) {
+    focusPaneIndex(fallbackIdx);
+    return true;
+  }
+
+  const pane = paneManager.addPane('chat');
+  const idx = panes.indexOf(pane);
+  if (idx >= 0) focusPaneIndex(idx);
+  return true;
+}
+
 function cyclePaneFocus() {
   const panes = paneManager.panes;
   if (!panes || panes.length === 0) return;
@@ -8707,6 +8750,13 @@ window.addEventListener('keydown', (event) => {
   if ((event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey && String(event.key || '').toLowerCase() === 'k') {
     event.preventDefault();
     openCommandPalette();
+    return;
+  }
+
+  // Cmd/Ctrl+L focuses the active/most recent Chat composer (even while typing).
+  if ((event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey && String(event.key || '').toLowerCase() === 'l') {
+    event.preventDefault();
+    focusChatComposer();
     return;
   }
 

--- a/bin/clawnsole.js
+++ b/bin/clawnsole.js
@@ -10,7 +10,8 @@ const {
   statePaths,
   listAssignments,
   setAssignments,
-  resolveClaimQueues
+  resolveClaimQueues,
+  collapseIssueDuplicates
 } = require('../lib/workqueue');
 
 function parseArgs(argv) {
@@ -60,6 +61,7 @@ Workqueue commands:
   progress           <itemId> --agent <id> --note <text> [--leaseMs <ms>]
   inspect            <itemId>
   list               [--queue <name>] [--status <s1,s2>]
+  collapse-duplicates [--queue <name>] [--apply]
   assignments list
   assignments set    --agent <id> --queues <q1,q2>
 
@@ -207,6 +209,14 @@ async function main() {
       })
       .sort((a, b) => String(a.createdAt).localeCompare(String(b.createdAt)));
     printJson({ ok: true, items });
+    return;
+  }
+
+  if (cmd === 'collapse-duplicates') {
+    const queue = args.queue;
+    const dryRun = !args.apply;
+    const result = collapseIssueDuplicates(null, { queue, dryRun });
+    printJson({ ok: true, ...result });
     return;
   }
 

--- a/index.html
+++ b/index.html
@@ -255,6 +255,7 @@
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Focus next pane</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd></div><div class="shortcut-desc">Focus previous pane</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>g</kbd> <kbd>c</kbd></div><div class="shortcut-desc">Return to last active Chat pane</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>L</kbd></div><div class="shortcut-desc">Focus Chat composer</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Ctrl</kbd>+<kbd>Tab</kbd></div><div class="shortcut-desc">Switch panes by most-recent focus order</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Tab</kbd></div><div class="shortcut-desc">Reverse most-recent pane traversal</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>]</kbd></div><div class="shortcut-desc">Next unread pane</div></div>

--- a/lib/workqueue.js
+++ b/lib/workqueue.js
@@ -258,6 +258,94 @@ function findItemByDedupeKey(state, { queue, dedupeKey, title, instructions, rep
   return null;
 }
 
+function isIssueDedupeKey(key) {
+  return /^[a-z0-9_.-]+\/[a-z0-9_.-]+#\d+$/i.test(String(key || '').trim());
+}
+
+function summarizeDuplicateGroup(key, items) {
+  const sorted = items
+    .slice()
+    .sort((a, b) => {
+      const au = String(a.updatedAt || a.createdAt || '');
+      const bu = String(b.updatedAt || b.createdAt || '');
+      const updatedCmp = bu.localeCompare(au);
+      if (updatedCmp !== 0) return updatedCmp;
+      return String(b.id || '').localeCompare(String(a.id || ''));
+    });
+  return {
+    key,
+    keep: sorted[0] || null,
+    remove: sorted.slice(1)
+  };
+}
+
+function collapseIssueDuplicates(rootDir, { queue, dryRun = true } = {}) {
+  const { lockFile } = statePaths(rootDir);
+  return withFileLock(lockFile, () => {
+    const state = loadState(rootDir);
+    const queueFilter = String(queue || '').trim();
+    const groups = new Map();
+
+    for (const item of state.items) {
+      if (!item) continue;
+      if (queueFilter && item.queue !== queueFilter) continue;
+      if (item.status !== 'ready' && item.status !== 'pending') continue;
+
+      const key = canonicalizeIssueDedupeKey({
+        dedupeKey: item.dedupeKey,
+        title: item.title,
+        instructions: item.instructions,
+        repo: item.meta?.repo,
+        issueNumber: item.meta?.issueNumber ?? item.meta?.issue,
+        meta: item.meta
+      });
+      if (!isIssueDedupeKey(key)) continue;
+
+      const scopedKey = `${item.queue}:${key}`;
+      if (!groups.has(scopedKey)) groups.set(scopedKey, []);
+      groups.get(scopedKey).push(item);
+    }
+
+    const duplicateGroups = Array.from(groups.values())
+      .filter((items) => items.length > 1)
+      .map((items) => {
+        const key = canonicalizeIssueDedupeKey({
+          dedupeKey: items[0].dedupeKey,
+          title: items[0].title,
+          instructions: items[0].instructions,
+          repo: items[0].meta?.repo,
+          issueNumber: items[0].meta?.issueNumber ?? items[0].meta?.issue,
+          meta: items[0].meta
+        });
+        return summarizeDuplicateGroup(key, items);
+      });
+
+    if (!dryRun) {
+      const now = new Date().toISOString();
+      for (const group of duplicateGroups) {
+        for (const item of group.remove) {
+          item.status = 'failed';
+          item.lastError = `duplicate-cleanup:${group.key}`;
+          item.lastNote = `duplicate cleanup archived; kept ${group.keep?.id || 'unknown'}`;
+          item.updatedAt = now;
+        }
+      }
+      if (duplicateGroups.length) saveState(rootDir, state);
+    }
+
+    const removed = duplicateGroups.reduce((sum, group) => sum + group.remove.length, 0);
+    return {
+      dryRun: !!dryRun,
+      groups: duplicateGroups.map((group) => ({
+        key: group.key,
+        keepId: group.keep?.id || '',
+        removeIds: group.remove.map((item) => item.id)
+      })),
+      removed
+    };
+  });
+}
+
 function enqueueItem(rootDir, { queue, title, instructions, priority, dedupeKey, repo, issueNumber, meta }) {
   const { lockFile } = statePaths(rootDir);
   return withFileLock(lockFile, () => {
@@ -584,6 +672,7 @@ module.exports = {
   transitionItem,
   updateItem,
   deleteItem,
+  collapseIssueDuplicates,
   listAssignments,
   setAssignments,
   resolveClaimQueues,

--- a/tests/ui/chat-composer-shortcut.spec.js
+++ b/tests/ui/chat-composer-shortcut.spec.js
@@ -1,0 +1,42 @@
+const { test, expect } = require('@playwright/test');
+
+const { startTestEnv, loginAdmin, attachConsoleErrorAsserts, addPane } = require('./_helpers');
+
+let env;
+
+test.beforeAll(async () => {
+  env = await startTestEnv();
+});
+
+test.afterAll(() => {
+  env?.stop?.();
+});
+
+test.afterEach(async ({ page }) => {
+  if (page.__consoleAsserts) {
+    page.__consoleAsserts.assertNoErrors();
+  }
+});
+
+test('chat composer shortcut: focuses most recent chat composer from a workqueue pane', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+
+  const chatPane = page.locator('[data-pane][data-pane-kind="chat"]').first();
+  const chatInput = chatPane.locator('[data-pane-input]');
+  await expect(chatInput).toBeVisible();
+  await chatInput.click();
+  await expect(chatInput).toBeFocused();
+
+  await addPane(page, 'New Workqueue pane');
+  const workqueuePane = page.locator('[data-pane][data-pane-kind="workqueue"]').last();
+  const queueSelect = workqueuePane.locator('[data-wq-queue-select]');
+  await expect(queueSelect).toBeFocused();
+
+  await page.keyboard.press('ControlOrMeta+L');
+  await expect(chatInput).toBeFocused();
+});

--- a/tests/unit/clawnsole-cli-assignments.test.js
+++ b/tests/unit/clawnsole-cli-assignments.test.js
@@ -44,3 +44,38 @@ test('clawnsole workqueue assignments set requires non-empty queues', () => {
     /assignments set requires --queues/
   );
 });
+
+test('clawnsole workqueue collapse-duplicates defaults to dry-run', () => {
+  const home = tempHome();
+  const env = { OPENCLAW_HOME: path.join(home, '.openclaw') };
+
+  run([
+    'workqueue',
+    'enqueue',
+    '--queue',
+    'dev-team',
+    '--title',
+    'Issue coverage',
+    '--instructions',
+    'Ship https://github.com/rmdmattingly/clawnsole/issues/392'
+  ], env);
+
+  const statePath = path.join(home, '.openclaw', 'clawnsole', 'work-queues.json');
+  const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+  state.items.push({
+    ...state.items[0],
+    id: 'legacy-duplicate',
+    title: '[issue] rmdmattingly/clawnsole#392 legacy',
+    dedupeKey: 'legacy-freeform'
+  });
+  fs.writeFileSync(statePath, JSON.stringify(state, null, 2) + '\n');
+
+  const out = run(['workqueue', 'collapse-duplicates', '--queue', 'dev-team'], env);
+  const json = JSON.parse(out);
+  assert.equal(json.ok, true);
+  assert.equal(json.dryRun, true);
+  assert.equal(json.removed, 1);
+
+  const after = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+  assert.equal(after.items.filter((it) => it.status === 'failed').length, 0);
+});

--- a/tests/unit/workqueue.test.js
+++ b/tests/unit/workqueue.test.js
@@ -4,7 +4,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
-const { enqueueItem, claimNext, loadState, saveState, transitionItem } = require('../../lib/workqueue');
+const { enqueueItem, claimNext, loadState, saveState, transitionItem, collapseIssueDuplicates } = require('../../lib/workqueue');
 
 function withFakeNow(ms, fn) {
   const realNow = Date.now;
@@ -414,4 +414,76 @@ test('workqueue: issue-backed enqueue creates new row when only terminal matches
   assert.equal(second._enqueueAction, 'created');
   assert.equal(second.dedupeKey, 'rmdmattingly/clawnsole#392');
   assert.equal(loadState(root).items.length, 2);
+});
+
+test('workqueue: collapse issue duplicates dry-run reports ready/pending rows without mutation', () => {
+  const root = tempRoot();
+
+  const first = enqueueItem(root, {
+    queue: 'dev-team',
+    title: 'Issue coverage',
+    instructions: 'Ship https://github.com/rmdmattingly/clawnsole/issues/392',
+    priority: 1
+  });
+  const state = loadState(root);
+  state.items[0].updatedAt = '2026-01-01T00:00:00.000Z';
+  state.items.push({
+    ...state.items[0],
+    id: 'legacy-duplicate',
+    title: '[Issue] rmdmattingly/clawnsole#392 legacy duplicate',
+    dedupeKey: 'legacy-freeform',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-02T00:00:00.000Z'
+  });
+  saveState(root, state);
+
+  const result = collapseIssueDuplicates(root, { queue: 'dev-team', dryRun: true });
+
+  assert.equal(result.dryRun, true);
+  assert.equal(result.removed, 1);
+  assert.equal(result.groups[0].key, 'rmdmattingly/clawnsole#392');
+  assert.equal(result.groups[0].keepId, 'legacy-duplicate');
+  assert.deepEqual(result.groups[0].removeIds, [first.id]);
+  assert.equal(loadState(root).items.filter((it) => it.status === 'failed').length, 0);
+});
+
+test('workqueue: collapse issue duplicates archives duplicate ready rows and ignores active items', () => {
+  const root = tempRoot();
+
+  const keep = enqueueItem(root, {
+    queue: 'dev-team',
+    title: 'Open issue rmdmattingly/clawnsole#392',
+    instructions: 'Ship queued issue',
+    priority: 1
+  });
+  const state = loadState(root);
+  state.items.push({
+    ...state.items[0],
+    id: 'legacy-ready-duplicate',
+    title: '[coverage] rmdmattingly/clawnsole#392',
+    dedupeKey: 'coverage:rmdmattingly/clawnsole:392',
+    updatedAt: '2026-01-01T00:00:00.000Z'
+  });
+  state.items.push({
+    ...state.items[0],
+    id: 'active-duplicate',
+    title: '[coverage] rmdmattingly/clawnsole#392',
+    dedupeKey: 'active:rmdmattingly/clawnsole:392',
+    status: 'in_progress',
+    claimedBy: 'dev',
+    updatedAt: '2026-01-03T00:00:00.000Z'
+  });
+  saveState(root, state);
+
+  const result = collapseIssueDuplicates(root, { queue: 'dev-team', dryRun: false });
+
+  assert.equal(result.dryRun, false);
+  assert.equal(result.removed, 1);
+  const next = loadState(root);
+  assert.equal(next.items.find((it) => it.id === keep.id).status, 'ready');
+  assert.equal(next.items.find((it) => it.id === 'active-duplicate').status, 'in_progress');
+  const archived = next.items.find((it) => it.id === 'legacy-ready-duplicate');
+  assert.equal(archived.status, 'failed');
+  assert.equal(archived.lastError, 'duplicate-cleanup:rmdmattingly/clawnsole#392');
+  assert.match(archived.lastNote, new RegExp(keep.id));
 });


### PR DESCRIPTION
## Summary\n- add a workqueue collapse-duplicates helper and CLI command for issue-backed duplicate rows\n- default the command to dry-run and require --apply to archive duplicate ready/pending rows\n- add unit and CLI coverage for dry-run/apply behavior\n\n## Tests\n- npm test\n\nCloses #298