### PR TITLE
Keep shortcuts modal coverage in sync

### DIFF
--- a/app.js
+++ b/app.js
@@ -287,6 +287,36 @@ const ADMIN_AUTH_DESTINATION_TTL_MS = 10 * 60 * 1000;
 const WQ_RECENT_TARGETS_KEY = 'clawnsole.wq.recentTargets';
 const WQ_RECENT_ENQUEUE_AGENTS_KEY = 'clawnsole.wq.recentEnqueueAgents';
 const WQ_RECENT_TARGETS_MAX = 6;
+const REGISTERED_GLOBAL_SHORTCUT_ACTIONS = Object.freeze([
+  'shortcut.help.open',
+  'shortcut.overlay.close',
+  'pane.focus.visible.alt',
+  'pane.focus.visible.accel',
+  'pane.manager.open',
+  'pane.focus.next',
+  'pane.focus.previous',
+  'chat.focus.next',
+  'chat.focus.previous',
+  'chat.focus.last',
+  'chat.composer.focus',
+  'pane.focus.mru.next',
+  'pane.focus.mru.previous',
+  'pane.focus.unread.next',
+  'pane.focus.unread.previous',
+  'command.palette.open',
+  'pane.add.menu.open',
+  'pane.add.chat',
+  'pane.add.workqueue',
+  'pane.add.cron',
+  'pane.add.timeline',
+  'fleet.open',
+  'fleet.sort.stale',
+  'agents.refresh',
+  'workqueue.open',
+  'workqueue.open.activeAgent'
+]);
+
+window.CL_REGISTERED_GLOBAL_SHORTCUT_ACTIONS = REGISTERED_GLOBAL_SHORTCUT_ACTIONS;
 
 function readJsonFromStorage(key, fallback) {
   try {

--- a/index.html
+++ b/index.html
@@ -251,40 +251,45 @@
 
           <div class="shortcut-group">
             <h3 class="shortcut-group-title">Global</h3>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>?</kbd></div><div class="shortcut-desc">Open this help overlay</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Esc</kbd></div><div class="shortcut-desc">Close overlay / menus</div></div>
+            <div class="shortcut-row" data-shortcut-action="shortcut.help.open"><div class="shortcut-keys"><kbd>?</kbd></div><div class="shortcut-desc">Open this help overlay</div></div>
+            <div class="shortcut-row" data-shortcut-action="shortcut.overlay.close"><div class="shortcut-keys"><kbd>Esc</kbd></div><div class="shortcut-desc">Close overlay / menus</div></div>
           </div>
 
           <div class="shortcut-group">
             <h3 class="shortcut-group-title">Pane focus/navigation</h3>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Alt</kbd>/<kbd>Option</kbd>+<kbd>1</kbd>..<kbd>9</kbd></div><div class="shortcut-desc">Focus panes 1-9 by visible order</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>1</kbd>..<kbd>4</kbd></div><div class="shortcut-desc">Focus pane 1-4</div></div>
+            <div class="shortcut-row" data-shortcut-action="pane.focus.visible.alt"><div class="shortcut-keys"><kbd>Alt</kbd>/<kbd>Option</kbd>+<kbd>1</kbd>..<kbd>9</kbd></div><div class="shortcut-desc">Focus panes 1-9 by visible order</div></div>
+            <div class="shortcut-row" data-shortcut-action="pane.focus.visible.accel"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>1</kbd>..<kbd>4</kbd></div><div class="shortcut-desc">Focus pane 1-4</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>g</kbd> <kbd>a</kbd>..<kbd>z</kbd></div><div class="shortcut-desc">Focus pane by visible letter</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys" data-shortcut-help="pane-manager"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>P</kbd></div><div class="shortcut-desc">Open Pane Manager</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys" data-shortcut-help="pane-next"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Focus next pane</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys" data-shortcut-help="pane-previous"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd></div><div class="shortcut-desc">Focus previous pane</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Focus next Chat pane only</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>J</kbd></div><div class="shortcut-desc">Focus previous Chat pane only</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>g</kbd> <kbd>c</kbd></div><div class="shortcut-desc">Return to last active Chat pane</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>L</kbd></div><div class="shortcut-desc">Focus Chat composer</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Ctrl</kbd>+<kbd>Tab</kbd></div><div class="shortcut-desc">Switch panes by most-recent focus order</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Tab</kbd></div><div class="shortcut-desc">Reverse most-recent pane traversal</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>]</kbd></div><div class="shortcut-desc">Next unread pane</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>[</kbd></div><div class="shortcut-desc">Previous unread pane</div></div>
+            <div class="shortcut-row" data-shortcut-action="pane.manager.open"><div class="shortcut-keys" data-shortcut-help="pane-manager"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>P</kbd></div><div class="shortcut-desc">Open Pane Manager</div></div>
+            <div class="shortcut-row" data-shortcut-action="pane.focus.next"><div class="shortcut-keys" data-shortcut-help="pane-next"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Focus next pane</div></div>
+            <div class="shortcut-row" data-shortcut-action="pane.focus.previous"><div class="shortcut-keys" data-shortcut-help="pane-previous"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd></div><div class="shortcut-desc">Focus previous pane</div></div>
+            <div class="shortcut-row" data-shortcut-action="chat.focus.next"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Focus next Chat pane only</div></div>
+            <div class="shortcut-row" data-shortcut-action="chat.focus.previous"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>J</kbd></div><div class="shortcut-desc">Focus previous Chat pane only</div></div>
+            <div class="shortcut-row" data-shortcut-action="chat.focus.last"><div class="shortcut-keys"><kbd>g</kbd> <kbd>c</kbd></div><div class="shortcut-desc">Return to last active Chat pane</div></div>
+            <div class="shortcut-row" data-shortcut-action="chat.composer.focus"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>L</kbd></div><div class="shortcut-desc">Focus Chat composer</div></div>
+            <div class="shortcut-row" data-shortcut-action="pane.focus.mru.next"><div class="shortcut-keys"><kbd>Ctrl</kbd>+<kbd>Tab</kbd></div><div class="shortcut-desc">Switch panes by most-recent focus order</div></div>
+            <div class="shortcut-row" data-shortcut-action="pane.focus.mru.previous"><div class="shortcut-keys"><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Tab</kbd></div><div class="shortcut-desc">Reverse most-recent pane traversal</div></div>
+            <div class="shortcut-row" data-shortcut-action="pane.focus.unread.next"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>]</kbd></div><div class="shortcut-desc">Next unread pane</div></div>
+            <div class="shortcut-row" data-shortcut-action="pane.focus.unread.previous"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>[</kbd></div><div class="shortcut-desc">Previous unread pane</div></div>
           </div>
 
           <div class="shortcut-group">
             <h3 class="shortcut-group-title">Pane actions</h3>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Open command palette</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd></div><div class="shortcut-desc">Add pane</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>C/W/R/T</kbd></div><div class="shortcut-desc">Add Chat/Workqueue/Cron/Timeline pane (workspace only)</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys" data-shortcut-help="fleet-open"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd></div><div class="shortcut-desc">Open/focus Fleet pane</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>R</kbd></div><div class="shortcut-desc">Refresh agent list</div></div>
+            <div class="shortcut-row" data-shortcut-action="command.palette.open"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Open command palette</div></div>
+            <div class="shortcut-row" data-shortcut-action="pane.add.menu.open"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd></div><div class="shortcut-desc">Add pane</div></div>
+            <div class="shortcut-row" data-shortcut-action="pane.add.chat"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>C</kbd></div><div class="shortcut-desc">Add Chat pane (workspace only)</div></div>
+            <div class="shortcut-row" data-shortcut-action="pane.add.workqueue"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>W</kbd></div><div class="shortcut-desc">Add Workqueue pane (workspace only)</div></div>
+            <div class="shortcut-row" data-shortcut-action="pane.add.cron"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd></div><div class="shortcut-desc">Add Cron pane (workspace only)</div></div>
+            <div class="shortcut-row" data-shortcut-action="pane.add.timeline"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd></div><div class="shortcut-desc">Add Timeline pane (workspace only)</div></div>
+            <div class="shortcut-row" data-shortcut-action="fleet.open"><div class="shortcut-keys" data-shortcut-help="fleet-open"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd></div><div class="shortcut-desc">Open/focus Fleet pane</div></div>
+            <div class="shortcut-row" data-shortcut-action="fleet.sort.stale"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>H</kbd></div><div class="shortcut-desc">Open Fleet sorted stale-first</div></div>
+            <div class="shortcut-row" data-shortcut-action="agents.refresh"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>R</kbd></div><div class="shortcut-desc">Refresh agent list</div></div>
           </div>
 
           <div class="shortcut-group">
             <h3 class="shortcut-group-title">Workqueue actions</h3>
-            <div class="shortcut-row"><div class="shortcut-keys" data-shortcut-help="workqueue-open"><kbd>g</kbd> <kbd>w</kbd></div><div class="shortcut-desc">Open Workqueue modal</div></div>
+            <div class="shortcut-row" data-shortcut-action="workqueue.open"><div class="shortcut-keys" data-shortcut-help="workqueue-open"><kbd>g</kbd> <kbd>w</kbd></div><div class="shortcut-desc">Open Workqueue modal</div></div>
+            <div class="shortcut-row" data-shortcut-action="workqueue.open.activeAgent"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>G</kbd></div><div class="shortcut-desc">Open/focus Workqueue for active chat agent</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>j</kbd>/<kbd>k</kbd></div><div class="shortcut-desc">Move selected row in Workqueue keyboard mode</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Enter</kbd></div><div class="shortcut-desc">Inspect selected Workqueue row in keyboard mode</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>e</kbd></div><div class="shortcut-desc">Edit selected Workqueue row in keyboard mode</div></div>

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -58,6 +58,43 @@ test('shortcuts overlay: ? opens, Esc closes, content renders', async ({ page })
   await expect(modal).toHaveAttribute('aria-hidden', 'true');
 });
 
+test('shortcuts overlay documents every registered global shortcut once', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  await page.click('#connectionStatus');
+  await page.keyboard.press('Shift+/');
+  await expect(page.locator('#shortcutsModal')).toHaveAttribute('aria-hidden', 'false');
+
+  const coverage = await page.evaluate(() => {
+    const registered = Array.from(window.CL_REGISTERED_GLOBAL_SHORTCUT_ACTIONS || []);
+    const rendered = Array.from(document.querySelectorAll('#shortcutsModal [data-shortcut-action]'))
+      .map((row) => row.getAttribute('data-shortcut-action'))
+      .filter(Boolean);
+    const renderedSet = new Set(rendered);
+    const counts = rendered.reduce((acc, id) => {
+      acc[id] = (acc[id] || 0) + 1;
+      return acc;
+    }, {});
+    return {
+      missing: registered.filter((id) => !renderedSet.has(id)),
+      duplicateIds: Object.entries(counts).filter(([, count]) => count > 1).map(([id]) => id),
+      unknown: rendered.filter((id) => !registered.includes(id))
+    };
+  });
+
+  expect(coverage).toEqual({ missing: [], duplicateIds: [], unknown: [] });
+  await expect(page.locator('[data-shortcut-action="fleet.open"]')).toContainText('Fleet');
+  await expect(page.locator('[data-shortcut-action="fleet.sort.stale"]')).toContainText('stale-first');
+});
+
 test('pane-add shortcuts are scoped to workspace and blocked by overlays', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!app?.skipReason, app?.skipReason);


### PR DESCRIPTION
## Summary
- add a registered global shortcut action list exposed to the UI test harness
- mark shortcuts modal rows with stable action IDs
- add missing Fleet stale-first shortcut help and split combined add-pane help into testable rows
- add regression coverage that fails on missing, duplicate, or unknown shortcut help rows

Fixes #343

## Tests
- npm run test:syntax
- NODE_PATH=/Users/raysopenclaw/.openclaw/workspace-dev/clawnsole/node_modules /Users/raysopenclaw/.openclaw/workspace-dev/clawnsole/node_modules/.bin/playwright test tests/pane.shortcuts.e2e.spec.js --workers=1