### PR TITLE
Show auth-first admin state while signed out

### DIFF
--- a/app.js
+++ b/app.js
@@ -90,6 +90,8 @@ const globalElements = {
   addQueuePaneBtn: document.getElementById('addQueuePaneBtn'),
   layoutSelect: document.getElementById('layoutSelect'),
   paneGrid: document.getElementById('paneGrid'),
+  signedOutAdminState: document.getElementById('signedOutAdminState'),
+  signedOutUnlockBtn: document.getElementById('signedOutUnlockBtn'),
   paneTemplate: document.getElementById('paneTemplate')
 };
 
@@ -168,9 +170,9 @@ const deriveAuthOverlayState = __appCore.deriveAuthOverlayState || ((state) => (
   isAdmin: String(state?.role || '') === 'admin',
   startAgentAutoRefresh: String(state?.role || '') === 'admin' && !!state?.authed,
   stopAgentAutoRefresh: String(state?.role || '') !== 'admin' || !state?.authed,
-  rolePillText: String(state?.role || '') === 'admin' ? 'signed in' : (state?.role || 'signed out'),
-  rolePillAdmin: String(state?.role || '') === 'admin',
-  showAdminControls: String(state?.role || '') === 'admin',
+  rolePillText: String(state?.role || '') === 'admin' && !!state?.authed ? 'signed in' : (String(state?.role || '') && String(state?.role || '') !== 'admin' ? String(state?.role || '') : 'signed out'),
+  rolePillAdmin: String(state?.role || '') === 'admin' && !!state?.authed,
+  showAdminControls: String(state?.role || '') === 'admin' && !!state?.authed,
   logoutEnabled: !!state?.authed,
   logoutOpacity: !!state?.authed ? '1' : '0.5'
 }));
@@ -1240,12 +1242,28 @@ function updateConnectionControls() {
   globalElements.disconnectBtn.textContent = control.text;
 }
 
+function syncSignedOutAdminShell() {
+  const isAdminRoute = routeRole === 'admin';
+  const showSignedOut = isAdminRoute && !uiState.authed;
+  if (globalElements.signedOutAdminState) {
+    globalElements.signedOutAdminState.hidden = !showSignedOut;
+  }
+  if (globalElements.paneGrid) {
+    globalElements.paneGrid.hidden = showSignedOut;
+  }
+  if (globalElements.paneManagerBtn) {
+    globalElements.paneManagerBtn.hidden = showSignedOut;
+    globalElements.paneManagerBtn.disabled = showSignedOut;
+  }
+}
+
 function setAuthState(authed) {
   uiState.authed = authed;
   const authUi = deriveAuthOverlayState({ authed, role: roleState.role });
   updateGlobalStatus();
   updateConnectionControls();
   paneManager.refreshChatEnabled();
+  syncSignedOutAdminShell();
 
   if (authUi.startAgentAutoRefresh) {
     startAgentAutoRefresh();
@@ -1254,6 +1272,7 @@ function setAuthState(authed) {
   }
 
   if (globalElements.logoutBtn) {
+    globalElements.logoutBtn.hidden = !authUi.logoutEnabled;
     globalElements.logoutBtn.disabled = !authUi.logoutEnabled;
     globalElements.logoutBtn.style.opacity = authUi.logoutOpacity;
   }
@@ -1268,11 +1287,12 @@ function setRole(role) {
   }
 
   const isAdmin = authUi.isAdmin;
+  const showAdminControls = authUi.showAdminControls;
   const visibleOpacity = isAdmin ? '1' : '0.5';
 
   if (globalElements.refreshAgentsBtn) {
-    globalElements.refreshAgentsBtn.hidden = !isAdmin;
-    globalElements.refreshAgentsBtn.disabled = !isAdmin || !uiState.authed;
+    globalElements.refreshAgentsBtn.hidden = !showAdminControls;
+    globalElements.refreshAgentsBtn.disabled = !showAdminControls;
     globalElements.refreshAgentsBtn.style.opacity = visibleOpacity;
   }
 
@@ -1283,37 +1303,39 @@ function setRole(role) {
   }
 
   if (globalElements.settingsBtn) {
-    if (isAdmin) globalElements.settingsBtn.removeAttribute('disabled');
+    if (showAdminControls) globalElements.settingsBtn.removeAttribute('disabled');
     else globalElements.settingsBtn.setAttribute('disabled', 'disabled');
     globalElements.settingsBtn.style.opacity = visibleOpacity;
   }
 
   if (globalElements.paneControls) {
-    globalElements.paneControls.hidden = !isAdmin;
+    globalElements.paneControls.hidden = !showAdminControls;
   }
   if (globalElements.agentsBtn) {
-    globalElements.agentsBtn.hidden = !isAdmin;
-    globalElements.agentsBtn.disabled = !isAdmin;
+    globalElements.agentsBtn.hidden = !showAdminControls;
+    globalElements.agentsBtn.disabled = !showAdminControls;
     globalElements.agentsBtn.style.opacity = visibleOpacity;
   }
 
   if (globalElements.workqueueBtn) {
-    globalElements.workqueueBtn.hidden = !isAdmin;
-    globalElements.workqueueBtn.disabled = !isAdmin;
+    globalElements.workqueueBtn.hidden = !showAdminControls;
+    globalElements.workqueueBtn.disabled = !showAdminControls;
     globalElements.workqueueBtn.style.opacity = visibleOpacity;
   }
 
   if (globalElements.fleetBtn) {
-    globalElements.fleetBtn.hidden = !isAdmin;
-    globalElements.fleetBtn.disabled = !isAdmin;
+    globalElements.fleetBtn.hidden = !showAdminControls;
+    globalElements.fleetBtn.disabled = !showAdminControls;
     globalElements.fleetBtn.style.opacity = visibleOpacity;
   }
 
   if (globalElements.shortcutsBtn) {
-    globalElements.shortcutsBtn.hidden = !isAdmin;
-    globalElements.shortcutsBtn.disabled = !isAdmin;
+    globalElements.shortcutsBtn.hidden = !showAdminControls;
+    globalElements.shortcutsBtn.disabled = !showAdminControls;
     globalElements.shortcutsBtn.style.opacity = visibleOpacity;
   }
+
+  syncSignedOutAdminShell();
 }
 
 function showLogin(message = '') {
@@ -9183,6 +9205,7 @@ globalElements.status?.addEventListener('click', () => {
   paneManager.connectIfNeeded();
 });
 
+globalElements.signedOutUnlockBtn?.addEventListener('click', () => showLogin());
 globalElements.loginBtn?.addEventListener('click', () => attemptLogin());
 globalElements.loginPassword?.addEventListener('keydown', (event) => {
   if (event.key === 'Enter') {

--- a/index.html
+++ b/index.html
@@ -85,6 +85,14 @@
 
       <main class="chat-page">
         <canvas id="pulseCanvas" class="flux-canvas"></canvas>
+        <section id="signedOutAdminState" class="signed-out-admin-state" data-testid="signed-out-admin-state" hidden>
+          <div class="signed-out-admin-panel">
+            <div class="signed-out-kicker">Admin locked</div>
+            <h2>Unlock to access Chat + Workqueue + Fleet</h2>
+            <p>Sign in to load panes, agent controls, queue tools, and fleet status.</p>
+            <button id="signedOutUnlockBtn" class="primary signed-out-unlock" type="button" data-testid="signed-out-unlock">Unlock</button>
+          </div>
+        </section>
         <div id="paneGrid" class="pane-grid" aria-label="Chat panes" data-testid="pane-grid"></div>
 
         <template id="paneTemplate">

--- a/lib/app-core.js
+++ b/lib/app-core.js
@@ -275,13 +275,14 @@
 
   function deriveAuthOverlayState({ authed, role = null } = {}) {
     const isAdmin = role === 'admin';
+    const showAdminControls = isAdmin && !!authed;
     return {
       isAdmin,
       startAgentAutoRefresh: isAdmin && !!authed,
       stopAgentAutoRefresh: !isAdmin || !authed,
-      rolePillText: isAdmin ? 'signed in' : (role || 'signed out'),
-      rolePillAdmin: isAdmin,
-      showAdminControls: isAdmin,
+      rolePillText: showAdminControls ? 'signed in' : (role && !isAdmin ? role : 'signed out'),
+      rolePillAdmin: showAdminControls,
+      showAdminControls,
       logoutEnabled: !!authed,
       logoutOpacity: authed ? '1' : '0.5'
     };

--- a/styles.css
+++ b/styles.css
@@ -30,6 +30,10 @@ html {
   box-sizing: border-box;
 }
 
+[hidden] {
+  display: none !important;
+}
+
 *:focus-visible {
   outline: 2px solid rgba(127, 209, 185, 0.85);
   outline-offset: 2px;
@@ -393,6 +397,55 @@ body::before {
   grid-template-columns: repeat(var(--pane-cols, 1), minmax(0, 1fr));
   gap: 12px;
   min-height: 0;
+}
+
+.pane-grid[hidden],
+.signed-out-admin-state[hidden] {
+  display: none;
+}
+
+.signed-out-admin-state {
+  position: relative;
+  z-index: 1;
+  flex: 1;
+  display: grid;
+  place-items: center;
+  min-height: 0;
+  padding: 24px;
+}
+
+.signed-out-admin-panel {
+  width: min(520px, 100%);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.signed-out-kicker {
+  color: var(--warning);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.signed-out-admin-panel h2 {
+  margin: 0;
+  font-size: clamp(28px, 5vw, 46px);
+  line-height: 1;
+}
+
+.signed-out-admin-panel p {
+  margin: 0;
+  max-width: 42rem;
+  color: var(--muted);
+  font-size: 15px;
+  line-height: 1.5;
+}
+
+.signed-out-unlock {
+  margin-top: 6px;
 }
 
 .chat-panel {

--- a/tests/ui/signed-out-admin.spec.js
+++ b/tests/ui/signed-out-admin.spec.js
@@ -1,0 +1,44 @@
+const { test, expect } = require('@playwright/test');
+const { startTestEnv, attachConsoleErrorAsserts } = require('./_helpers');
+
+let env;
+
+test.beforeAll(async () => {
+  env = await startTestEnv();
+});
+
+test.afterAll(() => {
+  env?.stop?.();
+});
+
+test.afterEach(async ({ page }) => {
+  if (page.__consoleAsserts) {
+    page.__consoleAsserts.assertNoErrors();
+  }
+});
+
+test('signed-out admin shell shows auth-first state until unlock', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await page.goto(`http://127.0.0.1:${env.serverPort}/admin`);
+
+  await expect(page.getByTestId('signed-out-admin-state')).toBeVisible();
+  await expect(page.getByText('Unlock to access Chat + Workqueue + Fleet')).toBeVisible();
+  await expect(page.getByTestId('login-overlay')).toHaveClass(/open/);
+  await expect(page.getByTestId('pane-grid')).toBeHidden();
+  await expect(page.getByRole('button', { name: 'Add pane' })).toBeHidden();
+  await expect(page.locator('#layoutSelect')).toBeHidden();
+  await expect(page.getByTestId('panes-indicator')).toBeHidden();
+
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+
+  await expect(page.getByTestId('login-overlay')).not.toHaveClass(/open/, { timeout: 90000 });
+  await expect(page.getByTestId('signed-out-admin-state')).toBeHidden();
+  await expect(page.getByTestId('pane-grid')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Add pane' })).toBeVisible();
+  await expect(page.locator('[data-pane]')).toHaveCount(2);
+});

--- a/tests/unit/app-core.test.js
+++ b/tests/unit/app-core.test.js
@@ -178,7 +178,16 @@ test('deriveAuthOverlayState captures auth/role transition flags', () => {
     logoutOpacity: '1'
   });
 
-  assert.equal(deriveAuthOverlayState({ authed: false, role: 'admin' }).startAgentAutoRefresh, false);
+  assert.deepEqual(deriveAuthOverlayState({ authed: false, role: 'admin' }), {
+    isAdmin: true,
+    startAgentAutoRefresh: false,
+    stopAgentAutoRefresh: true,
+    rolePillText: 'signed out',
+    rolePillAdmin: false,
+    showAdminControls: false,
+    logoutEnabled: false,
+    logoutOpacity: '0.5'
+  });
   assert.equal(deriveAuthOverlayState({ authed: true, role: 'guest' }).rolePillText, 'guest');
   assert.equal(deriveAuthOverlayState({ authed: false, role: 'guest' }).logoutOpacity, '0.5');
 });


### PR DESCRIPTION
## Summary\n- add a signed-out admin empty state with a clear unlock CTA\n- hide pane grid, pane manager, and pane/workqueue/fleet controls until admin auth is active\n- cover signed-out-to-unlocked behavior with unit and Playwright tests\n\nFixes #312\n\n## Tests\n- npm test\n- npx playwright test tests/ui/signed-out-admin.spec.js --reporter=line