### PR TITLE
Finish Pane Manager quick-search keyboard flow

### DIFF
--- a/app.js
+++ b/app.js
@@ -2026,12 +2026,23 @@ function markPaneUnread(pane, increment = 1, kind = 'chat') {
 function paneSearchText(pane) {
   return [
     paneSummaryLabel(pane),
+    paneHeaderLetter(pane),
     paneLabel(pane),
     paneTargetLabel(pane),
+    pane?.workqueue?.queue || '',
     pane?.kind || ''
   ]
     .join(' ')
     .toLowerCase();
+}
+
+function paneManagerHighlight(text, query) {
+  const value = String(text || '');
+  const needle = String(query || '').trim().toLowerCase();
+  if (!needle) return escapeHtml(value);
+  const at = value.toLowerCase().indexOf(needle);
+  if (at < 0) return escapeHtml(value);
+  return `${escapeHtml(value.slice(0, at))}<mark class="pane-manager-match">${escapeHtml(value.slice(at, at + needle.length))}</mark>${escapeHtml(value.slice(at + needle.length))}`;
 }
 
 function paneGroupOrder(kind) {
@@ -2117,6 +2128,9 @@ function renderPaneManager() {
 
   list.innerHTML = '';
   empty.hidden = filtered.length > 0;
+  empty.textContent = panes.length === 0
+    ? 'No panes.'
+    : (query ? `No panes match "${String(paneManagerUiState.query || '').trim()}"` : 'No panes match this filter.');
   if (!filtered.length) return;
 
   const maxIndex = Math.max(0, visibleKeys.length - 1);
@@ -2167,7 +2181,7 @@ function renderPaneManager() {
           <div class="pane-manager-main">
             <div class="pane-manager-kind" title="${escapeHtml(paneIdentity)}">
               ${paneTypeBadgeMarkup(pane, { extraClass: 'pane-manager-type-badge', testId: 'pane-manager-type-badge' })}
-              <span class="pane-manager-kind-label">${escapeHtml(paneIdentity)}</span>
+              <span class="pane-manager-kind-label">${paneManagerHighlight(paneIdentity, query)}</span>
               <span class="pane-manager-pane-id" title="Internal pane id">${escapeHtml(String(pane?.key || ''))}</span>
               ${isDuplicate ? `<span class="pane-manager-duplicate-badge" data-testid="pane-manager-duplicate-badge" title="${escapeHtml(`${duplicateCount} duplicate panes`)}">duplicate</span>` : ''}
               ${unreadCount > 0 ? `<span class="pane-manager-unread-badge" data-testid="pane-manager-unread-badge" title="${escapeHtml(`${unreadCount} unread`)}">${escapeHtml(String(unreadCount))}</span>` : ''}
@@ -2293,13 +2307,28 @@ function closePaneManager({ restoreFocus = true } = {}) {
 function paneManagerHandleKeydown(event) {
   if (!isPaneManagerOpen()) return false;
   const panes = paneManager?.panes || [];
+  const activeEl = document.activeElement;
+  const searchFocused = activeEl === globalElements.paneManagerSearch;
+  if ((event.key === '/' && !searchFocused) || ((event.metaKey || event.ctrlKey) && String(event.key || '').toLowerCase() === 'f')) {
+    event.preventDefault();
+    globalElements.paneManagerSearch?.focus?.();
+    globalElements.paneManagerSearch?.select?.();
+    return true;
+  }
   if (event.key === 'Escape') {
     event.preventDefault();
+    if (String(paneManagerUiState.query || '').trim()) {
+      paneManagerUiState.query = '';
+      if (globalElements.paneManagerSearch) globalElements.paneManagerSearch.value = '';
+      paneManagerUiState.selectedIndex = 0;
+      renderPaneManager();
+      globalElements.paneManagerSearch?.focus?.();
+      return true;
+    }
     closePaneManager();
     return true;
   }
 
-  const activeEl = document.activeElement;
   if (activeEl === globalElements.paneManagerSearch && (event.key === 'ArrowLeft' || event.key === 'ArrowRight')) {
     return false;
   }
@@ -8827,6 +8856,9 @@ window.addEventListener('keydown', (event) => {
     return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
   })();
 
+  // If Pane Manager is open, it gets first dibs on keys, including Esc clear-before-close.
+  if (paneManagerHandleKeydown(event)) return;
+
   if (event.key === 'Escape') {
     const closedOverlay = closeTopmostOverlay();
     if (closedOverlay || !isEditableTarget) {
@@ -8835,9 +8867,6 @@ window.addEventListener('keydown', (event) => {
     if (closedOverlay) event.stopPropagation();
     return;
   }
-
-  // If Pane Manager is open, it gets first dibs on keys.
-  if (paneManagerHandleKeydown(event)) return;
 
   const blockedReason = blockedGlobalShortcutReason(event);
   if (blockedReason) {

--- a/index.html
+++ b/index.html
@@ -287,11 +287,11 @@
         </div>
         <div class="modal-body">
           <div class="hint" style="margin-bottom: 10px;">
-            Arrow keys to navigate • Enter to focus • Esc to close
+            / or Cmd/Ctrl+F to search • Arrow keys to navigate • Enter to focus • Esc to clear/close
           </div>
           <label class="pane-manager-search-wrap" for="paneManagerSearch">
             <span class="pane-manager-search-label">Quick find</span>
-            <input id="paneManagerSearch" class="pane-manager-search" type="search" placeholder="Filter by title, type, or target" autocomplete="off" data-testid="pane-manager-search" />
+            <input id="paneManagerSearch" class="pane-manager-search" type="search" placeholder="Find pane (A, Workqueue, dev-agent...)" autocomplete="off" data-testid="pane-manager-search" />
           </label>
           <label class="pane-manager-unread-only"><input id="paneManagerUnreadOnly" type="checkbox" data-testid="pane-manager-unread-only" /> Unread only</label>
           <div id="paneManagerList" class="pane-manager-list" role="listbox" aria-label="Open panes" data-testid="pane-manager-list"></div>

--- a/styles.css
+++ b/styles.css
@@ -1280,6 +1280,13 @@ button.send-btn .btn-icon {
   width: 100%;
 }
 
+.pane-manager-match {
+  border-radius: 4px;
+  background: rgba(255, 179, 71, 0.28);
+  color: var(--text);
+  padding: 0 2px;
+}
+
 .pane-manager-unread-only {
   display: inline-flex;
   align-items: center;

--- a/tests/pane.manager.e2e.spec.js
+++ b/tests/pane.manager.e2e.spec.js
@@ -109,13 +109,44 @@ test('pane manager: quick-find filters and groups by kind', async ({ page }) => 
   await expect(page.locator('.pane-manager-group-header').nth(2)).toContainText('Cron (1)');
 
   const search = page.getByTestId('pane-manager-search');
+  await expect(search).toHaveAttribute('placeholder', 'Find pane (A, Workqueue, dev-agent...)');
   await search.fill('cron');
   await expect(page.locator('.pane-manager-row')).toHaveCount(1);
   await expect(page.locator('.pane-manager-row').first()).toContainText('Cron');
+  await expect(page.locator('.pane-manager-row').first().locator('.pane-manager-match')).toContainText(/cron/i);
+
+  await page.keyboard.press('Enter');
+  await expect(modal).toHaveAttribute('aria-hidden', 'true');
+  await expect
+    .poll(async () => page.evaluate(() => {
+      const cronPane = document.querySelector('[data-pane][data-pane-kind="cron"]');
+      return !!(cronPane && document.activeElement && (cronPane === document.activeElement || cronPane.contains(document.activeElement)));
+    }))
+    .toBe(true);
+
+  await page.keyboard.press('Control+P');
+  if ((await modal.getAttribute('aria-hidden')) !== 'false') {
+    await page.click('#paneManagerBtn');
+  }
+  await expect(modal).toHaveAttribute('aria-hidden', 'false');
+  await page.keyboard.press('Slash');
+  await expect(search).toBeFocused();
 
   await search.fill('B');
   await expect(page.locator('.pane-manager-row')).toHaveCount(1);
   await expect(page.locator('.pane-manager-row').first()).toContainText('Workqueue');
+
+  await search.fill('zzz-no-pane');
+  await expect(page.locator('.pane-manager-row')).toHaveCount(0);
+  await expect(page.locator('#paneManagerEmpty')).toHaveText('No panes match "zzz-no-pane"');
+
+  await page.keyboard.press('Escape');
+  await expect(search).toHaveValue('');
+  await expect(modal).toHaveAttribute('aria-hidden', 'false');
+  await expect(page.locator('.pane-manager-row')).toHaveCount(3);
+
+  await page.keyboard.press('Escape');
+  await expect(modal).toHaveAttribute('aria-hidden', 'true');
 });
 
 test('pane manager: shows summary + duplicate badge and supports close others', async ({ page }) => {


### PR DESCRIPTION
## Summary
- finish Pane Manager quick-find keyboard flow with / and Cmd/Ctrl+F search focus
- make Esc clear the current query before closing the modal
- highlight matched pane identity text and show explicit no-match copy
- extend Pane Manager E2E coverage for Enter-to-focus and Esc behavior

Fixes #304

## Verification
- npm run test:syntax
- npx playwright test tests/pane.manager.e2e.spec.js --reporter=line