### PR TITLE
Add agent row health chips

### DIFF
--- a/app.js
+++ b/app.js
@@ -3343,18 +3343,28 @@ function renderAgentsModalList() {
       const heartbeatTs = Number(lastSeenMap[id]) || 0;
       const heartbeatAge = heartbeatTs > 0 ? formatRelativeAge(Date.now() - heartbeatTs) : 'unknown';
       const triage = classify(id);
-      const bucketLabel = triage.bucket === 'offline_error' ? 'offline/error' : triage.bucket;
+      const healthLabel = triage.bucket === 'offline_error'
+        ? 'Offline/Error'
+        : triage.bucket === 'stale'
+          ? 'Stale'
+          : 'Healthy';
       const heatBucketLabel = heartbeatAgeBucketLabel(triage.ageBucket);
       const statusSnippet = String(statusSnippetMap[id] || '').trim();
       const statusSnippetHtml = statusSnippet ? ` · <span class="agents-status-snippet">${escapeHtml(statusSnippet)}</span>` : '';
       row.dataset.heartbeatBucket = triage.ageBucket;
+      row.dataset.healthState = triage.bucket;
       row.classList.toggle('agents-row-heatmap', heatmapEnabled);
 
       row.innerHTML = `
         <button type="button" class="agents-pin" aria-label="${pinnedNow ? 'Unpin agent' : 'Pin agent'}" aria-pressed="${pinnedNow ? 'true' : 'false'}" data-agent-pin="${escapeHtml(id)}">${pinnedNow ? '★' : '☆'}</button>
         <div class="agents-row-main">
           <div class="agents-row-title">${escapeHtml(label)}</div>
-          <div class="agents-row-meta">${escapeHtml(id)} · ${escapeHtml(bucketLabel)} · <span class="agents-age-chip" data-heartbeat-bucket="${escapeHtml(triage.ageBucket)}">${escapeHtml(heartbeatAge)} · ${escapeHtml(heatBucketLabel)}</span>${statusSnippetHtml}</div>
+          <div class="agents-row-meta">
+            <span class="agents-row-id">${escapeHtml(id)}</span>
+            <span class="agents-health-state-chip" data-health-state="${escapeHtml(triage.bucket)}">${escapeHtml(healthLabel)}</span>
+            <span class="agents-age-chip" data-heartbeat-bucket="${escapeHtml(triage.ageBucket)}" title="Heartbeat age: ${escapeHtml(heartbeatAge)} (${escapeHtml(heatBucketLabel)})">${escapeHtml(heartbeatAge)}</span>
+            <span class="agents-age-label">${escapeHtml(heatBucketLabel)}</span>${statusSnippetHtml}
+          </div>
         </div>
         <div class="agents-row-actions agents-row-actions-inline" role="group" aria-label="Quick actions for ${escapeHtml(label)}">
           <button type="button" class="secondary agents-action-btn" data-agent-action="triage" data-agent-id="${escapeHtml(id)}" title="Open Chat and Workqueue" aria-label="Triage agent ${escapeHtml(label)}">Triage</button>

--- a/styles.css
+++ b/styles.css
@@ -1741,6 +1741,10 @@ button.agents-section-title:hover {
 
 .agents-row-meta {
   margin-top: 2px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 5px;
   font-size: 12px;
   color: var(--muted);
 }
@@ -1754,12 +1758,36 @@ button.agents-section-title:hover {
   text-overflow: ellipsis;
 }
 
+.agents-row-id {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.agents-health-state-chip,
 .agents-age-chip {
   display: inline-block;
   border: 1px solid rgba(255, 255, 255, 0.14);
   border-radius: 999px;
   padding: 1px 8px;
   color: var(--text);
+  line-height: 1.45;
+  white-space: nowrap;
+}
+
+.agents-health-state-chip[data-health-state="active"] {
+  border-color: rgba(86, 211, 100, 0.5);
+  background: rgba(86, 211, 100, 0.13);
+}
+
+.agents-health-state-chip[data-health-state="stale"] {
+  border-color: rgba(255, 138, 76, 0.58);
+  background: rgba(255, 138, 76, 0.14);
+}
+
+.agents-health-state-chip[data-health-state="offline_error"] {
+  border-color: rgba(255, 93, 116, 0.66);
+  background: rgba(255, 93, 116, 0.16);
 }
 
 .agents-age-chip[data-heartbeat-bucket="fresh"] {
@@ -1776,6 +1804,10 @@ button.agents-section-title:hover {
 
 .agents-age-chip[data-heartbeat-bucket="critical"] {
   border-color: rgba(255, 93, 116, 0.66);
+}
+
+.agents-age-label {
+  color: var(--muted);
 }
 
 .agents-status-snippet {

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -116,6 +116,47 @@ test('agents modal shows fleet health summary counts and refreshes them', async 
   await expect(summary.locator('.agents-health-chip.disconnected')).toContainText('0');
 });
 
+test('agents modal shows row health and heartbeat-age chips', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  const agents = [
+    { id: 'healthy-agent', name: 'healthy-agent', displayName: 'healthy-agent' },
+    { id: 'stale-agent', name: 'stale-agent', displayName: 'stale-agent' },
+    { id: 'offline-agent', name: 'offline-agent', displayName: 'offline-agent' }
+  ];
+
+  await clawnsole.gotoAndLoginAdmin(page);
+  await page.route(/\/agents(?:\?|$)/, async (route) => {
+    await route.fulfill({ json: { agents } });
+  });
+  await page.evaluate(() => {
+    const now = Date.now();
+    localStorage.setItem('clawnsole.admin.agentLastSeenAtMs', JSON.stringify({
+      'healthy-agent': now - 12_000,
+      'stale-agent': now - 70 * 60 * 1000
+    }));
+  });
+  await page.getByRole('button', { name: 'Refresh agent list' }).click();
+
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsModal')).toHaveClass(/open/);
+
+  const healthyRow = page.locator('#agentsList .agents-row').filter({ hasText: 'healthy-agent' });
+  await expect(healthyRow.locator('.agents-health-state-chip')).toHaveText('Healthy');
+  await expect(healthyRow.locator('.agents-health-state-chip')).toHaveAttribute('data-health-state', 'active');
+  await expect(healthyRow.locator('.agents-age-chip')).toHaveText(/\d+s/);
+
+  const staleRow = page.locator('#agentsList .agents-row').filter({ hasText: 'stale-agent' });
+  await expect(staleRow.locator('.agents-health-state-chip')).toHaveText('Stale');
+  await expect(staleRow.locator('.agents-health-state-chip')).toHaveAttribute('data-health-state', 'stale');
+  await expect(staleRow.locator('.agents-age-chip')).toHaveText(/\d+h/);
+
+  const offlineRow = page.locator('#agentsList .agents-row').filter({ hasText: 'offline-agent' });
+  await expect(offlineRow.locator('.agents-health-state-chip')).toHaveText('Offline/Error');
+  await expect(offlineRow.locator('.agents-health-state-chip')).toHaveAttribute('data-health-state', 'offline_error');
+  await expect(offlineRow.locator('.agents-age-chip')).toHaveText('unknown');
+});
+
 test('agents modal quick filter narrows list and Esc clears it', async ({ page, clawnsole }) => {
   if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
 


### PR DESCRIPTION
## Summary
- add explicit per-row health chips for Healthy, Stale, and Offline/Error states in the Agents modal
- split heartbeat age into its own always-visible row chip with bucket context
- add UI coverage for row health and heartbeat-age chip rendering

Closes #344

## Tests
- npm run test:syntax
- npx playwright test tests/ui/agents-modal.spec.js --workers=1