### PR TITLE
Polish unlock form submit state

### DIFF
--- a/app.js
+++ b/app.js
@@ -537,6 +537,7 @@ const uiState = {
   agents: []
 };
 
+let loginInFlight = false;
 let toastSeq = 0;
 function showToast(
   message,
@@ -1322,6 +1323,7 @@ function showLogin(message = '') {
   globalElements.loginOverlay.setAttribute('aria-hidden', 'false');
   globalElements.loginError.textContent = message;
   globalElements.loginPassword.value = '';
+  setLoginSubmitting(false);
 
   // Guest role selection removed.
 
@@ -1337,10 +1339,33 @@ function showLogin(message = '') {
   globalElements.fleetBtn?.setAttribute('disabled', 'disabled');
   if (globalElements.fleetBtn) globalElements.fleetBtn.style.opacity = '0.5';
 
-  const isTouch = window.matchMedia && window.matchMedia('(hover: none) and (pointer: coarse)').matches;
-  if (!isTouch) {
-    globalElements.loginPassword.focus();
+  focusLoginPassword();
+}
+
+function setLoginSubmitting(submitting) {
+  loginInFlight = Boolean(submitting);
+  if (globalElements.loginPassword) {
+    globalElements.loginPassword.disabled = loginInFlight;
   }
+  if (globalElements.loginBtn) {
+    globalElements.loginBtn.disabled = loginInFlight;
+    globalElements.loginBtn.textContent = loginInFlight ? 'Unlocking...' : 'Unlock';
+    globalElements.loginBtn.setAttribute('aria-busy', loginInFlight ? 'true' : 'false');
+  }
+}
+
+function focusLoginPassword() {
+  const isTouch = window.matchMedia && window.matchMedia('(hover: none) and (pointer: coarse)').matches;
+  if (isTouch) return;
+
+  const focusIfOpen = () => {
+    if (!globalElements.loginOverlay?.classList.contains('open')) return;
+    if (globalElements.loginPassword?.disabled) return;
+    globalElements.loginPassword?.focus();
+  };
+
+  window.requestAnimationFrame?.(focusIfOpen);
+  window.setTimeout(focusIfOpen, 50);
 }
 
 function hideLogin() {
@@ -1351,11 +1376,15 @@ function hideLogin() {
 }
 
 async function attemptLogin() {
+  if (loginInFlight) return;
+
   const password = globalElements.loginPassword.value.trim();
   if (!password) {
     showLogin('Password required.');
     return;
   }
+
+  setLoginSubmitting(true);
   try {
     const res = await fetch('/auth/login', {
       method: 'POST',
@@ -1364,6 +1393,7 @@ async function attemptLogin() {
       credentials: 'include'
     });
     if (!res.ok) {
+      setLoginSubmitting(false);
       showLogin('Invalid password. Try again.');
       return;
     }
@@ -1382,6 +1412,7 @@ async function attemptLogin() {
     }
     window.location.replace(nextHref);
   } catch {
+    setLoginSubmitting(false);
     showLogin('Login failed. Please retry.');
   }
 }

--- a/tests/ui/auth-lifecycle.spec.js
+++ b/tests/ui/auth-lifecycle.spec.js
@@ -10,6 +10,40 @@ test('visiting /admin without auth shows login overlay', async ({ page, clawnsol
   await expect(page.getByTestId('role-pill')).toContainText('signed out');
 });
 
+test('unlock form autofocuses, submits on Enter, and prevents duplicate in-flight submits', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  let loginRequests = 0;
+  let releaseLogin;
+  const loginReleased = new Promise((resolve) => {
+    releaseLogin = resolve;
+  });
+
+  await page.route('**/auth/login', async (route) => {
+    loginRequests += 1;
+    await loginReleased;
+    await route.continue();
+  });
+
+  await page.goto(clawnsole.serverUrl);
+  await expect(page.getByTestId('login-overlay')).toHaveClass(/open/);
+  await expect(page.getByTestId('login-password')).toBeFocused();
+
+  await page.getByTestId('login-password').fill('admin');
+  await page.getByTestId('login-password').press('Enter');
+
+  await expect(page.getByTestId('login-button')).toBeDisabled();
+  await expect(page.getByTestId('login-button')).toHaveText('Unlocking...');
+  await expect(page.getByTestId('login-password')).toBeDisabled();
+
+  await page.getByTestId('login-button').click({ force: true });
+  await page.keyboard.press('Enter');
+  await expect.poll(() => loginRequests).toBe(1);
+
+  releaseLogin();
+  await clawnsole.waitForAdminUiReady(page);
+});
+
 test('admin login restores the intended in-app destination', async ({ page, clawnsole }) => {
   if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
 


### PR DESCRIPTION
Closes #316\n\n## Summary\n- keep unlock focus deterministic when the login overlay appears\n- guard duplicate unlock submissions while auth is in flight\n- show disabled/loading state for password input and unlock button\n- add UI coverage for autofocus, Enter submit, and duplicate-submit prevention\n\n## Tests\n- npm test\n- npm run test:ui -- tests/ui/auth-lifecycle.spec.js -g "unlock form autofocuses, submits on Enter, and prevents duplicate in-flight submits" --workers=1