### PR TITLE
Upgrade topbar pane attention summary

### DIFF
--- a/app.js
+++ b/app.js
@@ -175,22 +175,33 @@ const deriveAuthOverlayState = __appCore.deriveAuthOverlayState || ((state) => (
   logoutOpacity: !!state?.authed ? '1' : '0.5'
 }));
 const deriveGlobalConnectionState = __appCore.deriveGlobalConnectionState || ((state) => {
-  if (!state?.authed) return { state: 'disconnected', meta: 'sign in required' };
+  if (!state?.authed) return { state: 'disconnected', meta: 'sign in required', ariaLabel: 'Pane status: sign in required' };
   const panes = Array.isArray(state?.panes) ? state.panes : [];
-  if (panes.length === 0) return { state: 'disconnected', meta: '' };
+  if (panes.length === 0) return { state: 'disconnected', meta: '', ariaLabel: 'Pane status: no panes' };
   const connectedCount = panes.filter((pane) => !!pane?.connected).length;
   const total = panes.length;
+  const disconnectedCount = Math.max(0, total - connectedCount);
+  const attentionCount = panes.filter((pane) => {
+    const status = String(pane?.statusState || '').toLowerCase();
+    const unread = Math.max(0, Number(pane?.unreadCount || 0));
+    return !pane?.connected || unread > 0 || status === 'error' || status === 'offline' || status === 'disconnected';
+  }).length;
   const anyConnecting = panes.some((pane) => pane?.statusState === 'connecting' || pane?.statusState === 'reconnecting');
   const anyError = panes.some((pane) => pane?.statusState === 'error');
-  const firstError = panes.find((pane) => pane?.statusState === 'error' && pane?.statusMeta);
   let nextState = 'disconnected';
   if (connectedCount === total) nextState = 'connected';
   else if (connectedCount > 0 || anyConnecting) nextState = 'reconnecting';
   else if (anyError) nextState = 'error';
-  const meta = connectedCount === 0 && anyError && firstError
-    ? String(firstError.statusMeta || '')
-    : `panes: ${connectedCount}/${total} connected`;
-  return { state: nextState, meta };
+  const meta = `panes: ${connectedCount} connected, ${disconnectedCount} disconnected, ${attentionCount} attention`;
+  return {
+    state: nextState,
+    meta,
+    connectedCount,
+    disconnectedCount,
+    attentionCount,
+    total,
+    ariaLabel: `Pane status: ${connectedCount} connected, ${disconnectedCount} disconnected, ${attentionCount} need attention`
+  };
 });
 const deriveDisconnectButtonState = __appCore.deriveDisconnectButtonState || ((state) => {
   if (!state?.authed) return { disabled: true, text: 'Reconnect' };
@@ -1230,7 +1241,11 @@ function setStatusPill(el, state, meta = '') {
 function updateGlobalStatus() {
   const status = deriveGlobalConnectionState({ authed: uiState.authed, panes: paneManager.panes });
   setStatusPill(globalElements.status, status.state, status.meta);
-  if (globalElements.paneManagerBtn) globalElements.paneManagerBtn.textContent = status.meta;
+  if (globalElements.paneManagerBtn) {
+    globalElements.paneManagerBtn.textContent = status.meta;
+    globalElements.paneManagerBtn.setAttribute('aria-label', status.ariaLabel || `Open pane manager. ${status.meta || 'No pane status'}`);
+    globalElements.paneManagerBtn.title = status.attentionCount > 0 ? 'Open attention panes' : 'Open pane manager';
+  }
 }
 
 function updateConnectionControls() {
@@ -1734,6 +1749,7 @@ const paneManagerUiState = {
   selectedIndex: 0,
   query: '',
   unreadOnly: false,
+  attentionOnly: false,
   visiblePaneKeys: [],
   collapsedKinds: {
     chat: false,
@@ -1973,6 +1989,12 @@ function paneUnreadCount(pane) {
   return Math.max(0, Number(pane?.unreadCount || 0));
 }
 
+function paneNeedsAttention(pane) {
+  if (!pane) return false;
+  const state = String(pane.statusState || '').toLowerCase();
+  return !pane.connected || paneUnreadCount(pane) > 0 || state === 'error' || state === 'offline' || state === 'disconnected';
+}
+
 function clearPaneUnread(pane) {
   if (!pane) return;
   if (!pane.unreadCount) return;
@@ -1980,6 +2002,7 @@ function clearPaneUnread(pane) {
   pane.unreadKind = '';
   renderPaneIdentity(pane);
   renderPaneActivityBadge(pane);
+  updateGlobalStatus();
   if (isPaneManagerOpen()) renderPaneManager();
 }
 
@@ -2020,6 +2043,7 @@ function markPaneUnread(pane, increment = 1, kind = 'chat') {
   pane.unreadKind = String(kind || 'activity');
   renderPaneIdentity(pane);
   renderPaneActivityBadge(pane);
+  updateGlobalStatus();
   if (isPaneManagerOpen()) renderPaneManager();
 }
 
@@ -2091,6 +2115,7 @@ function renderPaneManager() {
 
   const query = String(paneManagerUiState.query || '').trim().toLowerCase();
   const filtered = panes.filter((pane) => {
+    if (paneManagerUiState.attentionOnly && !paneNeedsAttention(pane)) return false;
     if (paneManagerUiState.unreadOnly && paneUnreadCount(pane) <= 0) return false;
     return !query || paneSearchText(pane).includes(query);
   });
@@ -2253,7 +2278,7 @@ function renderPaneManager() {
   });
 }
 
-function openPaneManager() {
+function openPaneManager({ attentionOnly = false } = {}) {
   if (roleState.role !== 'admin') return;
   if (!uiState.authed) {
     showLogin('Please sign in to continue.');
@@ -2263,8 +2288,13 @@ function openPaneManager() {
 
   paneManagerUiState.open = true;
   paneManagerUiState.selectedIndex = 0;
-  paneManagerUiState.query = String(globalElements.paneManagerSearch?.value || '').trim();
-  paneManagerUiState.unreadOnly = !!globalElements.paneManagerUnreadOnly?.checked;
+  paneManagerUiState.attentionOnly = !!attentionOnly;
+  paneManagerUiState.query = attentionOnly ? '' : String(globalElements.paneManagerSearch?.value || '').trim();
+  paneManagerUiState.unreadOnly = attentionOnly ? false : !!globalElements.paneManagerUnreadOnly?.checked;
+  if (attentionOnly) {
+    if (globalElements.paneManagerSearch) globalElements.paneManagerSearch.value = '';
+    if (globalElements.paneManagerUnreadOnly) globalElements.paneManagerUnreadOnly.checked = false;
+  }
 
   globalElements.paneManagerModal.classList.add('open');
   globalElements.paneManagerModal.setAttribute('aria-hidden', 'false');
@@ -9032,18 +9062,20 @@ globalElements.resetLayoutBtn?.addEventListener('click', () => {
 
 globalElements.paneManagerBtn?.addEventListener('click', (event) => {
   event?.preventDefault?.();
-  openPaneManager();
+  openPaneManager({ attentionOnly: true });
 });
 
 globalElements.paneManagerCloseBtn?.addEventListener('click', () => closePaneManager());
 
 globalElements.paneManagerSearch?.addEventListener('input', () => {
+  paneManagerUiState.attentionOnly = false;
   paneManagerUiState.query = String(globalElements.paneManagerSearch?.value || '').trim();
   paneManagerUiState.selectedIndex = 0;
   renderPaneManager();
 });
 
 globalElements.paneManagerUnreadOnly?.addEventListener('change', () => {
+  paneManagerUiState.attentionOnly = false;
   paneManagerUiState.unreadOnly = !!globalElements.paneManagerUnreadOnly?.checked;
   paneManagerUiState.selectedIndex = 0;
   renderPaneManager();

--- a/lib/app-core.js
+++ b/lib/app-core.js
@@ -289,19 +289,24 @@
 
   function deriveGlobalConnectionState({ authed, panes } = {}) {
     if (!authed) {
-      return { state: 'disconnected', meta: 'sign in required' };
+      return { state: 'disconnected', meta: 'sign in required', ariaLabel: 'Pane status: sign in required' };
     }
 
     const list = Array.isArray(panes) ? panes : [];
     if (list.length === 0) {
-      return { state: 'disconnected', meta: '' };
+      return { state: 'disconnected', meta: '', ariaLabel: 'Pane status: no panes' };
     }
 
     const connectedCount = list.filter((pane) => !!pane?.connected).length;
     const total = list.length;
+    const disconnectedCount = Math.max(0, total - connectedCount);
+    const attentionCount = list.filter((pane) => {
+      const status = String(pane?.statusState || '').toLowerCase();
+      const unread = Math.max(0, Number(pane?.unreadCount || 0));
+      return !pane?.connected || unread > 0 || status === 'error' || status === 'offline' || status === 'disconnected';
+    }).length;
     const anyConnecting = list.some((pane) => pane?.statusState === 'connecting' || pane?.statusState === 'reconnecting');
     const anyError = list.some((pane) => pane?.statusState === 'error');
-    const firstError = list.find((pane) => pane?.statusState === 'error' && pane?.statusMeta);
 
     let state = 'disconnected';
     if (connectedCount === total) {
@@ -312,12 +317,17 @@
       state = 'error';
     }
 
-    const meta =
-      connectedCount === 0 && anyError && firstError
-        ? String(firstError.statusMeta || '')
-        : `panes: ${connectedCount}/${total} connected`;
+    const meta = `panes: ${connectedCount} connected, ${disconnectedCount} disconnected, ${attentionCount} attention`;
 
-    return { state, meta };
+    return {
+      state,
+      meta,
+      connectedCount,
+      disconnectedCount,
+      attentionCount,
+      total,
+      ariaLabel: `Pane status: ${connectedCount} connected, ${disconnectedCount} disconnected, ${attentionCount} need attention`
+    };
   }
 
   function deriveDisconnectButtonState({ authed, panes } = {}) {

--- a/tests/pane.manager.e2e.spec.js
+++ b/tests/pane.manager.e2e.spec.js
@@ -165,6 +165,23 @@ test('pane manager: unread-only filter toggle', async ({ page }) => {
   await page.click('#loginBtn');
   await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
 
+  await expect(page.getByTestId('panes-indicator')).toContainText(/panes: \d+ connected, \d+ disconnected, \d+ attention/);
+  await expect(page.getByTestId('panes-indicator')).toHaveAttribute('aria-label', /Pane status: \d+ connected, \d+ disconnected, \d+ need attention/);
+
+  await page.getByTestId('panes-indicator').click();
+  await expect(page.getByTestId('pane-manager-modal')).toHaveAttribute('aria-hidden', 'false');
+  const attentionCount = await page.getByTestId('panes-indicator').evaluate((el) => {
+    const match = String(el.textContent || '').match(/(\d+) attention/);
+    return match ? Number(match[1]) : 0;
+  });
+  await expect(page.locator('.pane-manager-row')).toHaveCount(attentionCount);
+
+  await page.keyboard.press('Escape');
+  await page.keyboard.press('Control+P');
+  await expect(page.getByTestId('pane-manager-modal')).toHaveAttribute('aria-hidden', 'false');
+  await expect(page.locator('.pane-manager-row')).toHaveCount(2);
+
+  await page.keyboard.press('Escape');
   await page.getByTestId('panes-indicator').click();
   await expect(page.getByTestId('pane-manager-modal')).toHaveAttribute('aria-hidden', 'false');
   await page.locator('.pane-manager-unread-only').click();
@@ -203,6 +220,7 @@ test('pane manager: status stays in sync with pane header while modal is open', 
     btn?.click();
   });
 
+  await expect(page.getByTestId('panes-indicator')).toContainText(/\d+ connected, 1 disconnected, 1 attention/);
   await expect(chatHeaderStatus).toHaveText('disconnected');
   await expect(chatManagerState).toHaveText('disconnected');
 });

--- a/tests/ui/pane-accents.spec.js
+++ b/tests/ui/pane-accents.spec.js
@@ -33,7 +33,7 @@ test('pane accents: each pane kind exposes deterministic accent selectors', asyn
     await expect(page.locator(`[data-pane][data-pane-kind="${kind}"] [data-pane-type-pill][data-pane-accent="${kind}"]`)).toHaveCount(1);
   }
 
-  await page.locator('#paneManagerBtn').click();
+  await page.keyboard.press(process.platform === 'darwin' ? 'Meta+P' : 'Control+P');
   await expect(page.locator('#paneManagerModal')).toHaveClass(/open/);
 
   for (const kind of ['chat', 'workqueue', 'cron', 'timeline']) {

--- a/tests/unit/app-core.test.js
+++ b/tests/unit/app-core.test.js
@@ -217,12 +217,14 @@ test('normalizeHistoryEntries supports gateway payload variants', () => {
 test('deriveGlobalConnectionState handles signed-out, reconnecting, and hard error transitions', () => {
   assert.deepEqual(deriveGlobalConnectionState({ authed: false, panes: [{ connected: true }] }), {
     state: 'disconnected',
-    meta: 'sign in required'
+    meta: 'sign in required',
+    ariaLabel: 'Pane status: sign in required'
   });
 
   assert.deepEqual(deriveGlobalConnectionState({ authed: true, panes: [] }), {
     state: 'disconnected',
-    meta: ''
+    meta: '',
+    ariaLabel: 'Pane status: no panes'
   });
 
   assert.deepEqual(
@@ -233,7 +235,15 @@ test('deriveGlobalConnectionState handles signed-out, reconnecting, and hard err
         { connected: false, statusState: 'reconnecting' }
       ]
     }),
-    { state: 'reconnecting', meta: 'panes: 1/2 connected' }
+    {
+      state: 'reconnecting',
+      meta: 'panes: 1 connected, 1 disconnected, 1 attention',
+      connectedCount: 1,
+      disconnectedCount: 1,
+      attentionCount: 1,
+      total: 2,
+      ariaLabel: 'Pane status: 1 connected, 1 disconnected, 1 need attention'
+    }
   );
 
   assert.deepEqual(
@@ -244,7 +254,34 @@ test('deriveGlobalConnectionState handles signed-out, reconnecting, and hard err
         { connected: false, statusState: 'error', statusMeta: 'gateway disconnected' }
       ]
     }),
-    { state: 'error', meta: 'auth expired' }
+    {
+      state: 'error',
+      meta: 'panes: 0 connected, 2 disconnected, 2 attention',
+      connectedCount: 0,
+      disconnectedCount: 2,
+      attentionCount: 2,
+      total: 2,
+      ariaLabel: 'Pane status: 0 connected, 2 disconnected, 2 need attention'
+    }
+  );
+
+  assert.deepEqual(
+    deriveGlobalConnectionState({
+      authed: true,
+      panes: [
+        { connected: true, statusState: 'connected', unreadCount: 3 },
+        { connected: true, statusState: 'connected', unreadCount: 0 }
+      ]
+    }),
+    {
+      state: 'connected',
+      meta: 'panes: 2 connected, 0 disconnected, 1 attention',
+      connectedCount: 2,
+      disconnectedCount: 0,
+      attentionCount: 1,
+      total: 2,
+      ariaLabel: 'Pane status: 2 connected, 0 disconnected, 1 need attention'
+    }
   );
 });
 


### PR DESCRIPTION
## Summary
- Replace the coarse topbar pane count with connected, disconnected, and attention-needed counts.
- Add an accessible aria label for the full pane summary.
- Make the topbar pane summary open Pane Manager filtered to panes needing attention.
- Refresh the topbar summary when unread pane counts change.

Closes #307

## Tests
- NODE_PATH=/Users/raysopenclaw/src/clawnsole/node_modules npm test -- --runInBand tests/unit/app-core.test.js
- NODE_PATH=/Users/raysopenclaw/src/clawnsole/node_modules /Users/raysopenclaw/src/clawnsole/node_modules/.bin/playwright test tests/pane.manager.e2e.spec.js