### PR TITLE
UX: add go-to-pane-by-letter shortcut

### DIFF
--- a/app.js
+++ b/app.js
@@ -2632,6 +2632,16 @@ function buildCommandPaletteItems() {
       'g c'
     ),
     withShortcut(
+      {
+        id: 'cmd:pane-go-to-letter',
+        label: 'Panes: Go to pane by letter',
+        detail: 'Press g, then the visible pane letter A-Z',
+        searchText: 'pane focus go to letter shortcut g then a z visible pane letter',
+        run: () => openShortcuts()
+      },
+      'g then A-Z'
+    ),
+    withShortcut(
       { id: 'cmd:focus-chat-composer', label: 'Chat: Focus composer', detail: 'Jump to the active or most recent Chat composer', run: () => focusChatComposer() },
       '⌘/Ctrl+L'
     ),
@@ -6164,6 +6174,7 @@ function paneHeaderLetter(pane) {
 
 function renderPaneIdentity(pane) {
   if (!pane?.elements?.name) return;
+  pane.elements.root?.setAttribute?.('data-pane-letter', paneHeaderLetter(pane));
   pane.elements.name.textContent = paneIdentityLabel(pane, { includeUnread: true });
   const activeKey = focusedPaneKey() || paneMruOrder()[0] || '';
   if (activeKey && String(pane.key || '') === activeKey) updateBrowserTitle(pane);
@@ -6603,6 +6614,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
           shortcuts: [
             ['Alt/Option+1..9', 'focus panes 1-9 by visible order'],
             ['Cmd/Ctrl+1..9', 'focus panes 1-9 by visible order'],
+            ['g then A-Z', 'focus pane by visible letter'],
             ['Cmd/Ctrl+L', 'focus Chat composer'],
             ['Cmd/Ctrl+Shift+K', 'focus next pane'],
             ['Cmd/Ctrl+Shift+J', 'focus previous pane']
@@ -8900,6 +8912,7 @@ globalElements.wqRefreshBtn?.addEventListener('click', () => {
 globalElements.wqEnqueueBtn?.addEventListener('click', () => workqueueEnqueueFromUi());
 globalElements.wqClaimBtn?.addEventListener('click', () => workqueueClaimNextFromUi());
 
+const GO_TO_PANE_TIMEOUT_MS = 1200;
 let shortcutState = { lastGAtMs: 0, blockedReasonLastShownAt: new Map() };
 const SHORTCUT_BLOCK_RATE_LIMIT_MS = 5000;
 const SHORTCUT_BLOCK_MESSAGES = {
@@ -9092,6 +9105,16 @@ function focusPaneIndex(idx, { trackMru = true, showHud = false } = {}) {
       }
     }
   }
+}
+
+function focusPaneByHeaderLetter(letter) {
+  const needle = String(letter || '').trim().toUpperCase();
+  if (!/^[A-Z]$/.test(needle)) return false;
+  const panes = paneManager?.panes || [];
+  const idx = panes.findIndex((pane) => paneHeaderLetter(pane) === needle);
+  if (idx < 0) return false;
+  focusPaneIndex(idx, { showHud: true });
+  return true;
 }
 
 function returnToLastActiveChatPane() {
@@ -9423,24 +9446,35 @@ window.addEventListener('keydown', (event) => {
     return;
   }
 
-  // 'g' chords jump between common triage surfaces.
+  // 'g' chords jump to pane letters and common triage surfaces.
   const now = Date.now();
-  if (!event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey) {
+  if (!event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey && !isAnyOverlayOpen()) {
     if (key.toLowerCase() === 'g') {
       shortcutState.lastGAtMs = now;
+      event.preventDefault();
       return;
     }
-    if (key.toLowerCase() === 'c' && shortcutState.lastGAtMs && now - shortcutState.lastGAtMs < 1000) {
+    const pendingGoToPane = shortcutState.lastGAtMs && now - shortcutState.lastGAtMs < GO_TO_PANE_TIMEOUT_MS;
+    if (pendingGoToPane && /^[a-z]$/i.test(key)) {
+      shortcutState.lastGAtMs = 0;
+      event.preventDefault();
+      if (focusPaneByHeaderLetter(key)) return;
+      if (key.toLowerCase() !== 'c' && key.toLowerCase() !== 'w') return;
+    }
+    if (key.toLowerCase() === 'c' && pendingGoToPane) {
       shortcutState.lastGAtMs = 0;
       event.preventDefault();
       returnToLastActiveChatPane();
       return;
     }
-    if (key.toLowerCase() === 'w' && shortcutState.lastGAtMs && now - shortcutState.lastGAtMs < 1000) {
+    if (key.toLowerCase() === 'w' && pendingGoToPane) {
       shortcutState.lastGAtMs = 0;
       event.preventDefault();
       openTopbarWorkqueueAction();
       return;
+    }
+    if (shortcutState.lastGAtMs && now - shortcutState.lastGAtMs >= GO_TO_PANE_TIMEOUT_MS) {
+      shortcutState.lastGAtMs = 0;
     }
   }
 });

--- a/index.html
+++ b/index.html
@@ -256,6 +256,7 @@
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd></div><div class="shortcut-desc">Focus previous pane</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Focus next Chat pane only</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>J</kbd></div><div class="shortcut-desc">Focus previous Chat pane only</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>g</kbd> <kbd>A</kbd>..<kbd>Z</kbd></div><div class="shortcut-desc">Focus pane by visible letter</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>g</kbd> <kbd>c</kbd></div><div class="shortcut-desc">Return to last active Chat pane</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>L</kbd></div><div class="shortcut-desc">Focus Chat composer</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Ctrl</kbd>+<kbd>Tab</kbd></div><div class="shortcut-desc">Switch panes by most-recent focus order</div></div>

--- a/tests/ui/command-palette.spec.js
+++ b/tests/ui/command-palette.spec.js
@@ -142,6 +142,41 @@ test('pane navigation: returns to the last active chat pane from shortcut and co
   await expect(chatInput).toBeFocused();
 });
 
+test('pane navigation: g then visible pane letter focuses pane with no-match and typing guards', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+  await loginAdmin(page, env.serverPort);
+
+  const chatPane = page.locator('[data-pane][data-pane-kind="chat"]').first();
+  const chatInput = chatPane.locator('[data-pane-input]');
+  const workqueuePane = page.locator('[data-pane][data-pane-kind="workqueue"]').first();
+  const queueButton = workqueuePane.getByTestId('pane-agent-button');
+
+  await expect(chatPane).toHaveAttribute('data-pane-letter', 'A');
+  await expect(workqueuePane).toHaveAttribute('data-pane-letter', 'B');
+
+  await page.evaluate(() => document.activeElement?.blur?.());
+  await page.keyboard.press('g');
+  await page.keyboard.press('b');
+  await expect(queueButton).toBeFocused();
+
+  const addPaneBtn = page.locator('#addPaneBtn');
+  await addPaneBtn.focus();
+  await expect(addPaneBtn).toBeFocused();
+  await page.keyboard.press('g');
+  await page.keyboard.press('z');
+  await expect(addPaneBtn).toBeFocused();
+
+  await chatInput.click();
+  await expect(chatInput).toBeFocused();
+  await chatInput.fill('');
+  await chatInput.type('gb');
+  await expect(chatInput).toBeFocused();
+  await expect(chatInput).toHaveValue('gb');
+});
+
 test('command palette: opens or focuses Workqueue for active chat agent', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);


### PR DESCRIPTION
## Summary
- Add g then visible pane letter (A-Z) shortcut to focus panes by their displayed identity.
- Keep existing g c / g w chords when no matching pane letter exists.
- Add shortcut help, command palette discoverability, and regression coverage for success/no-match/typing suppression.

## Tests
- npm test
- npm run test:syntax && npx playwright test tests/ui/command-palette.spec.js --workers=1

Fixes #334