### PR TITLE
Persist Agents modal triage state

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,6 +37,7 @@ const globalElements = {
   agentsSortResetBtn: document.getElementById('agentsSortResetBtn'),
   agentsSortIndicator: document.getElementById('agentsSortIndicator'),
   agentsActiveMinutes: document.getElementById('agentsActiveMinutes'),
+  agentsResetTriageBtn: document.getElementById('agentsResetTriageBtn'),
   agentsLastRefreshed: document.getElementById('agentsLastRefreshed'),
   agentsList: document.getElementById('agentsList'),
   agentsEmpty: document.getElementById('agentsEmpty'),
@@ -245,6 +246,7 @@ const storage = {
 // Agent list UX (pins + triage)
 const ADMIN_AGENT_PINS_KEY = 'clawnsole.admin.agentPins';
 const ADMIN_AGENT_LAST_SEEN_KEY = 'clawnsole.admin.agentLastSeenAtMs';
+const ADMIN_AGENT_QUERY_KEY = 'clawnsole.admin.agents.query';
 const ADMIN_AGENT_FILTER_KEY = 'clawnsole.admin.agents.filter';
 const ADMIN_AGENT_SORT_KEY = 'clawnsole.admin.agents.sort';
 const ADMIN_AGENT_PRE_HEARTBEAT_SORT_KEY = 'clawnsole.admin.agents.preHeartbeatSort';
@@ -477,6 +479,31 @@ function getFleetSort() {
   const raw = String(storage.get(ADMIN_AGENT_SORT_KEY, 'recent_desc') || 'recent_desc').trim();
   const allowed = new Set(['recent_desc', 'heartbeat_age_desc', 'agent_id_asc']);
   return allowed.has(raw) ? raw : 'recent_desc';
+}
+
+function getFleetQuery() {
+  return String(storage.get(ADMIN_AGENT_QUERY_KEY, '') || '');
+}
+
+function setAgentsFilterUi(filter) {
+  globalElements.agentsFilterButtons.forEach((btn) => {
+    const key = btn.getAttribute('data-agents-filter') || '';
+    const active = key === filter;
+    btn.classList.toggle('active', active);
+    btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+  });
+}
+
+function resetAgentsTriageView() {
+  storage.remove(ADMIN_AGENT_QUERY_KEY);
+  storage.remove(ADMIN_AGENT_FILTER_KEY);
+  storage.remove(ADMIN_AGENT_SORT_KEY);
+  storage.remove(ADMIN_AGENT_PRE_HEARTBEAT_SORT_KEY);
+  if (globalElements.agentsSearch) globalElements.agentsSearch.value = '';
+  if (globalElements.agentsSort) globalElements.agentsSort.value = 'recent_desc';
+  setAgentsFilterUi('all');
+  renderAgentsModalList();
+  globalElements.agentsSearch?.focus?.();
 }
 
 function getFleetHeatmapEnabled() {
@@ -2948,15 +2975,11 @@ function openAgentsModal() {
   globalElements.agentsModal?.setAttribute('aria-hidden', 'false');
 
   // Bootstrap persisted controls.
+  if (globalElements.agentsSearch) globalElements.agentsSearch.value = getFleetQuery();
   const filter = getFleetFilter();
   const sort = getFleetSort();
   const heatmapEnabled = getFleetHeatmapEnabled();
-  globalElements.agentsFilterButtons.forEach((btn) => {
-    const key = btn.getAttribute('data-agents-filter') || '';
-    const active = key === filter;
-    btn.classList.toggle('active', active);
-    btn.setAttribute('aria-pressed', active ? 'true' : 'false');
-  });
+  setAgentsFilterUi(filter);
   if (globalElements.agentsSort) globalElements.agentsSort.value = sort;
   if (globalElements.agentsHeatmapToggle) globalElements.agentsHeatmapToggle.checked = heatmapEnabled;
   if (globalElements.agentsActiveMinutes) {
@@ -8803,25 +8826,29 @@ globalElements.agentsModal?.addEventListener('keydown', (event) => {
   else resetFleetSort();
 });
 
-globalElements.agentsSearch?.addEventListener('input', () => renderAgentsModalList());
+globalElements.agentsSearch?.addEventListener('input', () => {
+  storage.set(ADMIN_AGENT_QUERY_KEY, globalElements.agentsSearch.value || '');
+  renderAgentsModalList();
+});
 globalElements.agentsSearch?.addEventListener('keydown', (event) => {
   if (event.key !== 'Escape') return;
   event.preventDefault();
   event.stopPropagation();
-  globalElements.agentsSearch.value = '';
-  renderAgentsModalList();
-  globalElements.agentsSearch.focus();
+  if (globalElements.agentsSearch.value) {
+    globalElements.agentsSearch.value = '';
+    storage.remove(ADMIN_AGENT_QUERY_KEY);
+    renderAgentsModalList();
+    globalElements.agentsSearch.focus();
+    return;
+  }
+  closeAgentsModal();
 });
 
 globalElements.agentsFilterButtons.forEach((btn) => {
   btn.addEventListener('click', () => {
     const key = String(btn.getAttribute('data-agents-filter') || 'all').trim() || 'all';
     storage.set(ADMIN_AGENT_FILTER_KEY, key);
-    globalElements.agentsFilterButtons.forEach((chip) => {
-      const active = (chip.getAttribute('data-agents-filter') || '') === key;
-      chip.classList.toggle('active', active);
-      chip.setAttribute('aria-pressed', active ? 'true' : 'false');
-    });
+    setAgentsFilterUi(key);
     renderAgentsModalList();
   });
 });
@@ -8846,6 +8873,7 @@ globalElements.agentsHeatmapToggle?.addEventListener('change', () => {
 
 globalElements.agentsHeartbeatSortBtn?.addEventListener('click', () => setFleetHeartbeatSort());
 globalElements.agentsSortResetBtn?.addEventListener('click', () => resetFleetSort());
+globalElements.agentsResetTriageBtn?.addEventListener('click', () => resetAgentsTriageView());
 
 globalElements.agentsActiveMinutes?.addEventListener('change', () => {
   const minutes = Math.max(1, Number(globalElements.agentsActiveMinutes.value) || 10);

--- a/index.html
+++ b/index.html
@@ -455,6 +455,10 @@
               <span class="agents-label">Active window (min)</span>
               <input id="agentsActiveMinutes" type="number" min="1" step="1" value="10" aria-label="Active within minutes" />
             </label>
+            <div class="agents-field agents-reset-field">
+              <span class="agents-label">View</span>
+              <button id="agentsResetTriageBtn" class="agents-chip" type="button">Reset triage view</button>
+            </div>
             <div class="agents-field agents-density">
               <span class="agents-label">Density</span>
               <div class="agents-density-toggle" role="group" aria-label="Fleet density">

--- a/styles.css
+++ b/styles.css
@@ -1473,6 +1473,10 @@ button.send-btn .btn-icon {
   gap: 8px;
 }
 
+.agents-reset-field {
+  align-items: flex-start;
+}
+
 .agents-heatmap-controls {
   min-width: 280px;
 }

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -136,6 +136,39 @@ test('agents modal quick filter narrows list and Esc clears it', async ({ page, 
   await expect(search).toBeFocused();
   await expect(search).toHaveValue('');
   await expect(rows).toHaveCount(initialCount);
+
+  await search.press('Escape');
+  await expect(page.locator('#agentsModal')).not.toHaveClass(/open/);
+});
+
+test('agents modal persists triage query and sort until reset', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  await clawnsole.gotoAndLoginAdmin(page);
+
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsModal')).toHaveClass(/open/);
+
+  const search = page.locator('#agentsSearch');
+  const sort = page.locator('#agentsSort');
+  await search.fill('main');
+  await sort.selectOption('agent_id_asc');
+  await page.getByRole('button', { name: 'Close agents' }).click();
+
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(search).toHaveValue('main');
+  await expect(sort).toHaveValue('agent_id_asc');
+
+  await page.reload();
+  await clawnsole.waitForAdminUiReady(page);
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsSearch')).toHaveValue('main');
+  await expect(page.locator('#agentsSort')).toHaveValue('agent_id_asc');
+
+  await page.getByRole('button', { name: 'Reset triage view' }).click();
+  await expect(page.locator('#agentsSearch')).toHaveValue('');
+  await expect(page.locator('#agentsSort')).toHaveValue('recent_desc');
+  await expect(page.getByLabel('Fleet triage filters').getByRole('button', { name: 'All' })).toHaveAttribute('aria-pressed', 'true');
 });
 
 test('fleet attention mode sections healthy agents and keeps filters while expanding', async ({ page, clawnsole }) => {


### PR DESCRIPTION
Fixes #333.\n\n## Summary\n- persist the Agents modal quick-filter query alongside existing triage filter and sort state\n- restore query/filter/sort when reopening the modal and after reload\n- add a Reset triage view action and make Escape clear a non-empty query before closing\n\n## Tests\n- npm test\n- npx playwright test tests/ui/agents-modal.spec.js --workers=1