### PR TITLE
Add workqueue all-scope guardrail

### DIFF
--- a/app.js
+++ b/app.js
@@ -4295,6 +4295,8 @@ function runFleetSelectedAgent() {
 const WORKQUEUE_STATUSES = ['ready', 'pending', 'blocked', 'claimed', 'in_progress', 'done', 'failed'];
 const WORKQUEUE_PANE_INITIAL_RENDER_LIMIT = 100;
 const WORKQUEUE_PANE_RENDER_CHUNK_SIZE = 100;
+const WORKQUEUE_ALL_SCOPE_GUARD_THRESHOLD_KEY = 'clawnsole.admin.workqueue.allScopeGuardThreshold';
+const WORKQUEUE_ALL_SCOPE_GUARD_DEFAULT_THRESHOLD = 200;
 const WORKQUEUE_HEADER_META = {
   title: { label: 'Task', tooltip: 'Sort by task title.' },
   status: { label: 'Status', tooltip: 'Sort by queue status.' },
@@ -4340,6 +4342,12 @@ function buildWorkqueueStatusCounts(items) {
     counts[status] += 1;
   }
   return counts;
+}
+
+function getWorkqueueAllScopeGuardThreshold() {
+  const raw = storage.get(WORKQUEUE_ALL_SCOPE_GUARD_THRESHOLD_KEY, String(WORKQUEUE_ALL_SCOPE_GUARD_DEFAULT_THRESHOLD));
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : WORKQUEUE_ALL_SCOPE_GUARD_DEFAULT_THRESHOLD;
 }
 
 const workqueueState = {
@@ -5555,6 +5563,7 @@ function renderWorkqueuePaneItems(pane) {
   const quickResult = getWorkqueueQuickFilterBreakdown(scopedItems, pane.workqueue?.quickFilters);
   const filteredItems = quickResult.items;
   const items = sortWorkqueueItems(filteredItems, { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
+  renderWorkqueueAllScopeGuard(pane, items.length);
   const totalCount = Math.max(items.length, countItems.length);
   const hiddenCounts = {
     status: Math.max(0, countItems.length - fetchedItems.length),
@@ -5690,6 +5699,47 @@ function renderWorkqueuePaneItems(pane) {
     pane.workqueue.selectedItemId = null;
     renderWorkqueuePaneInspect(pane, null);
   }
+}
+
+function renderWorkqueueAllScopeGuard(pane, visibleCount) {
+  const root = pane?.elements?.thread?.querySelector?.('[data-wq-all-scope-guard]');
+  if (!root) return;
+
+  const scope = normalizeWorkqueueScope(pane?.workqueue?.scopeFilter || 'all');
+  const threshold = getWorkqueueAllScopeGuardThreshold();
+  const count = Number(visibleCount || 0);
+  const guardKey = `${scope}:${count}:${threshold}`;
+  const shouldShow = scope === 'all' && count > threshold && !pane.workqueue?.allScopeGuardDismissed;
+
+  root.hidden = !shouldShow;
+  if (!shouldShow) {
+    root.innerHTML = '';
+    return;
+  }
+
+  if (pane.workqueue.allScopeGuardShownKey !== guardKey) {
+    pane.workqueue.allScopeGuardShownKey = guardKey;
+    addFeed('event', 'workqueue.guardrail', `all-scope shown count=${count} threshold=${threshold}`);
+  }
+
+  root.innerHTML = `
+    <span class="wq-all-scope-guard-text">Viewing all items (${escapeHtml(String(count))}). Narrow scope?</span>
+    <button type="button" class="wq-scope-btn" data-wq-downscope="assigned">Assigned to active target</button>
+    <button type="button" class="wq-scope-btn" data-wq-downscope="unassigned">Unassigned</button>
+    <button type="button" class="wq-scope-btn wq-guard-dismiss" data-wq-guard-dismiss aria-label="Dismiss all scope guardrail">Dismiss</button>
+  `;
+  root.querySelectorAll('[data-wq-downscope]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const scopeKey = btn.getAttribute('data-wq-downscope') || '';
+      addFeed('event', 'workqueue.guardrail', `all-scope action=${scopeKey} count=${count} threshold=${threshold}`);
+      pane?.elements?.thread?.querySelector?.(`[data-wq-scope="${scopeKey}"]`)?.click?.();
+    });
+  });
+  root.querySelector('[data-wq-guard-dismiss]')?.addEventListener('click', () => {
+    pane.workqueue.allScopeGuardDismissed = true;
+    addFeed('event', 'workqueue.guardrail', `all-scope dismissed count=${count} threshold=${threshold}`);
+    renderWorkqueueAllScopeGuard(pane, count);
+  });
 }
 
 function selectWorkqueuePaneItemByDelta(pane, delta) {
@@ -7981,6 +8031,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
             <button type="button" class="wq-scope-btn" data-wq-scope="unassigned">Unassigned</button>
             <button type="button" class="wq-scope-btn" data-wq-scope="all">All</button>
           </div>
+          <div class="wq-all-scope-guard" data-wq-all-scope-guard role="status" aria-live="polite" hidden></div>
 
           <div class="wq-field" data-wq-source-group role="group" aria-label="Filter by source">
             <span class="wq-label">Source</span>

--- a/styles.css
+++ b/styles.css
@@ -2506,6 +2506,27 @@ kbd {
   background: rgba(127, 209, 185, 0.12);
 }
 
+.wq-all-scope-guard {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  padding: 6px 8px;
+  border: 1px solid rgba(255, 179, 71, 0.28);
+  border-radius: 8px;
+  background: rgba(255, 179, 71, 0.1);
+  color: var(--text);
+}
+
+.wq-all-scope-guard[hidden] {
+  display: none;
+}
+
+.wq-all-scope-guard-text {
+  font-size: 12px;
+  color: var(--text);
+}
+
 .wq-enqueue {
   margin-top: 10px;
 }

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -906,6 +906,36 @@ test('workqueue pane: large queues render an initial capped slice and load more 
   await pane.locator('[data-wq-refresh]').click();
   await refreshResP;
 
+  const guard = pane.locator('[data-wq-all-scope-guard]');
+  await page.evaluate(() => localStorage.setItem('clawnsole.admin.workqueue.allScopeGuardThreshold', '600'));
+  await pane.locator('[data-wq-scope="all"]').click();
+  await expect(guard).toBeHidden();
+
+  await page.evaluate(() => localStorage.setItem('clawnsole.admin.workqueue.allScopeGuardThreshold', '200'));
+  await pane.locator('[data-wq-scope="assigned"]').click();
+  await pane.locator('[data-wq-scope="all"]').click();
+  await expect(guard).toBeVisible();
+  await expect(guard).toContainText('Viewing all items (505). Narrow scope?');
+
+  await guard.locator('[data-wq-downscope="assigned"]').click();
+  await expect(pane.locator('[data-wq-scope="assigned"]')).toHaveClass(/active/);
+  await expect(guard).toBeHidden();
+  await expect(pane.locator('.wq-row')).toHaveCount(0);
+
+  await pane.locator('[data-wq-scope="all"]').click();
+  await expect(guard).toBeVisible();
+  await guard.locator('[data-wq-downscope="unassigned"]').click();
+  await expect(pane.locator('[data-wq-scope="unassigned"]')).toHaveClass(/active/);
+  await expect(guard).toBeHidden();
+
+  await pane.locator('[data-wq-scope="all"]').click();
+  await expect(guard).toBeVisible();
+  await guard.locator('[data-wq-guard-dismiss]').click();
+  await expect(guard).toBeHidden();
+  await pane.locator('[data-wq-scope="assigned"]').click();
+  await pane.locator('[data-wq-scope="all"]').click();
+  await expect(guard).toBeHidden();
+
   await expect(pane.locator('.wq-row')).toHaveCount(100);
   await expect(pane.locator('[data-wq-load-more]')).toHaveText('Load more (100/505)');
 


### PR DESCRIPTION
## Summary
- Add an inline guard chip when Workqueue scope is All and the visible item count exceeds the configurable threshold (default 200)
- Provide one-click downscope actions for assigned-to-active-target and unassigned views, plus session-scoped dismissal
- Emit lightweight guardrail events for shown/action/dismissed tuning and cover display, downscope, dismissal, and under-threshold behavior

Fixes #408

## Tests
- npm run test:syntax
- NODE_PATH=/Users/raysopenclaw/src/clawnsole/node_modules /Users/raysopenclaw/src/clawnsole/node_modules/.bin/playwright test tests/ui/workqueue-pane.spec.js --grep "large queues render" --workers=1

Ready for 🚢