### PR TITLE
Clarify workqueue enqueue destination

### DIFF
--- a/app.js
+++ b/app.js
@@ -6537,11 +6537,12 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     elements.thread.innerHTML = `
       <div class="wq-toolbar">
         <div class="wq-toolbar-row">
-          <label class="wq-field">
-            <span class="wq-label">Queue</span>
+          <label class="wq-field wq-target-group" data-wq-viewing-group title="Controls which queue is shown in this pane.">
+            <span class="wq-label">Viewing queue</span>
             <input data-wq-queue-search type="search" placeholder="Search queues" aria-label="Search queues" autocomplete="off" />
-            <select data-wq-queue-select aria-label="Select workqueue target"></select>
+            <select data-wq-queue-select aria-label="Viewing queue to display"></select>
             <input data-wq-queue-custom type="text" value="${escapeHtml(pane.workqueue.queue)}" placeholder="Custom queue" hidden />
+            <span class="hint">Filters the items shown below.</span>
           </label>
 
           <div class="wq-field wq-status-field">
@@ -6622,6 +6623,12 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
               <textarea data-wq-enqueue-instructions rows="3" placeholder="Links, context, acceptance criteria"></textarea>
             </label>
 
+            <label class="wq-field wq-enqueue-destination">
+              <span class="wq-label">Enqueue to</span>
+              <input data-wq-enqueue-destination type="text" value="${escapeHtml(pane.workqueue.queue || 'dev-team')}" readonly aria-label="Queue new items will be enqueued to" title="New items are enqueued to the current Viewing queue." />
+              <span class="hint">New items go to the selected Viewing queue.</span>
+            </label>
+
             <div class="wq-enqueue-actions">
               <label class="wq-field wq-agent-picker-field">
                 <span class="wq-label">Assign to</span>
@@ -6671,6 +6678,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     const queueSearchEl = elements.thread.querySelector('[data-wq-queue-search]');
     const queueSelectEl = elements.thread.querySelector('[data-wq-queue-select]');
     const queueCustomEl = elements.thread.querySelector('[data-wq-queue-custom]');
+    const enqueueDestinationEl = elements.thread.querySelector('[data-wq-enqueue-destination]');
 
     // Make header pill focus the queue selector in the body (no duplicated selector state).
     paneSetHeaderTarget(pane, {
@@ -6707,6 +6715,13 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       const sel = String(queueSelectEl?.value || '').trim();
       if (sel === '__custom__') return String(queueCustomEl?.value || '').trim();
       return sel;
+    };
+
+    const updateEnqueueDestination = (queue) => {
+      if (!enqueueDestinationEl) return;
+      const q = String(queue || '').trim() || 'dev-team';
+      enqueueDestinationEl.value = q;
+      enqueueDestinationEl.title = `New items will be enqueued to ${q}.`;
     };
 
     const initQuick = pane.workqueue?.quickFilters || {};
@@ -6770,6 +6785,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     const doRefresh = async () => {
       const q = getQueueValue() || 'dev-team';
       pane.workqueue.queue = q;
+      updateEnqueueDestination(q);
       resetRenderLimit();
       rememberRecentWorkqueueTarget(q);
       paneSetHeaderTarget(pane, {
@@ -7088,6 +7104,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         setEnqueueStatus('Select a queue first.');
         return;
       }
+      updateEnqueueDestination(queue);
       if (!title) {
         setEnqueueStatus('Title is required.');
         enqueueTitle?.focus();
@@ -7114,7 +7131,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         const assignLabel = assignToAgentId
           ? `Queued for ${formatAgentLabel(getAgentRecord(assignToAgentId), { includeId: false })}`
           : 'Queued as Unassigned';
-        setEnqueueStatus(item && item._deduped ? `Deduped: ${item.id} (${assignLabel})` : assignLabel);
+        setEnqueueStatus(item && item._deduped ? `Deduped: ${item.id} to ${queue} (${assignLabel})` : `Enqueued to ${queue}. ${assignLabel}.`);
         if (enqueueTitle) enqueueTitle.value = '';
         if (enqueueInstructions) enqueueInstructions.value = '';
         if (enqueueDedupe) enqueueDedupe.value = '';

--- a/styles.css
+++ b/styles.css
@@ -2071,6 +2071,29 @@ kbd {
   flex: 0 0 auto;
 }
 
+.wq-target-group,
+.wq-enqueue-destination {
+  padding: 8px;
+  border: 1px solid rgba(255, 179, 71, 0.28);
+  border-radius: 8px;
+  background: rgba(255, 179, 71, 0.08);
+}
+
+.wq-target-group {
+  min-width: 220px;
+  margin-right: 4px;
+}
+
+.wq-enqueue-destination {
+  min-width: 240px;
+}
+
+.wq-enqueue-destination input[readonly] {
+  color: var(--text);
+  border-style: dashed;
+  background: rgba(255, 255, 255, 0.035);
+}
+
 .wq-duplicate-health {
   display: flex;
   align-items: center;

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -238,6 +238,39 @@ test('workqueue pane: queue target supports search + recent persistence', async 
   await expect(secondSelect.locator('option', { hasText: '★ qa-hotfix' })).toHaveCount(1);
 });
 
+test('workqueue pane: viewing queue and enqueue destination are distinct and confirmed', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  const wqPane = page.locator('[data-pane]').last();
+  const queueSelect = wqPane.locator('[data-wq-queue-select]');
+  const customQueue = wqPane.locator('[data-wq-queue-custom]');
+
+  await expect(wqPane.locator('[data-wq-viewing-group] .wq-label')).toHaveText('Viewing queue');
+  await expect(queueSelect).toHaveAttribute('aria-label', 'Viewing queue to display');
+
+  await queueSelect.selectOption('__custom__');
+  await customQueue.fill('issue-327-destination');
+  await customQueue.press('Enter');
+
+  await wqPane.locator('details.wq-enqueue summary').click();
+  const destination = wqPane.locator('[data-wq-enqueue-destination]');
+  await expect(wqPane.locator('.wq-enqueue-destination .wq-label')).toHaveText('Enqueue to');
+  await expect(destination).toHaveAttribute('aria-label', 'Queue new items will be enqueued to');
+  await expect(destination).toHaveValue('issue-327-destination');
+
+  await wqPane.locator('[data-wq-enqueue-title]').fill('Unambiguous destination');
+  await wqPane.locator('[data-wq-enqueue-instructions]').fill('prove destination confirmation');
+  await wqPane.locator('[data-wq-enqueue-submit]').click();
+
+  await expect(wqPane.locator('[data-wq-enqueue-status]')).toContainText('Enqueued to issue-327-destination.');
+});
+
 test('workqueue pane: enqueue assignment target supports search, keyboard select, and recents', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);


### PR DESCRIPTION
## Summary
- Rename the workqueue pane queue control to "Viewing queue" with distinct helper text and ARIA label.
- Add a read-only "Enqueue to" destination field in the enqueue form that tracks the selected viewing queue.
- Include the destination queue in enqueue confirmation status text and cover the flow with a Playwright spec.

## Tests
- npm run test:syntax
- npx playwright test tests/ui/workqueue-pane.spec.js -g "viewing queue and enqueue destination" --workers=1
- npx playwright test tests/ui/workqueue-pane.spec.js --workers=1

Fixes #327