### PR TITLE
Keep pane tab type token visible

### DIFF
--- a/app.js
+++ b/app.js
@@ -6164,7 +6164,16 @@ function paneHeaderLetter(pane) {
 
 function renderPaneIdentity(pane) {
   if (!pane?.elements?.name) return;
-  pane.elements.name.textContent = paneIdentityLabel(pane, { includeUnread: true });
+  const label = paneIdentityLabel(pane, { includeUnread: true });
+  pane.elements.name.title = paneIdentityLabel(pane, { includeUnread: false });
+  if (pane.elements.tabToken) {
+    pane.elements.tabToken.dataset.paneToken = paneIcon(pane);
+  }
+  if (pane.elements.tabTitle) {
+    pane.elements.tabTitle.textContent = label;
+  } else {
+    pane.elements.name.textContent = label;
+  }
   const activeKey = focusedPaneKey() || paneMruOrder()[0] || '';
   if (activeKey && String(pane.key || '') === activeKey) updateBrowserTitle(pane);
 }
@@ -6457,6 +6466,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
   const elements = {
     root,
     name: root.querySelector('[data-pane-name]'),
+    tabToken: root.querySelector('[data-pane-tab-token]'),
+    tabTitle: root.querySelector('[data-pane-tab-title]'),
     typePill: root.querySelector('[data-pane-type-pill]'),
     typeIcon: root.querySelector('[data-pane-type-icon]'),
     typeText: root.querySelector('[data-pane-type-text]'),
@@ -6548,7 +6559,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
 
   // Pane header: kind label + type pill (icon + text)
   try {
-    if (elements.name) elements.name.textContent = paneLabel(pane);
+    if (elements.tabTitle) elements.tabTitle.textContent = paneLabel(pane);
+    else if (elements.name) elements.name.textContent = paneLabel(pane);
     if (elements.typeIcon) elements.typeIcon.textContent = paneIcon(pane);
     if (elements.typeText) elements.typeText.textContent = String(paneLabel(pane) || pane.kind || 'chat').toUpperCase();
     if (elements.typePill) {

--- a/index.html
+++ b/index.html
@@ -95,7 +95,10 @@
                   <span class="pane-type-icon" data-pane-type-icon aria-hidden="true">💬</span>
                   <span class="pane-type-text" data-pane-type-text>CHAT</span>
                 </div>
-                <div class="pane-name" data-pane-name data-testid="pane-type-label">Pane</div>
+                <div class="pane-name" data-pane-name data-testid="pane-type-label" title="Pane">
+                  <span class="pane-tab-token" data-pane-tab-token aria-hidden="true"></span>
+                  <span class="pane-tab-title" data-pane-tab-title>Pane</span>
+                </div>
                 <div class="pane-agent" data-pane-agent-wrap>
                   <span class="agent-label" data-pane-target-label data-testid="pane-target-label">Agent</span>
                   <button class="agent-pill-btn" type="button" data-pane-agent-button aria-label="Change agent" data-testid="pane-agent-button">

--- a/styles.css
+++ b/styles.css
@@ -468,14 +468,51 @@ body::before {
   display: flex;
   align-items: center;
   gap: 12px;
+  flex: 1 1 auto;
   min-width: 0;
 }
 
 .pane-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1 1 auto;
+  min-width: 0;
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.14em;
   color: var(--muted);
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.pane-tab-token {
+  flex: 0 0 2.25em;
+  width: 2.25em;
+  min-width: 2.25em;
+  max-width: 2.25em;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 20px;
+  border-radius: 6px;
+  background: rgba(var(--pane-accent-rgb, 255, 255, 255), 0.16);
+  border: 1px solid rgba(var(--pane-accent-rgb, 255, 255, 255), 0.36);
+  color: rgba(255, 255, 255, 0.92);
+  font-size: 10px;
+  font-weight: 750;
+  letter-spacing: 0;
+  line-height: 1;
+}
+
+.pane-tab-token::before {
+  content: attr(data-pane-token);
+}
+
+.pane-tab-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -679,6 +716,7 @@ body::before {
   display: inline-flex;
   align-items: center;
   gap: 10px;
+  flex: 0 0 auto;
 }
 
 .pane-activity-badge {

--- a/tests/ui/pane-accents.spec.js
+++ b/tests/ui/pane-accents.spec.js
@@ -43,6 +43,58 @@ test('pane accents: each pane kind exposes deterministic accent selectors', asyn
   }
 });
 
+test('pane tab identity keeps fixed type token before truncated title', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await page.setViewportSize({ width: 760, height: 720 });
+  await loginAdmin(page, env.serverPort);
+
+  // Default layout includes chat + workqueue; add the remaining kinds.
+  await addPane(page, 'Cron pane');
+  await addPane(page, 'Timeline pane');
+
+  const expectedTokens = {
+    chat: '💬',
+    workqueue: 'WQ',
+    cron: '⏰',
+    timeline: '🕒'
+  };
+
+  for (const [kind, token] of Object.entries(expectedTokens)) {
+    const pane = page.locator(`[data-pane][data-pane-kind="${kind}"]`).first();
+    const name = pane.getByTestId('pane-type-label');
+    const tokenEl = name.locator('[data-pane-tab-token]');
+    const titleEl = name.locator('[data-pane-tab-title]');
+
+    await expect(tokenEl).toHaveAttribute('data-pane-token', token);
+    await expect(name).toHaveAttribute('title', new RegExp(`^[A-D] ${paneLabelForKind(kind)} · .+`));
+
+    const metrics = await name.evaluate((el) => {
+      el.style.width = '78px';
+      el.style.flex = '0 0 78px';
+      const tokenNode = el.querySelector('[data-pane-tab-token]');
+      const titleNode = el.querySelector('[data-pane-tab-title]');
+      const tokenRect = tokenNode.getBoundingClientRect();
+      const titleRect = titleNode.getBoundingClientRect();
+      return {
+        tokenWidth: tokenRect.width,
+        tokenLeft: tokenRect.left,
+        tokenRight: tokenRect.right,
+        titleLeft: titleRect.left,
+        titleClientWidth: titleNode.clientWidth,
+        titleScrollWidth: titleNode.scrollWidth
+      };
+    });
+
+    expect(metrics.tokenWidth).toBeGreaterThan(20);
+    expect(metrics.titleLeft).toBeGreaterThanOrEqual(metrics.tokenRight);
+    expect(metrics.titleScrollWidth).toBeGreaterThan(metrics.titleClientWidth);
+  }
+});
+
 function paneLabelForKind(kind) {
   if (kind === 'workqueue') return 'Workqueue';
   return kind.charAt(0).toUpperCase() + kind.slice(1);


### PR DESCRIPTION
## Summary
- Split pane tab identity into a fixed compact type token and a truncating title label
- Add tooltip text with the full pane identity
- Cover Chat, Workqueue, Cron, and Timeline token visibility in a narrow tab regression

Fixes #331

## Tests
- npm test
- npx playwright test tests/ui/pane-accents.spec.js --workers=1

Ready for 🚢