### PR TITLE
Add pane letter jump shortcut

### DIFF
--- a/app.js
+++ b/app.js
@@ -9223,6 +9223,18 @@ function cycleUnreadPaneFocus(direction = 1) {
   return true;
 }
 
+function focusPaneByHeaderLetter(letter) {
+  const key = String(letter || '').trim().toUpperCase();
+  if (!/^[A-Z]$/.test(key)) return false;
+
+  const panes = Array.isArray(paneManager?.panes) ? paneManager.panes : [];
+  const idx = panes.findIndex((pane) => paneHeaderLetter(pane) === key);
+  if (idx < 0) return false;
+
+  focusPaneIndex(idx, { showHud: true });
+  return true;
+}
+
 function isBlockingOverlayOpenForPaneShortcuts() {
   const blockers = [
     globalElements.loginOverlay,
@@ -9423,20 +9435,27 @@ window.addEventListener('keydown', (event) => {
     return;
   }
 
-  // 'g' chords jump between common triage surfaces.
+  // 'g' chords jump by visible pane letter first, then between common triage surfaces.
   const now = Date.now();
   if (!event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey) {
     if (key.toLowerCase() === 'g') {
       shortcutState.lastGAtMs = now;
       return;
     }
-    if (key.toLowerCase() === 'c' && shortcutState.lastGAtMs && now - shortcutState.lastGAtMs < 1000) {
+    const keyLower = key.toLowerCase();
+    const hasActiveGPrefix = shortcutState.lastGAtMs && now - shortcutState.lastGAtMs < 1000;
+    if (hasActiveGPrefix && /^[a-z]$/.test(keyLower) && focusPaneByHeaderLetter(keyLower)) {
+      shortcutState.lastGAtMs = 0;
+      event.preventDefault();
+      return;
+    }
+    if (keyLower === 'c' && hasActiveGPrefix) {
       shortcutState.lastGAtMs = 0;
       event.preventDefault();
       returnToLastActiveChatPane();
       return;
     }
-    if (key.toLowerCase() === 'w' && shortcutState.lastGAtMs && now - shortcutState.lastGAtMs < 1000) {
+    if (keyLower === 'w' && hasActiveGPrefix) {
       shortcutState.lastGAtMs = 0;
       event.preventDefault();
       openTopbarWorkqueueAction();

--- a/index.html
+++ b/index.html
@@ -251,6 +251,7 @@
             <h3 class="shortcut-group-title">Pane focus/navigation</h3>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Alt</kbd>/<kbd>Option</kbd>+<kbd>1</kbd>..<kbd>9</kbd></div><div class="shortcut-desc">Focus panes 1-9 by visible order</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>1</kbd>..<kbd>4</kbd></div><div class="shortcut-desc">Focus pane 1-4</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>g</kbd> <kbd>A</kbd>..<kbd>Z</kbd></div><div class="shortcut-desc">Focus pane by visible letter</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>P</kbd></div><div class="shortcut-desc">Open Pane Manager</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Focus next pane</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd></div><div class="shortcut-desc">Focus previous pane</div></div>

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -383,6 +383,44 @@ test('ctrl+tab switches panes by MRU order and reverses with shift', async ({ pa
   await expect.poll(activePaneIndex).toBe(0);
 });
 
+test('g then pane letter focuses the matching visible pane identity', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  await page.getByTestId('add-pane-btn').click();
+  await page.getByTestId('pane-add-menu-cron').click();
+  await expect(page.locator('[data-pane]')).toHaveCount(3);
+
+  const activePaneIndex = async () => page.evaluate(() => {
+    const panes = Array.from(document.querySelectorAll('[data-pane]'));
+    const active = document.activeElement;
+    if (!active) return -1;
+    return panes.findIndex((p) => p === active || p.contains(active));
+  });
+
+  await page.locator('[data-pane]').first().locator('[data-pane-input]').focus();
+  await expect.poll(activePaneIndex).toBe(0);
+
+  await page.click('#connectionStatus');
+  await page.keyboard.press('g');
+  await page.keyboard.press('c');
+  await expect.poll(activePaneIndex).toBe(2);
+  await expect(page.locator('#paneSwitchHud')).toContainText('C Cron');
+
+  await page.click('#connectionStatus');
+  await page.keyboard.press('g');
+  await page.keyboard.press('b');
+  await expect.poll(activePaneIndex).toBe(1);
+  await expect(page.locator('#paneSwitchHud')).toContainText('B Workqueue');
+});
+
 test('add-pane shortcuts do not fire while typing in chat input', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!app?.skipReason, app?.skipReason);


### PR DESCRIPTION
## Summary
- Add a g then pane-letter shortcut that focuses the matching visible pane letter (A-Z).
- Preserve existing g c / g w behavior as fallbacks when no matching pane letter exists.
- Document the shortcut in the keyboard shortcuts overlay.

## Tests
- npm run test:syntax
- npx playwright test tests/pane.shortcuts.e2e.spec.js --grep "g then pane letter" --workers=1

Note: full tests/pane.shortcuts.e2e.spec.js run was 12/13; existing test "cmd/ctrl+alt+j/k cycles chat panes only and keeps typing guard" failed before the new pane-letter test with focus remaining on pane 2 during setup.