### PR TITLE
Add triage layout preset

### DIFF
--- a/app.js
+++ b/app.js
@@ -77,6 +77,7 @@ const globalElements = {
   settingsBtn: document.getElementById('settingsBtn'),
   settingsModal: document.getElementById('settingsModal'),
   settingsCloseBtn: document.getElementById('settingsCloseBtn'),
+  triageLayoutPresetBtn: document.getElementById('triageLayoutPresetBtn'),
   paneSwitchHudEnabled: document.getElementById('paneSwitchHudEnabled'),
   rolePill: document.getElementById('rolePill'),
   loginOverlay: document.getElementById('loginOverlay'),
@@ -2575,6 +2576,17 @@ function buildCommandPaletteItems() {
     ),
     withShortcut(
       {
+        id: 'cmd:triage-layout-preset',
+        label: 'Layout: Triage preset',
+        detail: 'Open Chat + Workqueue + Fleet without duplicating existing panes',
+        paneMeta: commandPalettePaneMeta({ type: 'Layout', target: 'triage', mode: 'create or focus' }),
+        searchText: 'triage preset chat workqueue fleet layout',
+        run: () => applyTriageLayoutPreset()
+      },
+      ''
+    ),
+    withShortcut(
+      {
         id: 'cmd:toggle-shortcuts',
         label: 'Help: Toggle shortcuts overlay',
         detail: 'Show/hide keyboard shortcuts',
@@ -2692,9 +2704,9 @@ function buildCommandPaletteItems() {
       }
       return enriched;
     }
-    if (id === 'cmd:reset-layout') {
+    if (id === 'cmd:reset-layout' || id === 'cmd:triage-layout-preset') {
       enriched.group = 'Layout';
-      enriched.priority = 100;
+      enriched.priority = id === 'cmd:triage-layout-preset' ? 110 : 100;
       return enriched;
     }
     if (id === 'cmd:toggle-shortcuts') {
@@ -3111,6 +3123,26 @@ function openFleetPane({ forceNew = false } = {}) {
   pane.cronAgentId = target;
   paneManager.persistAdminPanes();
   paneManager.focusPanePrimary(pane);
+  return pane;
+}
+
+function applyTriageLayoutPreset() {
+  if (roleState.role !== 'admin') return;
+
+  const existingChat = findExistingPane('chat');
+  const chatPane = existingChat || paneManager.addPane('chat');
+  const agentId = normalizeAgentId(chatPane?.agentId || storage.get(ADMIN_DEFAULT_AGENT_KEY, 'main'));
+
+  paneManager.addPane('workqueue', { queue: 'dev-team', agentId });
+  const fleetPane = openFleetPane();
+
+  paneManager.persistAdminPanes();
+  if (uiState.authed) paneManager.connectIfNeeded();
+
+  if (fleetPane) paneManager.focusPanePrimary(fleetPane);
+  else if (chatPane) paneManager.focusPanePrimary(chatPane);
+
+  showToast('Triage preset applied', { kind: 'info', timeoutMs: 1600 });
 }
 
 function openAgentWorkqueueFromFleet(agentId) {
@@ -8801,6 +8833,10 @@ globalElements.settingsBtn?.addEventListener('click', () => openSettings());
 globalElements.settingsCloseBtn?.addEventListener('click', () => closeSettings());
 globalElements.settingsModal?.addEventListener('click', (event) => {
   if (event.target === globalElements.settingsModal) closeSettings();
+});
+globalElements.triageLayoutPresetBtn?.addEventListener('click', () => {
+  closeSettings();
+  applyTriageLayoutPreset();
 });
 globalElements.paneSwitchHudEnabled?.addEventListener('change', () => {
   storage.set(PANE_SWITCH_HUD_ENABLED_KEY, globalElements.paneSwitchHudEnabled.checked ? '1' : '0');

--- a/index.html
+++ b/index.html
@@ -507,6 +507,9 @@
 
           <section class="settings-section" aria-label="Pane navigation">
             <h3>Pane navigation</h3>
+            <div class="button-row">
+              <button id="triageLayoutPresetBtn" type="button" class="secondary" data-testid="triage-layout-preset-btn">Triage preset</button>
+            </div>
             <label class="inline-checkbox">
               <input id="paneSwitchHudEnabled" type="checkbox" checked />
               Show pane-switch HUD

--- a/tests/ui/command-palette.spec.js
+++ b/tests/ui/command-palette.spec.js
@@ -1,6 +1,6 @@
 const { test, expect } = require('@playwright/test');
 
-const { startTestEnv, loginAdmin, attachConsoleErrorAsserts } = require('./_helpers');
+const { startTestEnv, loginAdmin, waitForAdminUiReady, attachConsoleErrorAsserts } = require('./_helpers');
 
 let env;
 
@@ -31,6 +31,7 @@ async function loginAdminWithChatOnlyPane(page, serverPort, { agentId = 'main' }
   await page.fill('#loginPassword', 'admin');
   await page.click('#loginBtn');
   await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+  await waitForAdminUiReady(page);
 }
 
 test('command palette: keyboard flow can reuse a targeted pane and focus by pane letter', async ({ page }) => {
@@ -177,4 +178,38 @@ test('command palette: opens or focuses Workqueue for active chat agent', async 
   await wqPane.locator('[data-wq-queue-select]').focus();
   await runCommand('workqueue for active chat agent');
   await expect(page.getByTestId('toast').last()).toContainText('No active chat agent selected');
+});
+
+test('triage layout preset reuses panes and preserves chat draft', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+  await loginAdminWithChatOnlyPane(page, env.serverPort);
+
+  const chatInput = page.locator('[data-pane][data-pane-kind="chat"]').first().locator('[data-pane-input]');
+  await expect(chatInput).toBeVisible();
+  await chatInput.fill('draft survives triage preset');
+
+  await page.getByRole('button', { name: 'Open settings' }).click();
+  const settingsModal = page.locator('#settingsModal');
+  await expect(settingsModal).toHaveClass(/open/);
+  await settingsModal.getByTestId('triage-layout-preset-btn').click();
+
+  await expect(page.locator('[data-pane][data-pane-kind="chat"]')).toHaveCount(1);
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
+  await expect(page.locator('[data-pane][data-pane-kind="timeline"]')).toHaveCount(1);
+  await expect(chatInput).toHaveValue('draft survives triage preset');
+
+  await page.keyboard.press('ControlOrMeta+K');
+  const input = page.locator('#commandPaletteInput');
+  await expect(input).toBeVisible();
+  await input.fill('triage preset');
+  await expect(page.locator('#commandPaletteList [role="option"]').first()).toHaveAttribute('data-command-palette-id', 'cmd:triage-layout-preset');
+  await page.keyboard.press('Enter');
+
+  await expect(page.locator('[data-pane][data-pane-kind="chat"]')).toHaveCount(1);
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
+  await expect(page.locator('[data-pane][data-pane-kind="timeline"]')).toHaveCount(1);
+  await expect(chatInput).toHaveValue('draft survives triage preset');
 });


### PR DESCRIPTION
## Summary
- Add a Settings quick action for the Chat + Workqueue + Fleet triage preset
- Add the same preset to the command palette
- Reuse existing matching panes so repeated runs are idempotent and keep chat draft text intact

## Tests
- npm run test:syntax
- npx playwright test tests/ui/command-palette.spec.js --grep "triage layout preset"

Closes #340