### PR TITLE
Add labeled header controls setting

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,6 +19,7 @@ const globalElements = {
   recurringPromptHistoryRows: document.getElementById('recurringPromptHistoryRows'),
   recurringPromptHistoryEmpty: document.getElementById('recurringPromptHistoryEmpty'),
   status: document.getElementById('connectionStatus'),
+  topbar: document.getElementById('topbar'),
   paneManagerBtn: document.getElementById('paneManagerBtn'),
   pulseCanvas: document.getElementById('pulseCanvas'),
   workqueueBtn: document.getElementById('workqueueBtn'),
@@ -78,6 +79,7 @@ const globalElements = {
   settingsModal: document.getElementById('settingsModal'),
   settingsCloseBtn: document.getElementById('settingsCloseBtn'),
   paneSwitchHudEnabled: document.getElementById('paneSwitchHudEnabled'),
+  labeledHeaderControlsEnabled: document.getElementById('labeledHeaderControlsEnabled'),
   rolePill: document.getElementById('rolePill'),
   loginOverlay: document.getElementById('loginOverlay'),
   loginPassword: document.getElementById('loginPassword'),
@@ -257,6 +259,7 @@ const ADMIN_AUTH_DESTINATION_KEY = 'clawnsole.admin.authDestination.v1';
 const ADMIN_AUTH_RESTORE_PENDING_KEY = 'clawnsole.admin.authRestorePending.v1';
 const ADMIN_AUTH_RESTORE_NOTICE_KEY = 'clawnsole.admin.authRestoreNotice.v1';
 const PANE_SWITCH_HUD_ENABLED_KEY = 'clawnsole.admin.paneSwitchHud.enabled';
+const LABELED_HEADER_CONTROLS_ENABLED_KEY = 'clawnsole.admin.labeledHeaderControls.enabled';
 const ADMIN_AUTH_DESTINATION_TTL_MS = 10 * 60 * 1000;
 const WQ_RECENT_TARGETS_KEY = 'clawnsole.wq.recentTargets';
 const WQ_RECENT_ENQUEUE_AGENTS_KEY = 'clawnsole.wq.recentEnqueueAgents';
@@ -1390,6 +1393,9 @@ function openSettings() {
   if (globalElements.paneSwitchHudEnabled) {
     globalElements.paneSwitchHudEnabled.checked = isPaneSwitchHudEnabled();
   }
+  if (globalElements.labeledHeaderControlsEnabled) {
+    globalElements.labeledHeaderControlsEnabled.checked = isLabeledHeaderControlsEnabled();
+  }
   globalElements.settingsModal.classList.add('open');
   globalElements.settingsModal.setAttribute('aria-hidden', 'false');
 
@@ -1815,6 +1821,14 @@ function paneSummaryLabel(pane) {
 
 function isPaneSwitchHudEnabled() {
   return String(storage.get(PANE_SWITCH_HUD_ENABLED_KEY, '1') || '1') !== '0';
+}
+
+function isLabeledHeaderControlsEnabled() {
+  return String(storage.get(LABELED_HEADER_CONTROLS_ENABLED_KEY, '0') || '0') === '1';
+}
+
+function applyLabeledHeaderControls(enabled = isLabeledHeaderControlsEnabled()) {
+  globalElements.topbar?.classList.toggle('labeled-header-controls', !!enabled);
 }
 
 let paneSwitchHudHideTimer = null;
@@ -8358,6 +8372,11 @@ globalElements.settingsModal?.addEventListener('click', (event) => {
 globalElements.paneSwitchHudEnabled?.addEventListener('change', () => {
   storage.set(PANE_SWITCH_HUD_ENABLED_KEY, globalElements.paneSwitchHudEnabled.checked ? '1' : '0');
 });
+globalElements.labeledHeaderControlsEnabled?.addEventListener('change', () => {
+  const enabled = !!globalElements.labeledHeaderControlsEnabled.checked;
+  storage.set(LABELED_HEADER_CONTROLS_ENABLED_KEY, enabled ? '1' : '0');
+  applyLabeledHeaderControls(enabled);
+});
 
 globalElements.shortcutsBtn?.addEventListener('click', () => openShortcuts());
 globalElements.shortcutsCloseBtn?.addEventListener('click', () => closeShortcuts());
@@ -9217,6 +9236,8 @@ globalElements.addQueuePaneBtn?.addEventListener('click', (event) => {
 });
 
 // layoutSelect deprecated; layout is inferred from pane count.
+
+applyLabeledHeaderControls();
 
 window.addEventListener('online', () => {
   paneManager.connectIfNeeded();

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
   </head>
   <body>
     <div class="app">
-      <header class="topbar minimal">
+      <header id="topbar" class="topbar minimal">
         <div class="brand compact">
           <div class="brand-mark"></div>
           <div>
@@ -42,7 +42,7 @@
           </div>
           <div id="paneControls" class="pane-controls" hidden>
             <div class="pane-add-wrap">
-              <button id="addPaneBtn" class="icon-btn action-btn" type="button" aria-haspopup="menu" aria-expanded="false" aria-label="Add pane" title="Add Pane (Ctrl/Cmd+Shift+N)" data-testid="add-pane-btn">
+              <button id="addPaneBtn" class="icon-btn action-btn topbar-action-btn" type="button" aria-haspopup="menu" aria-expanded="false" aria-label="Add pane" title="Add Pane (Ctrl/Cmd+Shift+N)" data-testid="add-pane-btn">
                 <span class="btn-icon" aria-hidden="true">+</span>
                 <span class="btn-label">Add Pane</span>
               </button>
@@ -54,29 +54,31 @@
             </select>
           </div>
           <div class="role-pill" id="rolePill" data-testid="role-pill">signed out</div>
-          <button id="refreshAgentsBtn" class="icon-btn action-btn" type="button" aria-label="Refresh agent list" title="Refresh (Ctrl/Cmd+R)" hidden>
+          <button id="refreshAgentsBtn" class="icon-btn action-btn topbar-action-btn" type="button" aria-label="Refresh agent list" title="Refresh (Ctrl/Cmd+R)" hidden>
             <span class="btn-icon" aria-hidden="true">⟳</span>
             <span class="btn-label">Refresh</span>
           </button>
-          <button id="agentsBtn" class="icon-btn action-btn" type="button" aria-label="Open agents" title="Agents" hidden>
+          <button id="agentsBtn" class="icon-btn action-btn topbar-action-btn" type="button" aria-label="Open agents" title="Agents" hidden>
             <span class="btn-icon" aria-hidden="true">★</span>
             <span class="btn-label">Agents</span>
           </button>
-          <button id="fleetBtn" class="icon-btn" type="button" aria-label="Open fleet pane" title="Open Fleet pane (Cmd/Ctrl+Shift+F)" hidden>
-            FL
+          <button id="fleetBtn" class="icon-btn topbar-action-btn" type="button" aria-label="Open fleet pane" title="Open Fleet pane (Cmd/Ctrl+Shift+F)" hidden>
+            <span class="btn-icon" aria-hidden="true">FL</span>
+            <span class="btn-label">Fleet</span>
           </button>
-          <button id="workqueueBtn" class="icon-btn action-btn" type="button" aria-label="Open workqueue" title="Workqueue (g w)" hidden>
+          <button id="workqueueBtn" class="icon-btn action-btn topbar-action-btn" type="button" aria-label="Open workqueue" title="Workqueue (g w)" hidden>
             <span class="btn-icon" aria-hidden="true">WQ</span>
             <span class="btn-label">Workqueue</span>
           </button>
-          <button id="shortcutsBtn" class="icon-btn" type="button" aria-label="Open keyboard shortcuts" title="Keyboard shortcuts (?)" hidden data-testid="shortcuts-btn">
-            ?
+          <button id="shortcutsBtn" class="icon-btn topbar-action-btn" type="button" aria-label="Open keyboard shortcuts" title="Keyboard shortcuts (?)" hidden data-testid="shortcuts-btn">
+            <span class="btn-icon" aria-hidden="true">?</span>
+            <span class="btn-label">Shortcuts</span>
           </button>
-          <button id="settingsBtn" class="icon-btn action-btn" type="button" aria-label="Open settings" title="Settings">
+          <button id="settingsBtn" class="icon-btn action-btn topbar-action-btn" type="button" aria-label="Open settings" title="Settings">
             <span class="btn-icon" aria-hidden="true">⚙︎</span>
             <span class="btn-label">Settings</span>
           </button>
-          <button id="logoutBtn" class="icon-btn action-btn" type="button" aria-label="Log out" title="Logout">
+          <button id="logoutBtn" class="icon-btn action-btn topbar-action-btn" type="button" aria-label="Log out" title="Logout">
             <span class="btn-icon" aria-hidden="true">⎋</span>
             <span class="btn-label">Logout</span>
           </button>
@@ -504,6 +506,10 @@
             <label class="inline-checkbox">
               <input id="paneSwitchHudEnabled" type="checkbox" checked />
               Show pane-switch HUD
+            </label>
+            <label class="inline-checkbox">
+              <input id="labeledHeaderControlsEnabled" type="checkbox" />
+              Labeled header controls
             </label>
           </section>
 

--- a/styles.css
+++ b/styles.css
@@ -153,6 +153,7 @@ body::before {
   display: flex;
   align-items: center;
   gap: 10px;
+  min-width: 0;
 }
 
 .agent-switch {
@@ -203,12 +204,6 @@ body::before {
   font-size: 18px;
   min-height: 0;
   padding: 0;
-}
-
-.pane-controls .action-btn {
-  width: auto;
-  min-width: 36px;
-  padding: 0 12px;
 }
 
 .role-pill {
@@ -282,33 +277,47 @@ body::before {
 }
 
 .action-btn {
-  width: auto;
   min-width: 40px;
   height: 40px;
-  gap: 8px;
-  padding: 0 12px;
   font-size: 13px;
   font-weight: 600;
 }
 
-.action-btn .btn-icon {
+.topbar-action-btn .btn-icon {
   font-size: 14px;
   line-height: 1;
 }
 
-.action-btn .btn-label {
+.topbar-action-btn .btn-label {
+  display: none;
   white-space: nowrap;
 }
 
+.topbar.labeled-header-controls .topbar-action-btn {
+  width: auto;
+  max-width: 150px;
+  min-width: 40px;
+  gap: 8px;
+  padding: 0 12px;
+}
+
+.topbar.labeled-header-controls .topbar-action-btn .btn-label {
+  display: inline-block;
+  max-width: 92px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 @media (max-width: 920px) {
-  .action-btn {
+  .topbar.labeled-header-controls .topbar-action-btn {
     width: 36px;
+    max-width: 36px;
     min-width: 36px;
     padding: 0;
     gap: 0;
   }
 
-  .action-btn .btn-label {
+  .topbar.labeled-header-controls .topbar-action-btn .btn-label {
     display: none;
   }
 }

--- a/tests/ui/settings-recurring-prompts.spec.js
+++ b/tests/ui/settings-recurring-prompts.spec.js
@@ -43,3 +43,27 @@ test('settings: recurring prompt history error state is shown when runs API fail
   await page.locator('#recurringPromptRows [data-rp-action="edit"]').first().click();
   await expect(page.locator('#recurringPromptHistoryEmpty')).toContainText('Failed to load run history.');
 });
+
+test('settings: labeled header controls toggle persists with narrow-width fallback', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await clawnsole.gotoAndLoginAdmin(page);
+
+  const workqueueLabel = page.locator('#workqueueBtn .btn-label');
+  await expect(workqueueLabel).toBeHidden();
+
+  await page.getByRole('button', { name: 'Open settings' }).click();
+  await page.getByLabel('Labeled header controls').check();
+  await expect(page.locator('#topbar')).toHaveClass(/labeled-header-controls/);
+  await expect(workqueueLabel).toBeVisible();
+  await expect(page.locator('#shortcutsBtn .btn-label')).toHaveText('Shortcuts');
+
+  await page.reload();
+  await expect(page.locator('#topbar')).toHaveClass(/labeled-header-controls/);
+  await expect(workqueueLabel).toBeVisible();
+
+  await page.setViewportSize({ width: 800, height: 800 });
+  await expect(workqueueLabel).toBeHidden();
+  await expect(page.locator('#workqueueBtn')).toHaveAttribute('aria-label', 'Open workqueue');
+});


### PR DESCRIPTION
## Summary
- add a persisted Settings toggle for labeled header controls
- render topbar controls as icon+label only when enabled, with narrow-width icon fallback
- cover toggle persistence and responsive fallback in Playwright

## Tests
- npm run test:syntax
- npx playwright test tests/ui/settings-recurring-prompts.spec.js --workers=1

Closes #321