### PR TITLE
Clarify Workqueue enqueue destination

### DIFF
--- a/app.js
+++ b/app.js
@@ -4123,8 +4123,10 @@ async function workqueueEnqueueFromUi() {
     }
 
     const item = data.item || null;
-    const assignLabel = 'Queued as Unassigned';
-    setWorkqueueActionStatus(item && item._deduped ? `Deduped (already exists): ${item.id} (${assignLabel})` : assignLabel);
+    const destinationLabel = `Enqueued to ${queue}`;
+    const assignLabel = 'Unassigned';
+    setWorkqueueActionStatus(item && item._deduped ? `Deduped in ${queue}: ${item.id} (${assignLabel})` : `${destinationLabel} (${assignLabel})`);
+    showToast(`${destinationLabel}: ${title}`, { kind: 'info', testId: 'workqueue-enqueue-toast' });
 
     await fetchAndRenderWorkqueueItems();
     if (item?.id) {
@@ -6117,12 +6119,15 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     elements.thread.innerHTML = `
       <div class="wq-toolbar">
         <div class="wq-toolbar-row">
+          <div class="wq-control-group wq-control-group-viewing" role="group" aria-label="Viewing queue controls">
           <label class="wq-field">
-            <span class="wq-label">Queue</span>
+            <span class="wq-label">Viewing queue</span>
             <input data-wq-queue-search type="search" placeholder="Search queues" aria-label="Search queues" autocomplete="off" />
-            <select data-wq-queue-select aria-label="Select workqueue target"></select>
+            <select data-wq-queue-select aria-label="Viewing queue"></select>
             <input data-wq-queue-custom type="text" value="${escapeHtml(pane.workqueue.queue)}" placeholder="Custom queue" hidden />
+            <span class="hint">Controls which queue this pane displays.</span>
           </label>
+          </div>
 
           <div class="wq-field wq-status-field">
             <span class="wq-label">Status filter</span>
@@ -6181,6 +6186,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
 
         <details class="wq-enqueue">
           <summary>Enqueue new item</summary>
+          <div class="hint wq-enqueue-help">Enqueue to queue uses the current Viewing queue; assignment only suggests who should pick it up.</div>
           <form data-wq-enqueue-form class="wq-enqueue-form">
             <label class="wq-field">
               <span class="wq-label">Title</span>
@@ -6204,11 +6210,11 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
 
             <div class="wq-enqueue-actions">
               <label class="wq-field wq-agent-picker-field">
-                <span class="wq-label">Assign to</span>
+                <span class="wq-label">Assign to worker</span>
                 <div class="wq-agent-picker" data-wq-claim-agent-picker>
-                  <input data-wq-claim-agent-search type="search" aria-label="Search enqueue assignment target" autocomplete="off" />
+                  <input data-wq-claim-agent-search type="search" aria-label="Search worker assignment target" autocomplete="off" />
                   <input data-wq-claim-agent type="hidden" value="" />
-                  <div class="wq-agent-picker-list" data-wq-claim-agent-list role="listbox" aria-label="Enqueue assignment targets"></div>
+                  <div class="wq-agent-picker-list" data-wq-claim-agent-list role="listbox" aria-label="Worker assignment targets"></div>
                 </div>
                 <span class="hint">Who should pick this up</span>
               </label>
@@ -6216,7 +6222,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
                 <span class="wq-label">Lease ms</span>
                 <input data-wq-claim-lease type="number" value="900000" />
               </label>
-              <button data-wq-enqueue-submit type="submit">Enqueue</button>
+              <button data-wq-enqueue-submit type="submit">Enqueue to queue</button>
             </div>
 
             <div class="hint" data-wq-enqueue-status aria-live="polite"></div>
@@ -6686,11 +6692,13 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         }
 
         const item = data.item || null;
+        const destinationLabel = `Enqueued to ${queue}`;
         const assignToAgentId = String(enqueueAssignTo?.value || '').trim();
         const assignLabel = assignToAgentId
           ? `Queued for ${formatAgentLabel(getAgentRecord(assignToAgentId), { includeId: false })}`
           : 'Queued as Unassigned';
-        setEnqueueStatus(item && item._deduped ? `Deduped: ${item.id} (${assignLabel})` : assignLabel);
+        setEnqueueStatus(item && item._deduped ? `Deduped in ${queue}: ${item.id} (${assignLabel})` : `${destinationLabel} (${assignLabel})`);
+        showToast(`${destinationLabel}: ${title}`, { kind: 'info', testId: 'workqueue-enqueue-toast' });
         if (enqueueTitle) enqueueTitle.value = '';
         if (enqueueInstructions) enqueueInstructions.value = '';
         if (enqueueDedupe) enqueueDedupe.value = '';

--- a/index.html
+++ b/index.html
@@ -309,10 +309,13 @@
         </div>
         <div class="modal-body">
           <div class="wq-toolbar">
-            <label class="wq-field">
-              Queue
-              <select id="wqQueueSelect" aria-label="Select workqueue"></select>
-            </label>
+            <div class="wq-control-group wq-control-group-viewing" role="group" aria-labelledby="wqViewingQueueLabel">
+              <label class="wq-field">
+                <span id="wqViewingQueueLabel" class="wq-label">Viewing queue</span>
+                <select id="wqQueueSelect" aria-label="Viewing queue" title="Choose which queue to view and enqueue new items into"></select>
+                <span class="hint">Filters the items shown below.</span>
+              </label>
+            </div>
             <div class="wq-field">
               Status
               <div id="wqStatusFilters" class="wq-status-filters" aria-label="Status filters"></div>
@@ -335,7 +338,8 @@
           <div class="wq-actions" aria-label="Workqueue actions">
             <div class="wq-actions-row">
               <div class="wq-action-card">
-                <div class="wq-action-title">Enqueue</div>
+                <div class="wq-action-title">Enqueue to selected queue</div>
+                <div class="hint wq-action-help">New items are submitted to the current Viewing queue.</div>
                 <div class="wq-action-grid">
                   <label class="wq-action-field">
                     Title
@@ -355,7 +359,7 @@
                   </label>
                 </div>
                 <div class="wq-action-buttons">
-                  <button id="wqEnqueueBtn" class="primary" type="button">Enqueue</button>
+                  <button id="wqEnqueueBtn" class="primary" type="button" title="Submit this item to the current Viewing queue">Enqueue to queue</button>
                 </div>
               </div>
 

--- a/styles.css
+++ b/styles.css
@@ -1831,6 +1831,17 @@ kbd {
   margin-bottom: 12px;
 }
 
+.wq-control-group {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  padding: 8px;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.wq-control-group-viewing {
+  border-color: rgba(var(--pane-accent-workqueue-rgb), 0.28);
+}
+
 .wq-actions {
   display: flex;
   flex-direction: column;
@@ -1862,6 +1873,10 @@ kbd {
   letter-spacing: 0.04em;
   text-transform: uppercase;
   color: var(--muted);
+  margin-bottom: 4px;
+}
+
+.wq-action-help {
   margin-bottom: 10px;
 }
 
@@ -2135,6 +2150,10 @@ kbd {
   cursor: pointer;
   user-select: none;
   color: var(--text);
+}
+
+.wq-enqueue-help {
+  margin-top: 8px;
 }
 
 .wq-enqueue-form {

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -162,6 +162,36 @@ test('workqueue pane: queue target supports search + recent persistence', async 
   await expect(secondSelect.locator('option', { hasText: '★ qa-hotfix' })).toHaveCount(1);
 });
 
+test('workqueue pane: enqueue destination is distinct from worker assignment', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  seedAgentsForWorkqueuePicker();
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  const queue = `enqueue-destination-${Date.now()}`;
+  const pane = page.locator('[data-pane]').last();
+  await expect(pane.locator('.wq-control-group-viewing')).toContainText('Viewing queue');
+  await pane.locator('[data-wq-queue-select]').selectOption('__custom__');
+  await pane.locator('[data-wq-queue-custom]').fill(queue);
+  await pane.locator('[data-wq-queue-custom]').press('Enter');
+
+  await pane.locator('details.wq-enqueue summary').click();
+  await expect(pane.locator('.wq-enqueue-help')).toContainText('Enqueue to queue uses the current Viewing queue');
+  await expect(pane.locator('[data-wq-enqueue-submit]')).toHaveText('Enqueue to queue');
+  await expect(pane.locator('[data-wq-claim-agent-search]')).toHaveAttribute('aria-label', 'Search worker assignment target');
+
+  await pane.locator('[data-wq-enqueue-title]').fill('destination clarity item');
+  await pane.locator('[data-wq-enqueue-instructions]').fill('verify destination copy');
+  await pane.locator('[data-wq-enqueue-submit]').click();
+
+  await expect(pane.locator('[data-wq-enqueue-status]')).toContainText(`Enqueued to ${queue}`);
+  await expect(page.getByTestId('workqueue-enqueue-toast')).toContainText(`Enqueued to ${queue}`);
+});
+
 test('workqueue pane: enqueue assignment target supports search, keyboard select, and recents', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);


### PR DESCRIPTION
## Summary
- rename Workqueue queue controls to distinguish the Viewing queue from enqueue assignment
- add helper copy, grouped styling, and destination-aware enqueue status/toast feedback
- add focused UI coverage proving enqueue destination copy is distinct from worker assignment

Fixes #327

## Tests
- npm run test:syntax
- npx playwright test tests/ui/workqueue-pane.spec.js --grep "enqueue destination is distinct" --workers=1