### PR TITLE
Add Workqueue filter summary chips

### DIFF
--- a/app.js
+++ b/app.js
@@ -3449,6 +3449,21 @@ function formatWorkqueueStatusLabel(status) {
     .join(' ');
 }
 
+function formatWorkqueueScopeLabel(scope) {
+  const s = String(scope || '').trim().toLowerCase();
+  if (s === 'assigned') return 'Assigned';
+  if (s === 'unassigned') return 'Unassigned';
+  return 'All';
+}
+
+function formatWorkqueueSourceLabel(source) {
+  const s = String(source || '').trim().toLowerCase();
+  if (s === 'issue') return 'Issue';
+  if (s === 'routine') return 'Routine';
+  if (s === 'coordination') return 'Coordination';
+  return 'Other';
+}
+
 function buildWorkqueueStatusCounts(items) {
   const counts = Object.fromEntries(WORKQUEUE_STATUSES.map((s) => [s, 0]));
   for (const it of Array.isArray(items) ? items : []) {
@@ -4185,12 +4200,127 @@ function groupWorkqueueDuplicateIssues(items) {
 function applyWorkqueueQuickFilters(items, quickFilters) {
   const sourceSet = new Set(Array.isArray(quickFilters?.sources) ? quickFilters.sources.map((x) => String(x || '').trim()).filter(Boolean) : []);
   const repoSet = new Set(Array.isArray(quickFilters?.repos) ? quickFilters.repos.map((x) => String(x || '').trim()).filter(Boolean) : []);
+  const search = String(quickFilters?.search || '').trim().toLowerCase();
 
   return (Array.isArray(items) ? items : []).filter((it) => {
     if (sourceSet.size && !sourceSet.has(getWorkqueueItemSource(it))) return false;
     if (repoSet.size && !repoSet.has(getWorkqueueItemRepo(it))) return false;
+    if (search) {
+      const haystack = [
+        it?.id,
+        it?.title,
+        it?.instructions,
+        it?.dedupeKey,
+        it?.status,
+        it?.claimedBy,
+        getWorkqueueItemRepo(it),
+        getWorkqueueItemSource(it)
+      ].map((v) => String(v || '').toLowerCase()).join('\n');
+      if (!haystack.includes(search)) return false;
+    }
     return true;
   });
+}
+
+function formatWorkqueueCountText(shown, total) {
+  const shownNum = Number(shown) || 0;
+  const totalNum = Number(total) || 0;
+  const noun = shownNum === 1 ? 'item' : 'items';
+  if (totalNum > 0 && shownNum !== totalNum) return `Showing ${shownNum} of ${totalNum} ${totalNum === 1 ? 'item' : 'items'}`;
+  return `Showing ${shownNum} ${noun}`;
+}
+
+function renderWorkqueueFilterSummaryForPane(pane, { shownCount, totalCount } = {}) {
+  const root = pane?.elements?.thread?.querySelector?.('[data-wq-filter-summary]');
+  if (!root) return;
+
+  const queue = String(pane.workqueue?.queue || '').trim();
+  const scope = pane.workqueue?.scopeFilter || 'all';
+  const statuses = Array.isArray(pane.workqueue?.statusFilter) ? pane.workqueue.statusFilter.map((s) => String(s || '').trim()).filter(Boolean) : [];
+  const quick = pane.workqueue?.quickFilters || {};
+  const sources = Array.isArray(quick.sources) ? quick.sources.map((s) => String(s || '').trim()).filter(Boolean) : [];
+  const repos = Array.isArray(quick.repos) ? quick.repos.map((s) => String(s || '').trim()).filter(Boolean) : [];
+  const search = String(quick.search || '').trim();
+  const hasFilters = !!queue || !!scope || statuses.length || sources.length || repos.length || !!search;
+
+  root.innerHTML = '';
+  root.hidden = !hasFilters;
+  if (!hasFilters) return;
+
+  const count = document.createElement('span');
+  count.className = 'wq-filter-count';
+  count.textContent = formatWorkqueueCountText(shownCount, totalCount);
+  root.appendChild(count);
+
+  const addToken = ({ label, value, title, action, removable = true }) => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'wq-filter-token';
+    btn.title = title || (removable ? `Remove ${label} filter` : label);
+    btn.setAttribute('aria-label', btn.title);
+    btn.disabled = !removable;
+    btn.innerHTML = `<span class="wq-filter-token-label">${escapeHtml(label)}</span> <span>${escapeHtml(value)}</span>${removable ? ' <span aria-hidden="true">×</span>' : ''}`;
+    if (removable && typeof action === 'function') btn.addEventListener('click', action);
+    root.appendChild(btn);
+  };
+
+  if (queue) {
+    addToken({
+      label: 'Queue',
+      value: queue,
+      title: queue === 'dev-team' ? 'Queue target dev-team' : `Reset queue filter ${queue} to dev-team`,
+      removable: queue !== 'dev-team',
+      action: () => pane.workqueue?.setQueue?.('dev-team')
+    });
+  }
+  addToken({
+    label: 'Scope',
+    value: formatWorkqueueScopeLabel(scope),
+    title: `Reset scope filter ${formatWorkqueueScopeLabel(scope)} to All`,
+    removable: scope !== 'all',
+    action: () => pane.workqueue?.setScope?.('all')
+  });
+  for (const status of statuses) {
+    addToken({
+      label: 'Status',
+      value: formatWorkqueueStatusLabel(status),
+      title: `Remove status filter ${formatWorkqueueStatusLabel(status)}`,
+      action: () => pane.workqueue?.applyStatuses?.(statuses.filter((s) => s !== status))
+    });
+  }
+  for (const source of sources) {
+    addToken({
+      label: 'Source',
+      value: formatWorkqueueSourceLabel(source),
+      title: `Remove source filter ${formatWorkqueueSourceLabel(source)}`,
+      action: () => pane.workqueue?.removeQuickFilter?.('source', source)
+    });
+  }
+  for (const repo of repos) {
+    addToken({
+      label: 'Repo',
+      value: repo,
+      title: `Remove repo filter ${repo}`,
+      action: () => pane.workqueue?.removeQuickFilter?.('repo', repo)
+    });
+  }
+  if (search) {
+    addToken({
+      label: 'Search',
+      value: search,
+      title: `Clear search query ${search}`,
+      action: () => pane.workqueue?.setQuickSearch?.('')
+    });
+  }
+
+  const clear = document.createElement('button');
+  clear.type = 'button';
+  clear.className = 'secondary wq-clear-all-filters';
+  clear.setAttribute('data-wq-clear-all-filters', '');
+  clear.textContent = 'Clear all filters';
+  clear.title = 'Clear status, scope, search, source, and repo filters. Queue target is preserved.';
+  clear.addEventListener('click', () => pane.workqueue?.clearAllFilters?.());
+  root.appendChild(clear);
 }
 
 async function fetchAndRenderWorkqueueItemsForPane(pane) {
@@ -4239,7 +4369,6 @@ async function fetchAndRenderWorkqueueItemsForPane(pane) {
     if (previousSignature && previousSignature !== nextSignature) {
       markPaneUnread(pane, 1, 'workqueue');
     }
-    if (statusLine) statusLine.textContent = `${items.length} item(s)`;
     if (typeof pane.workqueue.renderStatusMultiSelect === 'function') pane.workqueue.renderStatusMultiSelect();
     renderWorkqueuePaneItems(pane);
   } catch (err) {
@@ -4338,6 +4467,10 @@ function renderWorkqueuePaneItems(pane) {
   const scopedItems = filterWorkqueuePaneItemsByScope(pane, pane.workqueue?.items);
   const filteredItems = applyWorkqueueQuickFilters(scopedItems, pane.workqueue?.quickFilters);
   const items = sortWorkqueueItems(filteredItems, { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
+  const totalCount = Array.isArray(pane.workqueue?.countItems) ? pane.workqueue.countItems.length : (Array.isArray(pane.workqueue?.items) ? pane.workqueue.items.length : items.length);
+  const statusLine = pane.elements?.thread?.querySelector('[data-wq-statusline]');
+  if (statusLine) statusLine.textContent = formatWorkqueueCountText(items.length, totalCount);
+  renderWorkqueueFilterSummaryForPane(pane, { shownCount: items.length, totalCount });
   const renderLimit = Math.max(
     WORKQUEUE_PANE_INITIAL_RENDER_LIMIT,
     Number(pane.workqueue?.renderLimit || WORKQUEUE_PANE_INITIAL_RENDER_LIMIT)
@@ -6362,7 +6495,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       scopeFilter: normalizeWorkqueueScope(scopeFilter ?? getDefaultWorkqueueScope()),
       quickFilters: {
         sources: Array.isArray(quickFilters?.sources) ? quickFilters.sources.map((s) => String(s || '').trim()).filter(Boolean) : [],
-        repos: Array.isArray(quickFilters?.repos) ? quickFilters.repos.map((s) => String(s || '').trim()).filter(Boolean) : []
+        repos: Array.isArray(quickFilters?.repos) ? quickFilters.repos.map((s) => String(s || '').trim()).filter(Boolean) : [],
+        search: String(quickFilters?.search || '').trim()
       },
       statusCounts: Object.fromEntries(WORKQUEUE_STATUSES.map((s) => [s, 0])),
       items: [],
@@ -6586,6 +6720,11 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
             <div class="wq-scope" data-wq-repo-chips></div>
           </div>
 
+          <label class="wq-field wq-search-field">
+            <span class="wq-label">Search</span>
+            <input data-wq-search type="search" placeholder="Filter tasks" autocomplete="off" />
+          </label>
+
           <button data-wq-preset-clawnsole class="secondary" type="button">Clawnsole only</button>
           <button data-wq-clear-quick class="secondary" type="button">Clear filters</button>
           <button data-wq-refresh class="secondary" type="button">Refresh</button>
@@ -6644,6 +6783,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         </details>
 
         <div class="hint" data-wq-statusline></div>
+        <div class="wq-filter-summary" data-wq-filter-summary aria-live="polite" hidden></div>
         <div class="wq-duplicate-health" data-wq-duplicate-health aria-live="polite" hidden></div>
       </div>
 
@@ -6693,6 +6833,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     const repoChipsEl = elements.thread.querySelector('[data-wq-repo-chips]');
     const clawnsoleOnlyBtn = elements.thread.querySelector('[data-wq-preset-clawnsole]');
     const clearQuickBtn = elements.thread.querySelector('[data-wq-clear-quick]');
+    const searchEl = elements.thread.querySelector('[data-wq-search]');
     const refreshBtn = elements.thread.querySelector('[data-wq-refresh]');
 
     const DEFAULT_STATUSES = ['ready', 'pending', 'claimed', 'in_progress'];
@@ -6712,9 +6853,11 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     const initQuick = pane.workqueue?.quickFilters || {};
     const sourceSet = new Set(Array.isArray(initQuick.sources) ? initQuick.sources.map((x) => String(x || '').trim()).filter(Boolean) : []);
     const repoSet = new Set(Array.isArray(initQuick.repos) ? initQuick.repos.map((x) => String(x || '').trim()).filter(Boolean) : []);
+    let searchQuery = String(initQuick.search || '').trim();
+    if (searchEl) searchEl.value = searchQuery;
 
     const persistQuickFilters = () => {
-      pane.workqueue.quickFilters = { sources: Array.from(sourceSet), repos: Array.from(repoSet) };
+      pane.workqueue.quickFilters = { sources: Array.from(sourceSet), repos: Array.from(repoSet), search: searchQuery };
       paneManager.persistAdminPanes();
     };
 
@@ -6755,6 +6898,24 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       }
     };
 
+    const setQuickSearch = (next) => {
+      searchQuery = String(next || '').trim();
+      if (searchEl && searchEl.value !== searchQuery) searchEl.value = searchQuery;
+      resetRenderLimit();
+      persistQuickFilters();
+      renderWorkqueuePaneItems(pane);
+    };
+
+    const removeQuickFilter = (type, value) => {
+      const key = String(value || '').trim();
+      if (type === 'source') sourceSet.delete(key);
+      if (type === 'repo') repoSet.delete(key);
+      resetRenderLimit();
+      persistQuickFilters();
+      updateQuickFilterUi();
+      renderWorkqueuePaneItems(pane);
+    };
+
     const applyStatuses = async (next, { closeMenu = false } = {}) => {
       statusSet.clear();
       for (const s of next) statusSet.add(s);
@@ -6791,6 +6952,24 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       await fetchAndRenderWorkqueueItemsForPane(pane);
       updateQuickFilterUi();
       paneManager.persistAdminPanes();
+    };
+
+    const setQueue = async (queue) => {
+      const q = String(queue || '').trim() || 'dev-team';
+      if (queueSelectEl) {
+        const existing = Array.from(queueSelectEl.options || []).find((opt) => String(opt.value) === q);
+        if (existing) {
+          queueSelectEl.value = q;
+          if (queueCustomEl) queueCustomEl.hidden = true;
+        } else {
+          queueSelectEl.value = '__custom__';
+          if (queueCustomEl) {
+            queueCustomEl.hidden = false;
+            queueCustomEl.value = q;
+          }
+        }
+      }
+      await doRefresh();
     };
 
     const renderStatusMultiSelect = () => {
@@ -6830,6 +7009,10 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       }
     };
     pane.workqueue.renderStatusMultiSelect = renderStatusMultiSelect;
+    pane.workqueue.applyStatuses = applyStatuses;
+    pane.workqueue.setQueue = setQueue;
+    pane.workqueue.setQuickSearch = setQuickSearch;
+    pane.workqueue.removeQuickFilter = removeQuickFilter;
 
     const applyQueueSearchFilter = () => {
       if (!queueSelectEl) return;
@@ -6983,6 +7166,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       renderWorkqueuePaneItems(pane);
       paneManager.persistAdminPanes();
     };
+    pane.workqueue.setScope = setScope;
     scopeBtns.forEach((btn) => {
       btn.addEventListener('click', () => setScope(btn.getAttribute('data-wq-scope')));
     });
@@ -7001,6 +7185,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       });
     });
 
+    searchEl?.addEventListener('input', () => setQuickSearch(searchEl.value));
+
     clawnsoleOnlyBtn?.addEventListener('click', () => {
       sourceSet.clear();
       repoSet.clear();
@@ -7011,9 +7197,24 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       renderWorkqueuePaneItems(pane);
     });
 
+    const clearAllFilters = async () => {
+      sourceSet.clear();
+      repoSet.clear();
+      searchQuery = '';
+      if (searchEl) searchEl.value = '';
+      resetRenderLimit();
+      persistQuickFilters();
+      updateQuickFilterUi();
+      setScope('all');
+      await applyStatuses(DEFAULT_STATUSES);
+    };
+    pane.workqueue.clearAllFilters = clearAllFilters;
+
     clearQuickBtn?.addEventListener('click', () => {
       sourceSet.clear();
       repoSet.clear();
+      searchQuery = '';
+      if (searchEl) searchEl.value = '';
       resetRenderLimit();
       persistQuickFilters();
       updateQuickFilterUi();
@@ -7794,6 +7995,7 @@ const paneManager = {
         queue: cfg.queue,
         statusFilter: cfg.statusFilter,
         scopeFilter: cfg.scopeFilter,
+        quickFilters: cfg.quickFilters,
         sortKey: cfg.sortKey,
         sortDir: cfg.sortDir,
         closable: true
@@ -7842,7 +8044,8 @@ const paneManager = {
           const scopeFilter = normalizeWorkqueueScope(item.scopeFilter ?? getDefaultWorkqueueScope());
           const quickFilters = {
             sources: Array.isArray(item?.quickFilters?.sources) ? item.quickFilters.sources.map((s) => String(s || '').trim()).filter(Boolean) : [],
-            repos: Array.isArray(item?.quickFilters?.repos) ? item.quickFilters.repos.map((s) => String(s || '').trim()).filter(Boolean) : []
+            repos: Array.isArray(item?.quickFilters?.repos) ? item.quickFilters.repos.map((s) => String(s || '').trim()).filter(Boolean) : [],
+            search: String(item?.quickFilters?.search || '').trim()
           };
           const sortKey = typeof item.sortKey === 'string' ? item.sortKey : 'priority';
           const sortDir = item.sortDir === 'asc' ? 'asc' : 'desc';
@@ -7890,7 +8093,8 @@ const paneManager = {
           scopeFilter: pane.workqueue?.scopeFilter || 'all',
           quickFilters: {
             sources: Array.isArray(pane.workqueue?.quickFilters?.sources) ? pane.workqueue.quickFilters.sources : [],
-            repos: Array.isArray(pane.workqueue?.quickFilters?.repos) ? pane.workqueue.quickFilters.repos : []
+            repos: Array.isArray(pane.workqueue?.quickFilters?.repos) ? pane.workqueue.quickFilters.repos : [],
+            search: String(pane.workqueue?.quickFilters?.search || '').trim()
           },
           sortKey: pane.workqueue?.sortKey || 'priority',
           sortDir: pane.workqueue?.sortDir || 'desc'

--- a/styles.css
+++ b/styles.css
@@ -2106,6 +2106,69 @@ kbd {
   flex: 1;
 }
 
+.wq-search-field {
+  min-width: 220px;
+}
+
+.wq-filter-summary {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-top: 8px;
+  min-height: 28px;
+}
+
+.wq-filter-summary[hidden] {
+  display: none;
+}
+
+.wq-filter-count {
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 650;
+  margin-right: 4px;
+}
+
+.wq-filter-token {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 26px;
+  max-width: 260px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(127, 209, 185, 0.28);
+  background: rgba(127, 209, 185, 0.1);
+  color: var(--text);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.wq-filter-token:disabled {
+  cursor: default;
+  opacity: 0.82;
+}
+
+.wq-filter-token span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wq-filter-token-label {
+  color: var(--muted);
+  text-transform: uppercase;
+  font-size: 10px;
+}
+
+.wq-clear-all-filters {
+  min-height: 26px;
+  padding: 4px 8px;
+  font-size: 11px;
+}
+
 .wq-status-multiselect {
   display: flex;
   flex-direction: column;

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -110,6 +110,50 @@ function seedLegacyIssueTitleVariants(queue) {
   fs.writeFileSync(path.join(dir, 'work-queues.json'), JSON.stringify(data, null, 2));
 }
 
+function seedFilterSummaryWorkqueueItems(queue) {
+  const dir = path.join(env.tempHome, '.openclaw', 'clawnsole');
+  fs.mkdirSync(dir, { recursive: true });
+  const now = new Date();
+  const iso = (offsetMs) => new Date(now.getTime() + offsetMs).toISOString();
+  const mkItem = (id, patch = {}) => ({
+    id,
+    queue,
+    title: '[issue] rmdmattingly/clawnsole#323 filter summary',
+    instructions: 'Repo: rmdmattingly/clawnsole\nIssue: https://github.com/rmdmattingly/clawnsole/issues/323',
+    priority: 10,
+    status: 'ready',
+    claimedBy: '',
+    claimedAt: '',
+    leaseUntil: 0,
+    attempts: 0,
+    lastError: '',
+    createdAt: iso(-60000),
+    updatedAt: iso(-60000),
+    dedupeKey: `filter-summary-${id}`,
+    ...patch
+  });
+
+  const data = {
+    version: 1,
+    queues: { [queue]: { name: queue, createdAt: iso(-120000) } },
+    assignments: {},
+    items: [
+      mkItem('summary-clawnsole-ready'),
+      mkItem('summary-other-ready', {
+        title: '[issue] other/repo#9 alternate repo',
+        instructions: 'Repo: other/repo\nIssue: https://github.com/other/repo/issues/9',
+        dedupeKey: 'filter-summary-other'
+      }),
+      mkItem('summary-clawnsole-failed', {
+        title: '[issue] rmdmattingly/clawnsole#324 failed row',
+        status: 'failed',
+        dedupeKey: 'filter-summary-failed'
+      })
+    ]
+  };
+  fs.writeFileSync(path.join(dir, 'work-queues.json'), JSON.stringify(data, null, 2));
+}
+
 test('workqueue pane: renders + has queue dropdown + does not show chat composer', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);
@@ -208,6 +252,51 @@ test('workqueue pane: status filter uses human labels and queue-scoped counts', 
   await customQueue.press('Enter');
   await expect(wqPane.locator('[data-wq-statusline]')).toContainText('1 item');
   await expect(wqPane.locator('[data-wq-status-options] .wq-status-chip', { hasText: 'Ready (1)' })).toHaveCount(1);
+});
+
+test('workqueue pane: filter summary chips show counts and remove filters', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  const queue = `filter-summary-${Date.now()}`;
+  seedFilterSummaryWorkqueueItems(queue);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  const wqPane = page.locator('[data-pane]').last();
+  await wqPane.locator('[data-wq-queue-select]').selectOption('__custom__');
+  await wqPane.locator('[data-wq-queue-custom]').fill(queue);
+  await wqPane.locator('[data-wq-queue-custom]').press('Enter');
+
+  const summary = wqPane.locator('[data-wq-filter-summary]');
+  await expect(wqPane.locator('[data-wq-statusline]')).toContainText('Showing 2 of 3 items');
+  await expect(summary).toBeVisible();
+  await expect(summary).toContainText(`Queue ${queue}`);
+  await expect(summary).toContainText('Scope Unassigned');
+  await expect(summary).toContainText('Status Ready');
+  await expect(wqPane.locator('.wq-row')).toHaveCount(2);
+
+  await wqPane.locator('[data-wq-preset-clawnsole]').click();
+  await expect(wqPane.locator('[data-wq-statusline]')).toContainText('Showing 1 of 3 items');
+  await expect(summary).toContainText('Repo rmdmattingly/clawnsole');
+  await expect(wqPane.locator('.wq-row')).toHaveCount(1);
+
+  await summary.getByRole('button', { name: /Remove repo filter rmdmattingly\/clawnsole/ }).click();
+  await expect(wqPane.locator('[data-wq-statusline]')).toContainText('Showing 2 of 3 items');
+  await expect(summary).not.toContainText('Repo rmdmattingly/clawnsole');
+  await expect(wqPane.locator('.wq-row')).toHaveCount(2);
+
+  await wqPane.locator('[data-wq-search]').fill('alternate repo');
+  await expect(wqPane.locator('[data-wq-statusline]')).toContainText('Showing 1 of 3 items');
+  await expect(summary).toContainText('Search alternate repo');
+
+  await summary.locator('[data-wq-clear-all-filters]').click();
+  await expect(wqPane.locator('[data-wq-statusline]')).toContainText('Showing 2 of 3 items');
+  await expect(summary).not.toContainText('Search alternate repo');
+  await expect(wqPane.locator('[data-wq-queue-custom]')).toHaveValue(queue);
 });
 
 test('workqueue pane: queue target supports search + recent persistence', async ({ page }) => {


### PR DESCRIPTION
## Summary\n- add contextual Workqueue result counts and active filter summary chips\n- support removable queue/status/scope/source/repo/search tokens plus a clear-all action that preserves queue\n- add pane-level search filtering and Playwright coverage\n\n## Tests\n- npm run test:syntax\n- npm run test:unit -- --test-name-pattern workqueue\n- npx playwright test tests/ui/workqueue-pane.spec.js --workers=1\n\nCloses #323