### PR TITLE
Add labeled header controls setting

### DIFF
--- a/app.js
+++ b/app.js
@@ -82,6 +82,7 @@ const globalElements = {
   settingsModal: document.getElementById('settingsModal'),
   settingsCloseBtn: document.getElementById('settingsCloseBtn'),
   paneSwitchHudEnabled: document.getElementById('paneSwitchHudEnabled'),
+  headerLabeledControlsEnabled: document.getElementById('headerLabeledControlsEnabled'),
   keybindConflictList: document.getElementById('keybindConflictList'),
   shortcutOverridesList: document.getElementById('shortcutOverridesList'),
   shortcutOverridesSave: document.getElementById('shortcutOverridesSave'),
@@ -301,6 +302,7 @@ const ADMIN_AUTH_DESTINATION_KEY = 'clawnsole.admin.authDestination.v1';
 const ADMIN_AUTH_RESTORE_PENDING_KEY = 'clawnsole.admin.authRestorePending.v1';
 const ADMIN_AUTH_RESTORE_NOTICE_KEY = 'clawnsole.admin.authRestoreNotice.v1';
 const PANE_SWITCH_HUD_ENABLED_KEY = 'clawnsole.admin.paneSwitchHud.enabled';
+const HEADER_LABELED_CONTROLS_ENABLED_KEY = 'clawnsole.header.labeledControls';
 const KEYBIND_OVERRIDES_KEY = 'clawnsole.admin.keybindOverrides.v1';
 const SHORTCUT_OVERRIDES_KEY = 'clawnsole.admin.shortcutOverrides.v1';
 const ADMIN_AUTH_DESTINATION_TTL_MS = 10 * 60 * 1000;
@@ -1887,6 +1889,9 @@ function openSettings() {
   if (globalElements.paneSwitchHudEnabled) {
     globalElements.paneSwitchHudEnabled.checked = isPaneSwitchHudEnabled();
   }
+  if (globalElements.headerLabeledControlsEnabled) {
+    globalElements.headerLabeledControlsEnabled.checked = areHeaderLabeledControlsEnabled();
+  }
   renderKeyboardSettings();
   shortcutOverridesDraft = readShortcutOverrides();
   renderShortcutOverrideSettings();
@@ -2744,6 +2749,16 @@ function paneSummaryLabel(pane) {
 function isPaneSwitchHudEnabled() {
   return String(storage.get(PANE_SWITCH_HUD_ENABLED_KEY, '1') || '1') !== '0';
 }
+
+function areHeaderLabeledControlsEnabled() {
+  return String(storage.get(HEADER_LABELED_CONTROLS_ENABLED_KEY, '1') || '1') !== '0';
+}
+
+function applyHeaderLabeledControlsSetting() {
+  document.body.classList.toggle('header-labels-off', !areHeaderLabeledControlsEnabled());
+}
+
+applyHeaderLabeledControlsSetting();
 
 let paneSwitchHudHideTimer = null;
 
@@ -10864,6 +10879,10 @@ globalElements.settingsModal?.addEventListener('click', (event) => {
 });
 globalElements.paneSwitchHudEnabled?.addEventListener('change', () => {
   storage.set(PANE_SWITCH_HUD_ENABLED_KEY, globalElements.paneSwitchHudEnabled.checked ? '1' : '0');
+});
+globalElements.headerLabeledControlsEnabled?.addEventListener('change', () => {
+  storage.set(HEADER_LABELED_CONTROLS_ENABLED_KEY, globalElements.headerLabeledControlsEnabled.checked ? '1' : '0');
+  applyHeaderLabeledControlsSetting();
 });
 function handleShortcutOverrideInputKeydown(event) {
   const input = event.target?.closest?.('[data-shortcut-action]');

--- a/index.html
+++ b/index.html
@@ -91,8 +91,9 @@
             <span class="btn-icon" aria-hidden="true">WQ</span>
             <span class="btn-label">Workqueue</span>
           </button>
-          <button id="shortcutsBtn" class="icon-btn" type="button" aria-label="Open keyboard shortcuts" title="Keyboard shortcuts (?)" hidden data-testid="shortcuts-btn">
-            ?
+          <button id="shortcutsBtn" class="icon-btn action-btn" type="button" aria-label="Open keyboard shortcuts" title="Keyboard shortcuts (?)" hidden data-testid="shortcuts-btn">
+            <span class="btn-icon" aria-hidden="true">?</span>
+            <span class="btn-label">Shortcuts</span>
           </button>
           <button id="settingsBtn" class="icon-btn action-btn" type="button" aria-label="Open settings" title="Settings">
             <span class="btn-icon" aria-hidden="true">⚙︎</span>
@@ -508,6 +509,14 @@
             <label class="inline-checkbox">
               <input id="paneSwitchHudEnabled" type="checkbox" checked />
               Show pane-switch HUD
+            </label>
+          </section>
+
+          <section class="settings-section" aria-label="Header controls">
+            <h3>Header controls</h3>
+            <label class="inline-checkbox">
+              <input id="headerLabeledControlsEnabled" type="checkbox" checked />
+              Labeled header controls
             </label>
           </section>
 

--- a/styles.css
+++ b/styles.css
@@ -350,6 +350,17 @@ body::before {
   white-space: nowrap;
 }
 
+body.header-labels-off .action-btn {
+  width: 40px;
+  min-width: 40px;
+  padding: 0;
+  gap: 0;
+}
+
+body.header-labels-off .action-btn .btn-label {
+  display: none;
+}
+
 @media (max-width: 920px) {
   .action-btn {
     width: 36px;

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -193,6 +193,46 @@ test('shortcuts modal restores prior focus on close', async ({ page }) => {
   await expect(openBtn).toBeFocused();
 });
 
+test('labeled header controls setting persists and respects narrow viewport fallback', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+  await page.setViewportSize({ width: 1280, height: 800 });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const settingsLabel = page.locator('#settingsBtn .btn-label');
+  const shortcutsLabel = page.locator('#shortcutsBtn .btn-label');
+  await expect(settingsLabel).toBeVisible();
+  await expect(shortcutsLabel).toBeVisible();
+  await expect(page.locator('#settingsBtn')).toHaveAttribute('aria-label', 'Open settings');
+
+  await page.getByRole('button', { name: 'Open settings' }).click();
+  await page.locator('#headerLabeledControlsEnabled').uncheck();
+  await page.keyboard.press('Escape');
+  await expect(page.locator('body')).toHaveClass(/header-labels-off/);
+  await expect(settingsLabel).toBeHidden();
+
+  await page.reload();
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+  await expect(page.locator('body')).toHaveClass(/header-labels-off/);
+  await expect(settingsLabel).toBeHidden();
+
+  await page.getByRole('button', { name: 'Open settings' }).click();
+  await page.locator('#headerLabeledControlsEnabled').check();
+  await page.keyboard.press('Escape');
+  await expect(page.locator('body')).not.toHaveClass(/header-labels-off/);
+  await expect(settingsLabel).toBeVisible();
+
+  await page.setViewportSize({ width: 760, height: 800 });
+  await expect(settingsLabel).toBeHidden();
+  await expect(page.locator('#settingsBtn')).toHaveAttribute('aria-label', 'Open settings');
+});
+
 test('keyboard settings flags risky shortcuts and updates cheatsheet after applying replacement', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!app?.skipReason, app?.skipReason);

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -133,6 +133,7 @@ test('pane-add shortcuts are scoped to workspace and blocked by overlays', async
     }));
   });
 
+  await expect(panes).toHaveCount(2);
   const initialCount = await paneCount();
   await page.click('#connectionStatus');
 


### PR DESCRIPTION
## Summary\n- add a persisted Settings toggle for labeled header controls\n- include Shortcuts in the icon+label topbar treatment\n- keep labels collapsed when the viewport is narrow\n\nCloses #321.\n\n## Tests\n- npm test\n- npx playwright test tests/pane.shortcuts.e2e.spec.js --grep "labeled header controls" --workers=1