### PR TITLE
Add workqueue modal filter summary

### DIFF
--- a/app.js
+++ b/app.js
@@ -4352,6 +4352,133 @@ function filterWorkqueuePaneItemsByScope(pane, items) {
   });
 }
 
+function getWorkqueuePaneStatusLabels(pane) {
+  const statuses = Array.isArray(pane?.workqueue?.statusFilter) ? pane.workqueue.statusFilter : [];
+  return statuses.map((status) => formatWorkqueueStatusLabel(status));
+}
+
+function renderWorkqueuePaneFilterSummary(pane, { filteredCount = 0, totalCount = 0 } = {}) {
+  const root = pane?.elements?.thread?.querySelector?.('[data-wq-filter-summary]');
+  if (!root) return;
+
+  const queue = String(pane.workqueue?.queue || '').trim() || 'dev-team';
+  const scope = normalizeWorkqueueScope(pane.workqueue?.scopeFilter || 'all');
+  const quick = pane.workqueue?.quickFilters || {};
+  const sources = Array.isArray(quick.sources) ? quick.sources.map((x) => String(x || '').trim()).filter(Boolean) : [];
+  const repos = Array.isArray(quick.repos) ? quick.repos.map((x) => String(x || '').trim()).filter(Boolean) : [];
+  const statusLabels = getWorkqueuePaneStatusLabels(pane);
+  const hasAnyFilter = Boolean(queue || scope || statusLabels.length || sources.length || repos.length);
+  const pluralBase = hasAnyFilter ? totalCount : filteredCount;
+  const plural = pluralBase === 1 ? 'item' : 'items';
+
+  root.innerHTML = '';
+  root.hidden = false;
+
+  const count = document.createElement('div');
+  count.className = 'wq-filter-count';
+  count.setAttribute('data-wq-filter-count', '');
+  count.textContent = hasAnyFilter
+    ? `Showing ${filteredCount} of ${totalCount} ${plural}`
+    : `Showing ${filteredCount} ${plural}`;
+  root.appendChild(count);
+
+  if (!hasAnyFilter) return;
+
+  const chips = document.createElement('div');
+  chips.className = 'wq-filter-chips';
+  chips.setAttribute('aria-label', 'Active workqueue pane filters');
+
+  const refresh = () => {
+    pane.workqueue.renderLimit = WORKQUEUE_PANE_INITIAL_RENDER_LIMIT;
+    pane.workqueue.statusCounts = buildWorkqueueStatusCounts(filterWorkqueuePaneItemsByScope(pane, pane.workqueue.countItems));
+    if (typeof pane.workqueue.renderStatusMultiSelect === 'function') pane.workqueue.renderStatusMultiSelect();
+    renderWorkqueuePaneItems(pane);
+    paneManager.persistAdminPanes();
+  };
+
+  const addChip = ({ label, onRemove }) => {
+    const chip = document.createElement('button');
+    chip.type = 'button';
+    chip.className = 'wq-filter-chip';
+    chip.textContent = label;
+    chip.setAttribute('aria-label', `Clear ${label}`);
+    chip.addEventListener('click', onRemove);
+    chips.appendChild(chip);
+  };
+
+  addChip({ label: `Queue: ${queue}`, onRemove: () => {} });
+  addChip({
+    label: `Scope: ${scope === 'assigned' ? 'Assigned' : scope === 'unassigned' ? 'Unassigned' : 'All'}`,
+    onRemove: () => {
+      if (typeof pane.workqueue.applyScopeFilter === 'function') pane.workqueue.applyScopeFilter('all');
+      else {
+        pane.workqueue.scopeFilter = 'all';
+        storage.set(WORKQUEUE_SCOPE_PREF_KEY, 'all');
+        refresh();
+      }
+    }
+  });
+  addChip({
+    label: `Statuses: ${statusLabels.length ? statusLabels.join(', ') : 'None'}`,
+    onRemove: () => {
+      if (typeof pane.workqueue.applyStatusFilter === 'function') pane.workqueue.applyStatusFilter(Array.from(WORKQUEUE_STATUSES));
+      else {
+        pane.workqueue.statusFilter = Array.from(WORKQUEUE_STATUSES);
+        refresh();
+        fetchAndRenderWorkqueueItemsForPane(pane);
+      }
+    }
+  });
+
+  if (sources.length) {
+    addChip({
+      label: `Source: ${sources.join(', ')}`,
+      onRemove: () => {
+        const next = { sources: [], repos };
+        if (typeof pane.workqueue.applyQuickFilters === 'function') pane.workqueue.applyQuickFilters(next);
+        else {
+          pane.workqueue.quickFilters = next;
+          refresh();
+        }
+      }
+    });
+  }
+
+  if (repos.length) {
+    addChip({
+      label: `Repo: ${repos.join(', ')}`,
+      onRemove: () => {
+        const next = { sources, repos: [] };
+        if (typeof pane.workqueue.applyQuickFilters === 'function') pane.workqueue.applyQuickFilters(next);
+        else {
+          pane.workqueue.quickFilters = next;
+          refresh();
+        }
+      }
+    });
+  }
+
+  const clearAll = document.createElement('button');
+  clearAll.type = 'button';
+  clearAll.className = 'wq-filter-clear';
+  clearAll.textContent = 'Clear all filters';
+  clearAll.addEventListener('click', () => {
+    if (typeof pane.workqueue.applyScopeFilter === 'function') pane.workqueue.applyScopeFilter('all');
+    if (typeof pane.workqueue.applyQuickFilters === 'function') pane.workqueue.applyQuickFilters({ sources: [], repos: [] });
+    if (typeof pane.workqueue.applyStatusFilter === 'function') pane.workqueue.applyStatusFilter(Array.from(WORKQUEUE_STATUSES));
+    if (typeof pane.workqueue.applyScopeFilter !== 'function' || typeof pane.workqueue.applyQuickFilters !== 'function' || typeof pane.workqueue.applyStatusFilter !== 'function') {
+      pane.workqueue.scopeFilter = 'all';
+      pane.workqueue.statusFilter = Array.from(WORKQUEUE_STATUSES);
+      pane.workqueue.quickFilters = { sources: [], repos: [] };
+      storage.set(WORKQUEUE_SCOPE_PREF_KEY, 'all');
+      refresh();
+      fetchAndRenderWorkqueueItemsForPane(pane);
+    }
+  });
+  chips.appendChild(clearAll);
+  root.appendChild(chips);
+}
+
 function renderWorkqueueDuplicateHealthForPane(pane) {
   const root = pane?.elements?.thread?.querySelector?.('[data-wq-duplicate-health]');
   if (!root) return;
@@ -4430,6 +4557,8 @@ function renderWorkqueuePaneItems(pane) {
   const scopedItems = filterWorkqueuePaneItemsByScope(pane, pane.workqueue?.items);
   const filteredItems = applyWorkqueueQuickFilters(scopedItems, pane.workqueue?.quickFilters);
   const items = sortWorkqueueItems(filteredItems, { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
+  const totalItems = Array.isArray(pane.workqueue?.countItems) ? pane.workqueue.countItems.length : filteredItems.length;
+  renderWorkqueuePaneFilterSummary(pane, { filteredCount: filteredItems.length, totalCount: totalItems });
   const renderLimit = Math.max(
     WORKQUEUE_PANE_INITIAL_RENDER_LIMIT,
     Number(pane.workqueue?.renderLimit || WORKQUEUE_PANE_INITIAL_RENDER_LIMIT)
@@ -6736,6 +6865,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         </details>
 
         <div class="hint" data-wq-statusline></div>
+        <div class="wq-filter-summary" data-wq-filter-summary aria-live="polite" hidden></div>
         <div class="wq-duplicate-health" data-wq-duplicate-health aria-live="polite" hidden></div>
       </div>
 
@@ -6847,6 +6977,23 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       }
     };
 
+    pane.workqueue.applyQuickFilters = (next = {}) => {
+      sourceSet.clear();
+      repoSet.clear();
+      for (const source of Array.isArray(next.sources) ? next.sources : []) {
+        const key = String(source || '').trim();
+        if (key) sourceSet.add(key);
+      }
+      for (const repo of Array.isArray(next.repos) ? next.repos : []) {
+        const key = String(repo || '').trim();
+        if (key) repoSet.add(key);
+      }
+      resetRenderLimit();
+      persistQuickFilters();
+      updateQuickFilterUi();
+      renderWorkqueuePaneItems(pane);
+    };
+
     const applyStatuses = async (next, { closeMenu = false } = {}) => {
       statusSet.clear();
       for (const s of next) statusSet.add(s);
@@ -6858,6 +7005,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       updateQuickFilterUi();
       paneManager.persistAdminPanes();
     };
+    pane.workqueue.applyStatusFilter = applyStatuses;
 
     const doRefresh = async () => {
       const q = getQueueValue() || 'dev-team';
@@ -7075,6 +7223,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       renderWorkqueuePaneItems(pane);
       paneManager.persistAdminPanes();
     };
+    pane.workqueue.applyScopeFilter = setScope;
     scopeBtns.forEach((btn) => {
       btn.addEventListener('click', () => setScope(btn.getAttribute('data-wq-scope')));
     });

--- a/app.js
+++ b/app.js
@@ -59,6 +59,7 @@ const globalElements = {
   workqueueCloseBtn: document.getElementById('workqueueCloseBtn'),
   wqQueueSelect: document.getElementById('wqQueueSelect'),
   wqStatusFilters: document.getElementById('wqStatusFilters'),
+  wqFilterSummary: document.getElementById('wqFilterSummary'),
   wqAutoRefreshEnabled: document.getElementById('wqAutoRefreshEnabled'),
   wqAutoRefreshInterval: document.getElementById('wqAutoRefreshInterval'),
   wqRefreshBtn: document.getElementById('wqRefreshBtn'),
@@ -3465,6 +3466,7 @@ const workqueueState = {
   statusFilter: new Set(['ready', 'pending', 'claimed', 'in_progress']),
   statusCounts: Object.fromEntries(WORKQUEUE_STATUSES.map((s) => [s, 0])),
   items: [],
+  totalItemsCount: 0,
   selectedItemId: null,
   sortKey: 'default',
   sortDir: 'desc',
@@ -3510,6 +3512,94 @@ function renderWorkqueueStatusFilters() {
     });
     root.appendChild(label);
   }
+}
+
+function getWorkqueueActiveStatusLabels() {
+  return WORKQUEUE_STATUSES
+    .filter((status) => workqueueState.statusFilter.has(status))
+    .map((status) => formatWorkqueueStatusLabel(status));
+}
+
+function isWorkqueueStatusFilterActive() {
+  if (workqueueState.statusFilter.size !== WORKQUEUE_STATUSES.length) return true;
+  return WORKQUEUE_STATUSES.some((status) => !workqueueState.statusFilter.has(status));
+}
+
+function resetWorkqueueStatusFilter() {
+  workqueueState.statusFilter = new Set(WORKQUEUE_STATUSES);
+}
+
+function renderWorkqueueFilterSummary({ filteredCount = 0, totalCount = 0 } = {}) {
+  const root = globalElements.wqFilterSummary;
+  if (!root) return;
+
+  const queue = String(workqueueState.selectedQueue || '').trim();
+  const hasStatusFilter = isWorkqueueStatusFilterActive();
+  const hasQueueFilter = Boolean(queue);
+  const hasAnyFilter = hasQueueFilter || hasStatusFilter;
+  const pluralCount = hasAnyFilter ? totalCount : filteredCount;
+  const plural = pluralCount === 1 ? 'item' : 'items';
+  const countText = hasAnyFilter
+    ? `Showing ${filteredCount} of ${totalCount} ${plural}`
+    : `Showing ${filteredCount} ${plural}`;
+
+  root.innerHTML = '';
+  root.hidden = false;
+
+  const count = document.createElement('div');
+  count.className = 'wq-filter-count';
+  count.setAttribute('data-wq-filter-count', '');
+  count.textContent = countText;
+  root.appendChild(count);
+
+  if (!hasAnyFilter) return;
+
+  const chips = document.createElement('div');
+  chips.className = 'wq-filter-chips';
+  chips.setAttribute('aria-label', 'Active workqueue filters');
+
+  const addChip = ({ label, onRemove }) => {
+    const chip = document.createElement('button');
+    chip.type = 'button';
+    chip.className = 'wq-filter-chip';
+    chip.textContent = label;
+    chip.setAttribute('aria-label', `Clear ${label}`);
+    chip.addEventListener('click', onRemove);
+    chips.appendChild(chip);
+  };
+
+  if (hasQueueFilter) {
+    addChip({
+      label: `Queue: ${queue}`,
+      onRemove: () => {
+        workqueueState.selectedQueue = '';
+        if (globalElements.wqQueueSelect) globalElements.wqQueueSelect.value = '';
+        fetchAndRenderWorkqueueItems();
+      }
+    });
+  }
+
+  if (hasStatusFilter) {
+    const labels = getWorkqueueActiveStatusLabels();
+    addChip({
+      label: `Statuses: ${labels.length ? labels.join(', ') : 'None'}`,
+      onRemove: () => {
+        resetWorkqueueStatusFilter();
+        fetchAndRenderWorkqueueItems();
+      }
+    });
+  }
+
+  const clearAll = document.createElement('button');
+  clearAll.type = 'button';
+  clearAll.className = 'wq-filter-clear';
+  clearAll.textContent = 'Clear all filters';
+  clearAll.addEventListener('click', () => {
+    resetWorkqueueStatusFilter();
+    fetchAndRenderWorkqueueItems();
+  });
+  chips.appendChild(clearAll);
+  root.appendChild(chips);
 }
 
 function ensureWorkqueueModalSorting() {
@@ -3647,6 +3737,7 @@ async function fetchAndRenderWorkqueueItems() {
     }
 
     workqueueState.items = items;
+    workqueueState.totalItemsCount = countItems.length;
     workqueueState.statusCounts = buildWorkqueueStatusCounts(countItems);
     renderWorkqueueStatusFilters();
     renderWorkqueueItems();
@@ -3713,6 +3804,7 @@ function renderWorkqueueItems() {
 
   const itemsRaw = Array.isArray(workqueueState.items) ? workqueueState.items : [];
   const items = sortWorkqueueItems(itemsRaw, { sortKey: workqueueState.sortKey, sortDir: workqueueState.sortDir });
+  renderWorkqueueFilterSummary({ filteredCount: itemsRaw.length, totalCount: Number(workqueueState.totalItemsCount || itemsRaw.length) });
 
   if (!items.length) {
     globalElements.wqListEmpty.hidden = false;

--- a/index.html
+++ b/index.html
@@ -335,6 +335,8 @@
             <button id="wqRefreshBtn" class="secondary" type="button">Refresh</button>
           </div>
 
+          <div id="wqFilterSummary" class="wq-filter-summary" aria-live="polite" hidden></div>
+
           <div class="wq-actions" aria-label="Workqueue actions">
             <div class="wq-actions-row">
               <div class="wq-action-card">

--- a/styles.css
+++ b/styles.css
@@ -2007,6 +2007,52 @@ kbd {
   accent-color: var(--accent);
 }
 
+.wq-filter-summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin: 0 0 12px;
+  padding: 10px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.wq-filter-count {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.wq-filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.wq-filter-chip,
+.wq-filter-clear {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  padding: 5px 9px;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.06);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.wq-filter-chip::after {
+  content: " x";
+  color: var(--muted);
+}
+
+.wq-filter-clear {
+  color: var(--muted);
+  background: transparent;
+}
+
 .wq-layout {
   display: grid;
   grid-template-columns: 1.2fr 0.8fr;

--- a/tests/ui/workqueue-modal.spec.js
+++ b/tests/ui/workqueue-modal.spec.js
@@ -37,11 +37,16 @@ test('workqueue modal: status filters use human labels and queue-scoped counts',
       }
     });
     expect(res.ok()).toBeTruthy();
+    return await res.json();
   };
 
   await enqueue('dev-team', 'dev item');
-  await enqueue('qa-team', 'qa item one');
+  const qaOne = await enqueue('qa-team', 'qa item one');
   await enqueue('qa-team', 'qa item two');
+  const updateRes = await page.request.post(`${baseUrl}/api/workqueue/update`, {
+    data: { itemId: qaOne.item.id, patch: { status: 'done' } }
+  });
+  expect(updateRes.ok()).toBeTruthy();
 
   await page.evaluate(() => window.openWorkqueue?.());
   await expect(page.locator('#workqueueModal')).toHaveClass(/open/);
@@ -67,7 +72,22 @@ test('workqueue modal: status filters use human labels and queue-scoped counts',
   const queueSelect = page.locator('#wqQueueSelect');
   await queueSelect.selectOption('dev-team');
   await expect(page.locator('#wqStatusFilters .wq-status-chip', { hasText: 'Ready (1)' })).toHaveCount(1);
+  await expect(page.locator('[data-wq-filter-count]')).toHaveText('Showing 1 of 1 item');
+  await expect(page.locator('#wqFilterSummary .wq-filter-chip', { hasText: 'Queue: dev-team' })).toHaveCount(1);
+  await expect(page.locator('#wqFilterSummary .wq-filter-chip', { hasText: 'Statuses: Ready, Pending, Claimed, In progress' })).toHaveCount(1);
 
   await queueSelect.selectOption('qa-team');
-  await expect(page.locator('#wqStatusFilters .wq-status-chip', { hasText: 'Ready (2)' })).toHaveCount(1);
+  await expect(page.locator('#wqStatusFilters .wq-status-chip', { hasText: 'Ready (1)' })).toHaveCount(1);
+  await expect(page.locator('#wqStatusFilters .wq-status-chip', { hasText: 'Done (1)' })).toHaveCount(1);
+  await expect(page.locator('[data-wq-filter-count]')).toHaveText('Showing 1 of 2 items');
+
+  await page.locator('#wqFilterSummary .wq-filter-chip', { hasText: 'Statuses:' }).click();
+  await expect(page.locator('[data-wq-filter-count]')).toHaveText('Showing 2 of 2 items');
+  await expect(page.locator('#wqFilterSummary .wq-filter-chip', { hasText: 'Statuses:' })).toHaveCount(0);
+
+  await page.locator('#wqStatusFilters input').first().setChecked(false);
+  await expect(page.locator('#wqFilterSummary .wq-filter-chip', { hasText: 'Statuses:' })).toHaveCount(1);
+  await page.locator('#wqFilterSummary .wq-filter-clear').click();
+  await expect(queueSelect).toHaveValue('qa-team');
+  await expect(page.locator('[data-wq-filter-count]')).toHaveText('Showing 2 of 2 items');
 });

--- a/tests/ui/workqueue-modal.spec.js
+++ b/tests/ui/workqueue-modal.spec.js
@@ -72,22 +72,22 @@ test('workqueue modal: status filters use human labels and queue-scoped counts',
   const queueSelect = page.locator('#wqQueueSelect');
   await queueSelect.selectOption('dev-team');
   await expect(page.locator('#wqStatusFilters .wq-status-chip', { hasText: 'Ready (1)' })).toHaveCount(1);
-  await expect(page.locator('[data-wq-filter-count]')).toHaveText('Showing 1 of 1 item');
+  await expect(page.locator('#wqFilterSummary [data-wq-filter-count]')).toHaveText('Showing 1 of 1 item');
   await expect(page.locator('#wqFilterSummary .wq-filter-chip', { hasText: 'Queue: dev-team' })).toHaveCount(1);
   await expect(page.locator('#wqFilterSummary .wq-filter-chip', { hasText: 'Statuses: Ready, Pending, Claimed, In progress' })).toHaveCount(1);
 
   await queueSelect.selectOption('qa-team');
   await expect(page.locator('#wqStatusFilters .wq-status-chip', { hasText: 'Ready (1)' })).toHaveCount(1);
   await expect(page.locator('#wqStatusFilters .wq-status-chip', { hasText: 'Done (1)' })).toHaveCount(1);
-  await expect(page.locator('[data-wq-filter-count]')).toHaveText('Showing 1 of 2 items');
+  await expect(page.locator('#wqFilterSummary [data-wq-filter-count]')).toHaveText('Showing 1 of 2 items');
 
   await page.locator('#wqFilterSummary .wq-filter-chip', { hasText: 'Statuses:' }).click();
-  await expect(page.locator('[data-wq-filter-count]')).toHaveText('Showing 2 of 2 items');
+  await expect(page.locator('#wqFilterSummary [data-wq-filter-count]')).toHaveText('Showing 2 of 2 items');
   await expect(page.locator('#wqFilterSummary .wq-filter-chip', { hasText: 'Statuses:' })).toHaveCount(0);
 
   await page.locator('#wqStatusFilters input').first().setChecked(false);
   await expect(page.locator('#wqFilterSummary .wq-filter-chip', { hasText: 'Statuses:' })).toHaveCount(1);
   await page.locator('#wqFilterSummary .wq-filter-clear').click();
   await expect(queueSelect).toHaveValue('qa-team');
-  await expect(page.locator('[data-wq-filter-count]')).toHaveText('Showing 2 of 2 items');
+  await expect(page.locator('#wqFilterSummary [data-wq-filter-count]')).toHaveText('Showing 2 of 2 items');
 });

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -340,11 +340,22 @@ test('workqueue pane: source chips + clawnsole preset filter items without reloa
   await enqueue('[ROUTINE] speechee routine item', 'https://github.com/rmdmattingly/speechee/pull/37');
 
   await pane.locator('[data-wq-refresh]').click();
+  await pane.locator('[data-wq-scope="all"]').click();
   await expect(pane.locator('.wq-row')).toHaveCount(2);
+  await expect(pane.locator('[data-wq-filter-count]')).toHaveText('Showing 2 of 2 items');
+  await expect(pane.locator('[data-wq-filter-summary] .wq-filter-chip', { hasText: 'Queue: dev-team' })).toHaveCount(1);
+  await expect(pane.locator('[data-wq-filter-summary] .wq-filter-chip', { hasText: 'Scope: All' })).toHaveCount(1);
+  await expect(pane.locator('[data-wq-filter-summary] .wq-filter-chip', { hasText: 'Statuses:' })).toHaveCount(1);
 
   await pane.locator('[data-wq-source="issue"]').click();
   await expect(pane.locator('.wq-row')).toHaveCount(1);
   await expect(pane.locator('.wq-row .wq-col.title')).toContainText(/clawnsole issue item/i);
+  await expect(pane.locator('[data-wq-filter-count]')).toHaveText('Showing 1 of 2 items');
+  await expect(pane.locator('[data-wq-filter-summary] .wq-filter-chip', { hasText: 'Source: issue' })).toHaveCount(1);
+
+  await pane.locator('[data-wq-filter-summary] .wq-filter-chip', { hasText: 'Source: issue' }).click();
+  await expect(pane.locator('.wq-row')).toHaveCount(2);
+  await expect(pane.locator('[data-wq-filter-summary] .wq-filter-chip', { hasText: 'Source:' })).toHaveCount(0);
 
   await pane.locator('[data-wq-clear-quick]').click();
   await expect(pane.locator('.wq-row')).toHaveCount(2);
@@ -352,6 +363,12 @@ test('workqueue pane: source chips + clawnsole preset filter items without reloa
   await pane.locator('[data-wq-preset-clawnsole]').click();
   await expect(pane.locator('.wq-row')).toHaveCount(1);
   await expect(pane.locator('.wq-row .wq-col.title')).toContainText(/clawnsole issue item/i);
+  await expect(pane.locator('[data-wq-filter-summary] .wq-filter-chip', { hasText: 'Repo: rmdmattingly/clawnsole' })).toHaveCount(1);
+
+  await pane.locator('[data-wq-filter-summary] .wq-filter-clear').click();
+  await expect(pane.locator('[data-wq-queue-select]')).toHaveValue('dev-team');
+  await expect(pane.locator('.wq-row')).toHaveCount(2);
+  await expect(pane.locator('[data-wq-filter-count]')).toHaveText('Showing 2 of 2 items');
 });
 
 test('workqueue pane: normalizes mixed legacy issue title prefixes', async ({ page }) => {


### PR DESCRIPTION
## Summary
- add a compact Workqueue modal filter summary with contextual "Showing X of Y items" wording
- render removable queue/status chips and a clear-all action that preserves the selected queue
- extend Workqueue modal Playwright coverage for summary counts and chip removal

## Tests
- npm test
- npx playwright test tests/ui/workqueue-modal.spec.js

Refs #323