### PR TITLE
Keep Fleet header and identity visible while scrolling

### DIFF
--- a/app.js
+++ b/app.js
@@ -3262,6 +3262,19 @@ function renderAgentsModalList() {
 
   root.innerHTML = '';
 
+  const renderGridHeader = () => {
+    const header = document.createElement('div');
+    header.className = 'agents-grid-header';
+    header.setAttribute('aria-hidden', 'true');
+    header.innerHTML = `
+      <div class="agents-grid-cell agents-grid-cell-pin">Pin</div>
+      <div class="agents-grid-cell agents-grid-cell-agent">Agent / state</div>
+      <div class="agents-grid-cell">Actions</div>
+      <div class="agents-grid-cell">More</div>
+    `;
+    root.appendChild(header);
+  };
+
   const renderSummary = () => {
     const summary = document.createElement('div');
     summary.className = 'agents-health-summary';
@@ -3398,6 +3411,7 @@ function renderAgentsModalList() {
   };
 
   renderSummary();
+  renderGridHeader();
   if (pinned.length > 0) renderSection('Pinned', pinned);
   renderSection('Needs attention', needsAttention);
   renderSection('Healthy', healthy, { collapsible: true, collapsed: healthyCollapsed });

--- a/styles.css
+++ b/styles.css
@@ -1534,10 +1534,20 @@ button.send-btn .btn-icon {
   display: flex;
   flex-direction: column;
   gap: 12px;
+  flex: 1 1 auto;
+  min-height: 280px;
+  overflow: auto;
+  padding-bottom: 2px;
 }
 
 .agents-list.compact {
   gap: 6px;
+}
+
+#agentsModal .modal-body {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 .agents-health-summary {
@@ -1637,6 +1647,7 @@ button.agents-section-title:hover {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  min-width: 920px;
 }
 
 .agents-list.compact .agents-rows {
@@ -1649,7 +1660,7 @@ button.agents-section-title:hover {
 
 .agents-row {
   display: grid;
-  grid-template-columns: 42px 1fr auto;
+  grid-template-columns: 42px minmax(280px, 1fr) minmax(220px, 0.9fr) minmax(220px, auto);
   gap: 10px;
   align-items: center;
   border: 1px solid rgba(255, 255, 255, 0.09);
@@ -1683,10 +1694,37 @@ button.agents-section-title:hover {
 }
 
 .agents-list.compact .agents-row {
-  grid-template-columns: 32px minmax(0, 1fr) auto;
+  grid-template-columns: 32px minmax(240px, 1fr) minmax(200px, 0.9fr) minmax(180px, auto);
   gap: 8px;
   border-radius: 10px;
   padding: 3px 8px;
+}
+
+.agents-grid-header {
+  min-width: 920px;
+  display: grid;
+  grid-template-columns: 42px minmax(280px, 1fr) minmax(220px, 0.9fr) minmax(220px, auto);
+  gap: 10px;
+  align-items: center;
+  position: sticky;
+  top: 0;
+  z-index: 8;
+  padding: 0 12px 8px;
+  background: linear-gradient(180deg, rgba(12, 15, 19, 0.98), rgba(12, 15, 19, 0.92));
+}
+
+.agents-list.compact .agents-grid-header {
+  grid-template-columns: 32px minmax(240px, 1fr) minmax(200px, 0.9fr) minmax(180px, auto);
+  gap: 8px;
+  padding-inline: 8px;
+}
+
+.agents-grid-cell {
+  min-width: 0;
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .agents-pin {
@@ -1697,6 +1735,35 @@ button.agents-section-title:hover {
   background: rgba(9, 12, 16, 0.35);
   color: var(--text);
   cursor: pointer;
+}
+
+.agents-grid-cell-pin,
+.agents-pin {
+  position: sticky;
+  left: 12px;
+  z-index: 5;
+}
+
+.agents-grid-cell-pin {
+  background: rgba(12, 15, 19, 0.98);
+}
+
+.agents-grid-cell-agent,
+.agents-row-main {
+  position: sticky;
+  left: 64px;
+  z-index: 4;
+  background: linear-gradient(90deg, rgba(12, 15, 19, 0.98), rgba(12, 15, 19, 0.86));
+}
+
+.agents-list.compact .agents-grid-cell-pin,
+.agents-list.compact .agents-pin {
+  left: 8px;
+}
+
+.agents-list.compact .agents-grid-cell-agent,
+.agents-list.compact .agents-row-main {
+  left: 48px;
 }
 
 .agents-list.compact .agents-pin {
@@ -1829,6 +1896,11 @@ button.agents-section-title:hover {
 
   .agents-row-actions-overflow {
     display: block;
+  }
+
+  .agents-row-actions-menu {
+    position: static;
+    margin-top: 6px;
   }
 }
 

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -224,6 +224,54 @@ test('agents modal heartbeat heatmap and stale-first sort are toggleable and res
   await expect(page.locator('#agentsSortIndicator')).toHaveText('');
 });
 
+test('fleet list keeps header and identity columns visible while scrolling', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  const agents = Array.from({ length: 30 }, (_, index) => {
+    const id = `agent-${String(index + 1).padStart(2, '0')}`;
+    return { id, name: id, displayName: id };
+  });
+
+  await clawnsole.gotoAndLoginAdmin(page);
+  await page.route(/\/agents(?:\?|$)/, async (route) => {
+    await route.fulfill({ json: { agents } });
+  });
+  await page.getByRole('button', { name: 'Refresh agent list' }).click();
+
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsModal')).toHaveClass(/open/);
+
+  const list = page.locator('#agentsList');
+  const stickyHeader = list.locator('.agents-grid-header');
+  const firstPin = list.locator('.agents-row .agents-pin').first();
+  const firstIdentity = list.locator('.agents-row .agents-row-main').first();
+
+  await expect(stickyHeader).toBeVisible();
+  await expect(firstIdentity).toBeVisible();
+
+  const beforePin = await firstPin.boundingBox();
+  const beforeIdentity = await firstIdentity.boundingBox();
+
+  await list.evaluate((el) => {
+    el.scrollTop = 420;
+    el.scrollLeft = 360;
+  });
+
+  const listBox = await list.boundingBox();
+  const afterHeader = await stickyHeader.boundingBox();
+  const afterPin = await firstPin.boundingBox();
+  const afterIdentity = await firstIdentity.boundingBox();
+  const headerPosition = await stickyHeader.evaluate((el) => getComputedStyle(el).position);
+  const identityPosition = await firstIdentity.evaluate((el) => getComputedStyle(el).position);
+
+  expect(headerPosition).toBe('sticky');
+  expect(identityPosition).toBe('sticky');
+  expect(listBox && afterHeader && beforePin && afterPin && beforeIdentity && afterIdentity).toBeTruthy();
+  expect((afterHeader?.y || 0) - (listBox?.y || 0)).toBeLessThan(8);
+  expect(Math.abs((afterPin?.x || 0) - (beforePin?.x || 0))).toBeLessThan(4);
+  expect(Math.abs((afterIdentity?.x || 0) - (beforeIdentity?.x || 0))).toBeLessThan(4);
+});
+
 test('agents modal quick actions open/reuse chat, timeline, and workqueue context', async ({ page, clawnsole }) => {
   if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
 


### PR DESCRIPTION
## Summary
- add a sticky Fleet header row inside the agents modal scroll region
- freeze the pin and agent/state cells during horizontal scans
- keep mobile overflow actions inline with row height so menus are not clipped
- add Playwright regression coverage for vertical and horizontal scrolling

## Tests
- npm run test:syntax
- npx playwright test tests/ui/agents-modal.spec.js --grep "keeps header" --workers=1
- npx playwright test tests/ui/agents-modal.spec.js --workers=1

Closes #356