### PR TITLE
Add triage layout preset

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ const globalElements = {
   deviceId: document.getElementById('deviceId'),
   disconnectBtn: document.getElementById('disconnectBtn'),
   resetLayoutBtn: document.getElementById('resetLayoutBtn'),
+  triageLayoutBtn: document.getElementById('triageLayoutBtn'),
   recurringPromptTarget: document.getElementById('recurringPromptTarget'),
   recurringPromptInterval: document.getElementById('recurringPromptInterval'),
   recurringPromptTimezone: document.getElementById('recurringPromptTimezone'),
@@ -2575,6 +2576,15 @@ function buildCommandPaletteItems() {
     ),
     withShortcut(
       {
+        id: 'cmd:triage-layout',
+        label: 'Layout: Triage preset',
+        detail: 'Open Chat + Workqueue + Fleet visibility',
+        run: () => applyTriageLayoutPreset()
+      },
+      ''
+    ),
+    withShortcut(
+      {
         id: 'cmd:toggle-shortcuts',
         label: 'Help: Toggle shortcuts overlay',
         detail: 'Show/hide keyboard shortcuts',
@@ -3111,6 +3121,27 @@ function openFleetPane({ forceNew = false } = {}) {
   pane.cronAgentId = target;
   paneManager.persistAdminPanes();
   paneManager.focusPanePrimary(pane);
+}
+
+function applyTriageLayoutPreset() {
+  if (roleState.role !== 'admin') return null;
+
+  const defaultAgent = normalizeAgentId(storage.get(ADMIN_DEFAULT_AGENT_KEY, 'main') || 'main');
+  let chatPane = findExistingPane('chat', (p) => normalizeAgentId(p.agentId || 'main') === defaultAgent) || findExistingPane('chat');
+  if (!chatPane) {
+    chatPane = paneManager.addPane('chat', { agentId: defaultAgent });
+  }
+
+  let workqueuePane = findExistingPane('workqueue', (p) => String(p.workqueue?.queue || '').trim() === 'dev-team') || findExistingPane('workqueue');
+  if (!workqueuePane) {
+    workqueuePane = paneManager.addPane('workqueue', { queue: 'dev-team' });
+  }
+
+  const fleetPane = openFleetPane();
+  paneManager.persistAdminPanes();
+  if (chatPane) paneManager.focusPanePrimary(chatPane);
+  showToast('Triage preset applied', { kind: 'info', timeoutMs: 1600 });
+  return { chatPane, workqueuePane, fleetPane };
 }
 
 function openAgentWorkqueueFromFleet(agentId) {
@@ -9572,6 +9603,10 @@ if (globalElements.resetLayoutBtn) {
 
 globalElements.resetLayoutBtn?.addEventListener('click', () => {
   paneManager.resetAdminLayoutToDefault({ confirm: true });
+});
+
+globalElements.triageLayoutBtn?.addEventListener('click', () => {
+  applyTriageLayoutPreset();
 });
 
 globalElements.paneManagerBtn?.addEventListener('click', (event) => {

--- a/index.html
+++ b/index.html
@@ -497,6 +497,7 @@
           <div class="button-row">
             <button id="disconnectBtn">Disconnect</button>
             <button id="resetLayoutBtn" type="button" class="secondary">Reset to recommended layout</button>
+            <button id="triageLayoutBtn" type="button" class="secondary" data-testid="triage-layout-btn">Triage preset</button>
           </div>
           <div class="hint">
             Auto-connecting with the gateway token from your local OpenClaw config.

--- a/tests/ui/command-palette.spec.js
+++ b/tests/ui/command-palette.spec.js
@@ -178,3 +178,38 @@ test('command palette: opens or focuses Workqueue for active chat agent', async 
   await runCommand('workqueue for active chat agent');
   await expect(page.getByTestId('toast').last()).toContainText('No active chat agent selected');
 });
+
+test('layout triage preset is available and idempotently opens chat workqueue and fleet visibility', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+  await loginAdminWithChatOnlyPane(page, env.serverPort);
+
+  const chatInput = page.locator('[data-pane][data-pane-kind="chat"]').first().locator('[data-pane-input]');
+  await expect(chatInput).toBeVisible();
+  await chatInput.fill('keep this draft');
+
+  await page.getByRole('button', { name: 'Open settings' }).click();
+  await expect(page.getByTestId('triage-layout-btn')).toBeVisible();
+  await page.locator('#settingsCloseBtn').click();
+
+  const runTriagePreset = async () => {
+    await page.keyboard.press('ControlOrMeta+K');
+    const input = page.locator('#commandPaletteInput');
+    await expect(input).toBeVisible();
+    await input.fill('triage preset');
+    await page.keyboard.press('Enter');
+  };
+
+  await runTriagePreset();
+  await expect(page.locator('[data-pane][data-pane-kind="chat"]')).toHaveCount(1);
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
+  await expect(page.locator('[data-pane][data-pane-kind="timeline"]')).toHaveCount(1);
+  await expect(chatInput).toHaveValue('keep this draft');
+
+  const countAfterFirstRun = await page.locator('[data-pane]').count();
+  await runTriagePreset();
+  await expect(page.locator('[data-pane]')).toHaveCount(countAfterFirstRun);
+  await expect(chatInput).toHaveValue('keep this draft');
+});


### PR DESCRIPTION
## Summary
- add a Settings quick action for the Triage preset
- add a command-palette Layout: Triage preset action
- reuse existing Chat/Workqueue/Fleet-visible panes and only create missing panes

Closes #340

## Tests
- npm test
- npx playwright test tests/ui/command-palette.spec.js --workers=1