### PR TITLE
Keep pane type token visible in headers

### DIFF
--- a/app.js
+++ b/app.js
@@ -6239,7 +6239,19 @@ function paneHeaderLetter(pane) {
 
 function renderPaneIdentity(pane) {
   if (!pane?.elements?.name) return;
-  pane.elements.name.textContent = paneIdentityLabel(pane, { includeUnread: true });
+  const letter = paneHeaderLetter(pane);
+  const type = paneLabel(pane);
+  const target = paneTargetLabel(pane);
+  const unread = paneUnreadCount(pane);
+  const identity = `${letter} ${type} · ${target}${unread > 0 ? ` • ${unread} unread` : ''}`;
+  pane.elements.name.title = paneIdentityLabel(pane, { includeUnread: false });
+  pane.elements.name.setAttribute('aria-label', identity);
+  if (pane.elements.nameToken && pane.elements.nameTarget) {
+    pane.elements.nameToken.textContent = `${letter} ${type}`;
+    pane.elements.nameTarget.textContent = ` · ${target}${unread > 0 ? ` • ${unread} unread` : ''}`;
+  } else {
+    pane.elements.name.textContent = identity;
+  }
   const activeKey = focusedPaneKey() || paneMruOrder()[0] || '';
   if (activeKey && String(pane.key || '') === activeKey) updateBrowserTitle(pane);
 }
@@ -6532,6 +6544,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
   const elements = {
     root,
     name: root.querySelector('[data-pane-name]'),
+    nameToken: root.querySelector('[data-pane-name-token]'),
+    nameTarget: root.querySelector('[data-pane-name-target]'),
     typePill: root.querySelector('[data-pane-type-pill]'),
     typeIcon: root.querySelector('[data-pane-type-icon]'),
     typeText: root.querySelector('[data-pane-type-text]'),
@@ -6625,7 +6639,14 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
 
   // Pane header: kind label + type pill (icon + text)
   try {
-    if (elements.name) elements.name.textContent = paneLabel(pane);
+    if (elements.name) {
+      if (elements.nameToken && elements.nameTarget) {
+        elements.nameToken.textContent = `? ${paneLabel(pane)}`;
+        elements.nameTarget.textContent = '';
+      } else {
+        elements.name.textContent = paneLabel(pane);
+      }
+    }
     if (elements.typeIcon) elements.typeIcon.textContent = paneIcon(pane);
     if (elements.typeText) elements.typeText.textContent = String(paneLabel(pane) || pane.kind || 'chat').toUpperCase();
     if (elements.typePill) {

--- a/app.js
+++ b/app.js
@@ -6641,6 +6641,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
   try {
     if (elements.name) {
       if (elements.nameToken && elements.nameTarget) {
+        elements.name.replaceChildren(elements.nameToken, elements.nameTarget);
         elements.nameToken.textContent = `? ${paneLabel(pane)}`;
         elements.nameTarget.textContent = '';
       } else {

--- a/docs/testing-selectors.md
+++ b/docs/testing-selectors.md
@@ -27,6 +27,8 @@ Clawnsole’s E2E tests (Playwright) should prefer **stable, semantic selectors*
 
 - `pane`
 - `pane-type-label`
+- `pane-name-token`
+- `pane-name-target`
 - `pane-agent-select`
 - `pane-connection-status`
 - `pane-close`

--- a/index.html
+++ b/index.html
@@ -95,7 +95,10 @@
                   <span class="pane-type-icon" data-pane-type-icon aria-hidden="true">💬</span>
                   <span class="pane-type-text" data-pane-type-text>CHAT</span>
                 </div>
-                <div class="pane-name" data-pane-name data-testid="pane-type-label">Pane</div>
+                <div class="pane-name" data-pane-name data-testid="pane-type-label">
+                  <span class="pane-name-token" data-pane-name-token data-testid="pane-name-token">A Chat</span>
+                  <span class="pane-name-target" data-pane-name-target data-testid="pane-name-target"> · main</span>
+                </div>
                 <div class="pane-agent" data-pane-agent-wrap>
                   <span class="agent-label" data-pane-target-label data-testid="pane-target-label">Agent</span>
                   <button class="agent-pill-btn" type="button" data-pane-agent-button aria-label="Change agent" data-testid="pane-agent-button">

--- a/styles.css
+++ b/styles.css
@@ -472,10 +472,26 @@ body::before {
 }
 
 .pane-name {
+  display: inline-flex;
+  align-items: center;
+  flex: 1 1 auto;
+  min-width: 0;
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.14em;
   color: var(--muted);
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.pane-name-token {
+  flex: 0 0 auto;
+}
+
+.pane-name-target {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 

--- a/tests/ui/pane-header-token.spec.js
+++ b/tests/ui/pane-header-token.spec.js
@@ -1,0 +1,65 @@
+const { test, expect } = require('@playwright/test');
+
+const { startTestEnv, loginAdmin, attachConsoleErrorAsserts, addPane } = require('./_helpers');
+
+let env;
+
+test.beforeAll(async () => {
+  env = await startTestEnv();
+});
+
+test.afterAll(() => {
+  env?.stop?.();
+});
+
+test.afterEach(async ({ page }) => {
+  if (page.__consoleAsserts) page.__consoleAsserts.assertNoErrors();
+});
+
+test('pane header: type token stays visible while target truncates', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await page.setViewportSize({ width: 720, height: 720 });
+  await loginAdmin(page, env.serverPort);
+
+  await addPane(page, 'Cron pane');
+  await addPane(page, 'Timeline pane');
+
+  await page.locator('[data-pane-name]').evaluateAll((nodes) => {
+    for (const node of nodes) node.style.maxWidth = '140px';
+  });
+
+  const expectedTokens = ['A Chat', 'B Workqueue', 'C Cron', 'D Timeline'];
+
+  for (let i = 0; i < expectedTokens.length; i += 1) {
+    const header = page.locator('[data-pane-name]').nth(i);
+    const token = header.getByTestId('pane-name-token');
+    const target = header.getByTestId('pane-name-target');
+
+    await expect(token).toHaveText(expectedTokens[i]);
+    await expect(header).toHaveAttribute('title', new RegExp(`^${expectedTokens[i]} · .+`));
+
+    const metrics = await header.evaluate((node) => {
+      const tokenEl = node.querySelector('[data-pane-name-token]');
+      const targetEl = node.querySelector('[data-pane-name-target]');
+      const tokenBox = tokenEl.getBoundingClientRect();
+      const targetBox = targetEl.getBoundingClientRect();
+      return {
+        tokenWidth: tokenBox.width,
+        targetClientWidth: targetEl.clientWidth,
+        targetScrollWidth: targetEl.scrollWidth,
+        tokenRight: tokenBox.right,
+        headerRight: node.getBoundingClientRect().right,
+        targetLeft: targetBox.left
+      };
+    });
+
+    expect(metrics.tokenWidth).toBeGreaterThan(0);
+    expect(metrics.tokenRight).toBeLessThanOrEqual(metrics.headerRight + 0.5);
+    expect(metrics.targetLeft).toBeGreaterThanOrEqual(metrics.tokenRight - 0.5);
+    expect(metrics.targetScrollWidth).toBeGreaterThanOrEqual(metrics.targetClientWidth);
+  }
+});


### PR DESCRIPTION
## Summary
- Split pane header identity into a non-shrinking type token and a separately truncating target segment.
- Add tooltip/aria identity text for the full `[Letter] [Type] · [Target]` line.
- Add a Playwright regression covering Chat, Workqueue, Cron, and Timeline under constrained header width.

Closes #331.

## Tests
- npm run test:syntax
- NODE_PATH=/Users/raysopenclaw/src/clawnsole/node_modules /Users/raysopenclaw/src/clawnsole/node_modules/.bin/playwright test tests/ui/pane-header-token.spec.js --workers=1
- NODE_PATH=/Users/raysopenclaw/src/clawnsole/node_modules npm test

🚢