### PR TITLE
Add Fleet freshness stale indicators

### DIFF
--- a/app.js
+++ b/app.js
@@ -297,6 +297,7 @@ const ADMIN_AGENT_DENSITY_KEY = 'clawnsole.admin.agents.density';
 const ADMIN_AGENT_COLUMNS_KEY = 'clawnsole.admin.agents.columns';
 const ADMIN_AGENT_HEALTHY_COLLAPSED_KEY = 'clawnsole.admin.agents.healthyCollapsed';
 const ADMIN_AGENT_HEALTHY_COLLAPSE_THRESHOLD = 10;
+const ADMIN_AGENT_STALE_THRESHOLD_MS = 60_000;
 const FLEET_COLUMN_DEFS = [
   { key: 'id', label: 'Agent id', defaultVisible: true },
   { key: 'health', label: 'Health', defaultVisible: true },
@@ -1060,6 +1061,7 @@ let agentAutoRefreshInterval = null;
 let agentsModalAutoRefreshInterval = null;
 let agentsModalFreshnessTicker = null;
 let agentsLastRefreshedAtMs = 0;
+let agentsLastRefreshFailedAtMs = 0;
 const fleetRefreshLock = {
   lockedAtMs: 0,
   pointerInsideRow: false,
@@ -1180,10 +1182,16 @@ function formatRelativeAge(msAgo) {
 function renderAgentsLastRefreshed() {
   if (!globalElements.agentsLastRefreshed) return;
   if (!agentsLastRefreshedAtMs) {
-    globalElements.agentsLastRefreshed.textContent = 'Last refreshed: never';
+    globalElements.agentsLastRefreshed.textContent = 'Last updated: never';
+    globalElements.agentsLastRefreshed.dataset.freshness = 'unknown';
     return;
   }
-  globalElements.agentsLastRefreshed.textContent = `Last refreshed: ${formatRelativeAge(Date.now() - agentsLastRefreshedAtMs)}`;
+  const ageMs = Date.now() - agentsLastRefreshedAtMs;
+  const isStale = agentsLastRefreshFailedAtMs > agentsLastRefreshedAtMs || ageMs > ADMIN_AGENT_STALE_THRESHOLD_MS;
+  globalElements.agentsLastRefreshed.dataset.freshness = isStale ? 'stale' : 'fresh';
+  globalElements.agentsLastRefreshed.textContent = isStale
+    ? `Stale · ${formatRelativeAge(ageMs)}`
+    : `Last updated: ${formatRelativeAge(ageMs)}`;
 }
 
 function startAgentsModalAutoRefresh() {
@@ -1241,6 +1249,8 @@ async function refreshAgents({ reason = 'manual', showSuccessToast = false } = {
     }
 
     if (!Array.isArray(next) || next.length === 0) {
+      agentsLastRefreshFailedAtMs = Date.now();
+      renderAgentsLastRefreshed();
       if (prev.length > 0) {
         showToast('Agent refresh failed; showing last-known list.', { kind: 'error', timeoutMs: 3500 });
         return prev;
@@ -1251,6 +1261,7 @@ async function refreshAgents({ reason = 'manual', showSuccessToast = false } = {
 
     uiState.agents = next;
     agentsLastRefreshedAtMs = Date.now();
+    agentsLastRefreshFailedAtMs = 0;
     renderAgentsLastRefreshed();
 
     // Preserve UI state (selected agent per pane).
@@ -5051,7 +5062,8 @@ function renderAgentsModalList() {
       const label = formatAgentLabel(agent, { includeId: true });
       const pinnedNow = pins.has(id);
       const heartbeatTs = Number(lastSeenMap[id]) || 0;
-      const heartbeatAge = heartbeatTs > 0 ? formatRelativeAge(Date.now() - heartbeatTs) : 'unknown';
+      const heartbeatAgeMs = heartbeatTs > 0 ? Math.max(0, Date.now() - heartbeatTs) : Number.POSITIVE_INFINITY;
+      const heartbeatAge = heartbeatTs > 0 ? formatRelativeAge(heartbeatAgeMs) : 'unknown';
       const triage = classify(id);
       const healthLabel = triage.bucket === 'offline_error'
         ? 'Offline/Error'
@@ -5059,10 +5071,13 @@ function renderAgentsModalList() {
           ? 'Stale'
           : 'Healthy';
       const heatBucketLabel = heartbeatAgeBucketLabel(triage.ageBucket);
+      const rowFreshness = heartbeatAgeMs > ADMIN_AGENT_STALE_THRESHOLD_MS ? 'stale' : 'fresh';
+      const freshnessLabel = rowFreshness === 'stale' ? 'stale telemetry' : 'fresh telemetry';
       const statusSnippet = String(statusSnippetMap[id] || '').trim();
       const statusSnippetHtml = visibleColumns.status && statusSnippet
         ? `<span class="agents-status-snippet" data-fleet-column="status">${escapeHtml(statusSnippet)}</span>`
         : '';
+      const staleBadgeHtml = rowFreshness === 'stale' ? '<span class="agents-stale-badge">Stale</span>' : '';
       const model = String(agent?.model || '').trim();
       const host = String(agent?.host || '').trim();
       const modelHtml = visibleColumns.model && model
@@ -5092,6 +5107,8 @@ function renderAgentsModalList() {
         : '';
       row.dataset.heartbeatBucket = triage.ageBucket;
       row.dataset.healthState = triage.bucket;
+      row.dataset.freshness = rowFreshness;
+      row.setAttribute('aria-label', `${label}, ${freshnessLabel}, heartbeat ${heartbeatAge}`);
       row.classList.toggle('agents-row-heatmap', heatmapEnabled);
       row.classList.toggle('agents-row-no-actions', !visibleColumns.actions);
 
@@ -5106,7 +5123,7 @@ function renderAgentsModalList() {
         </div>
         <div class="agents-row-meta">
             ${visibleColumns.heartbeat ? `<span class="agents-age-chip" data-fleet-column="heartbeat" data-heartbeat-bucket="${escapeHtml(triage.ageBucket)}" title="Heartbeat age: ${escapeHtml(heartbeatAge)} (${escapeHtml(heatBucketLabel)})">${escapeHtml(heartbeatAge)}</span>` : ''}
-            ${visibleColumns.heartbeatDetail ? `<span class="agents-age-label" data-fleet-column="heartbeatDetail">${escapeHtml(heatBucketLabel)}</span>` : ''}${statusSnippetHtml}${modelHtml}${hostHtml}
+            ${visibleColumns.heartbeatDetail ? `<span class="agents-age-label" data-fleet-column="heartbeatDetail">${escapeHtml(heatBucketLabel)}</span>` : ''}${staleBadgeHtml}${statusSnippetHtml}${modelHtml}${hostHtml}
         </div>
         ${rowActionsHtml}
       `;
@@ -11537,6 +11554,13 @@ globalElements.agentsModal?.addEventListener('keydown', (event) => {
     if (key === 'Enter') {
       event.preventDefault();
       runFleetSelectedAgent(event.shiftKey ? 'workqueue' : 'chat');
+      return;
+    }
+    if (lower === 'r') {
+      event.preventDefault();
+      refreshAgents({ reason: 'fleet_key_refresh', showSuccessToast: true }).catch(() => {
+        showToast('Agent refresh failed.', { kind: 'error', timeoutMs: 3500 });
+      });
       return;
     }
   }

--- a/styles.css
+++ b/styles.css
@@ -1723,6 +1723,10 @@ button.send-btn .btn-icon {
   color: var(--muted);
 }
 
+.agents-last-refreshed[data-freshness="stale"] {
+  color: #ffc76e;
+}
+
 .agents-refresh-paused {
   display: inline-flex;
   align-items: center;
@@ -2049,6 +2053,10 @@ button.agents-section-title:hover {
   outline-offset: 2px;
 }
 
+.agents-row[data-freshness="stale"] {
+  border-color: rgba(255, 199, 70, 0.24);
+}
+
 .agents-row-heatmap {
   border-left-width: 4px;
 }
@@ -2195,6 +2203,19 @@ button.agents-section-title:hover {
 
 .agents-age-chip[data-heartbeat-bucket="critical"] {
   border-color: rgba(255, 93, 116, 0.66);
+}
+
+.agents-stale-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 18px;
+  margin-left: 6px;
+  padding: 1px 6px;
+  border: 1px solid rgba(255, 199, 70, 0.42);
+  border-radius: 999px;
+  color: #ffc76e;
+  font-size: 11px;
+  line-height: 1.2;
 }
 
 .agents-age-label {

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -65,13 +65,37 @@ test('agents modal renders pinned agents in a dedicated top section after reload
 test('agents modal shows live refresh freshness indicators', async ({ page, clawnsole }) => {
   if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
 
+  let requestCount = 0;
+  await page.route(/\/agents(?:\?|$)/, async (route) => {
+    requestCount += 1;
+    await route.fulfill({
+      json: {
+        agents: [
+          { id: 'fresh-agent', name: 'fresh-agent', displayName: 'Fresh Agent' },
+          { id: 'stale-agent', name: 'stale-agent', displayName: 'Stale Agent' }
+        ]
+      }
+    });
+  });
   await clawnsole.gotoAndLoginAdmin(page);
+  await page.evaluate(() => {
+    localStorage.setItem('clawnsole.admin.agentLastSeenAtMs', JSON.stringify({
+      'fresh-agent': Date.now(),
+      'stale-agent': Date.now() - 65_000
+    }));
+  });
 
   await page.getByRole('button', { name: 'Open agents' }).click();
   await expect(page.locator('#agentsModal')).toHaveClass(/open/);
 
-  await expect(page.locator('#agentsLastRefreshed')).toContainText('Last refreshed:');
-  await expect(page.locator('#agentsList .agents-row-meta').first()).toContainText(/\d+[smhd]/);
+  await expect(page.locator('#agentsLastRefreshed')).toContainText('Last updated:');
+  const staleRow = page.locator('#agentsList .agents-row').filter({ hasText: 'Stale Agent' });
+  await expect(staleRow).toHaveAttribute('data-freshness', 'stale');
+  await expect(staleRow.locator('.agents-stale-badge')).toHaveText('Stale');
+
+  await page.locator('#agentsSearch').blur();
+  await page.keyboard.press('r');
+  await expect.poll(() => requestCount).toBeGreaterThan(1);
 });
 
 test('agents modal defers auto-refresh while a fleet row is active, then catches up once', async ({ page, clawnsole }) => {


### PR DESCRIPTION
## Summary
- Show Fleet freshness as Last updated vs explicit Stale when data is older than 60s or refresh fails
- Add stale row styling/badge and screen-reader row freshness labels for stale telemetry
- Add one-key Fleet refresh via r, with existing button parity

## Tests
- npm test
- npx playwright test tests/ui/agents-modal.spec.js --workers=1

Fixes #301