### PR TITLE
Guard Enter send after pane switch

### DIFF
--- a/app.js
+++ b/app.js
@@ -1881,6 +1881,37 @@ function focusedPaneKey() {
 let paneFocusMruKeys = [];
 let paneMruTraversal = null;
 let paneMruSuppressFocusEvents = false;
+const PANE_SWITCH_SEND_GUARD_MS = 750;
+
+function paneArmSwitchSendGuard(pane, previousKey) {
+  if (!pane || pane.kind !== 'chat') return;
+  const key = String(pane.key || '');
+  const prior = String(previousKey || '');
+  if (!key || !prior || prior === key) return;
+  pane.switchSendGuard = {
+    until: Date.now() + PANE_SWITCH_SEND_GUARD_MS
+  };
+}
+
+function paneShowSwitchSendGuardHint(pane) {
+  const text = 'Pane changed: press Enter again to send';
+  const hints = pane?.elements?.commandHints;
+  if (hints) {
+    hints.innerHTML = `<div class="command-hint">${escapeHtml(text)}</div>`;
+    hints.classList.add('visible');
+  }
+  showToast(text, { kind: 'info', timeoutMs: 1600 });
+}
+
+function paneShouldBlockSwitchSend(pane, event) {
+  if (!pane || pane.kind !== 'chat') return false;
+  if (event?.metaKey || event?.ctrlKey) return false;
+  const guard = pane.switchSendGuard;
+  pane.switchSendGuard = null;
+  if (!guard || Date.now() > Number(guard.until || 0)) return false;
+  paneShowSwitchSendGuardHint(pane);
+  return true;
+}
 
 function paneMruOrder() {
   const panes = paneManager?.panes || [];
@@ -1899,6 +1930,8 @@ function notePaneFocused(pane) {
   if (!key) return;
   const panes = paneManager?.panes || [];
   if (!panes.some((entry) => String(entry?.key || '') === key)) return;
+  const previousKey = paneFocusMruKeys[0] || focusedPaneKey();
+  paneArmSwitchSendGuard(pane, previousKey);
   paneMruTraversal = null;
   paneMruOrder();
   paneFocusMruKeys = [key, ...paneFocusMruKeys.filter((entry) => entry !== key)];
@@ -7724,6 +7757,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault();
       if (elements.sendBtn.disabled) return;
+      if (paneShouldBlockSwitchSend(pane, event)) return;
       paneSendChat(pane);
     }
   });
@@ -8715,7 +8749,9 @@ function closeTopmostOverlay() {
 function focusPaneIndex(idx, { trackMru = true, showHud = false } = {}) {
   const pane = paneManager.panes[idx];
   if (!pane) return;
+  const previousKey = focusedPaneKey() || paneFocusMruKeys[0];
   clearPaneUnread(pane);
+  paneArmSwitchSendGuard(pane, previousKey);
   if (trackMru) notePaneFocused(pane);
   else updateBrowserTitle(pane);
   if (showHud) showPaneSwitchHud(pane);

--- a/tests/ui/chat-pane.spec.js
+++ b/tests/ui/chat-pane.spec.js
@@ -88,6 +88,45 @@ test('chat pane: stop button can cancel a running response', async ({ page }) =>
   await expect(pane.locator('.chat-bubble.assistant')).not.toContainText('mock-reply: please stream this', { timeout: 3000 });
 });
 
+test('chat pane: immediate Enter after pane switch is guarded once', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Chat pane');
+
+  const panes = page.locator('[data-pane][data-pane-kind="chat"]');
+  const firstPane = panes.first();
+  const secondPane = panes.last();
+  const firstInput = firstPane.locator('[data-pane-input]');
+  const secondInput = secondPane.locator('[data-pane-input]');
+
+  await expect(secondPane.locator('[data-pane-send]')).toBeEnabled({ timeout: 90000 });
+  await secondInput.fill('guarded send');
+
+  await firstInput.click();
+  await secondInput.click();
+  await page.keyboard.press('Enter');
+
+  await expect(secondPane.locator('[data-chat-role="user"]')).toHaveCount(0);
+  await expect(secondPane.locator('[data-pane-command-hints]')).toContainText('Pane changed: press Enter again to send');
+
+  await page.keyboard.press('Enter');
+
+  await expect(secondPane.locator('[data-chat-role="user"]').last()).toContainText('guarded send');
+  await expect(secondPane.locator('[data-chat-role="assistant"]').last()).toContainText('mock-reply: guarded send');
+
+  await secondInput.fill('override send');
+  await firstInput.click();
+  await secondInput.click();
+  await page.keyboard.press('ControlOrMeta+Enter');
+
+  await expect(secondPane.locator('[data-chat-role="user"]').last()).toContainText('override send');
+  await expect(secondPane.locator('[data-chat-role="assistant"]').last()).toContainText('mock-reply: override send');
+});
+
 test('chat pane: unread badge appears on inactive pane and clears on focus', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);


### PR DESCRIPTION
## Summary
- add a one-shot Enter send guard for chat panes immediately after switching panes
- show an inline hint/toast when the first Enter is blocked
- keep Cmd/Ctrl+Enter as an immediate override

Closes #309

## Tests
- npm run test:syntax
- npx playwright test tests/ui/chat-pane.spec.js --workers=1