### PR TITLE
Show unsent draft badges on panes

### DIFF
--- a/app.js
+++ b/app.js
@@ -1813,6 +1813,10 @@ function paneSummaryLabel(pane) {
   return paneIdentityLabel(pane, { includeUnread: false });
 }
 
+function paneDraftStatusLabel(pane) {
+  return paneHasDraftChanges(pane) ? 'has unsent draft' : 'no unsent draft';
+}
+
 function isPaneSwitchHudEnabled() {
   return String(storage.get(PANE_SWITCH_HUD_ENABLED_KEY, '1') || '1') !== '0';
 }
@@ -2161,14 +2165,17 @@ function renderPaneManager() {
         const duplicateCount = duplicateCounts.get(paneDuplicateKey(pane)) || 0;
         const isDuplicate = duplicateCount > 1;
         const unreadCount = paneUnreadCount(pane);
+        const hasDraft = paneHasDraftChanges(pane);
         const paneIdentity = paneSummaryLabel(pane);
 
+        row.setAttribute('aria-label', `${paneIdentity}; ${paneDraftStatusLabel(pane)}; ${state}`);
         row.innerHTML = `
           <div class="pane-manager-main">
             <div class="pane-manager-kind" title="${escapeHtml(paneIdentity)}">
               ${paneTypeBadgeMarkup(pane, { extraClass: 'pane-manager-type-badge', testId: 'pane-manager-type-badge' })}
               <span class="pane-manager-kind-label">${escapeHtml(paneIdentity)}</span>
               <span class="pane-manager-pane-id" title="Internal pane id">${escapeHtml(String(pane?.key || ''))}</span>
+              ${hasDraft ? '<span class="pane-manager-draft-badge" data-testid="pane-manager-draft-badge" title="Unsent draft">Draft</span>' : ''}
               ${isDuplicate ? `<span class="pane-manager-duplicate-badge" data-testid="pane-manager-duplicate-badge" title="${escapeHtml(`${duplicateCount} duplicate panes`)}">duplicate</span>` : ''}
               ${unreadCount > 0 ? `<span class="pane-manager-unread-badge" data-testid="pane-manager-unread-badge" title="${escapeHtml(`${unreadCount} unread`)}">${escapeHtml(String(unreadCount))}</span>` : ''}
             </div>
@@ -5525,6 +5532,7 @@ function paneRenderAttachments(pane) {
     pill.append(name, remove);
     list.appendChild(pill);
   });
+  renderPaneDraftState(pane);
 }
 
 function fileToBase64(file) {
@@ -5595,6 +5603,7 @@ async function paneUploadAttachments(pane) {
 function paneUpdateCommandHints(pane) {
   const hints = pane.elements.commandHints;
   if (!hints) return;
+  renderPaneDraftState(pane);
   const value = pane.elements.input.value.trim();
   if (!value.startsWith('/')) {
     hints.classList.remove('visible');
@@ -6165,8 +6174,26 @@ function paneHeaderLetter(pane) {
 function renderPaneIdentity(pane) {
   if (!pane?.elements?.name) return;
   pane.elements.name.textContent = paneIdentityLabel(pane, { includeUnread: true });
+  renderPaneDraftState(pane, { refreshManager: false });
   const activeKey = focusedPaneKey() || paneMruOrder()[0] || '';
   if (activeKey && String(pane.key || '') === activeKey) updateBrowserTitle(pane);
+}
+
+function renderPaneDraftState(pane, { refreshManager = true } = {}) {
+  if (!pane?.elements) return;
+  const hasDraft = paneHasDraftChanges(pane);
+  const status = paneDraftStatusLabel(pane);
+  const identity = paneIdentityLabel(pane, { includeUnread: true });
+  pane.elements.root?.classList?.toggle('has-draft', hasDraft);
+  pane.elements.root?.setAttribute('aria-label', `${identity}; ${status}`);
+  if (pane.elements.name) {
+    pane.elements.name.setAttribute('aria-label', `${identity}; ${status}`);
+  }
+  if (pane.elements.draftBadge) {
+    pane.elements.draftBadge.hidden = !hasDraft;
+    pane.elements.draftBadge.setAttribute('aria-label', status);
+  }
+  if (refreshManager && isPaneManagerOpen()) renderPaneManager();
 }
 
 function paneSetHeaderTarget(pane, { label, value, ariaLabel, onClick } = {}) {
@@ -6357,7 +6384,7 @@ function openAgentChooser(pane) {
 
 function paneHasDraftChanges(pane) {
   if (!pane?.elements) return false;
-  const draftText = String(pane.elements.input?.value || '').trim();
+  const draftText = String(pane.elements.input?.value || '');
   const hasAttachments = Array.isArray(pane.attachments?.files) && pane.attachments.files.length > 0;
   return Boolean(draftText || hasAttachments);
 }
@@ -6457,6 +6484,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
   const elements = {
     root,
     name: root.querySelector('[data-pane-name]'),
+    draftBadge: root.querySelector('[data-pane-draft-badge]'),
     typePill: root.querySelector('[data-pane-type-pill]'),
     typeIcon: root.querySelector('[data-pane-type-icon]'),
     typeText: root.querySelector('[data-pane-type-text]'),

--- a/index.html
+++ b/index.html
@@ -96,6 +96,7 @@
                   <span class="pane-type-text" data-pane-type-text>CHAT</span>
                 </div>
                 <div class="pane-name" data-pane-name data-testid="pane-type-label">Pane</div>
+                <span class="pane-draft-badge" data-pane-draft-badge data-testid="pane-draft-badge" hidden>Draft</span>
                 <div class="pane-agent" data-pane-agent-wrap>
                   <span class="agent-label" data-pane-target-label data-testid="pane-target-label">Agent</span>
                   <button class="agent-pill-btn" type="button" data-pane-agent-button aria-label="Change agent" data-testid="pane-agent-button">

--- a/styles.css
+++ b/styles.css
@@ -1409,6 +1409,28 @@ button.send-btn .btn-icon {
   text-transform: uppercase;
 }
 
+.pane-draft-badge,
+.pane-manager-draft-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 18px;
+  padding: 0 7px;
+  border-radius: 999px;
+  border: 1px solid rgba(77, 196, 255, 0.42);
+  background: rgba(77, 196, 255, 0.13);
+  color: #bfdbfe;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.pane-draft-badge[hidden],
+.pane-manager-draft-badge[hidden] {
+  display: none;
+}
+
 .pane-manager-unread-badge {
   display: inline-flex;
   align-items: center;

--- a/tests/pane.manager.e2e.spec.js
+++ b/tests/pane.manager.e2e.spec.js
@@ -207,6 +207,42 @@ test('pane manager: status stays in sync with pane header while modal is open', 
   await expect(chatManagerState).toHaveText('disconnected');
 });
 
+test('pane manager: draft badge appears, persists across panes, and clears on send', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const chatPane = page.locator('[data-pane][data-pane-kind="chat"]').first();
+  const workqueuePane = page.locator('[data-pane][data-pane-kind="workqueue"]').first();
+  await expect(chatPane.getByTestId('pane-send')).toBeEnabled({ timeout: 90000 });
+
+  await chatPane.getByTestId('pane-input').fill('draft for the right pane');
+  await expect(chatPane.getByTestId('pane-draft-badge')).toBeVisible();
+  await expect(chatPane.getByTestId('pane-type-label')).toHaveAttribute('aria-label', /has unsent draft/);
+
+  await workqueuePane.click();
+  await expect(chatPane.getByTestId('pane-draft-badge')).toBeVisible();
+
+  await page.keyboard.press('Control+P');
+  const chatManagerRow = page.locator('.pane-manager-row[data-pane-kind="chat"]').first();
+  await expect(chatManagerRow.getByTestId('pane-manager-draft-badge')).toBeVisible();
+  await expect(chatManagerRow).toHaveAttribute('aria-label', /has unsent draft/);
+
+  await page.keyboard.press('Escape');
+  await chatPane.getByTestId('pane-send').click();
+  await expect(chatPane.getByTestId('pane-draft-badge')).toBeHidden();
+
+  await page.keyboard.press('Control+P');
+  await expect(chatManagerRow.getByTestId('pane-manager-draft-badge')).toHaveCount(0);
+  await expect(chatManagerRow).toHaveAttribute('aria-label', /no unsent draft/);
+});
+
 test('pane manager: supports reordering panes', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!app?.skipReason, app?.skipReason);


### PR DESCRIPTION
## Summary\n- add visible Draft badges to pane headers and Pane Manager rows when a pane has unsent input or attachments\n- expose draft state through ARIA labels for pane headers and manager rows\n- add Playwright coverage for badge appearance, pane switching persistence, and clearing after send\n\n## Tests\n- npm run test:syntax\n- npx playwright test tests/pane.manager.e2e.spec.js --workers=1\n\nCloses #305\n\n🚢