### PR TITLE
UX/Fleet: add sticky selected-agent summary footer

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,6 +39,7 @@ const globalElements = {
   agentsActiveMinutes: document.getElementById('agentsActiveMinutes'),
   agentsLastRefreshed: document.getElementById('agentsLastRefreshed'),
   agentsList: document.getElementById('agentsList'),
+  agentsSelectionFooter: document.getElementById('agentsSelectionFooter'),
   agentsEmpty: document.getElementById('agentsEmpty'),
   toastHost: document.getElementById('toastHost'),
   commandPaletteModal: document.getElementById('commandPaletteModal'),
@@ -253,6 +254,7 @@ const ADMIN_AGENT_ACTIVE_MINUTES_KEY = 'clawnsole.admin.agents.activeMinutes';
 const ADMIN_AGENT_DENSITY_KEY = 'clawnsole.admin.agents.density';
 const ADMIN_AGENT_HEALTHY_COLLAPSED_KEY = 'clawnsole.admin.agents.healthyCollapsed';
 const ADMIN_AGENT_HEALTHY_COLLAPSE_THRESHOLD = 10;
+let agentsModalSelectedAgentId = '';
 const ADMIN_AUTH_DESTINATION_KEY = 'clawnsole.admin.authDestination.v1';
 const ADMIN_AUTH_RESTORE_PENDING_KEY = 'clawnsole.admin.authRestorePending.v1';
 const ADMIN_AUTH_RESTORE_NOTICE_KEY = 'clawnsole.admin.authRestoreNotice.v1';
@@ -3140,6 +3142,15 @@ function openAgentTriageFromFleet(agentId) {
   openAgentWorkqueueFromFleet(target);
 }
 
+function runFleetAgentAction(agentId, action) {
+  const target = normalizeAgentId(agentId || 'main');
+  if (!target) return;
+  if (action === 'triage') openAgentTriageFromFleet(target);
+  else if (action === 'open-chat') openAgentChatFromFleet(target);
+  else if (action === 'open-timeline') openAgentTimelineFromFleet(target);
+  else if (action === 'open-workqueue') openAgentWorkqueueFromFleet(target);
+}
+
 function findActivePaneFromFocus() {
   const active = document.activeElement;
   if (!active) return null;
@@ -3342,7 +3353,12 @@ function renderAgentsModalList() {
       const statusSnippet = String(statusSnippetMap[id] || '').trim();
       const statusSnippetHtml = statusSnippet ? ` · <span class="agents-status-snippet">${escapeHtml(statusSnippet)}</span>` : '';
       row.dataset.heartbeatBucket = triage.ageBucket;
+      row.dataset.agentId = id;
       row.classList.toggle('agents-row-heatmap', heatmapEnabled);
+      row.classList.toggle('selected', id === agentsModalSelectedAgentId);
+      row.tabIndex = 0;
+      row.setAttribute('aria-selected', id === agentsModalSelectedAgentId ? 'true' : 'false');
+      row.setAttribute('aria-label', `Select agent ${label}`);
 
       row.innerHTML = `
         <button type="button" class="agents-pin" aria-label="${pinnedNow ? 'Unpin agent' : 'Pin agent'}" aria-pressed="${pinnedNow ? 'true' : 'false'}" data-agent-pin="${escapeHtml(id)}">${pinnedNow ? '★' : '☆'}</button>
@@ -3377,16 +3393,27 @@ function renderAgentsModalList() {
         renderAgentsModalList();
       });
 
+      row.addEventListener('click', () => {
+        agentsModalSelectedAgentId = id;
+        renderAgentsModalList();
+      });
+      row.addEventListener('keydown', (e) => {
+        if (e.key !== 'Enter' && e.key !== ' ') return;
+        e.preventDefault();
+        agentsModalSelectedAgentId = id;
+        renderAgentsModalList();
+        try {
+          globalElements.agentsSelectionFooter?.querySelector?.('[data-agent-action]')?.focus?.();
+        } catch {}
+      });
+
       const actionButtons = Array.from(row.querySelectorAll('[data-agent-action]'));
       actionButtons.forEach((btn) => {
         btn.addEventListener('click', (e) => {
           e.preventDefault();
           e.stopPropagation();
           const action = String(btn.getAttribute('data-agent-action') || '').trim();
-          if (action === 'triage') openAgentTriageFromFleet(id);
-          else if (action === 'open-chat') openAgentChatFromFleet(id);
-          else if (action === 'open-timeline') openAgentTimelineFromFleet(id);
-          else if (action === 'open-workqueue') openAgentWorkqueueFromFleet(id);
+          runFleetAgentAction(id, action);
         });
       });
 
@@ -3397,10 +3424,53 @@ function renderAgentsModalList() {
     root.appendChild(section);
   };
 
+  const renderSelectedAgentFooter = () => {
+    const footer = globalElements.agentsSelectionFooter;
+    if (!footer) return;
+
+    const selectedAgent = ordered.find((agent) => String(agent?.id || '').trim() === agentsModalSelectedAgentId);
+    if (!selectedAgent) {
+      agentsModalSelectedAgentId = '';
+      footer.hidden = true;
+      footer.innerHTML = '';
+      return;
+    }
+
+    const id = String(selectedAgent?.id || '').trim();
+    const label = formatAgentLabel(selectedAgent, { includeId: true });
+    const heartbeatTs = Number(lastSeenMap[id]) || 0;
+    const heartbeatAge = heartbeatTs > 0 ? formatRelativeAge(Date.now() - heartbeatTs) : 'unknown';
+    const triage = classify(id);
+    const bucketLabel = triage.bucket === 'offline_error' ? 'offline/error' : triage.bucket;
+    const heatBucketLabel = heartbeatAgeBucketLabel(triage.ageBucket);
+
+    footer.hidden = false;
+    footer.innerHTML = `
+      <div class="agents-selection-main">
+        <div class="agents-selection-label">${escapeHtml(label)}</div>
+        <div class="agents-selection-meta">${escapeHtml(id)} · ${escapeHtml(bucketLabel)} · <span class="agents-age-chip" data-heartbeat-bucket="${escapeHtml(triage.ageBucket)}">${escapeHtml(heartbeatAge)} · ${escapeHtml(heatBucketLabel)}</span></div>
+      </div>
+      <div class="agents-selection-actions" role="group" aria-label="Selected agent actions for ${escapeHtml(label)}">
+        <button type="button" class="secondary agents-action-btn" data-agent-action="open-chat" data-agent-id="${escapeHtml(id)}" aria-label="Open Chat for selected agent ${escapeHtml(label)}">Chat</button>
+        <button type="button" class="secondary agents-action-btn" data-agent-action="open-workqueue" data-agent-id="${escapeHtml(id)}" aria-label="Open Workqueue for selected agent ${escapeHtml(label)}">Workqueue</button>
+        <button type="button" class="secondary agents-action-btn" data-agent-action="open-timeline" data-agent-id="${escapeHtml(id)}" aria-label="Open Timeline for selected agent ${escapeHtml(label)}">Timeline</button>
+      </div>
+    `;
+
+    footer.querySelectorAll('[data-agent-action]').forEach((btn) => {
+      btn.addEventListener('click', (e) => {
+        e.preventDefault();
+        const action = String(btn.getAttribute('data-agent-action') || '').trim();
+        runFleetAgentAction(id, action);
+      });
+    });
+  };
+
   renderSummary();
   if (pinned.length > 0) renderSection('Pinned', pinned);
   renderSection('Needs attention', needsAttention);
   renderSection('Healthy', healthy, { collapsible: true, collapsed: healthyCollapsed });
+  renderSelectedAgentFooter();
 
   if (globalElements.agentsHeatmapToggle) globalElements.agentsHeatmapToggle.checked = heatmapEnabled;
   if (globalElements.agentsHeartbeatSortBtn) {

--- a/index.html
+++ b/index.html
@@ -465,6 +465,7 @@
           </div>
 
           <div id="agentsList" class="agents-list" aria-label="Agent list"></div>
+          <div id="agentsSelectionFooter" class="agents-selection-footer" aria-live="polite" hidden></div>
           <div id="agentsEmpty" class="hint" hidden>No agents match.</div>
         </div>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -1658,6 +1658,16 @@ button.agents-section-title:hover {
   background: rgba(255, 255, 255, 0.02);
 }
 
+.agents-row.selected {
+  border-color: rgba(77, 196, 255, 0.55);
+  background: rgba(77, 196, 255, 0.08);
+}
+
+.agents-row:focus-visible {
+  outline: 2px solid rgba(77, 196, 255, 0.75);
+  outline-offset: 2px;
+}
+
 .agents-row-heatmap {
   border-left-width: 4px;
 }
@@ -1818,6 +1828,52 @@ button.agents-section-title:hover {
   min-width: 150px;
 }
 
+.agents-selection-footer {
+  position: sticky;
+  bottom: 0;
+  z-index: 5;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  margin-top: 4px;
+  border: 1px solid rgba(77, 196, 255, 0.26);
+  border-radius: 12px;
+  padding: 10px 12px;
+  background: rgba(12, 16, 22, 0.96);
+  box-shadow: 0 -12px 28px rgba(0, 0, 0, 0.24);
+}
+
+.agents-selection-footer[hidden] {
+  display: none;
+}
+
+.agents-selection-main {
+  min-width: 0;
+}
+
+.agents-selection-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.agents-selection-meta {
+  margin-top: 2px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.agents-selection-actions {
+  display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
 @media (max-width: 860px) {
   .agents-row {
     grid-template-columns: 42px 1fr auto;
@@ -1829,6 +1885,14 @@ button.agents-section-title:hover {
 
   .agents-row-actions-overflow {
     display: block;
+  }
+
+  .agents-selection-footer {
+    grid-template-columns: 1fr;
+  }
+
+  .agents-selection-actions {
+    justify-content: flex-start;
   }
 }
 

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -252,6 +252,45 @@ test('agents modal quick actions open/reuse chat, timeline, and workqueue contex
   await expect(page.locator('[data-pane][data-pane-kind="workqueue"] [data-wq-claim-agent]')).toHaveValue(agentId || 'main');
 });
 
+test('agents modal shows a sticky selected-agent footer with triage actions', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  let agents = [
+    { id: 'alpha', name: 'Alpha', displayName: 'Alpha' },
+    { id: 'beta', name: 'Beta', displayName: 'Beta' }
+  ];
+  await page.route(/\/agents(?:\?|$)/, async (route) => {
+    await route.fulfill({ json: { agents } });
+  });
+
+  await clawnsole.gotoAndLoginAdmin(page);
+  await page.evaluate(() => {
+    const now = Date.now();
+    localStorage.setItem('clawnsole.admin.agentLastSeenAtMs', JSON.stringify({ alpha: now, beta: now - 75_000 }));
+  });
+  await page.getByRole('button', { name: 'Refresh agent list' }).click();
+  await page.getByRole('button', { name: 'Open agents' }).click();
+
+  const row = page.locator('#agentsList .agents-row').filter({ hasText: 'Beta (beta)' });
+  await row.click();
+
+  const footer = page.locator('#agentsSelectionFooter');
+  await expect(footer).toBeVisible();
+  await expect(footer).toContainText('Beta (beta)');
+  await expect(footer.locator('.agents-age-chip')).toContainText(/\d+[smhd]|unknown/);
+  await expect(footer).toHaveCSS('position', 'sticky');
+
+  await footer.getByRole('button', { name: /Open Workqueue for selected agent/ }).click();
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"] [data-wq-claim-agent]')).toHaveValue('beta');
+
+  agents = [{ id: 'alpha', name: 'Alpha', displayName: 'Alpha' }];
+  await page.getByRole('button', { name: 'Close agents' }).click();
+  await page.getByRole('button', { name: 'Refresh agent list' }).click();
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(footer).toBeHidden();
+  await expect(footer.locator('[data-agent-action]')).toHaveCount(0);
+});
+
 test('agents modal triage action opens chat and workqueue from non-chat layout', async ({ page, clawnsole }) => {
   if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
 


### PR DESCRIPTION
## Summary\n- Add a sticky selected-agent footer to the Fleet agents modal with agent identity, health state, and heartbeat age.\n- Reuse existing Chat, Workqueue, and Timeline actions from the selected-agent footer.\n- Clear the footer when refresh/filtering removes the selected agent so stale actions are not shown.\n\nFixes #366\n\n## Tests\n- npm run test:syntax\n- npx playwright test tests/ui/agents-modal.spec.js --grep "sticky selected-agent footer" --workers=1 --timeout=30000 --reporter=line --trace=off\n