### PR TITLE
Add workqueue canonical issue duplicate backfill

### DIFF
--- a/bin/clawnsole.js
+++ b/bin/clawnsole.js
@@ -10,7 +10,8 @@ const {
   statePaths,
   listAssignments,
   setAssignments,
-  resolveClaimQueues
+  resolveClaimQueues,
+  collapseCanonicalIssueDuplicates
 } = require('../lib/workqueue');
 
 function parseArgs(argv) {
@@ -58,6 +59,7 @@ Workqueue commands:
   done               <itemId> --agent <id> [--result <json|@file>]
   fail               <itemId> --agent <id> --error <text>
   progress           <itemId> --agent <id> --note <text> [--leaseMs <ms>]
+  collapse-duplicates [--queue <name>] [--dryRun]
   inspect            <itemId>
   list               [--queue <name>] [--status <s1,s2>]
   assignments list
@@ -192,6 +194,15 @@ async function main() {
     const state = loadState(null);
     const item = state.items.find((it) => it.id === itemId) || null;
     printJson({ ok: true, item });
+    return;
+  }
+
+  if (cmd === 'collapse-duplicates') {
+    const result = collapseCanonicalIssueDuplicates(null, {
+      queue: args.queue,
+      dryRun: !!args.dryRun
+    });
+    printJson(result);
     return;
   }
 

--- a/lib/workqueue.js
+++ b/lib/workqueue.js
@@ -258,6 +258,31 @@ function findItemByDedupeKey(state, { queue, dedupeKey, title, instructions, rep
   return null;
 }
 
+function noteDedupedIssueTask(existing, { title, priority, dedupeKey, meta }) {
+  const now = new Date().toISOString();
+  const incomingMeta = meta && typeof meta === 'object' && !Array.isArray(meta) ? meta : {};
+  const currentMeta = existing.meta && typeof existing.meta === 'object' && !Array.isArray(existing.meta) ? existing.meta : {};
+  const seenCount = Number(existing.seenCount || currentMeta.seenCount || 1) + 1;
+  const provenance = Array.isArray(currentMeta.provenance) ? currentMeta.provenance.slice(-9) : [];
+
+  provenance.push({
+    at: now,
+    source: incomingMeta.source || '',
+    dedupeKey: dedupeKey || '',
+    title: String(title || '').trim(),
+    priority: Number.isFinite(Number(priority)) ? Number(priority) : undefined
+  });
+
+  existing.seenCount = seenCount;
+  existing.meta = cleanMeta({
+    ...currentMeta,
+    ...incomingMeta,
+    seenCount,
+    lastSeenAt: now,
+    provenance
+  });
+}
+
 function enqueueItem(rootDir, { queue, title, instructions, priority, dedupeKey, repo, issueNumber, meta }) {
   const { lockFile } = statePaths(rootDir);
   return withFileLock(lockFile, () => {
@@ -290,6 +315,7 @@ function enqueueItem(rootDir, { queue, title, instructions, priority, dedupeKey,
         if (instructions !== undefined) existing.instructions = String(instructions || '').trim();
         if (mergedMeta) existing.meta = cleanMeta({ ...(existing.meta || {}), ...mergedMeta });
         existing.dedupeKey = key;
+        noteDedupedIssueTask(existing, { title, priority, dedupeKey: key, meta: mergedMeta });
         existing.updatedAt = new Date().toISOString();
         saveState(rootDir, state);
         return { ...existing, _deduped: true, _enqueueAction: 'updated_existing' };
@@ -301,6 +327,58 @@ function enqueueItem(rootDir, { queue, title, instructions, priority, dedupeKey,
     state.items.push(item);
     saveState(rootDir, state);
     return { ...item, _enqueueAction: 'created' };
+  });
+}
+
+function collapseCanonicalIssueDuplicates(rootDir, { queue, dryRun } = {}) {
+  const { lockFile } = statePaths(rootDir);
+  return withFileLock(lockFile, () => {
+    const state = loadState(rootDir);
+    const q = String(queue || '').trim();
+    const keepByKey = new Map();
+    const items = [];
+    const removed = [];
+
+    for (const item of state.items) {
+      const key = canonicalizeIssueDedupeKey({
+        dedupeKey: item?.dedupeKey,
+        title: item?.title,
+        instructions: item?.instructions,
+        repo: item?.meta?.repo,
+        issueNumber: item?.meta?.issueNumber ?? item?.meta?.issue,
+        meta: item?.meta
+      });
+      if (!key || (q && item.queue !== q)) {
+        items.push(item);
+        continue;
+      }
+
+      const compoundKey = `${item.queue}\n${key}`;
+      const existing = keepByKey.get(compoundKey);
+      if (!existing) {
+        item.dedupeKey = key;
+        keepByKey.set(compoundKey, item);
+        items.push(item);
+        continue;
+      }
+
+      noteDedupedIssueTask(existing, {
+        title: item.title,
+        priority: item.priority,
+        dedupeKey: key,
+        meta: { ...(item.meta || {}), collapsedItemId: item.id }
+      });
+      existing.dedupeKey = key;
+      existing.updatedAt = new Date().toISOString();
+      removed.push({ id: item.id, queue: item.queue, dedupeKey: key, keptId: existing.id });
+    }
+
+    if (!dryRun && removed.length) {
+      state.items = items;
+      saveState(rootDir, state);
+    }
+
+    return { ok: true, dryRun: !!dryRun, removedCount: removed.length, removed };
   });
 }
 
@@ -587,6 +665,8 @@ module.exports = {
   listAssignments,
   setAssignments,
   resolveClaimQueues,
+  collapseCanonicalIssueDuplicates,
   // exported for tests
-  findItemByDedupeKey
+  findItemByDedupeKey,
+  canonicalizeIssueDedupeKey
 };

--- a/tests/unit/workqueue.test.js
+++ b/tests/unit/workqueue.test.js
@@ -4,7 +4,15 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
-const { enqueueItem, claimNext, loadState, saveState, transitionItem } = require('../../lib/workqueue');
+const {
+  enqueueItem,
+  claimNext,
+  loadState,
+  saveState,
+  transitionItem,
+  collapseCanonicalIssueDuplicates,
+  canonicalizeIssueDedupeKey
+} = require('../../lib/workqueue');
 
 function withFakeNow(ms, fn) {
   const realNow = Date.now;
@@ -414,4 +422,99 @@ test('workqueue: issue-backed enqueue creates new row when only terminal matches
   assert.equal(second._enqueueAction, 'created');
   assert.equal(second.dedupeKey, 'rmdmattingly/clawnsole#392');
   assert.equal(loadState(root).items.length, 2);
+});
+
+test('workqueue: canonical issue key extracts from meta, URLs, dedupe keys, and titles', () => {
+  assert.equal(
+    canonicalizeIssueDedupeKey({ meta: { repo: 'RmdMattingly/Clawnsole', issueNumber: '298' } }),
+    'rmdmattingly/clawnsole#298'
+  );
+  assert.equal(
+    canonicalizeIssueDedupeKey({ instructions: 'Work https://github.com/rmdmattingly/clawnsole/issues/298 now' }),
+    'rmdmattingly/clawnsole#298'
+  );
+  assert.equal(
+    canonicalizeIssueDedupeKey({ dedupeKey: 'issue:rmdmattingly/clawnsole#298' }),
+    'rmdmattingly/clawnsole#298'
+  );
+  assert.equal(
+    canonicalizeIssueDedupeKey({ title: '[coverage] Open issue rmdmattingly / clawnsole #298 please' }),
+    'rmdmattingly/clawnsole#298'
+  );
+});
+
+test('workqueue: canonical issue dedupe tracks seen count and provenance', () => {
+  const root = tempRoot();
+
+  const first = enqueueItem(root, {
+    queue: 'dev-team',
+    title: '[coverage] Open issue rmdmattingly/clawnsole#298',
+    instructions: 'first source',
+    priority: 10,
+    meta: { source: 'coverage' }
+  });
+
+  const second = enqueueItem(root, {
+    queue: 'dev-team',
+    title: '[Issue] Workqueue dedupe v2',
+    instructions: 'https://github.com/rmdmattingly/clawnsole/issues/298',
+    priority: 50,
+    dedupeKey: 'routine:clawnsole:298',
+    meta: { source: 'routine', repo: 'rmdmattingly/clawnsole', issueNumber: 298 }
+  });
+
+  assert.equal(second.id, first.id);
+  assert.equal(second._deduped, true);
+  assert.equal(second.dedupeKey, 'rmdmattingly/clawnsole#298');
+  assert.equal(second.seenCount, 2);
+
+  const state = loadState(root);
+  assert.equal(state.items.length, 1);
+  assert.equal(state.items[0].meta.source, 'routine');
+  assert.equal(state.items[0].meta.seenCount, 2);
+  assert.equal(state.items[0].meta.provenance.length, 1);
+});
+
+test('workqueue: canonical issue dedupe does not collapse non-issue tasks', () => {
+  const root = tempRoot();
+
+  enqueueItem(root, { queue: 'dev-team', title: 'Routine review', instructions: 'review', priority: 1 });
+  enqueueItem(root, { queue: 'dev-team', title: 'Routine review', instructions: 'review', priority: 1 });
+
+  const state = loadState(root);
+  assert.equal(state.items.length, 2);
+});
+
+test('workqueue: collapseCanonicalIssueDuplicates safely backfills existing duplicate rows', () => {
+  const root = tempRoot();
+  const first = enqueueItem(root, {
+    queue: 'dev-team',
+    title: '[coverage] rmdmattingly/clawnsole#298',
+    instructions: 'first',
+    priority: 1
+  });
+
+  const state = loadState(root);
+  state.items.push({
+    ...first,
+    id: 'duplicate-existing-row',
+    title: 'Open issue',
+    instructions: 'https://github.com/rmdmattingly/clawnsole/issues/298',
+    dedupeKey: 'issue:rmdmattingly/clawnsole#298',
+    createdAt: '2026-01-01T00:00:01.000Z',
+    updatedAt: '2026-01-01T00:00:01.000Z'
+  });
+  saveState(root, state);
+
+  const dryRun = collapseCanonicalIssueDuplicates(root, { queue: 'dev-team', dryRun: true });
+  assert.equal(dryRun.removedCount, 1);
+  assert.equal(loadState(root).items.length, 2);
+
+  const result = collapseCanonicalIssueDuplicates(root, { queue: 'dev-team' });
+  assert.equal(result.removedCount, 1);
+  const finalState = loadState(root);
+  assert.equal(finalState.items.length, 1);
+  assert.equal(finalState.items[0].id, first.id);
+  assert.equal(finalState.items[0].dedupeKey, 'rmdmattingly/clawnsole#298');
+  assert.equal(finalState.items[0].seenCount, 2);
 });


### PR DESCRIPTION
## Summary
- track seenCount/provenance when canonical issue enqueue updates an existing live item
- add `workqueue collapse-duplicates` with dry-run support for safe backfill of existing duplicate issue rows
- expand unit coverage for canonical extraction, issue dedupe metadata, non-issue preservation, and duplicate collapse

Fixes #298

## Tests
- `node --test tests/unit/workqueue.test.js`
- `npm run test:syntax && npm run test:unit`

🚢 ship sign-off requested.