### PR TITLE
Clarify Workqueue queue filter vs item search

### DIFF
--- a/app.js
+++ b/app.js
@@ -3189,6 +3189,20 @@ function openTopbarWorkqueueAction() {
   openWorkqueue();
 }
 
+function focusActiveWorkqueueItemSearch() {
+  const focusedPane = findActivePaneFromFocus();
+  const rememberedPane = paneMruOrder()
+    .map((key) => paneManager.panes.find((pane) => pane?.key && pane.key === key) || null)
+    .find((pane) => pane?.kind === 'workqueue') || null;
+  const pane = focusedPane?.kind === 'workqueue' ? focusedPane : rememberedPane;
+  const search = pane?.elements?.thread?.querySelector?.('[data-wq-search]');
+  if (!search) return false;
+  notePaneFocused(pane);
+  search.focus?.({ preventScroll: true });
+  search.select?.();
+  return true;
+}
+
 function renderAgentsModalList() {
   const root = globalElements.agentsList;
   if (!root) return;
@@ -4491,21 +4505,36 @@ function renderWorkqueuePaneItems(pane) {
       const statuses = Array.isArray(pane.workqueue?.statusFilter) ? pane.workqueue.statusFilter : [];
       const statusLabel = statuses.length ? statuses.join(', ') : 'default';
       const scopeLabel = pane.workqueue?.scopeFilter || 'all';
-      empty.innerHTML = `
-        <div class="empty-state">
-          <div style="font-weight:700; margin-bottom:6px;">No items in this queue.</div>
-          <div class="hint">Queue: <span class="mono">${escapeHtml(queue)}</span> · Status: <span class="mono">${escapeHtml(statusLabel)}</span> · Scope: <span class="mono">${escapeHtml(scopeLabel)}</span></div>
-          <div style="display:flex; gap:8px; margin-top:10px; flex-wrap:wrap;">
-            <button type="button" class="secondary" data-wq-empty-enqueue>Enqueue item</button>
-            <button type="button" class="secondary" data-wq-empty-refresh>Refresh</button>
+      const search = String(pane.workqueue?.quickFilters?.search || '').trim();
+      if (search) {
+        empty.innerHTML = `
+          <div class="empty-state">
+            <div style="font-weight:700; margin-bottom:6px;">No items match “${escapeHtml(search)}”.</div>
+            <div class="hint">Item search is filtering visible rows in <span class="mono">${escapeHtml(queue)}</span>.</div>
+            <div style="display:flex; gap:8px; margin-top:10px; flex-wrap:wrap;">
+              <button type="button" class="secondary" data-wq-empty-clear-search>Clear item search</button>
+              <button type="button" class="secondary" data-wq-empty-refresh>Refresh</button>
+            </div>
           </div>
-          <div class="hint" style="margin-top:8px;">Tip: use “Enqueue new item” above, or configure queues on the server.</div>
-        </div>
-      `;
+        `;
+      } else {
+        empty.innerHTML = `
+          <div class="empty-state">
+            <div style="font-weight:700; margin-bottom:6px;">No items in this queue.</div>
+            <div class="hint">Queue: <span class="mono">${escapeHtml(queue)}</span> · Status: <span class="mono">${escapeHtml(statusLabel)}</span> · Scope: <span class="mono">${escapeHtml(scopeLabel)}</span></div>
+            <div style="display:flex; gap:8px; margin-top:10px; flex-wrap:wrap;">
+              <button type="button" class="secondary" data-wq-empty-enqueue>Enqueue item</button>
+              <button type="button" class="secondary" data-wq-empty-refresh>Refresh</button>
+            </div>
+            <div class="hint" style="margin-top:8px;">Tip: use “Enqueue new item” above, or configure queues on the server.</div>
+          </div>
+        `;
+      }
 
       const refreshBtn = pane.elements?.thread?.querySelector('[data-wq-refresh]');
       const enqueueDetails = pane.elements?.thread?.querySelector('details.wq-enqueue');
       empty.querySelector('[data-wq-empty-refresh]')?.addEventListener('click', () => refreshBtn?.click());
+      empty.querySelector('[data-wq-empty-clear-search]')?.addEventListener('click', () => pane.workqueue?.setQuickSearch?.(''));
       empty.querySelector('[data-wq-empty-enqueue]')?.addEventListener('click', () => {
         try {
           enqueueDetails?.setAttribute('open', '');
@@ -6680,7 +6709,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         <div class="wq-toolbar-row">
           <label class="wq-field">
             <span class="wq-label">Queue</span>
-            <input data-wq-queue-search type="search" placeholder="Search queues" aria-label="Search queues" autocomplete="off" />
+            <input data-wq-queue-search type="search" placeholder="Filter queue list..." aria-label="Filter queue list" autocomplete="off" />
             <select data-wq-queue-select aria-label="Select workqueue target"></select>
             <input data-wq-queue-custom type="text" value="${escapeHtml(pane.workqueue.queue)}" placeholder="Custom queue" hidden />
           </label>
@@ -6728,8 +6757,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
           </div>
 
           <label class="wq-field wq-search-field">
-            <span class="wq-label">Search</span>
-            <input data-wq-search type="search" placeholder="Filter tasks" autocomplete="off" />
+            <span class="wq-label">Search items</span>
+            <input data-wq-search type="search" placeholder="Search items..." aria-label="Search workqueue items" title="/ focuses item search" autocomplete="off" />
           </label>
 
           <button data-wq-preset-clawnsole class="secondary" type="button">Clawnsole only</button>
@@ -9323,6 +9352,13 @@ window.addEventListener('keydown', (event) => {
     event.preventDefault();
     switchPaneByMru(event.shiftKey ? -1 : 1);
     return;
+  }
+
+  if (key === '/' && !event.shiftKey && !event.metaKey && !event.ctrlKey && !event.altKey && roleState.role === 'admin' && !isAnyOverlayOpen()) {
+    if (focusActiveWorkqueueItemSearch()) {
+      event.preventDefault();
+      return;
+    }
   }
 
   const isQuestion = key === '?' || (key === '/' && event.shiftKey);

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -154,6 +154,44 @@ function seedFilterSummaryWorkqueueItems(queue) {
   fs.writeFileSync(path.join(dir, 'work-queues.json'), JSON.stringify(data, null, 2));
 }
 
+function seedWorkqueueItemSearchItems(queue) {
+  const dir = path.join(env.tempHome, '.openclaw', 'clawnsole');
+  fs.mkdirSync(dir, { recursive: true });
+  const now = new Date().toISOString();
+  const mkItem = (id, patch = {}) => ({
+    id,
+    queue,
+    title: `Search fixture ${id}`,
+    instructions: 'ordinary fixture instructions',
+    priority: 10,
+    status: 'ready',
+    claimedBy: '',
+    claimedAt: '',
+    leaseUntil: 0,
+    attempts: 0,
+    lastError: '',
+    createdAt: now,
+    updatedAt: now,
+    meta: { repo: 'rmdmattingly/clawnsole' },
+    ...patch
+  });
+
+  const data = {
+    version: 1,
+    queues: {
+      [queue]: { name: queue, createdAt: now },
+      [`${queue}-archive`]: { name: `${queue}-archive`, createdAt: now }
+    },
+    assignments: {},
+    items: [
+      mkItem('alpha', { title: 'Alpha visible row' }),
+      mkItem('beta', { title: 'Beta visible row', instructions: 'contains hidden needle token' }),
+      mkItem('gamma', { title: 'Gamma visible row' })
+    ]
+  };
+  fs.writeFileSync(path.join(dir, 'work-queues.json'), JSON.stringify(data, null, 2));
+}
+
 test('workqueue pane: renders + has queue dropdown + does not show chat composer', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);
@@ -325,6 +363,46 @@ test('workqueue pane: queue target supports search + recent persistence', async 
   const secondPane = page.locator('[data-pane]').last();
   const secondSelect = secondPane.locator('[data-wq-queue-select]');
   await expect(secondSelect.locator('option', { hasText: '★ qa-hotfix' })).toHaveCount(1);
+});
+
+test('workqueue pane: queue filter and item search stay distinct', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  const queue = `item-search-${Date.now()}`;
+  seedWorkqueueItemSearchItems(queue);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  const pane = page.locator('[data-pane]').last();
+  await expect(pane.locator('[data-wq-queue-search]')).toHaveAttribute('placeholder', 'Filter queue list...');
+  await expect(pane.locator('[data-wq-search]')).toHaveAttribute('placeholder', 'Search items...');
+
+  await pane.locator('[data-wq-queue-select]').selectOption(queue);
+  const refreshResP = page.waitForResponse((res) => res.url().includes('/api/workqueue/items') && res.ok(), { timeout: 15000 });
+  await pane.locator('[data-wq-refresh]').click();
+  await refreshResP;
+  await expect(pane.locator('.wq-row')).toHaveCount(3);
+
+  await pane.locator('[data-wq-queue-search]').fill('archive');
+  await expect(pane.locator('.wq-row')).toHaveCount(3);
+
+  const itemSearch = pane.locator('[data-wq-search]');
+  await itemSearch.fill('hidden needle');
+  await expect(pane.locator('.wq-row')).toHaveCount(1);
+  await expect(pane.locator('.wq-row')).toContainText('Beta visible row');
+
+  await itemSearch.fill('definitely absent');
+  await expect(pane.locator('[data-wq-empty]')).toContainText('No items match “definitely absent”.');
+  await pane.locator('[data-wq-empty-clear-search]').click();
+  await expect(pane.locator('.wq-row')).toHaveCount(3);
+
+  await pane.locator('.wq-row').first().focus();
+  await page.keyboard.press('/');
+  await expect(itemSearch).toBeFocused();
 });
 
 test('workqueue pane: enqueue assignment target supports search, keyboard select, and recents', async ({ page }) => {


### PR DESCRIPTION
## Summary\n- relabel the Workqueue queue search as a queue-list filter\n- make item search explicit, add / focus behavior, and add a search-empty clear action\n- add Playwright coverage proving queue filtering and item search stay distinct\n\n## Tests\n- npm run test:syntax\n- npx playwright test tests/ui/workqueue-pane.spec.js --workers=1\n\nCloses #332