### PR TITLE
Show unsent draft badges on panes

### DIFF
--- a/app.js
+++ b/app.js
@@ -1806,7 +1806,8 @@ function paneIdentityLabel(pane, { includeUnread = false } = {}) {
   const type = paneLabel(pane);
   const target = paneTargetLabel(pane);
   const unread = paneUnreadCount(pane);
-  return `${letter} ${type} · ${target}${includeUnread && unread > 0 ? ` • ${unread} unread` : ''}`;
+  const hasDraft = paneHasDraftChanges(pane);
+  return `${letter} ${type} · ${target}${hasDraft ? ' • draft' : ''}${includeUnread && unread > 0 ? ` • ${unread} unread` : ''}`;
 }
 
 function paneSummaryLabel(pane) {
@@ -1973,6 +1974,27 @@ function paneUnreadCount(pane) {
   return Math.max(0, Number(pane?.unreadCount || 0));
 }
 
+function paneDraftStatusLabel(pane) {
+  return paneHasDraftChanges(pane) ? 'Has unsent draft' : 'No unsent draft';
+}
+
+function renderPaneDraftBadge(pane) {
+  const badge = pane?.elements?.draftBadge;
+  if (!badge) return;
+
+  const hasDraft = paneHasDraftChanges(pane);
+  badge.hidden = !hasDraft;
+  badge.textContent = 'Draft';
+  badge.setAttribute('aria-label', paneDraftStatusLabel(pane));
+  badge.title = hasDraft ? 'Unsent draft' : 'No unsent draft';
+}
+
+function paneUpdateDraftState(pane) {
+  renderPaneIdentity(pane);
+  renderPaneDraftBadge(pane);
+  if (isPaneManagerOpen()) renderPaneManager();
+}
+
 function clearPaneUnread(pane) {
   if (!pane) return;
   if (!pane.unreadCount) return;
@@ -2028,7 +2050,8 @@ function paneSearchText(pane) {
     paneSummaryLabel(pane),
     paneLabel(pane),
     paneTargetLabel(pane),
-    pane?.kind || ''
+    pane?.kind || '',
+    paneHasDraftChanges(pane) ? 'draft unsent' : ''
   ]
     .join(' ')
     .toLowerCase();
@@ -2162,6 +2185,7 @@ function renderPaneManager() {
         const isDuplicate = duplicateCount > 1;
         const unreadCount = paneUnreadCount(pane);
         const paneIdentity = paneSummaryLabel(pane);
+        const hasDraft = paneHasDraftChanges(pane);
 
         row.innerHTML = `
           <div class="pane-manager-main">
@@ -2170,6 +2194,7 @@ function renderPaneManager() {
               <span class="pane-manager-kind-label">${escapeHtml(paneIdentity)}</span>
               <span class="pane-manager-pane-id" title="Internal pane id">${escapeHtml(String(pane?.key || ''))}</span>
               ${isDuplicate ? `<span class="pane-manager-duplicate-badge" data-testid="pane-manager-duplicate-badge" title="${escapeHtml(`${duplicateCount} duplicate panes`)}">duplicate</span>` : ''}
+              ${hasDraft ? '<span class="pane-manager-draft-badge" data-testid="pane-manager-draft-badge" title="Unsent draft" aria-label="Has unsent draft">Draft</span>' : ''}
               ${unreadCount > 0 ? `<span class="pane-manager-unread-badge" data-testid="pane-manager-unread-badge" title="${escapeHtml(`${unreadCount} unread`)}">${escapeHtml(String(unreadCount))}</span>` : ''}
             </div>
             <div class="pane-manager-state" data-state="${escapeHtml(state)}">${escapeHtml(state)}</div>
@@ -2182,6 +2207,7 @@ function renderPaneManager() {
             <button class="secondary pane-manager-close" type="button" data-action="close">Close</button>
           </div>
         `;
+        row.setAttribute('aria-label', `${paneIdentity}. ${paneDraftStatusLabel(pane)}.`);
 
         row.querySelector('[data-action="close"]')?.addEventListener('click', (event) => {
           event.preventDefault();
@@ -5515,6 +5541,7 @@ function paneRenderAttachments(pane) {
     remove.addEventListener('click', () => {
       pane.attachments.files.splice(index, 1);
       paneRenderAttachments(pane);
+      paneUpdateDraftState(pane);
     });
     pill.append(name, remove);
     list.appendChild(pill);
@@ -5563,6 +5590,7 @@ async function paneHandleFileSelection(pane, event) {
   }
   event.target.value = '';
   paneRenderAttachments(pane);
+  paneUpdateDraftState(pane);
 }
 
 async function paneUploadAttachments(pane) {
@@ -5582,6 +5610,7 @@ async function paneUploadAttachments(pane) {
   const data = await res.json();
   pane.attachments.files = [];
   paneRenderAttachments(pane);
+  paneUpdateDraftState(pane);
   pane.elements.attachmentStatus.textContent = '';
   return Array.isArray(data.files) ? data.files : [];
 }
@@ -5886,6 +5915,7 @@ async function paneSendChat(pane) {
     paneClearChatHistory(pane, { wipeStorage: true });
     pane.elements.input.value = '';
     paneUpdateCommandHints(pane);
+    paneUpdateDraftState(pane);
     addFeed('event', 'chat', `cleared local history (${pane.sessionKey()})`);
     return;
   }
@@ -5894,6 +5924,7 @@ async function paneSendChat(pane) {
     paneClearChatHistory(pane, { wipeStorage: true });
     pane.elements.input.value = '';
     paneUpdateCommandHints(pane);
+    paneUpdateDraftState(pane);
     pane.client.request('sessions.reset', { key });
     addFeed('event', 'chat', `reset session (${key})`);
     return;
@@ -5975,6 +6006,7 @@ async function paneSendChat(pane) {
 
   pane.elements.input.value = '';
   paneUpdateCommandHints(pane);
+  paneUpdateDraftState(pane);
 }
 
 function handleGatewayFrame(pane, data) {
@@ -6159,6 +6191,7 @@ function paneHeaderLetter(pane) {
 function renderPaneIdentity(pane) {
   if (!pane?.elements?.name) return;
   pane.elements.name.textContent = paneIdentityLabel(pane, { includeUnread: true });
+  pane.elements.root?.setAttribute('aria-label', `${paneIdentityLabel(pane)}. ${paneDraftStatusLabel(pane)}.`);
   const activeKey = focusedPaneKey() || paneMruOrder()[0] || '';
   if (activeKey && String(pane.key || '') === activeKey) updateBrowserTitle(pane);
 }
@@ -6397,7 +6430,9 @@ function paneSetAgent(pane, nextAgentId, { requireDraftConfirm = true } = {}) {
   renderPaneAgentIdentity(pane);
 
   pane.attachments.files = [];
+  if (pane.elements?.input) pane.elements.input.value = '';
   paneRenderAttachments(pane);
+  paneUpdateDraftState(pane);
   paneStopThinking(pane);
   paneClearChatHistory(pane, { wipeStorage: false });
   paneRestoreChatHistory(pane);
@@ -6453,6 +6488,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     typePill: root.querySelector('[data-pane-type-pill]'),
     typeIcon: root.querySelector('[data-pane-type-icon]'),
     typeText: root.querySelector('[data-pane-type-text]'),
+    draftBadge: root.querySelector('[data-pane-draft-badge]'),
     agentSelect: root.querySelector('[data-pane-agent-select]'),
     agentWrap: root.querySelector('[data-pane-agent-wrap]') || root.querySelector('.pane-agent'),
     targetLabel: root.querySelector('[data-pane-target-label]') || root.querySelector('.agent-label'),
@@ -6652,6 +6688,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     clearPaneUnread(pane);
   });
   renderPaneActivityBadge(pane);
+  renderPaneDraftBadge(pane);
 
   // WORKQUEUE PANE
   if (pane.role === 'admin' && pane.kind === 'workqueue') {
@@ -7931,6 +7968,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
 
   elements.input.addEventListener('input', () => {
     paneUpdateCommandHints(pane);
+    paneUpdateDraftState(pane);
   });
 
   elements.attachBtn.addEventListener('click', () => {

--- a/index.html
+++ b/index.html
@@ -96,6 +96,7 @@
                   <span class="pane-type-text" data-pane-type-text>CHAT</span>
                 </div>
                 <div class="pane-name" data-pane-name data-testid="pane-type-label">Pane</div>
+                <div class="pane-draft-badge" data-pane-draft-badge data-testid="pane-draft-badge" hidden aria-label="No unsent draft">Draft</div>
                 <div class="pane-agent" data-pane-agent-wrap>
                   <span class="agent-label" data-pane-target-label data-testid="pane-target-label">Agent</span>
                   <button class="agent-pill-btn" type="button" data-pane-agent-button aria-label="Change agent" data-testid="pane-agent-button">

--- a/styles.css
+++ b/styles.css
@@ -479,6 +479,29 @@ body::before {
   white-space: nowrap;
 }
 
+.pane-draft-badge,
+.pane-manager-draft-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 20px;
+  padding: 0 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(251, 191, 36, 0.48);
+  background: rgba(251, 191, 36, 0.14);
+  color: #fde68a;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  line-height: 1;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.pane-draft-badge[hidden] {
+  display: none !important;
+}
+
 .pane-type-badge {
   display: inline-flex;
   align-items: center;

--- a/tests/ui/pane-draft-badge.spec.js
+++ b/tests/ui/pane-draft-badge.spec.js
@@ -1,0 +1,58 @@
+const { test, expect } = require('@playwright/test');
+
+const { startTestEnv, loginAdmin, attachConsoleErrorAsserts, addPane } = require('./_helpers');
+
+let env;
+
+test.beforeAll(async () => {
+  env = await startTestEnv();
+});
+
+test.afterAll(() => {
+  env?.stop?.();
+});
+
+test.afterEach(async ({ page }) => {
+  if (page.__consoleAsserts) page.__consoleAsserts.assertNoErrors();
+});
+
+test('pane draft badge appears, persists across pane switches, and clears on send', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Chat pane');
+
+  const chatPanes = page.locator('[data-pane][data-pane-kind="chat"]');
+  const firstPane = chatPanes.first();
+  const secondPane = chatPanes.nth(1);
+  const firstDraftBadge = firstPane.getByTestId('pane-draft-badge');
+
+  await expect(firstPane.locator('[data-pane-send]')).toBeEnabled({ timeout: 90000 });
+  await expect(firstDraftBadge).toBeHidden();
+
+  await firstPane.getByTestId('pane-input').fill('draft badge check');
+  await expect(firstDraftBadge).toBeVisible();
+  await expect(firstDraftBadge).toHaveAttribute('aria-label', 'Has unsent draft');
+  await expect(firstPane).toHaveAttribute('aria-label', /Has unsent draft/);
+
+  await secondPane.getByTestId('pane-input').focus();
+  await expect(firstDraftBadge).toBeVisible();
+
+  await page.locator('#paneManagerBtn').click();
+  const manager = page.getByTestId('pane-manager-modal');
+  await expect(manager).toHaveClass(/open/);
+  const draftRows = manager.locator('.pane-manager-row', { has: page.getByTestId('pane-manager-draft-badge') });
+  await expect(draftRows).toHaveCount(1);
+  await expect(draftRows.first()).toHaveAttribute('aria-label', /Has unsent draft/);
+
+  await page.locator('#paneManagerCloseBtn').click();
+  await firstPane.getByTestId('pane-send').click();
+  await expect(firstDraftBadge).toBeHidden();
+  await expect(firstPane).toHaveAttribute('aria-label', /No unsent draft/);
+
+  await page.locator('#paneManagerBtn').click();
+  await expect(page.getByTestId('pane-manager-draft-badge')).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary
- add a visible Draft badge to pane headers when a chat pane has unsent text or attachments
- show the same draft state in Pane Manager rows and row aria-labels
- clear the badge when drafts are emptied, sent, attachments are removed/uploaded, or destination changes discard pane state

Fixes #305

## Tests
- npm test
- npx playwright test tests/ui/pane-draft-badge.spec.js --workers=1