### PR TITLE
Add searchable keyboard shortcuts modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -12788,7 +12788,7 @@ window.addEventListener('load', () => {
       paneManager.connectAll();
 
       const isTouch = window.matchMedia && window.matchMedia('(hover: none) and (pointer: coarse)').matches;
-      if (!isTouch) {
+      if (!isTouch && !isAnyOverlayOpen()) {
         const firstPane = paneManager.panes[0];
         firstPane?.elements.input?.focus();
       }

--- a/app.js
+++ b/app.js
@@ -56,13 +56,9 @@ const globalElements = {
   shortcutsDialog: document.getElementById('shortcutsDialog'),
   shortcutsContent: document.getElementById('shortcutsContent'),
   shortcutsCloseBtn: document.getElementById('shortcutsCloseBtn'),
-  shortcutsUnlockedCopy: document.querySelector('[data-shortcuts-unlocked-copy]'),
-  shortcutsLockedCopy: document.querySelector('[data-shortcuts-locked-copy]'),
-  shortcutsGlobalUnlockedTitle: document.querySelector('[data-shortcuts-global-unlocked]'),
-  shortcutsGlobalLockedTitle: document.querySelector('[data-shortcuts-global-locked]'),
-  shortcutsLockedRow: document.querySelector('[data-shortcuts-locked-row]'),
-  shortcutsLockedLabels: Array.from(document.querySelectorAll('[data-shortcuts-locked-label]')),
-  shortcutsAdminGroups: Array.from(document.querySelectorAll('[data-shortcuts-admin-group]')),
+  shortcutsSearchInput: document.getElementById('shortcutsSearchInput'),
+  shortcutsFilterChips: document.getElementById('shortcutsFilterChips'),
+  shortcutsEmpty: document.getElementById('shortcutsEmpty'),
   paneManagerModal: document.getElementById('paneManagerModal'),
   paneManagerCloseBtn: document.getElementById('paneManagerCloseBtn'),
   paneManagerSearch: document.getElementById('paneManagerSearch'),
@@ -498,7 +494,7 @@ function renderShortcutsContent() {
     </div>
   `;
   const html = groups.map((group) => `
-    <div class="shortcut-group${locked && group.name !== 'Global' ? ' shortcut-group-locked' : ''}">
+    <div class="shortcut-group${locked && group.name !== 'Global' ? ' shortcut-group-locked' : ''}" data-shortcut-category="${escapeHtml(shortcutSearchCategory(group.name))}">
       <h3 class="shortcut-group-title">${locked && group.name === 'Global' ? 'Available now' : escapeHtml(group.name)}${locked && group.name !== 'Global' ? ' <span class="shortcut-locked-label">Available after unlock</span>' : ''}</h3>
       ${group.entries.map((entry) => `
         <div class="shortcut-row${locked && group.name !== 'Global' ? ' shortcut-row-locked' : ''}" data-shortcut-id="${escapeHtml(entry.id)}" data-shortcut-rule="${escapeHtml(shortcutStatusRule(entry))}">
@@ -510,6 +506,9 @@ function renderShortcutsContent() {
     </div>
   `).join('');
   root.innerHTML = hint + html;
+  shortcutsUiState.groups = [];
+  initShortcutsSearchIndex();
+  applyShortcutsFilters();
 }
 
 function shortcutCatalogSnapshot() {
@@ -2715,7 +2714,13 @@ async function deleteRecurringPrompt(id) {
 
 let shortcutsLastFocusedEl = null;
 let shortcutsStatusTimer = null;
+let shortcutsFocusTimer = null;
 let paneShortcutBadgesAltHeld = false;
+const shortcutsUiState = {
+  query: '',
+  filter: 'all',
+  groups: []
+};
 
 const SHORTCUT_STATUS_LABELS = {
   available: 'Available',
@@ -2803,26 +2808,120 @@ function stopShortcutsStatusUpdates() {
   shortcutsStatusTimer = null;
 }
 
+function shortcutSearchCategory(groupTitle) {
+  const title = String(groupTitle || '').toLowerCase();
+  if (title.includes('global')) return 'global';
+  if (title.includes('workqueue')) return 'workqueue';
+  if (title.includes('chat') || title.includes('focus') || title.includes('navigation')) return 'chat';
+  return 'fleet';
+}
+
+function initShortcutsSearchIndex() {
+  const modal = globalElements.shortcutsModal;
+  if (!modal) return;
+  shortcutsUiState.groups = Array.from(modal.querySelectorAll('.shortcut-group')).map((groupEl) => {
+    const title = groupEl.querySelector('.shortcut-group-title')?.textContent || '';
+    const category = String(groupEl.dataset.shortcutCategory || shortcutSearchCategory(title)).trim().toLowerCase();
+    const rows = Array.from(groupEl.querySelectorAll('.shortcut-row')).map((rowEl) => {
+      const keys = rowEl.querySelector('.shortcut-keys')?.textContent || '';
+      const desc = rowEl.querySelector('.shortcut-desc')?.textContent || '';
+      return {
+        el: rowEl,
+        searchText: `${keys} ${desc} ${title} ${category}`.replace(/\s+/g, ' ').toLowerCase()
+      };
+    });
+    return { el: groupEl, title, category, rows };
+  });
+}
+
+function setShortcutsFilter(filter) {
+  shortcutsUiState.filter = String(filter || 'all').toLowerCase();
+  const chips = globalElements.shortcutsFilterChips?.querySelectorAll?.('[data-shortcuts-filter]') || [];
+  chips.forEach((chip) => {
+    const active = String(chip.dataset.shortcutsFilter || '').toLowerCase() === shortcutsUiState.filter;
+    chip.classList.toggle('is-active', active);
+    chip.setAttribute('aria-pressed', active ? 'true' : 'false');
+  });
+  applyShortcutsFilters();
+}
+
+function applyShortcutsFilters() {
+  if (!shortcutsUiState.groups.length) initShortcutsSearchIndex();
+  const filter = shortcutsUiState.filter;
+  const query = String(shortcutsUiState.query || '').trim().toLowerCase();
+  let visibleRows = 0;
+
+  shortcutsUiState.groups.forEach((group) => {
+    const categoryMatches = filter === 'all' || group.category === filter;
+    let groupVisibleRows = 0;
+    group.rows.forEach((row) => {
+      const visible = categoryMatches && (!query || row.searchText.includes(query));
+      row.el.hidden = !visible;
+      if (visible) groupVisibleRows += 1;
+    });
+    group.el.hidden = groupVisibleRows === 0;
+    visibleRows += groupVisibleRows;
+  });
+
+  if (globalElements.shortcutsEmpty) {
+    globalElements.shortcutsEmpty.hidden = visibleRows !== 0;
+  }
+}
+
+function focusShortcutsSearch() {
+  const target = globalElements.shortcutsSearchInput || globalElements.shortcutsDialog || globalElements.shortcutsCloseBtn || globalElements.shortcutsModal;
+  try {
+    target?.focus?.({ preventScroll: true });
+  } catch {
+    target?.focus?.();
+  }
+}
+
+function scheduleShortcutsSearchFocus() {
+  if (shortcutsFocusTimer) {
+    window.clearInterval(shortcutsFocusTimer);
+    shortcutsFocusTimer = null;
+  }
+  focusShortcutsSearch();
+  const startedAt = Date.now();
+  shortcutsFocusTimer = window.setInterval(() => {
+    if (!globalElements.shortcutsModal?.classList.contains('open')) {
+      window.clearInterval(shortcutsFocusTimer);
+      shortcutsFocusTimer = null;
+      return;
+    }
+    focusShortcutsSearch();
+    if (document.activeElement === globalElements.shortcutsSearchInput || Date.now() - startedAt > 1500) {
+      window.clearInterval(shortcutsFocusTimer);
+      shortcutsFocusTimer = null;
+    }
+  }, 50);
+}
+
 function openShortcuts() {
   const modal = globalElements.shortcutsModal;
   if (!modal) return;
   if (modal.classList.contains('open')) {
     renderShortcutsContent();
     syncShortcutsLockedState();
+    initShortcutsSearchIndex();
+    applyShortcutsFilters();
     updatePaneShortcutBadges();
     updateShortcutsStatus();
     return;
   }
   renderShortcutsContent();
   syncShortcutsLockedState();
+  initShortcutsSearchIndex();
   shortcutsLastFocusedEl = document.activeElement instanceof HTMLElement ? document.activeElement : null;
   modal.classList.add('open');
   modal.setAttribute('aria-hidden', 'false');
+  shortcutsUiState.query = '';
+  if (globalElements.shortcutsSearchInput) globalElements.shortcutsSearchInput.value = '';
+  setShortcutsFilter('all');
   startShortcutsStatusUpdates();
   updatePaneShortcutBadges();
-  window.setTimeout(() => {
-    (globalElements.shortcutsDialog || globalElements.shortcutsCloseBtn || modal).focus?.();
-  }, 0);
+  scheduleShortcutsSearchFocus();
 }
 
 function closeShortcuts() {
@@ -2830,6 +2929,10 @@ function closeShortcuts() {
   if (!modal || !modal.classList.contains('open')) return;
   modal.classList.remove('open');
   modal.setAttribute('aria-hidden', 'true');
+  if (shortcutsFocusTimer) {
+    window.clearInterval(shortcutsFocusTimer);
+    shortcutsFocusTimer = null;
+  }
   stopShortcutsStatusUpdates();
   updatePaneShortcutBadges();
   if (shortcutsLastFocusedEl && document.contains(shortcutsLastFocusedEl)) {
@@ -11512,6 +11615,15 @@ globalElements.shortcutsBtn?.addEventListener('click', () => openShortcuts());
 globalElements.shortcutsCloseBtn?.addEventListener('click', () => closeShortcuts());
 globalElements.shortcutsModal?.addEventListener('click', (event) => {
   if (event.target === globalElements.shortcutsModal) closeShortcuts();
+});
+globalElements.shortcutsSearchInput?.addEventListener('input', () => {
+  shortcutsUiState.query = globalElements.shortcutsSearchInput.value || '';
+  applyShortcutsFilters();
+});
+globalElements.shortcutsFilterChips?.addEventListener('click', (event) => {
+  const target = event.target instanceof HTMLElement ? event.target.closest('[data-shortcuts-filter]') : null;
+  if (!target) return;
+  setShortcutsFilter(target.dataset.shortcutsFilter || 'all');
 });
 globalElements.shortcutsModal?.addEventListener('keydown', (event) => {
   if (!globalElements.shortcutsModal?.classList.contains('open')) return;

--- a/app.js
+++ b/app.js
@@ -2869,6 +2869,7 @@ function applyShortcutsFilters() {
 }
 
 function focusShortcutsSearch() {
+  if (!globalElements.shortcutsModal?.classList.contains('open')) return;
   const target = globalElements.shortcutsSearchInput || globalElements.shortcutsDialog || globalElements.shortcutsCloseBtn || globalElements.shortcutsModal;
   try {
     target?.focus?.({ preventScroll: true });
@@ -2882,7 +2883,10 @@ function scheduleShortcutsSearchFocus() {
     window.clearInterval(shortcutsFocusTimer);
     shortcutsFocusTimer = null;
   }
+
   focusShortcutsSearch();
+  window.requestAnimationFrame?.(focusShortcutsSearch);
+
   const startedAt = Date.now();
   shortcutsFocusTimer = window.setInterval(() => {
     if (!globalElements.shortcutsModal?.classList.contains('open')) {
@@ -2890,11 +2894,12 @@ function scheduleShortcutsSearchFocus() {
       shortcutsFocusTimer = null;
       return;
     }
-    focusShortcutsSearch();
     if (document.activeElement === globalElements.shortcutsSearchInput || Date.now() - startedAt > 1500) {
       window.clearInterval(shortcutsFocusTimer);
       shortcutsFocusTimer = null;
+      return;
     }
+    focusShortcutsSearch();
   }, 50);
 }
 

--- a/index.html
+++ b/index.html
@@ -280,7 +280,27 @@
             ✕
           </button>
         </div>
-        <div id="shortcutsContent" class="modal-body"></div>
+        <div class="modal-body">
+          <div class="shortcuts-controls" role="search" aria-label="Search keyboard shortcuts">
+            <input
+              id="shortcutsSearchInput"
+              class="shortcuts-search-input"
+              type="search"
+              placeholder="Search keys, actions, or categories"
+              autocomplete="off"
+              data-testid="shortcuts-search"
+            />
+            <div id="shortcutsFilterChips" class="shortcuts-filter-chips" role="toolbar" aria-label="Shortcut category filters">
+              <button class="shortcuts-chip is-active" type="button" data-shortcuts-filter="all" aria-pressed="true">All</button>
+              <button class="shortcuts-chip" type="button" data-shortcuts-filter="global" aria-pressed="false">Global</button>
+              <button class="shortcuts-chip" type="button" data-shortcuts-filter="chat" aria-pressed="false">Chat</button>
+              <button class="shortcuts-chip" type="button" data-shortcuts-filter="workqueue" aria-pressed="false">Workqueue</button>
+              <button class="shortcuts-chip" type="button" data-shortcuts-filter="fleet" aria-pressed="false">Fleet</button>
+            </div>
+          </div>
+          <div id="shortcutsEmpty" class="hint shortcuts-empty" hidden>No shortcuts match your filters.</div>
+          <div id="shortcutsContent"></div>
+        </div>
       </div>
     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -2449,6 +2449,47 @@ button.agents-section-title:hover {
 
 /* Shortcuts modal */
 
+.shortcuts-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.shortcuts-search-input {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--panel-border);
+  background: rgba(0, 0, 0, 0.24);
+  color: var(--text);
+}
+
+.shortcuts-filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.shortcuts-chip {
+  border-radius: 999px;
+  border: 1px solid var(--panel-border);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--muted);
+  padding: 6px 10px;
+  font-size: 0.85rem;
+}
+
+.shortcuts-chip.is-active {
+  border-color: rgba(125, 211, 252, 0.7);
+  background: rgba(125, 211, 252, 0.14);
+  color: var(--text);
+}
+
+.shortcuts-empty {
+  margin-bottom: 12px;
+}
+
 .shortcut-group {
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 12px;

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -39,6 +39,7 @@ test('shortcuts overlay: ? opens, Esc closes, content renders', async ({ page })
   await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
 
   const modal = page.locator('#shortcutsModal');
+  const trigger = page.getByTestId('shortcuts-btn');
   await expect(modal).toHaveAttribute('aria-hidden', 'true');
 
   // The app focuses the first chat input on load; shortcuts should *not* fire while typing.
@@ -47,6 +48,7 @@ test('shortcuts overlay: ? opens, Esc closes, content renders', async ({ page })
 
   await page.keyboard.press('Shift+/');
   await expect(modal).toHaveAttribute('aria-hidden', 'false');
+  await expect.poll(() => page.evaluate(() => document.activeElement?.id)).toBe('shortcutsSearchInput');
   await expect(modal).toContainText('Keyboard shortcuts');
   await expect(modal).toContainText('Pane focus/navigation');
   await expect(modal).toContainText('Pane actions');
@@ -60,6 +62,28 @@ test('shortcuts overlay: ? opens, Esc closes, content renders', async ({ page })
 
   await page.keyboard.press('Escape');
   await expect(modal).toHaveAttribute('aria-hidden', 'true');
+
+  await trigger.focus();
+  await page.keyboard.press('Enter');
+  await expect(modal).toHaveAttribute('aria-hidden', 'false');
+  await expect.poll(() => page.evaluate(() => document.activeElement?.id)).toBe('shortcutsSearchInput');
+
+  await page.getByTestId('shortcuts-search').fill('workqueue');
+  await expect(modal.locator('.shortcut-group-title', { hasText: 'Workqueue actions' })).toBeVisible();
+  await expect(modal.locator('.shortcut-group-title', { hasText: 'Global' })).toBeHidden();
+
+  await page.getByTestId('shortcuts-search').fill('zzzz');
+  await expect(modal.locator('#shortcutsEmpty')).toBeVisible();
+
+  await page.getByTestId('shortcuts-search').fill('');
+  await modal.locator('[data-shortcuts-filter="fleet"]').click();
+  await expect(modal.locator('.shortcut-group-title', { hasText: 'Pane actions' })).toBeVisible();
+  await expect(modal.locator('[data-shortcuts-filter="fleet"]')).toHaveAttribute('aria-pressed', 'true');
+  await expect(modal.locator('.shortcut-group-title', { hasText: 'Workqueue actions' })).toBeHidden();
+
+  await page.keyboard.press('Escape');
+  await expect(modal).toHaveAttribute('aria-hidden', 'true');
+  await expect.poll(() => page.evaluate(() => document.activeElement?.id)).toBe('shortcutsBtn');
 });
 
 test('shortcuts overlay: status panel shows typing-focus block reason', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Add a search input and category chips to the keyboard shortcuts modal.
- Filter existing shortcut rows by key combo, action text, and category text with an empty state.
- Keep Escape close/focus restoration intact and cover the behavior in the shortcuts UI spec.

Fixes #338

## Tests
- npm test
- npm run test:ui -- tests/pane.shortcuts.e2e.spec.js