### PR TITLE
Preserve pane identity in compact pane rows

### DIFF
--- a/app.js
+++ b/app.js
@@ -1813,6 +1813,29 @@ function paneSummaryLabel(pane) {
   return paneIdentityLabel(pane, { includeUnread: false });
 }
 
+function paneManagerStateChipMarkup(pane, state, unreadCount) {
+  const chips = [];
+  if (unreadCount > 0) {
+    chips.push({
+      key: 'unread',
+      label: unreadCount > 99 ? '99+ unread' : `${unreadCount} unread`,
+      title: `${unreadCount} unread`
+    });
+  }
+  if (pane?.kind === 'chat' && paneHasDraftChanges(pane)) {
+    chips.push({ key: 'draft', label: 'draft', title: 'Unsent draft' });
+  }
+  if (String(state || '').toLowerCase() === 'disconnected') {
+    chips.push({ key: 'disconnected', label: 'disconnected', title: 'Pane disconnected' });
+  }
+  return chips
+    .map(
+      (chip) =>
+        `<span class="pane-manager-state-chip pane-manager-state-chip-${escapeHtml(chip.key)}" data-testid="pane-manager-state-chip" data-chip="${escapeHtml(chip.key)}" title="${escapeHtml(chip.title)}">${escapeHtml(chip.label)}</span>`
+    )
+    .join('');
+}
+
 function isPaneSwitchHudEnabled() {
   return String(storage.get(PANE_SWITCH_HUD_ENABLED_KEY, '1') || '1') !== '0';
 }
@@ -2162,15 +2185,21 @@ function renderPaneManager() {
         const isDuplicate = duplicateCount > 1;
         const unreadCount = paneUnreadCount(pane);
         const paneIdentity = paneSummaryLabel(pane);
+        const letter = paneHeaderLetter(pane);
+        const type = paneLabel(pane);
+        const target = paneTargetLabel(pane);
+        const stateChips = paneManagerStateChipMarkup(pane, state, unreadCount);
 
         row.innerHTML = `
           <div class="pane-manager-main">
             <div class="pane-manager-kind" title="${escapeHtml(paneIdentity)}">
+              <span class="pane-manager-letter" data-testid="pane-manager-letter" aria-label="${escapeHtml(`Pane ${letter}`)}">${escapeHtml(letter)}</span>
               ${paneTypeBadgeMarkup(pane, { extraClass: 'pane-manager-type-badge', testId: 'pane-manager-type-badge' })}
-              <span class="pane-manager-kind-label">${escapeHtml(paneIdentity)}</span>
+              <span class="pane-manager-kind-label" data-testid="pane-manager-kind-label">${escapeHtml(type)}</span>
+              <span class="pane-manager-target-label" data-testid="pane-manager-target-label"><span aria-hidden="true">· </span>${escapeHtml(target)}</span>
               <span class="pane-manager-pane-id" title="Internal pane id">${escapeHtml(String(pane?.key || ''))}</span>
               ${isDuplicate ? `<span class="pane-manager-duplicate-badge" data-testid="pane-manager-duplicate-badge" title="${escapeHtml(`${duplicateCount} duplicate panes`)}">duplicate</span>` : ''}
-              ${unreadCount > 0 ? `<span class="pane-manager-unread-badge" data-testid="pane-manager-unread-badge" title="${escapeHtml(`${unreadCount} unread`)}">${escapeHtml(String(unreadCount))}</span>` : ''}
+              ${stateChips}
             </div>
             <div class="pane-manager-state" data-state="${escapeHtml(state)}">${escapeHtml(state)}</div>
           </div>

--- a/styles.css
+++ b/styles.css
@@ -1356,6 +1356,7 @@ button.send-btn .btn-icon {
   gap: 8px;
   align-items: center;
   min-width: 0;
+  flex-wrap: wrap;
 }
 
 .pane-manager-type-badge {
@@ -1382,6 +1383,12 @@ button.send-btn .btn-icon {
 
 .pane-manager-kind-label {
   font-weight: 600;
+  min-width: 0;
+}
+
+.pane-manager-target-label {
+  color: var(--muted);
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1409,19 +1416,39 @@ button.send-btn .btn-icon {
   text-transform: uppercase;
 }
 
-.pane-manager-unread-badge {
+.pane-manager-state-chip {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 18px;
-  height: 18px;
-  padding: 0 7px;
+  min-height: 18px;
+  padding: 1px 7px;
   border-radius: 999px;
-  border: 1px solid rgba(239, 68, 68, 0.45);
-  background: rgba(239, 68, 68, 0.14);
-  color: #fecaca;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(148, 163, 184, 0.12);
+  color: rgba(226, 232, 240, 0.84);
   font-size: 10px;
   font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.pane-manager-state-chip-unread {
+  border-color: rgba(239, 68, 68, 0.45);
+  background: rgba(239, 68, 68, 0.14);
+  color: #fecaca;
+}
+
+.pane-manager-state-chip-draft {
+  border-color: rgba(245, 158, 11, 0.42);
+  background: rgba(245, 158, 11, 0.12);
+  color: #fcd34d;
+}
+
+.pane-manager-state-chip-disconnected {
+  border-color: rgba(148, 163, 184, 0.3);
+  background: rgba(148, 163, 184, 0.12);
+  color: rgba(226, 232, 240, 0.78);
 }
 
 .pane-manager-state {

--- a/tests/pane.manager.e2e.spec.js
+++ b/tests/pane.manager.e2e.spec.js
@@ -80,9 +80,63 @@ test('pane header: identity line uses "[Letter] [Type] · [Target]" across pane 
   await expect(timelinePane.getByTestId('pane-type-label')).toHaveText(/^D Timeline · .+/);
 
   await page.keyboard.press('Control+P');
-  const firstPaneHeaderIdentity = await page.locator('[data-pane]').first().getByTestId('pane-type-label').textContent();
-  await expect(page.locator('.pane-manager-row .pane-manager-kind-label').first()).toHaveText(String(firstPaneHeaderIdentity || '').trim());
+  const firstRow = page.locator('.pane-manager-row').first();
+  await expect(firstRow.getByTestId('pane-manager-letter')).toHaveText(/^A$/);
+  await expect(firstRow.getByTestId('pane-manager-kind-label')).toHaveText('Chat');
+  await expect(firstRow.getByTestId('pane-manager-target-label')).toContainText('main');
+  await expect(firstRow).toContainText('A');
+  await expect(firstRow).toContainText('Chat');
+  await expect(firstRow).toContainText('· main');
   await expect(page.locator('.pane-manager-row .pane-manager-pane-id').first()).toHaveText(/^[a-zA-Z0-9]+$/);
+});
+
+test('pane manager: rows preserve pane identity and state chips in compact list', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  await page.locator('[data-pane][data-pane-kind="chat"]').first().locator('[data-pane-input]').fill('unsent draft');
+  await page.evaluate(() => {
+    markPaneUnread(paneManager.panes[1], 2, 'workqueue');
+    paneManager.panes.forEach((pane) => {
+      pane.connected = false;
+      pane.statusState = 'disconnected';
+    });
+  });
+
+  await page.keyboard.press('Control+P');
+  const rows = page.locator('.pane-manager-row');
+  await expect(rows).toHaveCount(2);
+
+  const chatRow = rows.filter({ hasText: 'Chat · main' }).first();
+  await expect(chatRow.getByTestId('pane-manager-letter')).toHaveText('A');
+  await expect(chatRow.getByTestId('pane-manager-type-badge')).toContainText('Chat');
+  await expect(chatRow.getByTestId('pane-manager-target-label')).toContainText('main');
+  await expect(chatRow.locator('[data-chip="draft"]')).toHaveText('draft');
+  await expect(chatRow.locator('[data-chip="disconnected"]')).toHaveText('disconnected');
+
+  const workqueueRow = rows.filter({ hasText: 'Workqueue · dev-team' }).first();
+  await expect(workqueueRow.getByTestId('pane-manager-letter')).toHaveText('B');
+  await expect(workqueueRow.getByTestId('pane-manager-type-badge')).toContainText('Workqueue');
+  await expect(workqueueRow.getByTestId('pane-manager-target-label')).toContainText('dev-team');
+  await expect(workqueueRow.locator('[data-chip="unread"]')).toHaveText('2 unread');
+
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.press('Enter');
+  await expect(page.locator('#paneManagerModal')).toHaveAttribute('aria-hidden', 'true');
+
+  const focusedPaneIndex = await page.evaluate(() => {
+    const panes = Array.from(document.querySelectorAll('[data-pane]'));
+    const active = document.activeElement;
+    return panes.findIndex((p) => p === active || (active && p.contains(active)));
+  });
+  expect(focusedPaneIndex).toBe(1);
 });
 
 test('pane manager: quick-find filters and groups by kind', async ({ page }) => {


### PR DESCRIPTION
## Summary\n- split compact Pane Manager rows into explicit pane letter, type badge, and target label primitives\n- add lightweight state chips for unread counts, unsent drafts, and disconnected panes\n- keep keyboard row navigation/focus behavior covered by the Pane Manager regression suite\n\nNote: current main does not have a separate tab-overflow menu component, so this applies the requested compact-row identity treatment to the existing keyboard-navigable Pane Manager surface.\n\nFixes #337\n\n## Tests\n- npm test\n- npx playwright test tests/pane.manager.e2e.spec.js --workers=1