### PR TITLE
Keep shortcuts help accessible while locked

### DIFF
--- a/app.js
+++ b/app.js
@@ -54,6 +54,13 @@ const globalElements = {
   shortcutsDialog: document.getElementById('shortcutsDialog'),
   shortcutsContent: document.getElementById('shortcutsContent'),
   shortcutsCloseBtn: document.getElementById('shortcutsCloseBtn'),
+  shortcutsUnlockedCopy: document.querySelector('[data-shortcuts-unlocked-copy]'),
+  shortcutsLockedCopy: document.querySelector('[data-shortcuts-locked-copy]'),
+  shortcutsGlobalUnlockedTitle: document.querySelector('[data-shortcuts-global-unlocked]'),
+  shortcutsGlobalLockedTitle: document.querySelector('[data-shortcuts-global-locked]'),
+  shortcutsLockedRow: document.querySelector('[data-shortcuts-locked-row]'),
+  shortcutsLockedLabels: Array.from(document.querySelectorAll('[data-shortcuts-locked-label]')),
+  shortcutsAdminGroups: Array.from(document.querySelectorAll('[data-shortcuts-admin-group]')),
   paneManagerModal: document.getElementById('paneManagerModal'),
   paneManagerCloseBtn: document.getElementById('paneManagerCloseBtn'),
   paneManagerSearch: document.getElementById('paneManagerSearch'),
@@ -466,6 +473,7 @@ function shortcutStatusRule(entry) {
 function renderShortcutsContent() {
   const root = globalElements.shortcutsContent;
   if (!root) return;
+  const locked = isAdminLocked();
   const groups = [];
   for (const entry of KEYBIND_CATALOG) {
     let group = groups.find((g) => g.name === entry.group);
@@ -475,20 +483,25 @@ function renderShortcutsContent() {
     }
     group.entries.push(entry);
   }
-  const hint = `
+  const hint = locked ? `
+    <div class="hint" style="margin-bottom: 10px;">
+      Admin is locked. These shortcuts are limited to sign-in and help until you unlock.
+    </div>
+  ` : `
     <div class="hint" style="margin-bottom: 10px;">
       Most shortcuts are disabled while typing in inputs, textareas, selects, or contenteditable fields. Global keys like <kbd>Esc</kbd>, <kbd>${escapeHtml(shortcutDisplay('pane.manager'))}</kbd>, and <kbd>${escapeHtml(shortcutDisplay('command.palette'))}</kbd> still work.
     </div>
   `;
   const html = groups.map((group) => `
-    <div class="shortcut-group">
-      <h3 class="shortcut-group-title">${escapeHtml(group.name)}</h3>
+    <div class="shortcut-group${locked && group.name !== 'Global' ? ' shortcut-group-locked' : ''}">
+      <h3 class="shortcut-group-title">${locked && group.name === 'Global' ? 'Available now' : escapeHtml(group.name)}${locked && group.name !== 'Global' ? ' <span class="shortcut-locked-label">Available after unlock</span>' : ''}</h3>
       ${group.entries.map((entry) => `
-        <div class="shortcut-row" data-shortcut-id="${escapeHtml(entry.id)}" data-shortcut-rule="${escapeHtml(shortcutStatusRule(entry))}">
+        <div class="shortcut-row${locked && group.name !== 'Global' ? ' shortcut-row-locked' : ''}" data-shortcut-id="${escapeHtml(entry.id)}" data-shortcut-rule="${escapeHtml(shortcutStatusRule(entry))}">
           <div class="shortcut-keys"${keybindIdToShortcutActionId(entry.id) ? ` data-shortcut-help="${escapeHtml(keybindIdToShortcutActionId(entry.id))}"` : ''}>${renderShortcutKeys(shortcutDisplay(entry.id))}</div>
           <div class="shortcut-desc">${escapeHtml(entry.label)}${isKeybindCustomized(entry.id) ? ' <span class="shortcut-custom">custom</span>' : ''}</div>
         </div>
       `).join('')}
+      ${locked && group.name === 'Global' ? '<div class="shortcut-row"><div class="shortcut-keys"><kbd>Enter</kbd></div><div class="shortcut-desc">Unlock after entering the admin password</div></div>' : ''}
     </div>
   `).join('');
   root.innerHTML = hint + html;
@@ -1855,8 +1868,11 @@ function showLogin(message = '') {
   closeAuthSessionPopover();
   globalElements.settingsBtn?.setAttribute('disabled', 'disabled');
   if (globalElements.settingsBtn) globalElements.settingsBtn.style.opacity = '0.5';
-  globalElements.shortcutsBtn?.setAttribute('disabled', 'disabled');
-  if (globalElements.shortcutsBtn) globalElements.shortcutsBtn.style.opacity = '0.5';
+  if (globalElements.shortcutsBtn && roleState.role === 'admin') {
+    globalElements.shortcutsBtn.hidden = false;
+    globalElements.shortcutsBtn.removeAttribute('disabled');
+    globalElements.shortcutsBtn.style.opacity = '1';
+  }
   globalElements.fleetBtn?.setAttribute('disabled', 'disabled');
   if (globalElements.fleetBtn) globalElements.fleetBtn.style.opacity = '0.5';
 
@@ -2633,6 +2649,19 @@ const SHORTCUT_STATUS_LABELS = {
   'layout-state': 'Blocked: layout-state'
 };
 
+function isAdminLocked() {
+  return !uiState.authed && (
+    roleState.role === 'admin' ||
+    globalElements.loginOverlay?.classList?.contains('open') ||
+    globalElements.loginOverlay?.getAttribute?.('aria-hidden') === 'false'
+  );
+}
+
+function syncShortcutsLockedState() {
+  const locked = isAdminLocked();
+  globalElements.shortcutsModal?.classList.toggle('locked-state', locked);
+}
+
 function getModalFocusableElements(modalEl) {
   if (!modalEl || !modalEl.querySelectorAll) return [];
   return Array.from(modalEl.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'))
@@ -2704,11 +2733,13 @@ function openShortcuts() {
   if (!modal) return;
   if (modal.classList.contains('open')) {
     renderShortcutsContent();
+    syncShortcutsLockedState();
     updatePaneShortcutBadges();
     updateShortcutsStatus();
     return;
   }
   renderShortcutsContent();
+  syncShortcutsLockedState();
   shortcutsLastFocusedEl = document.activeElement instanceof HTMLElement ? document.activeElement : null;
   modal.classList.add('open');
   modal.setAttribute('aria-hidden', 'false');
@@ -11573,6 +11604,9 @@ function isNonTrivialGlobalShortcut(event) {
 
 function blockedGlobalShortcutReason(event) {
   if (!isNonTrivialGlobalShortcut(event)) return '';
+  const key = String(event.key || '');
+  const isQuestion = (key === '?' || (key === '/' && event.shiftKey)) && !event.metaKey && !event.ctrlKey && !event.altKey;
+  if (isQuestion && isAdminLocked()) return '';
   if (isAnyOverlayOpen()) return 'modal';
   if (isTypingContext(event.target) && !isTypingShortcutExempt(event)) return 'typing';
   if (hasPaneNumberLayoutMismatch(event)) return 'layout';
@@ -11976,11 +12010,18 @@ window.addEventListener('keydown', (event) => {
     }
   }
 
+  const key = String(event.key || '');
+
+  const isQuestion = key === '?' || (key === '/' && event.shiftKey);
+  if (isAdminLocked() && isQuestion && !event.metaKey && !event.ctrlKey && !event.altKey) {
+    event.preventDefault();
+    openShortcuts();
+    return;
+  }
+
   // Never steal focus / override browser shortcuts while typing.
   if (isTypingContext(event.target)) return;
   if (isAnyOverlayOpen()) return;
-
-  const key = String(event.key || '');
 
   // Ctrl+Tab walks panes in most-recently-used order; Shift reverses the traversal.
   if (matchesKeybind(event, 'pane.mruNext') || matchesKeybind(event, 'pane.mruPrev')) {
@@ -11990,7 +12031,6 @@ window.addEventListener('keydown', (event) => {
     return;
   }
 
-  const isQuestion = key === '?' || (key === '/' && event.shiftKey);
   if (isQuestion && !event.metaKey && !event.ctrlKey && !event.altKey) {
     event.preventDefault();
     openShortcuts();

--- a/styles.css
+++ b/styles.css
@@ -1191,7 +1191,7 @@ button.send-btn .btn-icon {
 .login-overlay.open {
   opacity: 1;
   visibility: visible;
-  pointer-events: auto;
+  pointer-events: none;
 }
 
 .login-card {
@@ -1205,6 +1205,7 @@ button.send-btn .btn-icon {
   flex-direction: column;
   gap: 12px;
   opacity: 0;
+  pointer-events: auto;
   transform: translateY(10px) scale(0.985);
   transition: transform 0.22s ease, opacity 0.22s ease;
 }
@@ -2374,6 +2375,19 @@ button.agents-section-title:hover {
   opacity: 0.95;
 }
 
+.shortcut-locked-label {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 2px 7px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 500;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
 .shortcut-row {
   display: grid;
   grid-template-columns: minmax(180px, 220px) minmax(0, 1fr) max-content;
@@ -2434,6 +2448,10 @@ button.agents-section-title:hover {
   color: #bae6fd;
   font-size: 0.72rem;
   vertical-align: middle;
+}
+
+.shortcut-row-locked kbd {
+  opacity: 0.55;
 }
 
 kbd {

--- a/tests/ui/auth-lifecycle.spec.js
+++ b/tests/ui/auth-lifecycle.spec.js
@@ -35,6 +35,29 @@ test('signed-in auth chip shows session details and actions', async ({ page, cla
   await expect(popover.getByRole('button', { name: 'Logout' })).toBeVisible();
 });
 
+test('shortcuts help stays accessible while admin is locked', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  await page.goto(clawnsole.adminUrl);
+  await expect(page.getByTestId('login-overlay')).toHaveClass(/open/);
+
+  await expect(page.getByTestId('shortcuts-btn')).toBeVisible();
+  await expect(page.getByTestId('shortcuts-btn')).toBeEnabled();
+  await page.getByTestId('shortcuts-btn').click();
+  await expect(page.getByTestId('shortcuts-modal')).toHaveClass(/open/);
+  await expect(page.getByTestId('shortcuts-modal')).toContainText('Available now');
+  await expect(page.getByTestId('shortcuts-modal')).toContainText('Unlock after entering the admin password');
+  await expect(page.getByTestId('shortcuts-modal')).toContainText('Available after unlock');
+
+  await page.keyboard.press('Escape');
+  await expect(page.getByTestId('shortcuts-modal')).not.toHaveClass(/open/);
+
+  await page.keyboard.down('Shift');
+  await page.keyboard.press('Slash');
+  await page.keyboard.up('Shift');
+  await expect(page.getByTestId('shortcuts-modal')).toHaveClass(/open/);
+});
+
 test('admin login restores the intended in-app destination', async ({ page, clawnsole }) => {
   if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
 


### PR DESCRIPTION
## Summary
- keep the shortcuts help button enabled/reachable while the admin login overlay is locked
- show a locked-state shortcuts map with available-now unlock/help actions and unavailable-after-unlock sections
- cover locked mouse and keyboard access in auth lifecycle UI tests

Fixes #314

## Tests
- npm run test:syntax
- npx playwright test tests/ui/auth-lifecycle.spec.js --workers=1