### PR TITLE
Add canonical latest workqueue view

### DIFF
--- a/app.js
+++ b/app.js
@@ -115,6 +115,8 @@ const fmtRemaining = __appCore.fmtRemaining || ((msUntil) => {
   return `${sec}s`;
 });
 const formatWorkqueueIssueTitle = __appCore.formatWorkqueueIssueTitle || ((item) => String(item?.title || ''));
+const summarizeWorkqueueIssueDuplicateDensity = __appCore.summarizeWorkqueueIssueDuplicateDensity || (() => ({ density: 0, duplicateRows: 0, duplicateGroups: 0, totalRows: 0 }));
+const latestWorkqueueItemsPerCanonicalIssue = __appCore.latestWorkqueueItemsPerCanonicalIssue || ((items) => (Array.isArray(items) ? items.slice() : []));
 const sortWorkqueueItems = __appCore.sortWorkqueueItems || ((items, opts) => (Array.isArray(items) ? items.slice() : []));
 const inferPaneCols = __appCore.inferPaneCols || ((count) => {
   const n = Number(count);
@@ -3427,6 +3429,7 @@ function renderAgentsModalList() {
 const WORKQUEUE_STATUSES = ['ready', 'pending', 'claimed', 'in_progress', 'done', 'failed'];
 const WORKQUEUE_PANE_INITIAL_RENDER_LIMIT = 100;
 const WORKQUEUE_PANE_RENDER_CHUNK_SIZE = 100;
+const WORKQUEUE_CANONICAL_DENSITY_THRESHOLD = 0.2;
 const WORKQUEUE_HEADER_META = {
   title: { label: 'Task', tooltip: 'Sort by task title.' },
   status: { label: 'Status', tooltip: 'Sort by queue status.' },
@@ -4328,6 +4331,31 @@ async function cleanWorkqueueDuplicatesForPane(pane) {
   await fetchAndRenderWorkqueueItemsForPane(pane);
 }
 
+function getWorkqueuePaneViewMode(pane, items) {
+  const selected = String(pane.workqueue?.viewMode || 'auto').toLowerCase();
+  if (selected === 'grouped') return { mode: 'grouped', summary: summarizeWorkqueueIssueDuplicateDensity(items) };
+  if (selected === 'raw') return { mode: 'raw', summary: summarizeWorkqueueIssueDuplicateDensity(items) };
+
+  const summary = summarizeWorkqueueIssueDuplicateDensity(items);
+  return {
+    mode: summary.density >= WORKQUEUE_CANONICAL_DENSITY_THRESHOLD ? 'grouped' : 'raw',
+    summary
+  };
+}
+
+function updateWorkqueuePaneViewSummary(pane, summary, mode) {
+  const el = pane?.elements?.thread?.querySelector?.('[data-wq-view-summary]');
+  if (!el) return;
+  if (!summary?.duplicateRows) {
+    el.textContent = '';
+    return;
+  }
+  const pct = Math.round(Number(summary.density || 0) * 100);
+  el.textContent = mode === 'grouped'
+    ? `Grouped ${summary.duplicateRows} duplicate row${summary.duplicateRows === 1 ? '' : 's'} across ${summary.duplicateGroups} issue${summary.duplicateGroups === 1 ? '' : 's'} (${pct}%).`
+    : `${summary.duplicateRows} duplicate row${summary.duplicateRows === 1 ? '' : 's'} across ${summary.duplicateGroups} issue${summary.duplicateGroups === 1 ? '' : 's'} (${pct}%).`;
+}
+
 function renderWorkqueuePaneItems(pane) {
   const body = pane.elements?.thread?.querySelector('[data-wq-list-body]');
   const empty = pane.elements?.thread?.querySelector('[data-wq-empty]');
@@ -4337,7 +4365,10 @@ function renderWorkqueuePaneItems(pane) {
 
   const scopedItems = filterWorkqueuePaneItemsByScope(pane, pane.workqueue?.items);
   const filteredItems = applyWorkqueueQuickFilters(scopedItems, pane.workqueue?.quickFilters);
-  const items = sortWorkqueueItems(filteredItems, { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
+  const sortedItems = sortWorkqueueItems(filteredItems, { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
+  const { mode: viewMode, summary: viewSummary } = getWorkqueuePaneViewMode(pane, sortedItems);
+  const items = viewMode === 'grouped' ? latestWorkqueueItemsPerCanonicalIssue(sortedItems) : sortedItems;
+  updateWorkqueuePaneViewSummary(pane, viewSummary, viewMode);
   const renderLimit = Math.max(
     WORKQUEUE_PANE_INITIAL_RENDER_LIMIT,
     Number(pane.workqueue?.renderLimit || WORKQUEUE_PANE_INITIAL_RENDER_LIMIT)
@@ -4388,11 +4419,12 @@ function renderWorkqueuePaneItems(pane) {
     const leaseLabel = it.leaseUntil ? fmtRemaining(leaseMs) : '';
     const status = String(it.status || '');
     const title = formatWorkqueueIssueTitle(it);
+    const groupSize = Number(it._canonicalGroupSize || 0);
     row.title = title;
     row.setAttribute('aria-label', `Workqueue item: ${title}`);
 
     row.innerHTML = `
-      <div class="wq-col title"><span class="wq-title-text" title="${escapeHtml(title)}">${escapeHtml(title)}</span></div>
+      <div class="wq-col title"><span class="wq-title-text" title="${escapeHtml(title)}">${escapeHtml(title)}</span>${groupSize > 1 ? `<span class="wq-group-count" title="Latest row shown; ${escapeHtml(String(groupSize - 1))} older duplicate row${groupSize === 2 ? '' : 's'} hidden">×${escapeHtml(String(groupSize))}</span>` : ''}</div>
       <div class="wq-col status"><span class="wq-badge wq-badge-${escapeHtml(status)}">${escapeHtml(status)}</span></div>
       <div class="wq-col prio mono">${escapeHtml(String(it.priority ?? ''))}</div>
       <div class="wq-col attempts mono">${escapeHtml(String(it.attempts ?? ''))}</div>
@@ -6311,7 +6343,7 @@ function renderAgentOptions(selectEl, agentId) {
   selectEl.value = normalizeAgentId(agentId || 'main');
 }
 
-function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, scopeFilter, quickFilters, sortKey, sortDir, cronAgentId, closable = true } = {}) {
+function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, scopeFilter, quickFilters, sortKey, sortDir, viewMode, cronAgentId, closable = true } = {}) {
   const template = globalElements.paneTemplate;
   const root = template.content.firstElementChild.cloneNode(true);
   const elements = {
@@ -6370,7 +6402,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       selectedItemId: null,
       renderLimit: WORKQUEUE_PANE_INITIAL_RENDER_LIMIT,
       sortKey: typeof sortKey === 'string' && sortKey.trim() ? sortKey.trim() : 'priority',
-      sortDir: sortDir === 'asc' ? 'asc' : 'desc'
+      sortDir: sortDir === 'asc' ? 'asc' : 'desc',
+      viewMode: ['auto', 'grouped', 'raw'].includes(String(viewMode || '').toLowerCase()) ? String(viewMode).toLowerCase() : 'auto'
     },
     cronAgentId: typeof cronAgentId === 'string' ? cronAgentId.trim() : '',
     connected: false,
@@ -6597,6 +6630,15 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
             <button type="button" class="wq-sort-btn" data-wq-sort="updatedAt">Updated</button>
             <button type="button" class="wq-sort-btn" data-wq-sort="createdAt">Created</button>
           </div>
+
+          <label class="wq-field">
+            <span class="wq-label">View</span>
+            <select data-wq-view-mode aria-label="Workqueue row grouping view">
+              <option value="auto">Auto</option>
+              <option value="grouped">Grouped (latest)</option>
+              <option value="raw">Raw rows</option>
+            </select>
+          </label>
         </div>
 
         <details class="wq-enqueue">
@@ -6644,6 +6686,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         </details>
 
         <div class="hint" data-wq-statusline></div>
+        <div class="hint" data-wq-view-summary></div>
         <div class="wq-duplicate-health" data-wq-duplicate-health aria-live="polite" hidden></div>
       </div>
 
@@ -6694,8 +6737,10 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     const clawnsoleOnlyBtn = elements.thread.querySelector('[data-wq-preset-clawnsole]');
     const clearQuickBtn = elements.thread.querySelector('[data-wq-clear-quick]');
     const refreshBtn = elements.thread.querySelector('[data-wq-refresh]');
+    const viewModeEl = elements.thread.querySelector('[data-wq-view-mode]');
 
     const DEFAULT_STATUSES = ['ready', 'pending', 'claimed', 'in_progress'];
+    if (viewModeEl) viewModeEl.value = pane.workqueue.viewMode || 'auto';
 
     const statusSet = new Set(
       (Array.isArray(pane.workqueue?.statusFilter) && pane.workqueue.statusFilter.length ? pane.workqueue.statusFilter : DEFAULT_STATUSES)
@@ -7018,6 +7063,14 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       persistQuickFilters();
       updateQuickFilterUi();
       renderWorkqueuePaneItems(pane);
+    });
+
+    viewModeEl?.addEventListener('change', () => {
+      const mode = String(viewModeEl.value || 'auto').toLowerCase();
+      pane.workqueue.viewMode = ['auto', 'grouped', 'raw'].includes(mode) ? mode : 'auto';
+      resetRenderLimit();
+      renderWorkqueuePaneItems(pane);
+      paneManager.persistAdminPanes();
     });
 
     updateQuickFilterUi();
@@ -7796,6 +7849,7 @@ const paneManager = {
         scopeFilter: cfg.scopeFilter,
         sortKey: cfg.sortKey,
         sortDir: cfg.sortDir,
+        viewMode: cfg.viewMode,
         closable: true
       })
     );
@@ -7846,7 +7900,10 @@ const paneManager = {
           };
           const sortKey = typeof item.sortKey === 'string' ? item.sortKey : 'priority';
           const sortDir = item.sortDir === 'asc' ? 'asc' : 'desc';
-          return { key, kind, agentId, queue, statusFilter, scopeFilter, quickFilters, sortKey, sortDir };
+          const viewMode = ['auto', 'grouped', 'raw'].includes(String(item.viewMode || '').toLowerCase())
+            ? String(item.viewMode).toLowerCase()
+            : 'auto';
+          return { key, kind, agentId, queue, statusFilter, scopeFilter, quickFilters, sortKey, sortDir, viewMode };
         }
         if (kind === 'cron' || kind === 'timeline') {
           return { key, kind };
@@ -7893,7 +7950,8 @@ const paneManager = {
             repos: Array.isArray(pane.workqueue?.quickFilters?.repos) ? pane.workqueue.quickFilters.repos : []
           },
           sortKey: pane.workqueue?.sortKey || 'priority',
-          sortDir: pane.workqueue?.sortDir || 'desc'
+          sortDir: pane.workqueue?.sortDir || 'desc',
+          viewMode: pane.workqueue?.viewMode || 'auto'
         };
       }
       if (pane.kind === 'cron' || pane.kind === 'timeline') {

--- a/lib/app-core.js
+++ b/lib/app-core.js
@@ -209,6 +209,83 @@
     return `[ISSUE] ${ref.repo}#${ref.issueNumber}${displayTitle ? ` - ${displayTitle}` : ''}`;
   }
 
+  function getWorkqueueIssueKey(item) {
+    const ref = getWorkqueueIssueRef(item);
+    return ref?.repo && ref?.issueNumber ? `${ref.repo}#${ref.issueNumber}` : '';
+  }
+
+  function getWorkqueueLatestIssueItem(items) {
+    return (Array.isArray(items) ? items : [])
+      .slice()
+      .sort((a, b) => {
+        const ua = Date.parse(String(a?.updatedAt || '')) || 0;
+        const ub = Date.parse(String(b?.updatedAt || '')) || 0;
+        if (ub !== ua) return ub - ua;
+        const ca = Date.parse(String(a?.createdAt || '')) || 0;
+        const cb = Date.parse(String(b?.createdAt || '')) || 0;
+        if (cb !== ca) return cb - ca;
+        return String(a?.id || '').localeCompare(String(b?.id || ''));
+      })[0] || null;
+  }
+
+  function summarizeWorkqueueIssueDuplicateDensity(items) {
+    const rows = Array.isArray(items) ? items : [];
+    const groups = new Map();
+    for (const item of rows) {
+      const key = getWorkqueueIssueKey(item);
+      if (!key) continue;
+      if (!groups.has(key)) groups.set(key, []);
+      groups.get(key).push(item);
+    }
+
+    let duplicateRows = 0;
+    let duplicateGroups = 0;
+    for (const group of groups.values()) {
+      if (group.length <= 1) continue;
+      duplicateGroups += 1;
+      duplicateRows += group.length - 1;
+    }
+
+    return {
+      totalRows: rows.length,
+      issueRows: Array.from(groups.values()).reduce((sum, group) => sum + group.length, 0),
+      duplicateRows,
+      duplicateGroups,
+      density: rows.length ? duplicateRows / rows.length : 0
+    };
+  }
+
+  function latestWorkqueueItemsPerCanonicalIssue(items) {
+    const rows = Array.isArray(items) ? items : [];
+    const groups = new Map();
+    const unkeyed = new Set();
+    for (const item of rows) {
+      const key = getWorkqueueIssueKey(item);
+      if (!key) {
+        if (item?.id) unkeyed.add(item.id);
+        continue;
+      }
+      if (!groups.has(key)) groups.set(key, []);
+      groups.get(key).push(item);
+    }
+
+    const keepIds = new Set(unkeyed);
+    const groupSizes = new Map();
+    for (const [key, group] of groups.entries()) {
+      const keep = getWorkqueueLatestIssueItem(group);
+      if (!keep?.id) continue;
+      keepIds.add(keep.id);
+      groupSizes.set(keep.id, group.length);
+    }
+
+    return rows
+      .filter((item) => keepIds.has(item?.id))
+      .map((item) => {
+        const size = groupSizes.get(item?.id) || 1;
+        return size > 1 ? Object.assign({}, item, { _canonicalGroupSize: size }) : item;
+      });
+  }
+
   function inferPaneCols(count) {
     const n = Number(count);
     if (!Number.isFinite(n) || n <= 1) return 1;
@@ -451,6 +528,9 @@
     escapeHtml,
     fmtRemaining,
     formatWorkqueueIssueTitle,
+    getWorkqueueIssueKey,
+    summarizeWorkqueueIssueDuplicateDensity,
+    latestWorkqueueItemsPerCanonicalIssue,
     sortWorkqueueItems,
     inferPaneCols,
     normalizePaneKind,

--- a/styles.css
+++ b/styles.css
@@ -2571,14 +2571,34 @@ kbd {
 
 .wq-col.title {
   font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
 }
 
 .wq-title-text {
   display: block;
+  flex: 1 1 auto;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.wq-group-count {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.07);
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.2;
 }
 
 .wq-col.mono {

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -500,11 +500,12 @@ test('workqueue pane: default rows collapse exact duplicates with expandable mem
   await wqPane.locator('[data-wq-queue-custom]').fill(queue);
   await wqPane.locator('[data-wq-queue-custom]').press('Enter');
   await wqPane.locator('[data-wq-scope="all"]').click();
+  await wqPane.locator('[data-wq-group-mode="rows"]').click();
 
   const rows = wqPane.locator('[data-wq-list-body] .wq-row');
   const duplicateRow = wqPane.locator('[data-wq-duplicate-row]').first();
 
-  await expect(wqPane.locator('[data-wq-group-mode="auto"]')).toHaveAttribute('aria-pressed', 'true');
+  await expect(wqPane.locator('[data-wq-group-mode="rows"]')).toHaveAttribute('aria-pressed', 'true');
   await expect(wqPane.locator('[data-wq-statusline]')).toContainText('Showing 4 items');
   await expect(rows).toHaveCount(3);
   await expect(duplicateRow).toContainText('x2');
@@ -799,6 +800,7 @@ test('workqueue pane: duplicate health summary cleans legacy issue duplicates', 
   await pane.locator('[data-wq-queue-select]').selectOption('__custom__');
   await pane.locator('[data-wq-queue-custom]').fill(queue);
   await pane.locator('[data-wq-queue-custom]').press('Enter');
+  await pane.locator('[data-wq-group-mode="rows"]').click();
   await expect(pane.locator('[data-wq-statusline]')).toContainText('4 item');
 
   const duplicateHealth = pane.locator('[data-wq-duplicate-health]');
@@ -834,9 +836,10 @@ test('workqueue pane: default rows auto-collapse exact duplicates with count and
   await pane.locator('[data-wq-queue-select]').selectOption('__custom__');
   await pane.locator('[data-wq-queue-custom]').fill(queue);
   await pane.locator('[data-wq-queue-custom]').press('Enter');
+  await pane.locator('[data-wq-group-mode="rows"]').click();
 
   const duplicateRow = pane.locator('[data-wq-duplicate-row]').first();
-  await expect(pane.locator('[data-wq-group-mode="auto"]')).toHaveClass(/active/);
+  await expect(pane.locator('[data-wq-group-mode="rows"]')).toHaveClass(/active/);
   await expect(duplicateRow).toBeVisible();
   await expect(duplicateRow).toContainText('x2');
   await expect(duplicateRow).toHaveAttribute('data-wq-item', 'exact-dup-latest');
@@ -864,6 +867,7 @@ test('workqueue pane: grouped mode collapses duplicate issue rows and expands ch
   await pane.locator('[data-wq-queue-select]').selectOption('__custom__');
   await pane.locator('[data-wq-queue-custom]').fill(queue);
   await pane.locator('[data-wq-queue-custom]').press('Enter');
+  await pane.locator('[data-wq-group-mode="rows"]').click();
 
   await expect(pane.locator('.wq-row')).toHaveCount(4);
   await pane.locator('[data-wq-group-mode="grouped"]').click();

--- a/tests/unit/app-core.test.js
+++ b/tests/unit/app-core.test.js
@@ -5,6 +5,9 @@ const {
   escapeHtml,
   fmtRemaining,
   formatWorkqueueIssueTitle,
+  getWorkqueueIssueKey,
+  summarizeWorkqueueIssueDuplicateDensity,
+  latestWorkqueueItemsPerCanonicalIssue,
   sortWorkqueueItems,
   inferPaneCols,
   normalizePaneKind,
@@ -132,6 +135,48 @@ test('sortWorkqueueItems title sort uses normalized issue display titles', () =>
 
   const sorted = sortWorkqueueItems(items, { sortKey: 'title', sortDir: 'asc' });
   assert.deepEqual(sorted.map((it) => it.id), ['a', 'b']);
+});
+
+test('workqueue canonical issue helpers calculate density and latest row', () => {
+  const items = [
+    {
+      id: 'old',
+      title: '[issue] rmdmattingly/clawnsole#320 Old',
+      updatedAt: '2026-03-01T00:00:00Z',
+      createdAt: '2026-03-01T00:00:00Z'
+    },
+    {
+      id: 'new',
+      title: 'Follow-up',
+      instructions: 'Repo: rmdmattingly/clawnsole\nIssue: #320',
+      updatedAt: '2026-03-02T00:00:00Z',
+      createdAt: '2026-03-02T00:00:00Z'
+    },
+    {
+      id: 'other',
+      title: 'Routine sweep',
+      updatedAt: '2026-03-03T00:00:00Z'
+    },
+    {
+      id: 'solo',
+      meta: { repo: 'RMDMATTINGLY/CLAWNSOLE', issueNumber: 321 },
+      title: 'Solo issue',
+      updatedAt: '2026-03-04T00:00:00Z'
+    }
+  ];
+
+  assert.equal(getWorkqueueIssueKey(items[0]), 'rmdmattingly/clawnsole#320');
+  assert.deepEqual(summarizeWorkqueueIssueDuplicateDensity(items), {
+    totalRows: 4,
+    issueRows: 3,
+    duplicateRows: 1,
+    duplicateGroups: 1,
+    density: 0.25
+  });
+
+  const latest = latestWorkqueueItemsPerCanonicalIssue(items);
+  assert.deepEqual(latest.map((item) => item.id), ['new', 'other', 'solo']);
+  assert.equal(latest[0]._canonicalGroupSize, 2);
 });
 
 test('sortWorkqueueItems priority sort uses updatedAt desc tie-breaker', () => {


### PR DESCRIPTION
## Summary
- compute canonical issue duplicate density for Workqueue rows
- auto-switch dense queues to a latest-per-canonical-issue view
- add persisted View selector with Auto, Grouped (latest), and Raw rows modes

## Tests
- npm run test:syntax
- node --test tests/unit/app-core.test.js

Note: npm run test:unit currently fails in this fresh worktree because server-backed tests cannot resolve the missing local ws dependency.