### PR TITLE
Fix locked admin header auth state

### DIFF
--- a/app.js
+++ b/app.js
@@ -166,13 +166,17 @@ const normalizeAdminDestination = __appCore.normalizeAdminDestination || ((candi
 });
 const deriveAuthOverlayState = __appCore.deriveAuthOverlayState || ((state) => ({
   isAdmin: String(state?.role || '') === 'admin',
+  isLocked: !state?.authed,
   startAgentAutoRefresh: String(state?.role || '') === 'admin' && !!state?.authed,
   stopAgentAutoRefresh: String(state?.role || '') !== 'admin' || !state?.authed,
-  rolePillText: String(state?.role || '') === 'admin' ? 'signed in' : (state?.role || 'signed out'),
-  rolePillAdmin: String(state?.role || '') === 'admin',
-  showAdminControls: String(state?.role || '') === 'admin',
-  logoutEnabled: !!state?.authed,
-  logoutOpacity: !!state?.authed ? '1' : '0.5'
+  rolePillText: !state?.authed ? 'Locked' : (String(state?.role || '') === 'admin' ? 'signed in' : (state?.role || 'signed out')),
+  rolePillAdmin: String(state?.role || '') === 'admin' && !!state?.authed,
+  rolePillLocked: !state?.authed,
+  showAdminControls: String(state?.role || '') === 'admin' && !!state?.authed,
+  authActionText: !state?.authed ? 'Unlock' : 'Logout',
+  authActionLabel: !state?.authed ? 'Unlock admin' : 'Log out',
+  logoutEnabled: true,
+  logoutOpacity: '1'
 }));
 const deriveGlobalConnectionState = __appCore.deriveGlobalConnectionState || ((state) => {
   if (!state?.authed) return { state: 'disconnected', meta: 'sign in required' };
@@ -1218,9 +1222,10 @@ async function prepareGateway(kind) {
 function setStatusPill(el, state, meta = '') {
   if (!el) return;
   el.textContent = state;
-  el.classList.remove('connected', 'error', 'working');
+  el.classList.remove('connected', 'error', 'working', 'locked');
   if (state === 'connected') el.classList.add('connected');
   if (state === 'error') el.classList.add('error');
+  if (state === 'locked') el.classList.add('locked');
   if (state === 'connecting' || state === 'reconnecting' || state === 'offline') {
     el.classList.add('working');
   }
@@ -1230,7 +1235,11 @@ function setStatusPill(el, state, meta = '') {
 function updateGlobalStatus() {
   const status = deriveGlobalConnectionState({ authed: uiState.authed, panes: paneManager.panes });
   setStatusPill(globalElements.status, status.state, status.meta);
-  if (globalElements.paneManagerBtn) globalElements.paneManagerBtn.textContent = status.meta;
+  if (globalElements.status) globalElements.status.hidden = !uiState.authed;
+  if (globalElements.paneManagerBtn) {
+    globalElements.paneManagerBtn.hidden = !uiState.authed || !status.meta;
+    globalElements.paneManagerBtn.textContent = uiState.authed ? status.meta : '';
+  }
 }
 
 function updateConnectionControls() {
@@ -1238,6 +1247,16 @@ function updateConnectionControls() {
   const control = deriveDisconnectButtonState({ authed: uiState.authed, panes: paneManager.panes });
   globalElements.disconnectBtn.disabled = !!control.disabled;
   globalElements.disconnectBtn.textContent = control.text;
+}
+
+function updateAuthAction(authUi) {
+  if (!globalElements.logoutBtn) return;
+  globalElements.logoutBtn.disabled = !authUi.logoutEnabled;
+  globalElements.logoutBtn.style.opacity = authUi.logoutOpacity;
+  globalElements.logoutBtn.setAttribute('aria-label', authUi.authActionLabel);
+  globalElements.logoutBtn.setAttribute('title', authUi.authActionText);
+  const label = globalElements.logoutBtn.querySelector('.btn-label');
+  if (label) label.textContent = authUi.authActionText;
 }
 
 function setAuthState(authed) {
@@ -1253,10 +1272,7 @@ function setAuthState(authed) {
     stopAgentAutoRefresh();
   }
 
-  if (globalElements.logoutBtn) {
-    globalElements.logoutBtn.disabled = !authUi.logoutEnabled;
-    globalElements.logoutBtn.style.opacity = authUi.logoutOpacity;
-  }
+  updateAuthAction(authUi);
 }
 
 function setRole(role) {
@@ -1265,14 +1281,17 @@ function setRole(role) {
   if (globalElements.rolePill) {
     globalElements.rolePill.textContent = authUi.rolePillText;
     globalElements.rolePill.classList.toggle('admin', authUi.rolePillAdmin);
+    globalElements.rolePill.classList.toggle('locked', authUi.rolePillLocked);
   }
 
-  const isAdmin = authUi.isAdmin;
-  const visibleOpacity = isAdmin ? '1' : '0.5';
+  updateAuthAction(authUi);
+
+  const showAdminControls = authUi.showAdminControls;
+  const visibleOpacity = showAdminControls ? '1' : '0.5';
 
   if (globalElements.refreshAgentsBtn) {
-    globalElements.refreshAgentsBtn.hidden = !isAdmin;
-    globalElements.refreshAgentsBtn.disabled = !isAdmin || !uiState.authed;
+    globalElements.refreshAgentsBtn.hidden = !showAdminControls;
+    globalElements.refreshAgentsBtn.disabled = !showAdminControls;
     globalElements.refreshAgentsBtn.style.opacity = visibleOpacity;
   }
 
@@ -1283,35 +1302,35 @@ function setRole(role) {
   }
 
   if (globalElements.settingsBtn) {
-    if (isAdmin) globalElements.settingsBtn.removeAttribute('disabled');
+    if (showAdminControls) globalElements.settingsBtn.removeAttribute('disabled');
     else globalElements.settingsBtn.setAttribute('disabled', 'disabled');
     globalElements.settingsBtn.style.opacity = visibleOpacity;
   }
 
   if (globalElements.paneControls) {
-    globalElements.paneControls.hidden = !isAdmin;
+    globalElements.paneControls.hidden = !showAdminControls;
   }
   if (globalElements.agentsBtn) {
-    globalElements.agentsBtn.hidden = !isAdmin;
-    globalElements.agentsBtn.disabled = !isAdmin;
+    globalElements.agentsBtn.hidden = !showAdminControls;
+    globalElements.agentsBtn.disabled = !showAdminControls;
     globalElements.agentsBtn.style.opacity = visibleOpacity;
   }
 
   if (globalElements.workqueueBtn) {
-    globalElements.workqueueBtn.hidden = !isAdmin;
-    globalElements.workqueueBtn.disabled = !isAdmin;
+    globalElements.workqueueBtn.hidden = !showAdminControls;
+    globalElements.workqueueBtn.disabled = !showAdminControls;
     globalElements.workqueueBtn.style.opacity = visibleOpacity;
   }
 
   if (globalElements.fleetBtn) {
-    globalElements.fleetBtn.hidden = !isAdmin;
-    globalElements.fleetBtn.disabled = !isAdmin;
+    globalElements.fleetBtn.hidden = !showAdminControls;
+    globalElements.fleetBtn.disabled = !showAdminControls;
     globalElements.fleetBtn.style.opacity = visibleOpacity;
   }
 
   if (globalElements.shortcutsBtn) {
-    globalElements.shortcutsBtn.hidden = !isAdmin;
-    globalElements.shortcutsBtn.disabled = !isAdmin;
+    globalElements.shortcutsBtn.hidden = !showAdminControls;
+    globalElements.shortcutsBtn.disabled = !showAdminControls;
     globalElements.shortcutsBtn.style.opacity = visibleOpacity;
   }
 }
@@ -1327,8 +1346,9 @@ function showLogin(message = '') {
 
   setAuthState(false);
   if (globalElements.rolePill) {
-    globalElements.rolePill.textContent = 'signed out';
+    globalElements.rolePill.textContent = 'Locked';
     globalElements.rolePill.classList.remove('admin');
+    globalElements.rolePill.classList.add('locked');
   }
   globalElements.settingsBtn?.setAttribute('disabled', 'disabled');
   if (globalElements.settingsBtn) globalElements.settingsBtn.style.opacity = '0.5';
@@ -9192,6 +9212,10 @@ globalElements.loginPassword?.addEventListener('keydown', (event) => {
 });
 
 globalElements.logoutBtn?.addEventListener('click', async () => {
+  if (!uiState.authed) {
+    showLogin();
+    return;
+  }
   try {
     await fetch('/auth/logout', { method: 'POST' });
   } catch {}

--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
               <option value="3">3-up</option>
             </select>
           </div>
-          <div class="role-pill" id="rolePill" data-testid="role-pill">signed out</div>
+          <div class="role-pill locked" id="rolePill" data-testid="role-pill">Locked</div>
           <button id="refreshAgentsBtn" class="icon-btn action-btn" type="button" aria-label="Refresh agent list" title="Refresh (Ctrl/Cmd+R)" hidden>
             <span class="btn-icon" aria-hidden="true">⟳</span>
             <span class="btn-label">Refresh</span>
@@ -76,9 +76,9 @@
             <span class="btn-icon" aria-hidden="true">⚙︎</span>
             <span class="btn-label">Settings</span>
           </button>
-          <button id="logoutBtn" class="icon-btn action-btn" type="button" aria-label="Log out" title="Logout">
+          <button id="logoutBtn" class="icon-btn action-btn" type="button" aria-label="Unlock admin" title="Unlock">
             <span class="btn-icon" aria-hidden="true">⎋</span>
-            <span class="btn-label">Logout</span>
+            <span class="btn-label">Unlock</span>
           </button>
         </div>
       </header>

--- a/lib/app-core.js
+++ b/lib/app-core.js
@@ -275,15 +275,20 @@
 
   function deriveAuthOverlayState({ authed, role = null } = {}) {
     const isAdmin = role === 'admin';
+    const isLocked = !authed;
     return {
       isAdmin,
+      isLocked,
       startAgentAutoRefresh: isAdmin && !!authed,
       stopAgentAutoRefresh: !isAdmin || !authed,
-      rolePillText: isAdmin ? 'signed in' : (role || 'signed out'),
-      rolePillAdmin: isAdmin,
-      showAdminControls: isAdmin,
-      logoutEnabled: !!authed,
-      logoutOpacity: authed ? '1' : '0.5'
+      rolePillText: isLocked ? 'Locked' : (isAdmin ? 'signed in' : (role || 'signed out')),
+      rolePillAdmin: isAdmin && !isLocked,
+      rolePillLocked: isLocked,
+      showAdminControls: isAdmin && !isLocked,
+      authActionText: isLocked ? 'Unlock' : 'Logout',
+      authActionLabel: isLocked ? 'Unlock admin' : 'Log out',
+      logoutEnabled: true,
+      logoutOpacity: '1'
     };
   }
 

--- a/styles.css
+++ b/styles.css
@@ -228,6 +228,12 @@ body::before {
   color: var(--accent-2);
 }
 
+.role-pill.locked {
+  background: rgba(255, 179, 71, 0.18);
+  border-color: rgba(255, 179, 71, 0.55);
+  color: var(--accent);
+}
+
 .channel-switch select {
   background: rgba(9, 12, 16, 0.6);
   border: 1px solid rgba(255, 255, 255, 0.12);
@@ -358,6 +364,12 @@ body::before {
   background: rgba(255, 107, 107, 0.25);
   border-color: rgba(255, 107, 107, 0.8);
   color: var(--warning);
+}
+
+.status-pill.locked {
+  background: rgba(255, 179, 71, 0.12);
+  border-color: rgba(255, 179, 71, 0.45);
+  color: var(--accent);
 }
 
 @keyframes status-sweep {

--- a/tests/ui/auth-lifecycle.spec.js
+++ b/tests/ui/auth-lifecycle.spec.js
@@ -7,7 +7,11 @@ test('visiting /admin without auth shows login overlay', async ({ page, clawnsol
 
   await page.goto(clawnsole.adminUrl);
   await expect(page.getByTestId('login-overlay')).toHaveClass(/open/);
-  await expect(page.getByTestId('role-pill')).toContainText('signed out');
+  await expect(page.getByTestId('role-pill')).toHaveText('Locked');
+  await expect(page.getByTestId('connection-status')).toBeHidden();
+  await expect(page.getByTestId('panes-indicator')).toBeHidden();
+  await expect(page.locator('#logoutBtn')).toContainText('Unlock');
+  await expect(page.locator('#logoutBtn')).toBeEnabled();
 });
 
 test('admin login restores the intended in-app destination', async ({ page, clawnsole }) => {

--- a/tests/unit/app-core.test.js
+++ b/tests/unit/app-core.test.js
@@ -169,18 +169,25 @@ test('normalizePaneKind handles aliases safely', () => {
 test('deriveAuthOverlayState captures auth/role transition flags', () => {
   assert.deepEqual(deriveAuthOverlayState({ authed: true, role: 'admin' }), {
     isAdmin: true,
+    isLocked: false,
     startAgentAutoRefresh: true,
     stopAgentAutoRefresh: false,
     rolePillText: 'signed in',
     rolePillAdmin: true,
+    rolePillLocked: false,
     showAdminControls: true,
+    authActionText: 'Logout',
+    authActionLabel: 'Log out',
     logoutEnabled: true,
     logoutOpacity: '1'
   });
 
   assert.equal(deriveAuthOverlayState({ authed: false, role: 'admin' }).startAgentAutoRefresh, false);
+  assert.equal(deriveAuthOverlayState({ authed: false, role: 'admin' }).rolePillText, 'Locked');
+  assert.equal(deriveAuthOverlayState({ authed: false, role: 'admin' }).showAdminControls, false);
+  assert.equal(deriveAuthOverlayState({ authed: false, role: 'admin' }).authActionText, 'Unlock');
   assert.equal(deriveAuthOverlayState({ authed: true, role: 'guest' }).rolePillText, 'guest');
-  assert.equal(deriveAuthOverlayState({ authed: false, role: 'guest' }).logoutOpacity, '0.5');
+  assert.equal(deriveAuthOverlayState({ authed: false, role: 'guest' }).logoutOpacity, '1');
 });
 
 test('extractChatText converts attachment/file payloads to markdown links', () => {


### PR DESCRIPTION
## Summary\n- collapse signed-out admin header into one Locked auth chip\n- hide connection/pane status until unlock and make the header auth action read Unlock\n- restore normal admin controls/status after auth\n\nFixes #313\n\n## Tests\n- node --test tests/unit/app-core.test.js\n- npm run test:syntax\n- npm run test:unit\n- npx playwright test tests/ui/auth-lifecycle.spec.js --workers=1