### PR TITLE
UX: Add explicit agents modal health chips

### DIFF
--- a/app.js
+++ b/app.js
@@ -3343,10 +3343,11 @@ function renderAgentsModalList() {
       const heartbeatTs = Number(lastSeenMap[id]) || 0;
       const heartbeatAge = heartbeatTs > 0 ? formatRelativeAge(Date.now() - heartbeatTs) : 'unknown';
       const triage = classify(id);
-      const bucketLabel = triage.bucket === 'offline_error' ? 'offline/error' : triage.bucket;
+      const healthLabel = triage.bucket === 'offline_error' ? 'Offline/Error' : triage.bucket === 'active' ? 'Healthy' : 'Stale';
       const heatBucketLabel = heartbeatAgeBucketLabel(triage.ageBucket);
       const statusSnippet = String(statusSnippetMap[id] || '').trim();
       const statusSnippetHtml = statusSnippet ? ` · <span class="agents-status-snippet">${escapeHtml(statusSnippet)}</span>` : '';
+      row.dataset.healthState = triage.bucket;
       row.dataset.heartbeatBucket = triage.ageBucket;
       row.classList.toggle('agents-row-heatmap', heatmapEnabled);
 
@@ -3354,7 +3355,11 @@ function renderAgentsModalList() {
         <button type="button" class="agents-pin" aria-label="${pinnedNow ? 'Unpin agent' : 'Pin agent'}" aria-pressed="${pinnedNow ? 'true' : 'false'}" data-agent-pin="${escapeHtml(id)}">${pinnedNow ? '★' : '☆'}</button>
         <div class="agents-row-main">
           <div class="agents-row-title">${escapeHtml(label)}</div>
-          <div class="agents-row-meta">${escapeHtml(id)} · ${escapeHtml(bucketLabel)} · <span class="agents-age-chip" data-heartbeat-bucket="${escapeHtml(triage.ageBucket)}">${escapeHtml(heartbeatAge)} · ${escapeHtml(heatBucketLabel)}</span>${statusSnippetHtml}</div>
+          <div class="agents-row-meta">
+            <span class="agents-row-id">${escapeHtml(id)}</span>
+            <span class="agents-health-state-chip" data-health-state="${escapeHtml(triage.bucket)}">${escapeHtml(healthLabel)}</span>
+            <span class="agents-age-chip" data-heartbeat-bucket="${escapeHtml(triage.ageBucket)}">${escapeHtml(heartbeatAge)} · ${escapeHtml(heatBucketLabel)}</span>${statusSnippetHtml}
+          </div>
         </div>
         <div class="agents-row-actions agents-row-actions-inline" role="group" aria-label="Quick actions for ${escapeHtml(label)}">
           <button type="button" class="secondary agents-action-btn" data-agent-action="triage" data-agent-id="${escapeHtml(id)}" title="Open Chat and Workqueue" aria-label="Triage agent ${escapeHtml(label)}">Triage</button>

--- a/styles.css
+++ b/styles.css
@@ -1740,6 +1740,10 @@ button.agents-section-title:hover {
 }
 
 .agents-row-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 5px 8px;
   margin-top: 2px;
   font-size: 12px;
   color: var(--muted);
@@ -1754,12 +1758,36 @@ button.agents-section-title:hover {
   text-overflow: ellipsis;
 }
 
+.agents-row-id {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.agents-health-state-chip,
 .agents-age-chip {
   display: inline-block;
   border: 1px solid rgba(255, 255, 255, 0.14);
   border-radius: 999px;
   padding: 1px 8px;
   color: var(--text);
+  background: rgba(255, 255, 255, 0.035);
+  white-space: nowrap;
+}
+
+.agents-health-state-chip[data-health-state="active"] {
+  border-color: rgba(83, 211, 150, 0.5);
+  background: rgba(83, 211, 150, 0.13);
+}
+
+.agents-health-state-chip[data-health-state="stale"] {
+  border-color: rgba(255, 199, 70, 0.56);
+  background: rgba(255, 199, 70, 0.14);
+}
+
+.agents-health-state-chip[data-health-state="offline_error"] {
+  border-color: rgba(255, 93, 116, 0.66);
+  background: rgba(255, 93, 116, 0.15);
 }
 
 .agents-age-chip[data-heartbeat-bucket="fresh"] {

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -74,6 +74,47 @@ test('agents modal shows live refresh freshness indicators', async ({ page, claw
   await expect(page.locator('#agentsList .agents-row-meta').first()).toContainText(/\d+[smhd]/);
 });
 
+test('agents modal rows show explicit health and heartbeat age chips', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  const agents = [
+    { id: 'healthy-agent', name: 'healthy-agent', displayName: 'healthy-agent' },
+    { id: 'stale-agent', name: 'stale-agent', displayName: 'stale-agent' },
+    { id: 'offline-agent', name: 'offline-agent', displayName: 'offline-agent' }
+  ];
+
+  await clawnsole.gotoAndLoginAdmin(page);
+  await page.route(/\/agents(?:\?|$)/, async (route) => {
+    await route.fulfill({ json: { agents } });
+  });
+  await page.evaluate(() => {
+    localStorage.setItem('clawnsole.admin.agentLastSeenAtMs', JSON.stringify({
+      'healthy-agent': Date.now(),
+      'stale-agent': Date.now() - 20 * 60 * 1000
+    }));
+  });
+  await page.getByRole('button', { name: 'Refresh agent list' }).click();
+
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsModal')).toHaveClass(/open/);
+
+  const healthyRow = page.locator('#agentsList .agents-row').filter({ hasText: 'healthy-agent' });
+  const staleRow = page.locator('#agentsList .agents-row').filter({ hasText: 'stale-agent' });
+  const offlineRow = page.locator('#agentsList .agents-row').filter({ hasText: 'offline-agent' });
+
+  await expect(healthyRow.locator('.agents-health-state-chip')).toHaveText('Healthy');
+  await expect(healthyRow.locator('.agents-health-state-chip')).toHaveAttribute('data-health-state', 'active');
+  await expect(healthyRow.locator('.agents-age-chip')).toContainText(/\d+[smhd] ago/);
+
+  await expect(staleRow.locator('.agents-health-state-chip')).toHaveText('Stale');
+  await expect(staleRow.locator('.agents-health-state-chip')).toHaveAttribute('data-health-state', 'stale');
+  await expect(staleRow.locator('.agents-age-chip')).toContainText(/20m ago/);
+
+  await expect(offlineRow.locator('.agents-health-state-chip')).toHaveText('Offline/Error');
+  await expect(offlineRow.locator('.agents-health-state-chip')).toHaveAttribute('data-health-state', 'offline_error');
+  await expect(offlineRow.locator('.agents-age-chip')).toContainText('unknown');
+});
+
 test('agents modal shows fleet health summary counts and refreshes them', async ({ page, clawnsole }) => {
   if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
 


### PR DESCRIPTION
Fixes #344.

## Summary
- add explicit Healthy/Stale/Offline/Error chips to every Agents modal row
- keep heartbeat age visible as a separate chip with existing age bucket styling
- add UI coverage for row health and age chips

## Tests
- npm run test:syntax
- npx playwright test tests/ui/agents-modal.spec.js --workers=1