### PR TITLE
UX: show pane index badges while holding Option

### DIFF
--- a/app.js
+++ b/app.js
@@ -7275,10 +7275,12 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
   const root = template.content.firstElementChild.cloneNode(true);
   const elements = {
     root,
+    headerLeft: root.querySelector('.pane-header-left'),
     name: root.querySelector('[data-pane-name]'),
     nameToken: root.querySelector('[data-pane-name-token]'),
     nameTarget: root.querySelector('[data-pane-name-target]'),
     nicknameBtn: root.querySelector('[data-pane-nickname]'),
+    indexBadge: null,
     typePill: root.querySelector('[data-pane-type-pill]'),
     typeIcon: root.querySelector('[data-pane-type-icon]'),
     typeText: root.querySelector('[data-pane-type-text]'),
@@ -7380,6 +7382,14 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
 
   // Pane header: kind label + type pill (icon + text)
   try {
+    if (elements.headerLeft) {
+      const indexBadge = document.createElement('span');
+      indexBadge.className = 'pane-index-badge';
+      indexBadge.setAttribute('data-pane-index-badge', '');
+      indexBadge.setAttribute('aria-hidden', 'true');
+      elements.headerLeft.insertBefore(indexBadge, elements.headerLeft.firstChild);
+      elements.indexBadge = indexBadge;
+    }
     if (elements.name) {
       if (elements.nameToken && elements.nameTarget) {
         elements.name.replaceChildren(elements.nameToken, elements.nameTarget);
@@ -8914,6 +8924,7 @@ const paneManager = {
     );
     this.panes.forEach((pane) => globalElements.paneGrid.appendChild(pane.elements.root));
     this.updatePaneLabels();
+    updatePaneIndexBadges();
     this.updateCloseButtons();
     this.applyInferredLayout();
     updateBrowserTitle(this.panes[0] || null);
@@ -9538,12 +9549,14 @@ const paneManager = {
     }
 
     this.updatePaneLabels();
+    updatePaneIndexBadges();
     this.persistAdminPanes();
     updateGlobalStatus();
     return true;
   },
   updatePaneLabels() {
     this.panes.forEach((pane) => renderPaneIdentity(pane));
+    updatePaneIndexBadges();
     this.updatePaneGridLabel();
   },
   updatePaneGridLabel() {
@@ -9866,7 +9879,7 @@ globalElements.wqRefreshBtn?.addEventListener('click', () => {
 globalElements.wqEnqueueBtn?.addEventListener('click', () => workqueueEnqueueFromUi());
 globalElements.wqClaimBtn?.addEventListener('click', () => workqueueClaimNextFromUi());
 
-let shortcutState = { lastGAtMs: 0, blockedReasonLastShownAt: new Map() };
+let shortcutState = { lastGAtMs: 0, blockedReasonLastShownAt: new Map(), paneIndexBadgesVisible: false };
 const GO_TO_PANE_TIMEOUT_MS = 1200;
 const SHORTCUT_BLOCK_RATE_LIMIT_MS = 5000;
 const SHORTCUT_BLOCK_MESSAGES = {
@@ -9874,6 +9887,31 @@ const SHORTCUT_BLOCK_MESSAGES = {
   modal: 'Close modal to use this shortcut',
   layout: 'Use Cmd/Ctrl+1..9 on this keyboard layout'
 };
+
+function updatePaneIndexBadges() {
+  const panes = paneManager?.panes || [];
+  panes.forEach((pane, idx) => {
+    const badge = pane?.elements?.indexBadge;
+    const root = pane?.elements?.root;
+    if (!badge || !root) return;
+    const focusNumber = idx + 1;
+    const eligible = focusNumber >= 1 && focusNumber <= 9;
+    badge.textContent = eligible ? String(focusNumber) : '';
+    badge.hidden = !eligible || !shortcutState.paneIndexBadgesVisible;
+    badge.setAttribute('aria-hidden', 'true');
+    root.dataset.paneFocusIndex = eligible ? String(focusNumber) : '';
+    if (eligible) root.setAttribute('aria-keyshortcuts', `Alt+${focusNumber} Meta+Shift+${focusNumber} Control+Shift+${focusNumber}`);
+    else root.removeAttribute('aria-keyshortcuts');
+  });
+}
+
+function setPaneIndexBadgesVisible(visible) {
+  const next = !!visible;
+  if (shortcutState.paneIndexBadgesVisible === next) return;
+  shortcutState.paneIndexBadgesVisible = next;
+  document.body?.classList?.toggle('pane-index-badges-visible', next);
+  updatePaneIndexBadges();
+}
 
 function reportBlockedShortcut(reason) {
   const key = String(reason || '').trim();
@@ -10213,6 +10251,8 @@ function isBlockingOverlayOpenForPaneShortcuts() {
 }
 
 window.addEventListener('keydown', (event) => {
+  if (event.key === 'Alt' || event.altKey) setPaneIndexBadgesVisible(true);
+
   const isEditableTarget = (() => {
     const el = event.target;
     if (!el) return false;
@@ -10434,6 +10474,16 @@ window.addEventListener('keydown', (event) => {
       shortcutState.lastGAtMs = 0;
     }
   }
+});
+
+window.addEventListener('keyup', (event) => {
+  if (event.key === 'Alt' || !event.altKey) setPaneIndexBadgesVisible(false);
+});
+
+window.addEventListener('blur', () => setPaneIndexBadgesVisible(false));
+
+document.addEventListener('visibilitychange', () => {
+  if (document.hidden) setPaneIndexBadgesVisible(false);
 });
 
 globalElements.disconnectBtn?.addEventListener('click', () => {

--- a/styles.css
+++ b/styles.css
@@ -471,6 +471,28 @@ body::before {
   min-width: 0;
 }
 
+.pane-index-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  border-radius: 8px;
+  border: 1px solid rgba(var(--pane-accent-rgb, 255, 179, 71), 0.58);
+  background: rgba(8, 12, 18, 0.86);
+  color: rgba(255, 255, 255, 0.94);
+  font-size: 12px;
+  font-weight: 800;
+  line-height: 1;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+}
+
+.pane-index-badge[hidden] {
+  display: inline-flex !important;
+  visibility: hidden;
+}
+
 .pane-name {
   display: inline-flex;
   align-items: center;

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -58,6 +58,36 @@ test('shortcuts overlay: ? opens, Esc closes, content renders', async ({ page })
   await expect(modal).toHaveAttribute('aria-hidden', 'true');
 });
 
+test('holding Alt reveals visible pane focus index badges', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const badges = page.locator('[data-pane-index-badge]');
+  await expect(badges.first()).toHaveText('1');
+  await expect(badges.first()).toBeHidden();
+
+  await page.keyboard.down('Alt');
+  await expect(badges.first()).toBeVisible();
+  await expect(badges.first()).toHaveText('1');
+
+  await page.getByTestId('add-pane-btn').click();
+  await page.getByTestId('pane-add-menu-chat').click();
+  await expect(page.locator('[data-pane]')).toHaveCount(3);
+  await expect(badges.nth(2)).toBeVisible();
+  await expect(badges.nth(2)).toHaveText('3');
+
+  await page.keyboard.up('Alt');
+  await expect(badges.first()).toBeHidden();
+  await expect(badges.nth(2)).toBeHidden();
+});
+
 test('pane-add shortcuts are scoped to workspace and blocked by overlays', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!app?.skipReason, app?.skipReason);


### PR DESCRIPTION
Fixes #364.\n\n## Summary\n- Add reserved pane index badges to pane headers for direct-focus shortcuts\n- Toggle badges while Alt/Option is held and refresh labels as panes open/reorder/close\n- Cover the behavior with a focused Playwright shortcut test\n\n## Verification\n- node --check app.js\n- node --check tests/pane.shortcuts.e2e.spec.js\n- npx playwright test tests/pane.shortcuts.e2e.spec.js --grep "holding Alt reveals"