### PR TITLE
Add Fleet column visibility controls

### DIFF
--- a/app.js
+++ b/app.js
@@ -31,6 +31,7 @@ const globalElements = {
   agentsSearch: document.getElementById('agentsSearch'),
   agentsFilterButtons: Array.from(document.querySelectorAll('[data-agents-filter]')),
   agentsDensityButtons: Array.from(document.querySelectorAll('[data-agents-density]')),
+  agentsColumnInputs: Array.from(document.querySelectorAll('[data-agents-column]')),
   agentsSort: document.getElementById('agentsSort'),
   agentsHeatmapToggle: document.getElementById('agentsHeatmapToggle'),
   agentsHeartbeatSortBtn: document.getElementById('agentsHeartbeatSortBtn'),
@@ -251,8 +252,10 @@ const ADMIN_AGENT_PRE_HEARTBEAT_SORT_KEY = 'clawnsole.admin.agents.preHeartbeatS
 const ADMIN_AGENT_HEATMAP_KEY = 'clawnsole.admin.agents.heartbeatHeatmap';
 const ADMIN_AGENT_ACTIVE_MINUTES_KEY = 'clawnsole.admin.agents.activeMinutes';
 const ADMIN_AGENT_DENSITY_KEY = 'clawnsole.admin.agents.density';
+const ADMIN_AGENT_COLUMNS_KEY = 'clawnsole.admin.agents.columns';
 const ADMIN_AGENT_HEALTHY_COLLAPSED_KEY = 'clawnsole.admin.agents.healthyCollapsed';
 const ADMIN_AGENT_HEALTHY_COLLAPSE_THRESHOLD = 10;
+const ADMIN_AGENT_COLUMNS = ['state', 'heartbeat', 'status', 'actions'];
 const ADMIN_AUTH_DESTINATION_KEY = 'clawnsole.admin.authDestination.v1';
 const ADMIN_AUTH_RESTORE_PENDING_KEY = 'clawnsole.admin.authRestorePending.v1';
 const ADMIN_AUTH_RESTORE_NOTICE_KEY = 'clawnsole.admin.authRestoreNotice.v1';
@@ -497,6 +500,39 @@ function syncFleetDensityControl() {
     const active = String(btn.getAttribute('data-agents-density') || '') === density;
     btn.classList.toggle('active', active);
     btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+  });
+}
+
+function getFleetVisibleColumns() {
+  const saved = readJsonFromStorage(ADMIN_AGENT_COLUMNS_KEY, null);
+  const source = saved && typeof saved === 'object' ? saved : {};
+  const out = {};
+  ADMIN_AGENT_COLUMNS.forEach((key) => {
+    out[key] = source[key] !== false;
+  });
+  return out;
+}
+
+function setFleetColumnVisible(column, visible) {
+  const key = String(column || '').trim();
+  if (!ADMIN_AGENT_COLUMNS.includes(key)) return;
+  const columns = getFleetVisibleColumns();
+  columns[key] = !!visible;
+  writeJsonToStorage(ADMIN_AGENT_COLUMNS_KEY, columns);
+}
+
+function syncFleetColumnControl(columns = getFleetVisibleColumns()) {
+  if (globalElements.agentsList) {
+    ADMIN_AGENT_COLUMNS.forEach((key) => {
+      globalElements.agentsList.dataset[`show${key.charAt(0).toUpperCase()}${key.slice(1)}`] = columns[key] === false ? 'false' : 'true';
+    });
+    globalElements.agentsList.querySelectorAll('.agents-row').forEach((row) => {
+      row.classList.toggle('agents-row-no-actions', columns.actions === false);
+    });
+  }
+  globalElements.agentsColumnInputs.forEach((input) => {
+    const key = String(input.getAttribute('data-agents-column') || '').trim();
+    input.checked = columns[key] !== false;
   });
 }
 
@@ -3199,7 +3235,9 @@ function renderAgentsModalList() {
   const filterMode = getFleetFilter();
   const sortMode = getFleetSort();
   const heatmapEnabled = getFleetHeatmapEnabled();
+  const visibleColumns = getFleetVisibleColumns();
   syncFleetDensityControl();
+  syncFleetColumnControl(visibleColumns);
 
   const pins = getPinnedAgentIds();
   const lastSeenMap = getAgentLastSeenMap();
@@ -3346,23 +3384,36 @@ function renderAgentsModalList() {
       const bucketLabel = triage.bucket === 'offline_error' ? 'offline/error' : triage.bucket;
       const heatBucketLabel = heartbeatAgeBucketLabel(triage.ageBucket);
       const statusSnippet = String(statusSnippetMap[id] || '').trim();
-      const statusSnippetHtml = statusSnippet ? ` · <span class="agents-status-snippet">${escapeHtml(statusSnippet)}</span>` : '';
+      const stateHtml = visibleColumns.state ? `<span class="agents-state-column">${escapeHtml(bucketLabel)}</span>` : '';
+      const heartbeatHtml = visibleColumns.heartbeat
+        ? `<span class="agents-age-chip agents-heartbeat-column" data-heartbeat-bucket="${escapeHtml(triage.ageBucket)}">${escapeHtml(heartbeatAge)} · ${escapeHtml(heatBucketLabel)}</span>`
+        : '';
+      const statusSnippetHtml = visibleColumns.status && statusSnippet
+        ? `<span class="agents-status-snippet agents-status-column">${escapeHtml(statusSnippet)}</span>`
+        : '';
+      const metaParts = [
+        `<span class="agents-id-column">${escapeHtml(id)}</span>`,
+        stateHtml,
+        heartbeatHtml,
+        statusSnippetHtml
+      ].filter(Boolean).join(' <span class="agents-meta-separator">·</span> ');
       row.dataset.heartbeatBucket = triage.ageBucket;
       row.classList.toggle('agents-row-heatmap', heatmapEnabled);
+      row.classList.toggle('agents-row-no-actions', !visibleColumns.actions);
 
       row.innerHTML = `
         <button type="button" class="agents-pin" aria-label="${pinnedNow ? 'Unpin agent' : 'Pin agent'}" aria-pressed="${pinnedNow ? 'true' : 'false'}" data-agent-pin="${escapeHtml(id)}">${pinnedNow ? '★' : '☆'}</button>
         <div class="agents-row-main">
           <div class="agents-row-title">${escapeHtml(label)}</div>
-          <div class="agents-row-meta">${escapeHtml(id)} · ${escapeHtml(bucketLabel)} · <span class="agents-age-chip" data-heartbeat-bucket="${escapeHtml(triage.ageBucket)}">${escapeHtml(heartbeatAge)} · ${escapeHtml(heatBucketLabel)}</span>${statusSnippetHtml}</div>
+          <div class="agents-row-meta">${metaParts}</div>
         </div>
-        <div class="agents-row-actions agents-row-actions-inline" role="group" aria-label="Quick actions for ${escapeHtml(label)}">
+        <div class="agents-row-actions agents-row-actions-inline" role="group" aria-label="Quick actions for ${escapeHtml(label)}" ${visibleColumns.actions ? '' : 'hidden'}>
           <button type="button" class="secondary agents-action-btn" data-agent-action="triage" data-agent-id="${escapeHtml(id)}" title="Open Chat and Workqueue" aria-label="Triage agent ${escapeHtml(label)}">Triage</button>
           <button type="button" class="secondary agents-action-btn" data-agent-action="open-chat" data-agent-id="${escapeHtml(id)}" title="Open Chat" aria-label="Open Chat for ${escapeHtml(label)}">Chat</button>
           <button type="button" class="secondary agents-action-btn" data-agent-action="open-timeline" data-agent-id="${escapeHtml(id)}" title="Open Timeline" aria-label="Open Timeline for ${escapeHtml(label)}">Timeline</button>
           <button type="button" class="secondary agents-action-btn" data-agent-action="open-workqueue" data-agent-id="${escapeHtml(id)}" title="Open Workqueue" aria-label="Open Workqueue">Workqueue</button>
         </div>
-        <details class="agents-row-actions-overflow">
+        <details class="agents-row-actions-overflow" ${visibleColumns.actions ? '' : 'hidden'}>
           <summary class="secondary" aria-label="More actions for ${escapeHtml(label)}" title="More actions">⋯</summary>
           <div class="agents-row-actions-menu" role="group" aria-label="Quick actions for ${escapeHtml(label)}">
             <button type="button" class="secondary agents-action-btn" data-agent-action="triage" data-agent-id="${escapeHtml(id)}" title="Open Chat and Workqueue" aria-label="Triage agent ${escapeHtml(label)}">Triage agent</button>
@@ -8832,6 +8883,16 @@ globalElements.agentsDensityButtons.forEach((btn) => {
     storage.set(ADMIN_AGENT_DENSITY_KEY, density);
     syncFleetDensityControl();
   });
+});
+
+globalElements.agentsColumnInputs.forEach((input) => {
+  const sync = () => {
+    setFleetColumnVisible(input.getAttribute('data-agents-column'), input.checked);
+    syncFleetColumnControl();
+    renderAgentsModalList();
+  };
+  input.addEventListener('input', sync);
+  input.addEventListener('change', sync);
 });
 
 globalElements.agentsSort?.addEventListener('change', () => {

--- a/index.html
+++ b/index.html
@@ -462,6 +462,15 @@
                 <button type="button" class="agents-chip" data-agents-density="compact" aria-pressed="false">Compact</button>
               </div>
             </div>
+            <div class="agents-field agents-columns">
+              <span class="agents-label">Columns</span>
+              <div class="agents-column-toggle" role="group" aria-label="Fleet columns">
+                <label class="agents-toggle"><input type="checkbox" data-agents-column="state" checked /> <span>State</span></label>
+                <label class="agents-toggle"><input type="checkbox" data-agents-column="heartbeat" checked /> <span>Heartbeat</span></label>
+                <label class="agents-toggle"><input type="checkbox" data-agents-column="status" checked /> <span>Status</span></label>
+                <label class="agents-toggle"><input type="checkbox" data-agents-column="actions" checked /> <span>Actions</span></label>
+              </div>
+            </div>
           </div>
 
           <div id="agentsList" class="agents-list" aria-label="Agent list"></div>

--- a/styles.css
+++ b/styles.css
@@ -1509,6 +1509,14 @@ button.send-btn .btn-icon {
   align-items: center;
 }
 
+.agents-column-toggle {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  align-items: center;
+  max-width: 360px;
+}
+
 .agents-chip {
   border: 1px solid rgba(255, 255, 255, 0.16);
   background: rgba(255, 255, 255, 0.03);
@@ -1658,6 +1666,22 @@ button.agents-section-title:hover {
   background: rgba(255, 255, 255, 0.02);
 }
 
+.agents-row-no-actions {
+  grid-template-columns: 42px minmax(0, 1fr);
+}
+
+.agents-list[data-show-actions="false"] .agents-row {
+  grid-template-columns: 42px minmax(0, 1fr);
+}
+
+.agents-list[data-show-actions="false"] .agents-row-actions,
+.agents-list[data-show-actions="false"] .agents-row-actions-overflow,
+.agents-list[data-show-heartbeat="false"] .agents-heartbeat-column,
+.agents-list[data-show-status="false"] .agents-status-column,
+.agents-list[data-show-state="false"] .agents-state-column {
+  display: none;
+}
+
 .agents-row-heatmap {
   border-left-width: 4px;
 }
@@ -1687,6 +1711,14 @@ button.agents-section-title:hover {
   gap: 8px;
   border-radius: 10px;
   padding: 3px 8px;
+}
+
+.agents-list.compact .agents-row-no-actions {
+  grid-template-columns: 32px minmax(0, 1fr);
+}
+
+.agents-list.compact[data-show-actions="false"] .agents-row {
+  grid-template-columns: 32px minmax(0, 1fr);
 }
 
 .agents-pin {
@@ -1727,6 +1759,10 @@ button.agents-section-title:hover {
   margin-top: 2px;
   font-size: 12px;
   color: var(--muted);
+}
+
+.agents-meta-separator {
+  color: rgba(255, 255, 255, 0.34);
 }
 
 .agents-list.compact .agents-row-meta {

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -363,3 +363,45 @@ test('agents modal compact density tightens rows and persists', async ({ page, c
   await expect(page.locator('#agentsList')).toHaveClass(/compact/);
   await expect(page.getByRole('button', { name: 'Compact' })).toHaveAttribute('aria-pressed', 'true');
 });
+
+test('agents modal column picker hides optional columns and persists', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  const agents = [{ id: 'columns-agent', name: 'columns-agent', displayName: 'Columns Agent' }];
+
+  await clawnsole.gotoAndLoginAdmin(page);
+  await page.route(/\/agents(?:\?|$)/, async (route) => {
+    await route.fulfill({ json: { agents } });
+  });
+  await page.evaluate(() => {
+    localStorage.setItem('clawnsole.admin.agentLastSeenAtMs', JSON.stringify({ 'columns-agent': Date.now() }));
+  });
+  await page.getByRole('button', { name: 'Refresh agent list' }).click();
+
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsModal')).toHaveClass(/open/);
+
+  const row = page.locator('#agentsList .agents-row').filter({ hasText: 'Columns Agent' });
+  await expect(row.locator('.agents-id-column')).toHaveText('columns-agent');
+  await expect(row.locator('.agents-heartbeat-column')).toBeVisible();
+  await expect(row.locator('[data-agent-action="open-chat"]').first()).toBeVisible();
+
+  const heartbeatColumn = page.locator('[data-agents-column="heartbeat"]');
+  const statusColumn = page.locator('[data-agents-column="status"]');
+  const actionsColumn = page.locator('[data-agents-column="actions"]');
+  await heartbeatColumn.uncheck();
+  await statusColumn.uncheck();
+  await actionsColumn.uncheck();
+  await expect(row.locator('.agents-heartbeat-column')).toBeHidden();
+  await expect(row.locator('[data-agent-action="open-chat"]').first()).toBeHidden();
+  await expect(row).toHaveClass(/agents-row-no-actions/);
+  await expect(actionsColumn).toBeFocused();
+
+  await page.reload();
+  await clawnsole.waitForAdminUiReady(page);
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('[data-agents-column="heartbeat"]')).not.toBeChecked();
+  await expect(page.locator('[data-agents-column="status"]')).not.toBeChecked();
+  await expect(page.locator('[data-agents-column="actions"]')).not.toBeChecked();
+  await expect(page.locator('#agentsList .agents-row').filter({ hasText: 'Columns Agent' }).locator('.agents-heartbeat-column')).toBeHidden();
+});


### PR DESCRIPTION
Closes #350.

## Summary
- add persistent Fleet column toggles for state, heartbeat, status, and actions
- keep Comfortable/Compact density behavior and make existing rows react immediately to column preference changes
- add UI coverage for column persistence and focus stability

## Verification
- npm run test:syntax
- npx playwright test tests/ui/agents-modal.spec.js --grep "column picker|compact density" --workers=1