### PR TITLE
Add Workqueue control focus shortcuts

### DIFF
--- a/app.js
+++ b/app.js
@@ -8147,7 +8147,6 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     const queueSearchEl = elements.thread.querySelector('[data-wq-queue-search]');
     const queueSelectEl = elements.thread.querySelector('[data-wq-queue-select]');
     const queueCustomEl = elements.thread.querySelector('[data-wq-queue-custom]');
-
     // Make header pill focus the queue selector in the body (no duplicated selector state).
     paneSetHeaderTarget(pane, {
       label: 'Queue',
@@ -10386,7 +10385,9 @@ const SHORTCUT_BLOCK_RATE_LIMIT_MS = 5000;
 const SHORTCUT_BLOCK_MESSAGES = {
   typing: 'Shortcut paused while typing',
   modal: 'Close modal to use this shortcut',
-  layout: 'Use Cmd/Ctrl+1..9 on this keyboard layout'
+  layout: 'Use Cmd/Ctrl+1..9 on this keyboard layout',
+  workqueue: 'Focus a Workqueue pane to use this shortcut',
+  unavailable: 'Shortcut target is unavailable'
 };
 
 function reportBlockedShortcut(reason) {
@@ -10468,6 +10469,7 @@ function isNonTrivialGlobalShortcut(event) {
   if (event.ctrlKey && !event.metaKey && !event.altKey && key === 'Tab') return true;
   if ((key === '?' || (key === '/' && event.shiftKey)) && !event.metaKey && !event.ctrlKey && !event.altKey) return true;
   if (event.altKey && !event.metaKey && !event.ctrlKey && !event.shiftKey) {
+    if (['q', 'f', 's'].includes(lower)) return true;
     const n = Number.parseInt(key, 10);
     if (Number.isFinite(n) && n >= 1 && n <= 9) return true;
   }
@@ -10737,6 +10739,56 @@ function cycleUnreadPaneFocus(direction = 1) {
   return true;
 }
 
+function getFocusedWorkqueuePane() {
+  const panes = paneManager?.panes || [];
+  const active = document.activeElement;
+  const activePane = panes.find((pane) => pane?.kind === 'workqueue' && pane.elements?.root && (pane.elements.root === active || pane.elements.root.contains(active)));
+  if (activePane) return activePane;
+  const focusedKey = focusedPaneKey();
+  return panes.find((pane) => pane?.kind === 'workqueue' && pane.key === focusedKey) || null;
+}
+
+function isShortcutFocusable(el) {
+  if (!el || typeof el.focus !== 'function') return false;
+  try {
+    if (el.disabled || el.hidden) return false;
+    if (el.getClientRects && el.getClientRects().length === 0) return false;
+  } catch {
+    return true;
+  }
+  return true;
+}
+
+function focusWorkqueueShortcutTarget(target) {
+  const pane = getFocusedWorkqueuePane();
+  if (!pane) {
+    reportBlockedShortcut('workqueue');
+    return false;
+  }
+
+  let el = null;
+  if (target === 'queue') el = pane.elements?.thread?.querySelector('[data-wq-queue-search]');
+  if (target === 'items') el = pane.elements?.thread?.querySelector('[data-wq-search]');
+  if (target === 'status') {
+    const details = pane.elements?.thread?.querySelector('[data-wq-status-details]');
+    el = details?.querySelector('summary') || details;
+  }
+
+  if (!isShortcutFocusable(el)) {
+    reportBlockedShortcut('unavailable');
+    return false;
+  }
+
+  el.focus();
+  if (target === 'status') {
+    const details = pane.elements?.thread?.querySelector('[data-wq-status-details]');
+    details?.setAttribute('open', '');
+  } else if (typeof el.select === 'function') {
+    el.select();
+  }
+  return true;
+}
+
 function isBlockingOverlayOpenForPaneShortcuts() {
   const blockers = [
     globalElements.loginOverlay,
@@ -10869,6 +10921,14 @@ window.addEventListener('keydown', (event) => {
 
   // Alt/Option+1..9 focuses panes by visible order.
   if (event.altKey && !event.metaKey && !event.ctrlKey && !event.shiftKey) {
+    const lower = key.toLowerCase();
+    const workqueueTarget = lower === 'q' ? 'queue' : lower === 'f' ? 'items' : lower === 's' ? 'status' : '';
+    if (workqueueTarget) {
+      event.preventDefault();
+      focusWorkqueueShortcutTarget(workqueueTarget);
+      return;
+    }
+
     const n = Number.parseInt(key, 10);
     if (Number.isFinite(n) && n >= 1 && n <= 9) {
       event.preventDefault();

--- a/index.html
+++ b/index.html
@@ -289,6 +289,9 @@
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Enter</kbd></div><div class="shortcut-desc">Inspect selected Workqueue row in keyboard mode</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>e</kbd></div><div class="shortcut-desc">Edit selected Workqueue row in keyboard mode</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>1</kbd>..<kbd>4</kbd></div><div class="shortcut-desc">Set ready, in progress, blocked, or done in keyboard mode</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Alt</kbd>/<kbd>Option</kbd>+<kbd>Q</kbd></div><div class="shortcut-desc">Focus Workqueue queue search</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Alt</kbd>/<kbd>Option</kbd>+<kbd>F</kbd></div><div class="shortcut-desc">Focus Workqueue item search</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Alt</kbd>/<kbd>Option</kbd>+<kbd>S</kbd></div><div class="shortcut-desc">Focus Workqueue status filter</div></div>
           </div>
         </div>
       </div>

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -486,6 +486,79 @@ test('workqueue pane: default rows collapse exact duplicates with expandable mem
   await expect(wqPane.locator('[data-wq-list-body] .wq-row-child')).toHaveCount(2);
 });
 
+test('workqueue pane: direct shortcuts focus queue, item, and status controls with blocked feedback', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  const pane = page.locator('[data-pane]').last();
+  const queue = `shortcut-search-${Date.now()}`;
+  await page.evaluate(async ({ queue }) => {
+    const enqueue = async (title) => {
+      const res = await fetch('/api/workqueue/enqueue', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ queue, title, instructions: `seed ${title}`, priority: 1 })
+      });
+      if (!res.ok) throw new Error(`enqueue failed: ${res.status}`);
+    };
+    await enqueue('shortcut alpha target');
+    await enqueue('shortcut beta hidden');
+  }, { queue });
+
+  await pane.locator('[data-wq-queue-select]').selectOption('__custom__');
+  await pane.locator('[data-wq-queue-custom]').fill(queue);
+  await pane.locator('[data-wq-queue-custom]').press('Enter');
+  await expect(pane.locator('[data-wq-list-body] .wq-row')).toHaveCount(2);
+
+  await expect(pane.locator('[data-wq-queue-search]')).toBeVisible();
+  await expect(pane.locator('[data-wq-search]')).toBeVisible();
+  await expect(page.locator('#shortcutsModal')).toContainText('Focus Workqueue queue search');
+  await expect(page.locator('#shortcutsModal')).toContainText('Focus Workqueue item search');
+  await expect(page.locator('#shortcutsModal')).toContainText('Focus Workqueue status filter');
+
+  const pressAlt = async (key) => page.evaluate((nextKey) => {
+    window.dispatchEvent(new KeyboardEvent('keydown', {
+      key: nextKey,
+      altKey: true,
+      bubbles: true,
+      cancelable: true
+    }));
+  }, key);
+
+  await pane.locator('[data-wq-refresh]').focus();
+  await pressAlt('q');
+  await expect(pane.locator('[data-wq-queue-search]')).toBeFocused();
+
+  await pane.locator('[data-wq-refresh]').focus();
+  await pressAlt('f');
+  await expect(pane.locator('[data-wq-search]')).toBeFocused();
+  await pane.locator('[data-wq-search]').fill('alpha');
+  await expect(pane.locator('[data-wq-list-body] .wq-row')).toHaveCount(1);
+  await expect(pane.locator('[data-wq-list-body] .wq-row')).toContainText('shortcut alpha target');
+
+  await pane.locator('[data-wq-refresh]').focus();
+  await pressAlt('s');
+  await expect(pane.locator('[data-wq-status-details] summary')).toBeFocused();
+  await expect(pane.locator('[data-wq-status-details]')).toHaveAttribute('open', '');
+
+  await page.evaluate(() => {
+    document.querySelector('[data-wq-queue-search]')?.setAttribute('hidden', '');
+  });
+  await pane.locator('[data-wq-refresh]').focus();
+  await pressAlt('q');
+  await expect(page.getByTestId('shortcut-blocked-toast').last()).toContainText('Shortcut target is unavailable');
+
+  await page.locator('[data-pane][data-pane-kind="chat"] [data-pane-input]').focus();
+  await pressAlt('f');
+  await expect(page.getByTestId('shortcut-blocked-toast').last()).toContainText('Focus a Workqueue pane');
+});
+
 test('workqueue pane: queue target supports search + recent persistence', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);


### PR DESCRIPTION
## Summary
- Add Workqueue pane direct shortcuts: Alt/Option+Q for queue search, Alt/Option+F for item search, and Alt/Option+S for the status filter.
- Reuse the existing Workqueue task search for the item-search shortcut so it coexists with current quick filters and grouped rows.
- Document the shortcuts in the keyboard shortcuts modal and show non-disruptive blocked feedback when no Workqueue pane/target is available.

Fixes #379

## Tests
- npm test
- npm run test:ui -- tests/ui/workqueue-pane.spec.js --grep 'direct shortcuts focus queue|filter summary chips'