### PR TITLE
Clarify Workqueue viewing and enqueue targets

### DIFF
--- a/app.js
+++ b/app.js
@@ -6537,12 +6537,15 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     elements.thread.innerHTML = `
       <div class="wq-toolbar">
         <div class="wq-toolbar-row">
-          <label class="wq-field">
-            <span class="wq-label">Queue</span>
-            <input data-wq-queue-search type="search" placeholder="Search queues" aria-label="Search queues" autocomplete="off" />
-            <select data-wq-queue-select aria-label="Select workqueue target"></select>
-            <input data-wq-queue-custom type="text" value="${escapeHtml(pane.workqueue.queue)}" placeholder="Custom queue" hidden />
-          </label>
+          <div class="wq-control-group wq-viewing-group" role="group" aria-label="Viewing queue controls">
+            <label class="wq-field">
+              <span class="wq-label">Viewing queue</span>
+              <input data-wq-queue-search type="search" placeholder="Search queues" aria-label="Search queues to view" title="Filters the queue picker for this pane." autocomplete="off" />
+              <select data-wq-queue-select aria-label="Viewing queue" title="Changes which queue this pane is showing. New items use this queue unless you change it before submitting."></select>
+              <input data-wq-queue-custom type="text" value="${escapeHtml(pane.workqueue.queue)}" placeholder="Custom queue" aria-label="Custom viewing queue" hidden />
+              <span class="hint">Items shown in this pane</span>
+            </label>
+          </div>
 
           <div class="wq-field wq-status-field">
             <span class="wq-label">Status filter</span>
@@ -6602,6 +6605,12 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         <details class="wq-enqueue">
           <summary>Enqueue new item</summary>
           <form data-wq-enqueue-form class="wq-enqueue-form">
+            <div class="wq-control-group wq-enqueue-destination" role="group" aria-label="Enqueue destination">
+              <div class="wq-label">Enqueue to</div>
+              <div class="wq-enqueue-destination-value" data-wq-enqueue-destination title="New item destination queue">dev-team</div>
+              <span class="hint">Destination for this new item</span>
+            </div>
+
             <label class="wq-field">
               <span class="wq-label">Title</span>
               <input data-wq-enqueue-title type="text" required placeholder="Short title" />
@@ -6694,6 +6703,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     const clawnsoleOnlyBtn = elements.thread.querySelector('[data-wq-preset-clawnsole]');
     const clearQuickBtn = elements.thread.querySelector('[data-wq-clear-quick]');
     const refreshBtn = elements.thread.querySelector('[data-wq-refresh]');
+    const enqueueDestination = elements.thread.querySelector('[data-wq-enqueue-destination]');
 
     const DEFAULT_STATUSES = ['ready', 'pending', 'claimed', 'in_progress'];
 
@@ -6707,6 +6717,13 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       const sel = String(queueSelectEl?.value || '').trim();
       if (sel === '__custom__') return String(queueCustomEl?.value || '').trim();
       return sel;
+    };
+
+    const updateEnqueueDestination = () => {
+      if (!enqueueDestination) return;
+      const q = getQueueValue() || pane.workqueue.queue || 'dev-team';
+      enqueueDestination.textContent = String(q);
+      enqueueDestination.title = `New items will be enqueued to ${q}`;
     };
 
     const initQuick = pane.workqueue?.quickFilters || {};
@@ -6770,6 +6787,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     const doRefresh = async () => {
       const q = getQueueValue() || 'dev-team';
       pane.workqueue.queue = q;
+      updateEnqueueDestination();
       resetRenderLimit();
       rememberRecentWorkqueueTarget(q);
       paneSetHeaderTarget(pane, {
@@ -6895,6 +6913,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
           }
         }
         applyQueueSearchFilter();
+        updateEnqueueDestination();
       } catch {
         // fallback: keep current queue editable
         queueSelectEl.innerHTML = '';
@@ -6908,6 +6927,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         queueSelectEl.appendChild(customOpt);
         queueSelectEl.value = opt.value;
         applyQueueSearchFilter();
+        updateEnqueueDestination();
       }
     };
 
@@ -6917,6 +6937,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         queueCustomEl.hidden = !isCustom;
         if (isCustom) queueCustomEl.focus();
       }
+      updateEnqueueDestination();
       doRefresh();
     });
     queueSelectEl?.addEventListener('keydown', (e) => {
@@ -6926,7 +6947,10 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       }
     });
 
-    queueSearchEl?.addEventListener('input', () => applyQueueSearchFilter());
+    queueSearchEl?.addEventListener('input', () => {
+      applyQueueSearchFilter();
+      updateEnqueueDestination();
+    });
     queueSearchEl?.addEventListener('keydown', (e) => {
       if (!queueSelectEl) return;
       if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
@@ -6943,6 +6967,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     populateQueueSelect().then(() => doRefresh());
 
     refreshBtn?.addEventListener('click', () => doRefresh());
+    queueCustomEl?.addEventListener('input', () => updateEnqueueDestination());
     queueCustomEl?.addEventListener('keydown', (e) => {
       if (e.key === 'Enter') doRefresh();
     });
@@ -7115,6 +7140,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
           ? `Queued for ${formatAgentLabel(getAgentRecord(assignToAgentId), { includeId: false })}`
           : 'Queued as Unassigned';
         setEnqueueStatus(item && item._deduped ? `Deduped: ${item.id} (${assignLabel})` : assignLabel);
+        showToast(`Enqueued to ${queue}`, { kind: 'info', timeoutMs: 2400 });
         if (enqueueTitle) enqueueTitle.value = '';
         if (enqueueInstructions) enqueueInstructions.value = '';
         if (enqueueDedupe) enqueueDedupe.value = '';

--- a/styles.css
+++ b/styles.css
@@ -3167,6 +3167,7 @@ kbd {
   flex-direction: column;
   min-height: 0;
   overflow: auto;
+  scroll-padding-top: 52px;
   scrollbar-gutter: stable both-edges;
 }
 
@@ -3232,6 +3233,14 @@ kbd {
   color: var(--muted);
   background: rgba(12, 15, 20, 0.98);
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.wq-load-more {
+  align-self: flex-start;
+  margin: 10px 12px 12px;
+  position: relative;
+  scroll-margin-top: 52px;
+  z-index: 4;
 }
 
 [data-wq-empty] {

--- a/styles.css
+++ b/styles.css
@@ -2071,6 +2071,36 @@ kbd {
   flex: 0 0 auto;
 }
 
+.wq-control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.wq-viewing-group {
+  border-color: rgba(127, 209, 185, 0.2);
+}
+
+.wq-enqueue-destination {
+  min-width: 180px;
+}
+
+.wq-enqueue-destination-value {
+  min-height: 34px;
+  display: flex;
+  align-items: center;
+  padding: 7px 9px;
+  border-radius: 8px;
+  color: var(--text);
+  background: rgba(0, 0, 0, 0.24);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  font-size: 13px;
+}
+
 .wq-duplicate-health {
   display: flex;
   align-items: center;

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -269,6 +269,37 @@ test('workqueue pane: enqueue assignment target supports search, keyboard select
   await expect(firstRecent.locator('.wq-agent-picker-badge')).toHaveText('recent');
 });
 
+test('workqueue pane: viewing queue and enqueue destination are unambiguous', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  const pane = page.locator('[data-pane]').last();
+  const queue = `enqueue-dest-${Date.now()}`;
+
+  await expect(pane.getByText('Viewing queue')).toBeVisible();
+  await expect(pane.locator('[data-wq-queue-select]')).toHaveAttribute('aria-label', 'Viewing queue');
+
+  await pane.locator('[data-wq-queue-select]').selectOption('__custom__');
+  await pane.locator('[data-wq-queue-custom]').fill(queue);
+  await pane.locator('[data-wq-queue-custom]').press('Enter');
+
+  await pane.locator('details.wq-enqueue summary').click();
+  await expect(pane.getByText('Enqueue to')).toBeVisible();
+  await expect(pane.locator('[data-wq-enqueue-destination]')).toHaveText(queue);
+
+  await pane.locator('[data-wq-enqueue-title]').fill('Destination clarity item');
+  await pane.locator('[data-wq-enqueue-instructions]').fill('Verify destination copy and toast.');
+  await pane.locator('[data-wq-enqueue-submit]').click();
+
+  await expect(page.getByTestId('toast').last()).toContainText(`Enqueued to ${queue}`);
+  await expect(pane.locator('[data-wq-enqueue-status]')).toContainText('Queued');
+});
+
 test('workqueue pane: scope filter toggles assigned/unassigned/all deterministically', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);


### PR DESCRIPTION
Fixes #327.\n\n## Summary\n- Rename pane queue controls to explicit Viewing queue language with distinct aria labels and helper text.\n- Add an Enqueue to destination group inside the inline enqueue form.\n- Show a confirmation toast naming the destination queue after enqueue submission.\n- Add UI coverage for destination clarity.\n\n## Tests\n- npm run test:syntax\n- npx playwright test tests/ui/workqueue-pane.spec.js --grep "viewing queue and enqueue destination"