### PR TITLE
Upgrade topbar pane attention summary

### DIFF
--- a/app.js
+++ b/app.js
@@ -192,6 +192,40 @@ const deriveGlobalConnectionState = __appCore.deriveGlobalConnectionState || ((s
     : `panes: ${connectedCount}/${total} connected`;
   return { state: nextState, meta };
 });
+const derivePaneAttentionSummary = __appCore.derivePaneAttentionSummary || ((state) => {
+  const panes = Array.isArray(state?.panes) ? state.panes : [];
+  if (!state?.authed || panes.length === 0) {
+    const total = state?.authed ? panes.length : 0;
+    return {
+      connectedCount: 0,
+      disconnectedCount: 0,
+      unreadCount: 0,
+      attentionCount: 0,
+      total,
+      text: panes.length === 0 ? '' : '0 connected · 0 disconnected · 0 attention',
+      ariaLabel: panes.length === 0
+        ? 'Pane summary: no panes'
+        : 'Pane summary: 0 of 0 panes connected, 0 disconnected, 0 need attention, 0 with unread activity'
+    };
+  }
+  const connectedCount = panes.filter((pane) => !!pane?.connected).length;
+  const disconnectedCount = panes.filter((pane) => !pane?.connected).length;
+  const unreadCount = panes.filter((pane) => Math.max(0, Number(pane?.unreadCount || 0)) > 0).length;
+  const attentionCount = panes.filter((pane) => {
+    const stateText = String(pane?.statusState || (pane?.connected ? 'connected' : 'disconnected')).toLowerCase();
+    return Math.max(0, Number(pane?.unreadCount || 0)) > 0 || !pane?.connected || stateText === 'error' || stateText === 'offline';
+  }).length;
+  const total = panes.length;
+  return {
+    connectedCount,
+    disconnectedCount,
+    unreadCount,
+    attentionCount,
+    total,
+    text: `${connectedCount} connected · ${disconnectedCount} disconnected · ${attentionCount} attention`,
+    ariaLabel: `Pane summary: ${connectedCount} of ${total} panes connected, ${disconnectedCount} disconnected, ${attentionCount} need attention, ${unreadCount} with unread activity`
+  };
+});
 const deriveDisconnectButtonState = __appCore.deriveDisconnectButtonState || ((state) => {
   if (!state?.authed) return { disabled: true, text: 'Reconnect' };
   const panes = Array.isArray(state?.panes) ? state.panes : [];
@@ -1229,8 +1263,13 @@ function setStatusPill(el, state, meta = '') {
 
 function updateGlobalStatus() {
   const status = deriveGlobalConnectionState({ authed: uiState.authed, panes: paneManager.panes });
+  const paneSummary = derivePaneAttentionSummary({ authed: uiState.authed, panes: paneManager.panes });
   setStatusPill(globalElements.status, status.state, status.meta);
-  if (globalElements.paneManagerBtn) globalElements.paneManagerBtn.textContent = status.meta;
+  if (globalElements.paneManagerBtn) {
+    globalElements.paneManagerBtn.textContent = paneSummary.text || status.meta;
+    globalElements.paneManagerBtn.title = paneSummary.ariaLabel || status.meta || 'Open pane manager';
+    globalElements.paneManagerBtn.setAttribute('aria-label', `${paneSummary.ariaLabel || status.meta || 'Pane summary'}. Open Pane Manager filtered to panes needing attention.`);
+  }
 }
 
 function updateConnectionControls() {
@@ -1733,6 +1772,7 @@ const paneManagerUiState = {
   open: false,
   selectedIndex: 0,
   query: '',
+  attentionOnly: false,
   unreadOnly: false,
   visiblePaneKeys: [],
   collapsedKinds: {
@@ -1980,6 +2020,7 @@ function clearPaneUnread(pane) {
   pane.unreadKind = '';
   renderPaneIdentity(pane);
   renderPaneActivityBadge(pane);
+  updateGlobalStatus();
   if (isPaneManagerOpen()) renderPaneManager();
 }
 
@@ -2020,7 +2061,13 @@ function markPaneUnread(pane, increment = 1, kind = 'chat') {
   pane.unreadKind = String(kind || 'activity');
   renderPaneIdentity(pane);
   renderPaneActivityBadge(pane);
+  updateGlobalStatus();
   if (isPaneManagerOpen()) renderPaneManager();
+}
+
+function paneNeedsAttention(pane) {
+  const state = String(pane?.statusState || (pane?.connected ? 'connected' : 'disconnected')).toLowerCase();
+  return paneUnreadCount(pane) > 0 || !pane?.connected || state === 'error' || state === 'offline';
 }
 
 function paneSearchText(pane) {
@@ -2091,6 +2138,7 @@ function renderPaneManager() {
 
   const query = String(paneManagerUiState.query || '').trim().toLowerCase();
   const filtered = panes.filter((pane) => {
+    if (paneManagerUiState.attentionOnly && !paneNeedsAttention(pane)) return false;
     if (paneManagerUiState.unreadOnly && paneUnreadCount(pane) <= 0) return false;
     return !query || paneSearchText(pane).includes(query);
   });
@@ -2253,7 +2301,7 @@ function renderPaneManager() {
   });
 }
 
-function openPaneManager() {
+function openPaneManager(options = {}) {
   if (roleState.role !== 'admin') return;
   if (!uiState.authed) {
     showLogin('Please sign in to continue.');
@@ -2263,8 +2311,16 @@ function openPaneManager() {
 
   paneManagerUiState.open = true;
   paneManagerUiState.selectedIndex = 0;
-  paneManagerUiState.query = String(globalElements.paneManagerSearch?.value || '').trim();
-  paneManagerUiState.unreadOnly = !!globalElements.paneManagerUnreadOnly?.checked;
+  paneManagerUiState.attentionOnly = !!options.attentionOnly;
+  if (paneManagerUiState.attentionOnly) {
+    paneManagerUiState.query = '';
+    paneManagerUiState.unreadOnly = false;
+    if (globalElements.paneManagerSearch) globalElements.paneManagerSearch.value = '';
+    if (globalElements.paneManagerUnreadOnly) globalElements.paneManagerUnreadOnly.checked = false;
+  } else {
+    paneManagerUiState.query = String(globalElements.paneManagerSearch?.value || '').trim();
+    paneManagerUiState.unreadOnly = !!globalElements.paneManagerUnreadOnly?.checked;
+  }
 
   globalElements.paneManagerModal.classList.add('open');
   globalElements.paneManagerModal.setAttribute('aria-hidden', 'false');
@@ -9151,18 +9207,20 @@ globalElements.resetLayoutBtn?.addEventListener('click', () => {
 
 globalElements.paneManagerBtn?.addEventListener('click', (event) => {
   event?.preventDefault?.();
-  openPaneManager();
+  openPaneManager({ attentionOnly: true });
 });
 
 globalElements.paneManagerCloseBtn?.addEventListener('click', () => closePaneManager());
 
 globalElements.paneManagerSearch?.addEventListener('input', () => {
+  paneManagerUiState.attentionOnly = false;
   paneManagerUiState.query = String(globalElements.paneManagerSearch?.value || '').trim();
   paneManagerUiState.selectedIndex = 0;
   renderPaneManager();
 });
 
 globalElements.paneManagerUnreadOnly?.addEventListener('change', () => {
+  paneManagerUiState.attentionOnly = false;
   paneManagerUiState.unreadOnly = !!globalElements.paneManagerUnreadOnly?.checked;
   paneManagerUiState.selectedIndex = 0;
   renderPaneManager();

--- a/lib/app-core.js
+++ b/lib/app-core.js
@@ -320,6 +320,43 @@
     return { state, meta };
   }
 
+  function derivePaneAttentionSummary({ authed, panes } = {}) {
+    const list = Array.isArray(panes) ? panes : [];
+    if (!authed || list.length === 0) {
+      const total = authed ? list.length : 0;
+      return {
+        connectedCount: 0,
+        disconnectedCount: 0,
+        unreadCount: 0,
+        attentionCount: 0,
+        total,
+        text: list.length === 0 ? '' : '0 connected · 0 disconnected · 0 attention',
+        ariaLabel: list.length === 0
+          ? 'Pane summary: no panes'
+          : 'Pane summary: 0 of 0 panes connected, 0 disconnected, 0 need attention, 0 with unread activity'
+      };
+    }
+
+    const connectedCount = list.filter((pane) => !!pane?.connected).length;
+    const disconnectedCount = list.filter((pane) => !pane?.connected).length;
+    const unreadCount = list.filter((pane) => Math.max(0, Number(pane?.unreadCount || 0)) > 0).length;
+    const attentionCount = list.filter((pane) => {
+      const state = String(pane?.statusState || (pane?.connected ? 'connected' : 'disconnected')).toLowerCase();
+      return Math.max(0, Number(pane?.unreadCount || 0)) > 0 || !pane?.connected || state === 'error' || state === 'offline';
+    }).length;
+    const total = list.length;
+
+    return {
+      connectedCount,
+      disconnectedCount,
+      unreadCount,
+      attentionCount,
+      total,
+      text: `${connectedCount} connected · ${disconnectedCount} disconnected · ${attentionCount} attention`,
+      ariaLabel: `Pane summary: ${connectedCount} of ${total} panes connected, ${disconnectedCount} disconnected, ${attentionCount} need attention, ${unreadCount} with unread activity`
+    };
+  }
+
   function deriveDisconnectButtonState({ authed, panes } = {}) {
     if (!authed) {
       return { disabled: true, text: 'Reconnect' };
@@ -457,6 +494,7 @@
     normalizeAdminDestination,
     deriveAuthOverlayState,
     deriveGlobalConnectionState,
+    derivePaneAttentionSummary,
     deriveDisconnectButtonState,
     extractChatText,
     normalizeHistoryEntries,

--- a/tests/pane.manager.e2e.spec.js
+++ b/tests/pane.manager.e2e.spec.js
@@ -173,6 +173,54 @@ test('pane manager: unread-only filter toggle', async ({ page }) => {
   await page.keyboard.press('Escape');
 });
 
+test('topbar pane summary tracks attention and opens manager filtered to attention', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const summary = page.getByTestId('panes-indicator');
+  await expect(summary).toContainText(/2 connected · 0 disconnected · 0 attention/, { timeout: 30000 });
+  await expect(summary).toHaveAttribute(
+    'aria-label',
+    /2 of 2 panes connected, 0 disconnected, 0 need attention, 0 with unread activity/
+  );
+
+  await page.getByTestId('add-pane-btn').click();
+  await page.getByTestId('pane-add-menu-chat').click();
+  await expect(summary).toContainText(/3 connected · 0 disconnected · 0 attention/, { timeout: 30000 });
+
+  const chatPanes = page.locator('[data-pane][data-pane-kind="chat"]');
+  const firstChat = chatPanes.first();
+  const secondChat = chatPanes.nth(1);
+  await firstChat.locator('[data-pane-input]').fill('attention summary');
+  await firstChat.locator('[data-pane-send]').click();
+  await secondChat.locator('[data-pane-input]').focus();
+  await expect(firstChat.locator('[data-chat-role="assistant"]').last()).toContainText('mock-reply: attention summary', { timeout: 10000 });
+  await expect(summary).toContainText(/3 connected · 0 disconnected · 1 attention/);
+  await expect(summary).toHaveAttribute(
+    'aria-label',
+    /3 of 3 panes connected, 0 disconnected, 1 need attention, 1 with unread activity/
+  );
+
+  await summary.click();
+  await expect(page.getByTestId('pane-manager-modal')).toHaveAttribute('aria-hidden', 'false');
+  await expect(page.locator('.pane-manager-row')).toHaveCount(1);
+  await expect(page.locator('.pane-manager-row').first()).toContainText('Chat · main');
+
+  await page.keyboard.press('Escape');
+  await page.evaluate(() => document.getElementById('disconnectBtn')?.click());
+  await expect(summary).toContainText(/1 connected · 2 disconnected · 2 attention/, { timeout: 30000 });
+
+  await summary.click();
+  await expect(page.locator('.pane-manager-row')).toHaveCount(2);
+});
+
 test('pane manager: status stays in sync with pane header while modal is open', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!app?.skipReason, app?.skipReason);

--- a/tests/unit/app-core.test.js
+++ b/tests/unit/app-core.test.js
@@ -11,6 +11,7 @@ const {
   normalizeAdminDestination,
   deriveAuthOverlayState,
   deriveGlobalConnectionState,
+  derivePaneAttentionSummary,
   deriveDisconnectButtonState,
   extractChatText,
   normalizeHistoryEntries
@@ -245,6 +246,38 @@ test('deriveGlobalConnectionState handles signed-out, reconnecting, and hard err
       ]
     }),
     { state: 'error', meta: 'auth expired' }
+  );
+});
+
+test('derivePaneAttentionSummary counts connected, disconnected, unread, and attention panes', () => {
+  assert.deepEqual(derivePaneAttentionSummary({ authed: false, panes: [{ connected: true, unreadCount: 1 }] }), {
+    connectedCount: 0,
+    disconnectedCount: 0,
+    unreadCount: 0,
+    attentionCount: 0,
+    total: 0,
+    text: '0 connected · 0 disconnected · 0 attention',
+    ariaLabel: 'Pane summary: 0 of 0 panes connected, 0 disconnected, 0 need attention, 0 with unread activity'
+  });
+
+  assert.deepEqual(
+    derivePaneAttentionSummary({
+      authed: true,
+      panes: [
+        { connected: true, statusState: 'connected', unreadCount: 0 },
+        { connected: false, statusState: 'disconnected', unreadCount: 0 },
+        { connected: true, statusState: 'connected', unreadCount: 2 }
+      ]
+    }),
+    {
+      connectedCount: 2,
+      disconnectedCount: 1,
+      unreadCount: 1,
+      attentionCount: 2,
+      total: 3,
+      text: '2 connected · 1 disconnected · 2 attention',
+      ariaLabel: 'Pane summary: 2 of 3 panes connected, 1 disconnected, 2 need attention, 1 with unread activity'
+    }
   );
 });
 


### PR DESCRIPTION
## Summary
- Replace the topbar pane indicator with connected, disconnected, and attention counts plus a detailed screen-reader label.
- Make the topbar summary open Pane Manager filtered to panes needing attention.
- Refresh the summary when unread state changes, and cover live unread/disconnect transitions in tests.

## Tests
- npm test
- npx playwright test tests/pane.manager.e2e.spec.js --workers=1

No production deploy performed.