### PR TITLE
Add searchable keyboard shortcuts modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -49,6 +49,9 @@ const globalElements = {
   shortcutsModal: document.getElementById('shortcutsModal'),
   shortcutsDialog: document.getElementById('shortcutsDialog'),
   shortcutsCloseBtn: document.getElementById('shortcutsCloseBtn'),
+  shortcutsSearch: document.getElementById('shortcutsSearch'),
+  shortcutsEmpty: document.getElementById('shortcutsEmpty'),
+  shortcutsFilterButtons: Array.from(document.querySelectorAll('[data-shortcuts-filter]')),
   paneManagerModal: document.getElementById('paneManagerModal'),
   paneManagerCloseBtn: document.getElementById('paneManagerCloseBtn'),
   paneManagerSearch: document.getElementById('paneManagerSearch'),
@@ -1698,6 +1701,10 @@ async function deleteRecurringPrompt(id) {
 }
 
 let shortcutsLastFocusedEl = null;
+const shortcutsUiState = {
+  query: '',
+  category: 'all'
+};
 
 function getModalFocusableElements(modalEl) {
   if (!modalEl || !modalEl.querySelectorAll) return [];
@@ -1711,9 +1718,13 @@ function openShortcuts() {
   shortcutsLastFocusedEl = document.activeElement instanceof HTMLElement ? document.activeElement : null;
   modal.classList.add('open');
   modal.setAttribute('aria-hidden', 'false');
-  window.setTimeout(() => {
-    (globalElements.shortcutsDialog || globalElements.shortcutsCloseBtn || modal).focus?.();
-  }, 0);
+  shortcutsUiState.query = '';
+  shortcutsUiState.category = 'all';
+  if (globalElements.shortcutsSearch) globalElements.shortcutsSearch.value = '';
+  updateShortcutsFilter();
+  focusShortcutsSearch();
+  window.requestAnimationFrame?.(() => focusShortcutsSearch());
+  window.setTimeout(() => focusShortcutsSearch(), 50);
 }
 
 function closeShortcuts() {
@@ -1725,6 +1736,53 @@ function closeShortcuts() {
     shortcutsLastFocusedEl.focus?.();
   }
   shortcutsLastFocusedEl = null;
+}
+
+function normalizeShortcutSearchText(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function updateShortcutsFilter() {
+  const modal = globalElements.shortcutsModal;
+  if (!modal) return;
+  const query = normalizeShortcutSearchText(shortcutsUiState.query);
+  const category = shortcutsUiState.category || 'all';
+  let visibleRows = 0;
+
+  for (const btn of globalElements.shortcutsFilterButtons || []) {
+    const isActive = (btn.getAttribute('data-shortcuts-filter') || 'all') === category;
+    btn.classList.toggle('active', isActive);
+    btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+  }
+
+  for (const group of Array.from(modal.querySelectorAll('.shortcut-group'))) {
+    const categories = new Set(String(group.getAttribute('data-shortcut-category') || '').split(/\s+/).filter(Boolean));
+    const categoryMatches = category === 'all' || categories.has(category);
+    let groupVisibleRows = 0;
+    for (const row of Array.from(group.querySelectorAll('.shortcut-row'))) {
+      const haystack = normalizeShortcutSearchText(`${group.querySelector('.shortcut-group-title')?.textContent || ''} ${row.textContent || ''}`);
+      const rowMatches = categoryMatches && (!query || haystack.includes(query));
+      row.hidden = !rowMatches;
+      if (rowMatches) {
+        groupVisibleRows += 1;
+        visibleRows += 1;
+      }
+    }
+    group.hidden = groupVisibleRows === 0;
+  }
+
+  if (globalElements.shortcutsEmpty) {
+    globalElements.shortcutsEmpty.hidden = visibleRows !== 0;
+  }
+}
+
+function focusShortcutsSearch() {
+  const target = globalElements.shortcutsSearch || globalElements.shortcutsDialog || globalElements.shortcutsCloseBtn || globalElements.shortcutsModal;
+  if (!target?.focus) return;
+  target.focus({ preventScroll: true });
+  if (target === globalElements.shortcutsSearch) {
+    target.select?.();
+  }
 }
 
 // Pane Manager (admin-only)
@@ -8679,6 +8737,17 @@ globalElements.paneSwitchHudEnabled?.addEventListener('change', () => {
 
 globalElements.shortcutsBtn?.addEventListener('click', () => openShortcuts());
 globalElements.shortcutsCloseBtn?.addEventListener('click', () => closeShortcuts());
+globalElements.shortcutsSearch?.addEventListener('input', () => {
+  shortcutsUiState.query = globalElements.shortcutsSearch.value || '';
+  updateShortcutsFilter();
+});
+for (const btn of globalElements.shortcutsFilterButtons || []) {
+  btn.addEventListener('click', () => {
+    shortcutsUiState.category = btn.getAttribute('data-shortcuts-filter') || 'all';
+    updateShortcutsFilter();
+    globalElements.shortcutsSearch?.focus?.();
+  });
+}
 globalElements.shortcutsModal?.addEventListener('click', (event) => {
   if (event.target === globalElements.shortcutsModal) closeShortcuts();
 });

--- a/index.html
+++ b/index.html
@@ -240,14 +240,25 @@
           <div class="hint" style="margin-bottom: 10px;">
             Most shortcuts are disabled while typing in inputs, textareas, selects, or contenteditable fields. Global keys like <kbd>Esc</kbd>, <kbd>Cmd/Ctrl+P</kbd>, and <kbd>Cmd/Ctrl+K</kbd> still work.
           </div>
+          <div class="shortcuts-filterbar" aria-label="Filter keyboard shortcuts">
+            <input id="shortcutsSearch" class="shortcuts-search" type="search" placeholder="Search shortcuts" aria-label="Search keyboard shortcuts" autocomplete="off" data-testid="shortcuts-search">
+            <div class="shortcuts-filter-chips" role="group" aria-label="Shortcut category filters">
+              <button class="shortcuts-filter-chip active" type="button" data-shortcuts-filter="all" aria-pressed="true">All</button>
+              <button class="shortcuts-filter-chip" type="button" data-shortcuts-filter="global" aria-pressed="false">Global</button>
+              <button class="shortcuts-filter-chip" type="button" data-shortcuts-filter="chat" aria-pressed="false">Chat</button>
+              <button class="shortcuts-filter-chip" type="button" data-shortcuts-filter="workqueue" aria-pressed="false">Workqueue</button>
+              <button class="shortcuts-filter-chip" type="button" data-shortcuts-filter="fleet" aria-pressed="false">Fleet</button>
+            </div>
+          </div>
+          <div id="shortcutsEmpty" class="shortcuts-empty" hidden>No shortcuts match that filter.</div>
 
-          <div class="shortcut-group">
+          <div class="shortcut-group" data-shortcut-category="global">
             <h3 class="shortcut-group-title">Global</h3>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>?</kbd></div><div class="shortcut-desc">Open this help overlay</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Esc</kbd></div><div class="shortcut-desc">Close overlay / menus</div></div>
           </div>
 
-          <div class="shortcut-group">
+          <div class="shortcut-group" data-shortcut-category="pane chat">
             <h3 class="shortcut-group-title">Pane focus/navigation</h3>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Alt</kbd>/<kbd>Option</kbd>+<kbd>1</kbd>..<kbd>9</kbd></div><div class="shortcut-desc">Focus panes 1-9 by visible order</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>1</kbd>..<kbd>4</kbd></div><div class="shortcut-desc">Focus pane 1-4</div></div>
@@ -264,7 +275,7 @@
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>[</kbd></div><div class="shortcut-desc">Previous unread pane</div></div>
           </div>
 
-          <div class="shortcut-group">
+          <div class="shortcut-group" data-shortcut-category="pane chat workqueue fleet">
             <h3 class="shortcut-group-title">Pane actions</h3>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Open command palette</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd></div><div class="shortcut-desc">Add pane</div></div>
@@ -273,7 +284,7 @@
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>R</kbd></div><div class="shortcut-desc">Refresh agent list</div></div>
           </div>
 
-          <div class="shortcut-group">
+          <div class="shortcut-group" data-shortcut-category="workqueue">
             <h3 class="shortcut-group-title">Workqueue actions</h3>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>g</kbd> <kbd>w</kbd></div><div class="shortcut-desc">Open Workqueue modal</div></div>
           </div>

--- a/styles.css
+++ b/styles.css
@@ -1834,6 +1834,59 @@ button.agents-section-title:hover {
 
 /* Shortcuts modal */
 
+.shortcuts-filterbar {
+  display: grid;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.shortcuts-search {
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.25);
+  color: inherit;
+  padding: 10px 12px;
+  font: inherit;
+}
+
+.shortcuts-search:focus {
+  border-color: rgba(76, 201, 240, 0.75);
+  outline: 2px solid rgba(76, 201, 240, 0.22);
+  outline-offset: 1px;
+}
+
+.shortcuts-filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.shortcuts-filter-chip {
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.04);
+  color: inherit;
+  padding: 5px 10px;
+  font: inherit;
+  font-size: 0.82rem;
+  cursor: pointer;
+}
+
+.shortcuts-filter-chip.active {
+  border-color: rgba(76, 201, 240, 0.62);
+  background: rgba(76, 201, 240, 0.16);
+}
+
+.shortcuts-empty {
+  border: 1px dashed rgba(255, 255, 255, 0.16);
+  border-radius: 8px;
+  color: var(--muted);
+  margin-bottom: 12px;
+  padding: 14px;
+  text-align: center;
+}
+
 .shortcut-group {
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 12px;

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -53,6 +53,40 @@ test('shortcuts overlay: ? opens, Esc closes, content renders', async ({ page })
   await expect(modal).toContainText('Workqueue actions');
   await expect(modal).toContainText('disabled while typing');
   await expect(modal).toContainText('workspace only');
+  await expect(page.getByTestId('shortcuts-search')).toBeFocused();
+
+  await page.keyboard.press('Escape');
+  await expect(modal).toHaveAttribute('aria-hidden', 'true');
+});
+
+test('shortcuts modal search and category chips filter rows', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  await page.click('#connectionStatus');
+  await page.keyboard.press('Shift+/');
+
+  const modal = page.locator('#shortcutsModal');
+  const search = page.getByTestId('shortcuts-search');
+  await expect(search).toBeFocused();
+
+  await search.fill('workqueue');
+  await expect(modal.locator('.shortcut-row:visible').filter({ hasText: 'Open Workqueue modal' })).toHaveCount(1);
+  await expect(modal.locator('.shortcut-row:visible').filter({ hasText: 'Focus previous pane' })).toHaveCount(0);
+
+  await modal.getByRole('button', { name: 'Global' }).click();
+  await expect(page.locator('#shortcutsEmpty')).toBeVisible();
+
+  await search.fill('');
+  await expect(modal.locator('.shortcut-row:visible').filter({ hasText: 'Open this help overlay' })).toHaveCount(1);
+  await expect(modal.locator('.shortcut-row:visible').filter({ hasText: 'Open Workqueue modal' })).toHaveCount(0);
 
   await page.keyboard.press('Escape');
   await expect(modal).toHaveAttribute('aria-hidden', 'true');


### PR DESCRIPTION
## Summary
- add an autofocus search field to the keyboard shortcuts modal
- add category chips and an empty state for filtered shortcut rows
- cover search, category intersection, empty state, and focus in the shortcuts Playwright spec

## Tests
- npm run test:syntax
- npx playwright test tests/pane.shortcuts.e2e.spec.js --workers=1

Closes #338