### PR TITLE
Persist Agents modal triage state

### DIFF
--- a/app.js
+++ b/app.js
@@ -246,6 +246,7 @@ const storage = {
 const ADMIN_AGENT_PINS_KEY = 'clawnsole.admin.agentPins';
 const ADMIN_AGENT_LAST_SEEN_KEY = 'clawnsole.admin.agentLastSeenAtMs';
 const ADMIN_AGENT_FILTER_KEY = 'clawnsole.admin.agents.filter';
+const ADMIN_AGENT_QUERY_KEY = 'clawnsole.admin.agents.query';
 const ADMIN_AGENT_SORT_KEY = 'clawnsole.admin.agents.sort';
 const ADMIN_AGENT_PRE_HEARTBEAT_SORT_KEY = 'clawnsole.admin.agents.preHeartbeatSort';
 const ADMIN_AGENT_HEATMAP_KEY = 'clawnsole.admin.agents.heartbeatHeatmap';
@@ -471,6 +472,16 @@ function getFleetFilter() {
   const raw = String(storage.get(ADMIN_AGENT_FILTER_KEY, 'all') || 'all').trim();
   const allowed = new Set(['all', 'active', 'stale', 'offline_error']);
   return allowed.has(raw) ? raw : 'all';
+}
+
+function getAgentsQuickFilterQuery() {
+  return String(storage.get(ADMIN_AGENT_QUERY_KEY, '') || '');
+}
+
+function setAgentsQuickFilterQuery(query) {
+  const next = String(query || '');
+  if (next) storage.set(ADMIN_AGENT_QUERY_KEY, next);
+  else storage.remove(ADMIN_AGENT_QUERY_KEY);
 }
 
 function getFleetSort() {
@@ -2958,6 +2969,7 @@ function openAgentsModal() {
     btn.setAttribute('aria-pressed', active ? 'true' : 'false');
   });
   if (globalElements.agentsSort) globalElements.agentsSort.value = sort;
+  if (globalElements.agentsSearch) globalElements.agentsSearch.value = getAgentsQuickFilterQuery();
   if (globalElements.agentsHeatmapToggle) globalElements.agentsHeatmapToggle.checked = heatmapEnabled;
   if (globalElements.agentsActiveMinutes) {
     const minutes = Number(storage.get(ADMIN_AGENT_ACTIVE_MINUTES_KEY, '10')) || 10;
@@ -2990,6 +3002,15 @@ function resetFleetSort() {
   storage.set(ADMIN_AGENT_SORT_KEY, next);
   storage.remove(ADMIN_AGENT_PRE_HEARTBEAT_SORT_KEY);
   if (globalElements.agentsSort) globalElements.agentsSort.value = next;
+  renderAgentsModalList();
+}
+
+function resetAgentsTriageView() {
+  storage.remove(ADMIN_AGENT_QUERY_KEY);
+  storage.set(ADMIN_AGENT_SORT_KEY, 'recent_desc');
+  storage.remove(ADMIN_AGENT_PRE_HEARTBEAT_SORT_KEY);
+  if (globalElements.agentsSearch) globalElements.agentsSearch.value = '';
+  if (globalElements.agentsSort) globalElements.agentsSort.value = 'recent_desc';
   renderAgentsModalList();
 }
 
@@ -8796,6 +8817,15 @@ globalElements.agentsModal?.addEventListener('click', (event) => {
   if (event.target === globalElements.agentsModal) closeAgentsModal();
 });
 globalElements.agentsModal?.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape' && String(globalElements.agentsSearch?.value || '')) {
+    event.preventDefault();
+    event.stopPropagation();
+    setAgentsQuickFilterQuery('');
+    if (globalElements.agentsSearch) globalElements.agentsSearch.value = '';
+    renderAgentsModalList();
+    globalElements.agentsSearch?.focus?.();
+    return;
+  }
   if (isTypingContext(event.target)) return;
   if (String(event.key || '').toLowerCase() !== 'h' || event.metaKey || event.ctrlKey || event.altKey) return;
   event.preventDefault();
@@ -8803,11 +8833,19 @@ globalElements.agentsModal?.addEventListener('keydown', (event) => {
   else resetFleetSort();
 });
 
-globalElements.agentsSearch?.addEventListener('input', () => renderAgentsModalList());
+globalElements.agentsSearch?.addEventListener('input', () => {
+  setAgentsQuickFilterQuery(globalElements.agentsSearch.value);
+  renderAgentsModalList();
+});
 globalElements.agentsSearch?.addEventListener('keydown', (event) => {
   if (event.key !== 'Escape') return;
   event.preventDefault();
   event.stopPropagation();
+  if (!String(globalElements.agentsSearch.value || '')) {
+    closeAgentsModal();
+    return;
+  }
+  setAgentsQuickFilterQuery('');
   globalElements.agentsSearch.value = '';
   renderAgentsModalList();
   globalElements.agentsSearch.focus();
@@ -8845,7 +8883,7 @@ globalElements.agentsHeatmapToggle?.addEventListener('change', () => {
 });
 
 globalElements.agentsHeartbeatSortBtn?.addEventListener('click', () => setFleetHeartbeatSort());
-globalElements.agentsSortResetBtn?.addEventListener('click', () => resetFleetSort());
+globalElements.agentsSortResetBtn?.addEventListener('click', () => resetAgentsTriageView());
 
 globalElements.agentsActiveMinutes?.addEventListener('change', () => {
   const minutes = Math.max(1, Number(globalElements.agentsActiveMinutes.value) || 10);

--- a/index.html
+++ b/index.html
@@ -447,7 +447,7 @@
                   <span>Heatmap</span>
                 </label>
                 <button id="agentsHeartbeatSortBtn" type="button" class="agents-chip" title="Sort stale agents first (Cmd/Ctrl+Shift+H)">Stale first</button>
-                <button id="agentsSortResetBtn" type="button" class="agents-chip">Reset sort</button>
+                <button id="agentsSortResetBtn" type="button" class="agents-chip" aria-label="Reset agents triage view">Reset view</button>
               </div>
               <div id="agentsSortIndicator" class="agents-sort-indicator" aria-live="polite"></div>
             </div>

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -138,6 +138,71 @@ test('agents modal quick filter narrows list and Esc clears it', async ({ page, 
   await expect(rows).toHaveCount(initialCount);
 });
 
+test('agents modal persists triage query and sort across reopen and reload, then resets', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  const agents = [
+    { id: 'alpha', name: 'Alpha', displayName: 'Alpha' },
+    { id: 'beta', name: 'Beta', displayName: 'Beta' },
+    { id: 'gamma', name: 'Gamma', displayName: 'Gamma' }
+  ];
+
+  await clawnsole.gotoAndLoginAdmin(page);
+  await page.route(/\/agents(?:\?|$)/, async (route) => {
+    await route.fulfill({ json: { agents } });
+  });
+  await page.evaluate(() => {
+    localStorage.removeItem('clawnsole.admin.agents.query');
+    localStorage.removeItem('clawnsole.admin.agents.sort');
+    localStorage.removeItem('clawnsole.admin.agents.preHeartbeatSort');
+    localStorage.setItem('clawnsole.admin.agentLastSeenAtMs', JSON.stringify({
+      alpha: Date.now(),
+      beta: Date.now(),
+      gamma: Date.now()
+    }));
+  });
+  await page.getByRole('button', { name: 'Refresh agent list' }).click();
+
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsModal')).toHaveClass(/open/);
+
+  const search = page.locator('#agentsSearch');
+  const rows = page.locator('#agentsList .agents-row:visible');
+  await search.fill('beta');
+  await page.locator('#agentsSort').selectOption('agent_id_asc');
+  await expect(rows).toHaveCount(1);
+  await expect(rows.first()).toContainText('Beta (beta)');
+
+  await page.getByRole('button', { name: 'Close agents' }).click();
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(search).toHaveValue('beta');
+  await expect(page.locator('#agentsSort')).toHaveValue('agent_id_asc');
+  await expect(rows).toHaveCount(1);
+
+  await page.reload();
+  await clawnsole.waitForAdminUiReady(page);
+  await page.route(/\/agents(?:\?|$)/, async (route) => {
+    await route.fulfill({ json: { agents } });
+  });
+  await page.getByRole('button', { name: 'Refresh agent list' }).click();
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(search).toHaveValue('beta');
+  await expect(page.locator('#agentsSort')).toHaveValue('agent_id_asc');
+  await expect(rows).toHaveCount(1);
+
+  await search.press('Escape');
+  await expect(page.locator('#agentsModal')).toHaveClass(/open/);
+  await expect(search).toHaveValue('');
+  await expect(rows).toHaveCount(3);
+
+  await search.fill('beta');
+  await page.locator('#agentsSort').selectOption('heartbeat_age_desc');
+  await page.getByRole('button', { name: 'Reset agents triage view' }).click();
+  await expect(search).toHaveValue('');
+  await expect(page.locator('#agentsSort')).toHaveValue('recent_desc');
+  await expect(rows).toHaveCount(3);
+});
+
 test('fleet attention mode sections healthy agents and keeps filters while expanding', async ({ page, clawnsole }) => {
   if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
 
@@ -219,7 +284,7 @@ test('agents modal heartbeat heatmap and stale-first sort are toggleable and res
   await expect(page.locator('#agentsSortIndicator')).toContainText('Sorted by heartbeat age');
   await expect(page.locator('#agentsList .agents-row:visible').first()).toContainText('critical-agent');
 
-  await page.getByRole('button', { name: 'Reset sort' }).click();
+  await page.getByRole('button', { name: 'Reset agents triage view' }).click();
   await expect(page.locator('#agentsSort')).toHaveValue('recent_desc');
   await expect(page.locator('#agentsSortIndicator')).toHaveText('');
 });


### PR DESCRIPTION
## Summary
- Persist the Agents modal quick-filter query in localStorage and restore it when the modal opens or the admin reloads.
- Convert the existing sort reset control into a triage view reset that clears query plus sort state.
- Preserve Esc behavior: clear a nonempty query first, then close on the next Esc.

## Tests
- npm run test:syntax
- npx playwright test tests/ui/agents-modal.spec.js --workers=1

Closes #333