### PR TITLE
Add Caps Lock hint on unlock password input

### DIFF
--- a/app.js
+++ b/app.js
@@ -81,6 +81,7 @@ const globalElements = {
   rolePill: document.getElementById('rolePill'),
   loginOverlay: document.getElementById('loginOverlay'),
   loginPassword: document.getElementById('loginPassword'),
+  loginCapsHint: document.getElementById('loginCapsHint'),
   loginBtn: document.getElementById('loginBtn'),
   loginError: document.getElementById('loginError'),
   logoutBtn: document.getElementById('logoutBtn'),
@@ -1322,6 +1323,7 @@ function showLogin(message = '') {
   globalElements.loginOverlay.setAttribute('aria-hidden', 'false');
   globalElements.loginError.textContent = message;
   globalElements.loginPassword.value = '';
+  updateLoginCapsHint(false);
 
   // Guest role selection removed.
 
@@ -1347,7 +1349,22 @@ function hideLogin() {
   globalElements.loginOverlay.classList.remove('open');
   globalElements.loginOverlay.setAttribute('aria-hidden', 'true');
   globalElements.loginError.textContent = '';
+  updateLoginCapsHint(false);
   setAuthState(true);
+}
+
+function updateLoginCapsHint(visible) {
+  if (!globalElements.loginCapsHint) return;
+  globalElements.loginCapsHint.hidden = !visible;
+}
+
+function handleLoginPasswordCapsState(event) {
+  if (document.activeElement !== globalElements.loginPassword) {
+    updateLoginCapsHint(false);
+    return;
+  }
+  const getModifierState = event && typeof event.getModifierState === 'function' ? event.getModifierState.bind(event) : null;
+  updateLoginCapsHint(Boolean(getModifierState && getModifierState('CapsLock')));
 }
 
 async function attemptLogin() {
@@ -9185,11 +9202,14 @@ globalElements.status?.addEventListener('click', () => {
 
 globalElements.loginBtn?.addEventListener('click', () => attemptLogin());
 globalElements.loginPassword?.addEventListener('keydown', (event) => {
+  handleLoginPasswordCapsState(event);
   if (event.key === 'Enter') {
     event.preventDefault();
     attemptLogin();
   }
 });
+globalElements.loginPassword?.addEventListener('keyup', handleLoginPasswordCapsState);
+globalElements.loginPassword?.addEventListener('blur', () => updateLoginCapsHint(false));
 
 globalElements.logoutBtn?.addEventListener('click', async () => {
   try {

--- a/index.html
+++ b/index.html
@@ -200,6 +200,9 @@
           Password
           <input id="loginPassword" type="password" placeholder="Enter password" data-testid="login-password" />
         </label>
+        <div id="loginCapsHint" class="login-caps-hint" role="status" aria-live="polite" hidden data-testid="login-caps-hint">
+          Caps Lock is on
+        </div>
         <div id="loginError" class="login-error" role="alert" data-testid="login-error"></div>
         <button id="loginBtn" class="primary" data-testid="login-button">Unlock</button>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -1064,6 +1064,16 @@ button.send-btn .btn-icon {
   font-size: 12px;
 }
 
+.login-caps-hint {
+  min-height: 18px;
+  color: var(--warning);
+  font-size: 12px;
+}
+
+.login-caps-hint[hidden] {
+  display: none;
+}
+
 .modal {
   position: fixed;
   inset: 0;

--- a/tests/ui/auth-lifecycle.spec.js
+++ b/tests/ui/auth-lifecycle.spec.js
@@ -10,6 +10,45 @@ test('visiting /admin without auth shows login overlay', async ({ page, clawnsol
   await expect(page.getByTestId('role-pill')).toContainText('signed out');
 });
 
+test('login password shows Caps Lock hint only while active and focused', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  await page.goto(clawnsole.adminUrl);
+  const password = page.getByTestId('login-password');
+  const hint = page.getByTestId('login-caps-hint');
+
+  await expect(hint).toBeHidden();
+  await password.evaluate((node) => {
+    node.focus();
+    const event = Object.assign(new Event('keydown', { bubbles: true }), {
+      key: 'A',
+      getModifierState: (key) => key === 'CapsLock'
+    });
+    node.dispatchEvent(event);
+  });
+  await expect(hint).toBeVisible();
+
+  await password.evaluate((node) => {
+    const event = Object.assign(new Event('keyup', { bubbles: true }), {
+      key: 'a',
+      getModifierState: () => false
+    });
+    node.dispatchEvent(event);
+  });
+  await expect(hint).toBeHidden();
+
+  await password.evaluate((node) => {
+    const event = Object.assign(new Event('keydown', { bubbles: true }), {
+      key: 'A',
+      getModifierState: (key) => key === 'CapsLock'
+    });
+    node.dispatchEvent(event);
+  });
+  await expect(hint).toBeVisible();
+  await password.evaluate((node) => node.blur());
+  await expect(hint).toBeHidden();
+});
+
 test('admin login restores the intended in-app destination', async ({ page, clawnsole }) => {
   if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
 


### PR DESCRIPTION
## Summary\n- add an inline Caps Lock warning for the unlock password field\n- hide the warning when Caps Lock is off, the field blurs, or the login overlay resets\n- add UI coverage for show/hide behavior\n\n## Tests\n- npm run test:syntax\n- npx playwright test tests/ui/auth-lifecycle.spec.js --workers=1\n\nCloses #318