### PR TITLE
Add chat-only pane cycling shortcuts

### DIFF
--- a/app.js
+++ b/app.js
@@ -2609,6 +2609,14 @@ function buildCommandPaletteItems() {
       '⌘/Ctrl+Shift+J'
     ),
     withShortcut(
+      { id: 'cmd:chat-cycle-next', label: 'Chat: Focus next Chat pane', detail: 'Move to the next Chat pane by focus history, skipping non-chat panes', run: () => cycleChatPaneFocus(1) },
+      '⌘/Ctrl+Alt+K'
+    ),
+    withShortcut(
+      { id: 'cmd:chat-cycle-previous', label: 'Chat: Focus previous Chat pane', detail: 'Move to the previous Chat pane by focus history, skipping non-chat panes', run: () => cycleChatPaneFocus(-1) },
+      '⌘/Ctrl+Alt+J'
+    ),
+    withShortcut(
       { id: 'cmd:pane-return-last-chat', label: 'Panes: Return to last active Chat pane', detail: 'Jump back to the most recent chat pane in focus history', run: () => returnToLastActiveChatPane() },
       'g c'
     ),
@@ -8588,6 +8596,7 @@ function isNonTrivialGlobalShortcut(event) {
   const hasMetaCtrl = !!(event.metaKey || event.ctrlKey);
   const isAccel = hasMetaCtrl && event.shiftKey;
   if (isAccel && ['c', 'w', 'r', 't', 'k', 'j', 'n', 'f', 'h'].includes(lower)) return true;
+  if (hasMetaCtrl && event.altKey && !event.shiftKey && ['k', 'j'].includes(lower)) return true;
   if (isAccel && (key === ']' || key === '}' || key === '[' || key === '{')) return true;
   if (hasMetaCtrl && !event.shiftKey && !event.altKey && ['p', 'k', 'r'].includes(lower)) return true;
   if (hasMetaCtrl && !event.shiftKey && !event.altKey && lower === 'l') return true;
@@ -8782,6 +8791,34 @@ function cyclePaneFocusBackward() {
   focusPaneIndex(next, { showHud: true });
 }
 
+function cycleChatPaneFocus(direction = 1) {
+  const panes = paneManager?.panes || [];
+  const chatPanes = panes.filter((pane) => pane?.kind === 'chat');
+  if (chatPanes.length < 2) {
+    showToast('Only one Chat pane is open.', { kind: 'info', timeoutMs: 1600 });
+    return false;
+  }
+
+  const activeKey = focusedPaneKey();
+  const orderedKeys = [
+    activeKey,
+    ...paneMruOrder().filter((key) => key !== activeKey)
+  ].filter((key) => chatPanes.some((pane) => pane.key === key));
+
+  chatPanes.forEach((pane) => {
+    if (pane?.key && !orderedKeys.includes(pane.key)) orderedKeys.push(pane.key);
+  });
+
+  const currentIndex = Math.max(0, orderedKeys.indexOf(activeKey));
+  const step = direction >= 0 ? 1 : -1;
+  const nextKey = orderedKeys[(currentIndex + step + orderedKeys.length) % orderedKeys.length];
+  const nextIndex = panes.findIndex((pane) => pane?.key === nextKey);
+  if (nextIndex < 0) return false;
+
+  focusPaneIndex(nextIndex, { showHud: true });
+  return true;
+}
+
 function cycleUnreadPaneFocus(direction = 1) {
   const panes = paneManager?.panes || [];
   if (!panes.length) return false;
@@ -8938,6 +8975,18 @@ window.addEventListener('keydown', (event) => {
   if ((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey && key.toLowerCase() === 'j') {
     event.preventDefault();
     cyclePaneFocusBackward();
+    return;
+  }
+
+  // Cmd/Ctrl+Alt+K/J cycles only Chat panes, skipping Workqueue/Cron/Timeline/Fleet panes.
+  if ((event.metaKey || event.ctrlKey) && event.altKey && !event.shiftKey && key.toLowerCase() === 'k') {
+    event.preventDefault();
+    cycleChatPaneFocus(1);
+    return;
+  }
+  if ((event.metaKey || event.ctrlKey) && event.altKey && !event.shiftKey && key.toLowerCase() === 'j') {
+    event.preventDefault();
+    cycleChatPaneFocus(-1);
     return;
   }
 

--- a/index.html
+++ b/index.html
@@ -254,6 +254,8 @@
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>P</kbd></div><div class="shortcut-desc">Open Pane Manager</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Focus next pane</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd></div><div class="shortcut-desc">Focus previous pane</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Focus next Chat pane only</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>J</kbd></div><div class="shortcut-desc">Focus previous Chat pane only</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>g</kbd> <kbd>c</kbd></div><div class="shortcut-desc">Return to last active Chat pane</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>L</kbd></div><div class="shortcut-desc">Focus Chat composer</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Ctrl</kbd>+<kbd>Tab</kbd></div><div class="shortcut-desc">Switch panes by most-recent focus order</div></div>

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -164,6 +164,71 @@ test('cmd/ctrl+shift+j focuses previous pane with wraparound from unfocused stat
   await expect.poll(activePaneIndex).toBe(2);
 });
 
+test('cmd/ctrl+alt+j/k cycles chat panes only and keeps typing guard', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const panes = page.locator('[data-pane]');
+  await expect(panes).toHaveCount(2);
+
+  const activePaneIndex = async () => page.evaluate(() => {
+    const panes = Array.from(document.querySelectorAll('[data-pane]'));
+    const active = document.activeElement;
+    if (!active) return -1;
+    return panes.findIndex((p) => p === active || p.contains(active));
+  });
+
+  const triggerChatCycle = async (key, { targetInput = false } = {}) => {
+    await page.evaluate(({ key, targetInput }) => {
+      const event = new KeyboardEvent('keydown', {
+        key,
+        ctrlKey: true,
+        altKey: true,
+        bubbles: true,
+        cancelable: true
+      });
+      const target = targetInput
+        ? document.querySelector('[data-pane][data-pane-kind="chat"] [data-pane-input]')
+        : window;
+      target.dispatchEvent(event);
+    }, { key, targetInput });
+  };
+
+  await page.click('#connectionStatus');
+  await page.evaluate(() => focusPaneIndex(0));
+  await expect.poll(activePaneIndex).toBe(0);
+  await triggerChatCycle('K');
+  await expect.poll(activePaneIndex).toBe(0);
+  await expect(page.getByTestId('toast').last()).toContainText('Only one Chat pane is open.');
+
+  await page.getByTestId('add-pane-btn').click();
+  await page.getByTestId('pane-add-menu-chat').click();
+  await expect(panes).toHaveCount(3);
+  await expect(panes.nth(1)).toHaveAttribute('data-pane-kind', 'workqueue');
+  await expect(panes.nth(2)).toHaveAttribute('data-pane-kind', 'chat');
+
+  await page.evaluate(() => focusPaneIndex(0));
+  await expect.poll(activePaneIndex).toBe(0);
+  await triggerChatCycle('K');
+  await expect.poll(activePaneIndex).toBe(2);
+  await triggerChatCycle('J');
+  await expect.poll(activePaneIndex).toBe(0);
+
+  const firstPaneInput = panes.first().locator('[data-pane-input]');
+  await firstPaneInput.focus();
+  await expect(firstPaneInput).toBeFocused();
+  await triggerChatCycle('K', { targetInput: true });
+  await expect.poll(activePaneIndex).toBe(0);
+  await expect(page.getByTestId('shortcut-blocked-toast').last()).toContainText('Shortcut paused while typing');
+});
+
 test('alt+1..3 and cmd/ctrl+1..3 focus panes by visible order; shortcuts do not fire while typing', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!app?.skipReason, app?.skipReason);


### PR DESCRIPTION
## Summary
- Add Cmd/Ctrl+Alt+K/J shortcuts for next/previous Chat pane only.
- Skip non-chat panes while preserving typing/modal shortcut guards.
- Document shortcuts in help and command palette.

## Tests
- npm run test:syntax
- npx playwright test tests/pane.shortcuts.e2e.spec.js --grep "chat panes only" --workers=1

Fixes #306