### PR TITLE
Clarify Workqueue item search controls

### DIFF
--- a/app.js
+++ b/app.js
@@ -3017,6 +3017,27 @@ function getActiveChatAgentPane() {
   return (paneManager?.panes || []).find((pane) => String(pane?.key || '') === activeKey && pane.kind === 'chat') || null;
 }
 
+function getActiveWorkqueuePane() {
+  const focusedKey = focusedPaneKey();
+  const fallbackKey = paneMruOrder()[0] || '';
+  const activeKey = focusedKey || fallbackKey;
+  return (paneManager?.panes || []).find((pane) => String(pane?.key || '') === activeKey && pane.kind === 'workqueue') || null;
+}
+
+function focusActiveWorkqueueItemSearch() {
+  const pane = getActiveWorkqueuePane();
+  const search = pane?.elements?.thread?.querySelector?.('[data-wq-search]');
+  if (!search) return false;
+  try {
+    paneManager.focusPanePrimary(pane);
+    search.focus();
+    search.select?.();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function openWorkqueueForActiveChatAgent() {
   if (roleState.role !== 'admin') return null;
   const chatPane = getActiveChatAgentPane();
@@ -4312,9 +4333,9 @@ function renderWorkqueueFilterSummaryForPane(pane, { shownCount, totalCount } = 
   }
   if (search) {
     addToken({
-      label: 'Search',
+      label: 'Item search',
       value: search,
-      title: `Clear search query ${search}`,
+      title: `Clear item search query ${search}`,
       action: () => pane.workqueue?.setQuickSearch?.('')
     });
   }
@@ -4491,28 +4512,46 @@ function renderWorkqueuePaneItems(pane) {
       const statuses = Array.isArray(pane.workqueue?.statusFilter) ? pane.workqueue.statusFilter : [];
       const statusLabel = statuses.length ? statuses.join(', ') : 'default';
       const scopeLabel = pane.workqueue?.scopeFilter || 'all';
-      empty.innerHTML = `
-        <div class="empty-state">
-          <div style="font-weight:700; margin-bottom:6px;">No items in this queue.</div>
-          <div class="hint">Queue: <span class="mono">${escapeHtml(queue)}</span> · Status: <span class="mono">${escapeHtml(statusLabel)}</span> · Scope: <span class="mono">${escapeHtml(scopeLabel)}</span></div>
-          <div style="display:flex; gap:8px; margin-top:10px; flex-wrap:wrap;">
-            <button type="button" class="secondary" data-wq-empty-enqueue>Enqueue item</button>
-            <button type="button" class="secondary" data-wq-empty-refresh>Refresh</button>
+      const itemSearch = String(pane.workqueue?.quickFilters?.search || '').trim();
+      if (itemSearch) {
+        empty.innerHTML = `
+          <div class="empty-state">
+            <div style="font-weight:700; margin-bottom:6px;">No items match “${escapeHtml(itemSearch)}”.</div>
+            <div class="hint">Item search is filtering the visible rows in <span class="mono">${escapeHtml(queue)}</span>.</div>
+            <div style="display:flex; gap:8px; margin-top:10px; flex-wrap:wrap;">
+              <button type="button" class="secondary" data-wq-empty-clear-search>Clear item search</button>
+              <button type="button" class="secondary" data-wq-empty-refresh>Refresh</button>
+            </div>
           </div>
-          <div class="hint" style="margin-top:8px;">Tip: use “Enqueue new item” above, or configure queues on the server.</div>
-        </div>
-      `;
+        `;
 
-      const refreshBtn = pane.elements?.thread?.querySelector('[data-wq-refresh]');
-      const enqueueDetails = pane.elements?.thread?.querySelector('details.wq-enqueue');
-      empty.querySelector('[data-wq-empty-refresh]')?.addEventListener('click', () => refreshBtn?.click());
-      empty.querySelector('[data-wq-empty-enqueue]')?.addEventListener('click', () => {
-        try {
-          enqueueDetails?.setAttribute('open', '');
-          enqueueDetails?.scrollIntoView({ block: 'nearest' });
-          pane.elements?.thread?.querySelector('[data-wq-enqueue-title]')?.focus();
-        } catch {}
-      });
+        const refreshBtn = pane.elements?.thread?.querySelector('[data-wq-refresh]');
+        empty.querySelector('[data-wq-empty-refresh]')?.addEventListener('click', () => refreshBtn?.click());
+        empty.querySelector('[data-wq-empty-clear-search]')?.addEventListener('click', () => pane.workqueue?.setQuickSearch?.(''));
+      } else {
+        empty.innerHTML = `
+          <div class="empty-state">
+            <div style="font-weight:700; margin-bottom:6px;">No items in this queue.</div>
+            <div class="hint">Queue: <span class="mono">${escapeHtml(queue)}</span> · Status: <span class="mono">${escapeHtml(statusLabel)}</span> · Scope: <span class="mono">${escapeHtml(scopeLabel)}</span></div>
+            <div style="display:flex; gap:8px; margin-top:10px; flex-wrap:wrap;">
+              <button type="button" class="secondary" data-wq-empty-enqueue>Enqueue item</button>
+              <button type="button" class="secondary" data-wq-empty-refresh>Refresh</button>
+            </div>
+            <div class="hint" style="margin-top:8px;">Tip: use “Enqueue new item” above, or configure queues on the server.</div>
+          </div>
+        `;
+
+        const refreshBtn = pane.elements?.thread?.querySelector('[data-wq-refresh]');
+        const enqueueDetails = pane.elements?.thread?.querySelector('details.wq-enqueue');
+        empty.querySelector('[data-wq-empty-refresh]')?.addEventListener('click', () => refreshBtn?.click());
+        empty.querySelector('[data-wq-empty-enqueue]')?.addEventListener('click', () => {
+          try {
+            enqueueDetails?.setAttribute('open', '');
+            enqueueDetails?.scrollIntoView({ block: 'nearest' });
+            pane.elements?.thread?.querySelector('[data-wq-enqueue-title]')?.focus();
+          } catch {}
+        });
+      }
     }
   }
 
@@ -6680,7 +6719,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         <div class="wq-toolbar-row">
           <label class="wq-field">
             <span class="wq-label">Queue</span>
-            <input data-wq-queue-search type="search" placeholder="Search queues" aria-label="Search queues" autocomplete="off" />
+            <input data-wq-queue-search type="search" placeholder="Filter queue list" aria-label="Filter queue list" autocomplete="off" />
             <select data-wq-queue-select aria-label="Select workqueue target"></select>
             <input data-wq-queue-custom type="text" value="${escapeHtml(pane.workqueue.queue)}" placeholder="Custom queue" hidden />
           </label>
@@ -6728,8 +6767,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
           </div>
 
           <label class="wq-field wq-search-field">
-            <span class="wq-label">Search</span>
-            <input data-wq-search type="search" placeholder="Filter tasks" autocomplete="off" />
+            <span class="wq-label">Search items</span>
+            <input data-wq-search type="search" placeholder="Search items" aria-label="Search workqueue items" autocomplete="off" />
           </label>
 
           <button data-wq-preset-clawnsole class="secondary" type="button">Clawnsole only</button>
@@ -9330,6 +9369,13 @@ window.addEventListener('keydown', (event) => {
     event.preventDefault();
     openShortcuts();
     return;
+  }
+
+  if (key === '/' && !event.shiftKey && !event.metaKey && !event.ctrlKey && !event.altKey) {
+    if (focusActiveWorkqueueItemSearch()) {
+      event.preventDefault();
+      return;
+    }
   }
 
   // Alt/Option+1..9 focuses panes by visible order.

--- a/index.html
+++ b/index.html
@@ -276,6 +276,7 @@
           <div class="shortcut-group">
             <h3 class="shortcut-group-title">Workqueue actions</h3>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>g</kbd> <kbd>w</kbd></div><div class="shortcut-desc">Open Workqueue modal</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>/</kbd></div><div class="shortcut-desc">Search items in the active Workqueue pane</div></div>
           </div>
         </div>
       </div>

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -291,12 +291,54 @@ test('workqueue pane: filter summary chips show counts and remove filters', asyn
 
   await wqPane.locator('[data-wq-search]').fill('alternate repo');
   await expect(wqPane.locator('[data-wq-statusline]')).toContainText('Showing 1 of 3 items');
-  await expect(summary).toContainText('Search alternate repo');
+  await expect(summary).toContainText('Item search alternate repo');
 
   await summary.locator('[data-wq-clear-all-filters]').click();
   await expect(wqPane.locator('[data-wq-statusline]')).toContainText('Showing 2 of 3 items');
-  await expect(summary).not.toContainText('Search alternate repo');
+  await expect(summary).not.toContainText('Item search alternate repo');
   await expect(wqPane.locator('[data-wq-queue-custom]')).toHaveValue(queue);
+});
+
+test('workqueue pane: queue filter and item search are separate controls', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  const queue = `item-search-${Date.now()}`;
+  seedFilterSummaryWorkqueueItems(queue);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  const wqPane = page.locator('[data-pane]').last();
+  await wqPane.locator('[data-wq-queue-select]').selectOption('__custom__');
+  await wqPane.locator('[data-wq-queue-custom]').fill(queue);
+  await wqPane.locator('[data-wq-queue-custom]').press('Enter');
+
+  const queueSearch = wqPane.locator('[data-wq-queue-search]');
+  const itemSearch = wqPane.locator('[data-wq-search]');
+  await expect(queueSearch).toHaveAttribute('placeholder', 'Filter queue list');
+  await expect(itemSearch).toHaveAttribute('placeholder', 'Search items');
+  await expect(wqPane.locator('.wq-row')).toHaveCount(2);
+
+  await queueSearch.fill('alternate repo');
+  await expect(wqPane.locator('.wq-row')).toHaveCount(2);
+
+  await itemSearch.fill('alternate repo');
+  await expect(wqPane.locator('.wq-row')).toHaveCount(1);
+  await expect(wqPane.locator('[data-wq-filter-summary]')).toContainText('Item search alternate repo');
+
+  await wqPane.locator('.wq-row').first().click();
+  await page.keyboard.press('/');
+  await expect(itemSearch).toBeFocused();
+
+  await itemSearch.fill('missing-query');
+  await expect(wqPane.locator('.wq-row')).toHaveCount(0);
+  await expect(wqPane.locator('[data-wq-empty]')).toContainText('No items match “missing-query”.');
+  await wqPane.locator('[data-wq-empty-clear-search]').click();
+  await expect(itemSearch).toHaveValue('');
+  await expect(wqPane.locator('.wq-row')).toHaveCount(2);
 });
 
 test('workqueue pane: queue target supports search + recent persistence', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Rename the queue picker filter to make it clear it only filters queue names.
- Label the row filter as Search items, add an item-search empty state with a clear action, and wire `/` to focus item search from the active Workqueue pane.
- Add Playwright coverage that queue filtering does not filter rows while item search does.

## Tests
- npm test
- npx playwright test tests/ui/workqueue-pane.spec.js --grep "queue filter and item search" --workers=1

Fixes #332