### PR TITLE
Sync keyboard shortcuts modal from shared catalog

### DIFF
--- a/app.js
+++ b/app.js
@@ -48,6 +48,7 @@ const globalElements = {
   commandPaletteEmpty: document.getElementById('commandPaletteEmpty'),
   shortcutsModal: document.getElementById('shortcutsModal'),
   shortcutsDialog: document.getElementById('shortcutsDialog'),
+  shortcutsBody: document.getElementById('shortcutsBody'),
   shortcutsCloseBtn: document.getElementById('shortcutsCloseBtn'),
   paneManagerModal: document.getElementById('paneManagerModal'),
   paneManagerCloseBtn: document.getElementById('paneManagerCloseBtn'),
@@ -116,6 +117,7 @@ const fmtRemaining = __appCore.fmtRemaining || ((msUntil) => {
 });
 const formatWorkqueueIssueTitle = __appCore.formatWorkqueueIssueTitle || ((item) => String(item?.title || ''));
 const sortWorkqueueItems = __appCore.sortWorkqueueItems || ((items, opts) => (Array.isArray(items) ? items.slice() : []));
+const getShortcutGroups = __appCore.getShortcutGroups || (() => []);
 const inferPaneCols = __appCore.inferPaneCols || ((count) => {
   const n = Number(count);
   if (!Number.isFinite(n) || n <= 1) return 1;
@@ -1725,6 +1727,25 @@ function closeShortcuts() {
     shortcutsLastFocusedEl.focus?.();
   }
   shortcutsLastFocusedEl = null;
+}
+
+function renderShortcutsModal() {
+  const body = globalElements.shortcutsBody;
+  if (!body) return;
+  const groups = getShortcutGroups();
+  body.innerHTML = groups.map((group) => `
+    <div class="shortcut-group" data-shortcut-group="${escapeHtml(group.id)}">
+      <h3 class="shortcut-group-title">${escapeHtml(group.title)}</h3>
+      ${group.shortcuts.map((shortcut) => `
+        <div class="shortcut-row" data-shortcut-id="${escapeHtml(shortcut.id)}">
+          <div class="shortcut-keys">
+            ${shortcut.keys.map((key) => `<kbd>${escapeHtml(key)}</kbd>`).join(`<span aria-hidden="true">${escapeHtml(shortcut.joiner || '+')}</span>`)}
+          </div>
+          <div class="shortcut-desc">${escapeHtml(shortcut.description)}</div>
+        </div>
+      `).join('')}
+    </div>
+  `).join('');
 }
 
 // Pane Manager (admin-only)
@@ -9673,6 +9694,8 @@ document.addEventListener('visibilitychange', () => {
   if (document.hidden) return;
   paneManager.connectIfNeeded();
 });
+
+renderShortcutsModal();
 
 window.addEventListener('load', () => {
   const loginGuard = setTimeout(() => {

--- a/index.html
+++ b/index.html
@@ -244,45 +244,7 @@
             Most shortcuts are disabled while typing in inputs, textareas, selects, or contenteditable fields. Global keys like <kbd>Esc</kbd>, <kbd>Cmd/Ctrl+P</kbd>, and <kbd>Cmd/Ctrl+K</kbd> still work.
           </div>
 
-          <div class="shortcut-group">
-            <h3 class="shortcut-group-title">Global</h3>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>?</kbd></div><div class="shortcut-desc">Open this help overlay</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Esc</kbd></div><div class="shortcut-desc">Close overlay / menus</div></div>
-          </div>
-
-          <div class="shortcut-group">
-            <h3 class="shortcut-group-title">Pane focus/navigation</h3>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Alt</kbd>/<kbd>Option</kbd>+<kbd>1</kbd>..<kbd>9</kbd></div><div class="shortcut-desc">Focus panes 1-9 by visible order</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>1</kbd>..<kbd>4</kbd></div><div class="shortcut-desc">Focus pane 1-4</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>P</kbd></div><div class="shortcut-desc">Open Pane Manager</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Focus next pane</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd></div><div class="shortcut-desc">Focus previous pane</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Focus next Chat pane only</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>J</kbd></div><div class="shortcut-desc">Focus previous Chat pane only</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>g</kbd> <kbd>c</kbd></div><div class="shortcut-desc">Return to last active Chat pane</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>L</kbd></div><div class="shortcut-desc">Focus Chat composer</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Ctrl</kbd>+<kbd>Tab</kbd></div><div class="shortcut-desc">Switch panes by most-recent focus order</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Tab</kbd></div><div class="shortcut-desc">Reverse most-recent pane traversal</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>]</kbd></div><div class="shortcut-desc">Next unread pane</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>[</kbd></div><div class="shortcut-desc">Previous unread pane</div></div>
-          </div>
-
-          <div class="shortcut-group">
-            <h3 class="shortcut-group-title">Pane actions</h3>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Open command palette</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd></div><div class="shortcut-desc">Add pane</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>C/W/R/T</kbd></div><div class="shortcut-desc">Add Chat/Workqueue/Cron/Timeline pane (workspace only)</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd></div><div class="shortcut-desc">Open/focus Fleet pane</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>R</kbd></div><div class="shortcut-desc">Refresh agent list</div></div>
-          </div>
-
-          <div class="shortcut-group">
-            <h3 class="shortcut-group-title">Workqueue actions</h3>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>g</kbd> <kbd>w</kbd></div><div class="shortcut-desc">Open Workqueue modal</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>j</kbd>/<kbd>k</kbd></div><div class="shortcut-desc">Move selected row in Workqueue keyboard mode</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Enter</kbd></div><div class="shortcut-desc">Inspect selected Workqueue row in keyboard mode</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>1</kbd>..<kbd>4</kbd></div><div class="shortcut-desc">Set ready, in progress, blocked, or done in keyboard mode</div></div>
-          </div>
+          <div id="shortcutsBody"></div>
         </div>
       </div>
     </div>

--- a/lib/app-core.js
+++ b/lib/app-core.js
@@ -234,6 +234,83 @@
               : 'chat';
   }
 
+  const SHORTCUT_GROUPS = Object.freeze([
+    {
+      id: 'global',
+      title: 'Global',
+      shortcuts: [
+        { id: 'shortcuts.open', keys: ['?'], description: 'Open keyboard shortcuts' },
+        { id: 'overlay.close', keys: ['Esc'], description: 'Close overlay or menu' }
+      ]
+    },
+    {
+      id: 'pane-navigation',
+      title: 'Pane focus/navigation',
+      shortcuts: [
+        { id: 'pane.focus.option-number', keys: ['Alt/Option', '1..9'], description: 'Focus panes 1-9 by visible order' },
+        { id: 'pane.focus.accel-number', keys: ['Cmd/Ctrl', '1..9'], description: 'Focus panes 1-9 by visible order' },
+        { id: 'pane.manager.open', keys: ['Cmd/Ctrl', 'P'], description: 'Open Pane Manager' },
+        { id: 'pane.focus.next', keys: ['Cmd/Ctrl', 'Shift', 'K'], description: 'Focus next pane' },
+        { id: 'pane.focus.previous', keys: ['Cmd/Ctrl', 'Shift', 'J'], description: 'Focus previous pane' },
+        { id: 'pane.focus.chat-next', keys: ['Cmd/Ctrl', 'Alt/Option', 'K'], description: 'Focus next Chat pane only' },
+        { id: 'pane.focus.chat-previous', keys: ['Cmd/Ctrl', 'Alt/Option', 'J'], description: 'Focus previous Chat pane only' },
+        { id: 'pane.focus.last-chat', keys: ['g', 'c'], joiner: ' ', description: 'Return to last active Chat pane' },
+        { id: 'pane.focus.chat-composer', keys: ['Cmd/Ctrl', 'L'], description: 'Focus Chat composer' },
+        { id: 'pane.focus.mru-next', keys: ['Ctrl', 'Tab'], description: 'Switch panes by most-recent focus order' },
+        { id: 'pane.focus.mru-previous', keys: ['Ctrl', 'Shift', 'Tab'], description: 'Reverse most-recent pane traversal' },
+        { id: 'pane.focus.unread-next', keys: ['Cmd/Ctrl', 'Shift', ']'], description: 'Next unread pane' },
+        { id: 'pane.focus.unread-previous', keys: ['Cmd/Ctrl', 'Shift', '['], description: 'Previous unread pane' }
+      ]
+    },
+    {
+      id: 'pane-actions',
+      title: 'Pane actions',
+      shortcuts: [
+        { id: 'command-palette.open', keys: ['Cmd/Ctrl', 'K'], description: 'Open command palette' },
+        { id: 'pane.add-menu.open', keys: ['Cmd/Ctrl', 'Shift', 'N'], description: 'Open Add pane menu' },
+        { id: 'pane.add.chat', keys: ['Cmd/Ctrl', 'Shift', 'C'], description: 'Add Chat pane' },
+        { id: 'pane.add.workqueue', keys: ['Cmd/Ctrl', 'Shift', 'W'], description: 'Add or focus Workqueue pane' },
+        { id: 'pane.add.cron', keys: ['Cmd/Ctrl', 'Shift', 'R'], description: 'Add or focus Cron pane' },
+        { id: 'pane.add.timeline', keys: ['Cmd/Ctrl', 'Shift', 'T'], description: 'Add or focus Timeline pane' },
+        { id: 'fleet.open', keys: ['Cmd/Ctrl', 'Shift', 'F'], description: 'Open or focus Fleet pane' },
+        { id: 'fleet.open-heartbeat-sort', keys: ['Cmd/Ctrl', 'Shift', 'H'], description: 'Open Fleet and sort by heartbeat age' },
+        { id: 'agent-list.refresh', keys: ['Cmd/Ctrl', 'R'], description: 'Refresh agent list' }
+      ]
+    },
+    {
+      id: 'workqueue',
+      title: 'Workqueue actions',
+      shortcuts: [
+        { id: 'workqueue.open-modal', keys: ['g', 'w'], joiner: ' ', description: 'Open Workqueue modal' },
+        { id: 'workqueue.open-active-chat-agent', keys: ['Cmd/Ctrl', 'Shift', 'G'], description: 'Open Workqueue for the active Chat agent' },
+        { id: 'workqueue.keyboard.move-next', keys: ['j', 'ArrowDown'], joiner: ' / ', description: 'Move selected row down in Workqueue keyboard mode' },
+        { id: 'workqueue.keyboard.move-previous', keys: ['k', 'ArrowUp'], joiner: ' / ', description: 'Move selected row up in Workqueue keyboard mode' },
+        { id: 'workqueue.keyboard.inspect', keys: ['Enter'], description: 'Inspect selected Workqueue row in keyboard mode' },
+        { id: 'workqueue.keyboard.status-ready', keys: ['1'], description: 'Set selected Workqueue row to ready in keyboard mode' },
+        { id: 'workqueue.keyboard.status-in-progress', keys: ['2'], description: 'Set selected Workqueue row to in progress in keyboard mode' },
+        { id: 'workqueue.keyboard.status-blocked', keys: ['3'], description: 'Set selected Workqueue row to blocked in keyboard mode' },
+        { id: 'workqueue.keyboard.status-done', keys: ['4'], description: 'Set selected Workqueue row to done in keyboard mode' }
+      ]
+    }
+  ]);
+
+  function getShortcutGroups() {
+    return SHORTCUT_GROUPS.map((group) => ({
+      id: group.id,
+      title: group.title,
+      shortcuts: group.shortcuts.map((shortcut) => ({
+        id: shortcut.id,
+        keys: shortcut.keys.slice(),
+        joiner: shortcut.joiner || '+',
+        description: shortcut.description
+      }))
+    }));
+  }
+
+  function getShortcutIds() {
+    return getShortcutGroups().flatMap((group) => group.shortcuts.map((shortcut) => shortcut.id));
+  }
+
   function normalizeAdminDestination(candidate, { origin = '', now = Date.now(), ttlMs = 10 * 60 * 1000 } = {}) {
     const value = candidate && typeof candidate === 'object' ? candidate : {};
     const href = typeof value.href === 'string' ? value.href.trim() : '';
@@ -452,6 +529,8 @@
     fmtRemaining,
     formatWorkqueueIssueTitle,
     sortWorkqueueItems,
+    getShortcutGroups,
+    getShortcutIds,
     inferPaneCols,
     normalizePaneKind,
     normalizeAdminDestination,

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -52,7 +52,17 @@ test('shortcuts overlay: ? opens, Esc closes, content renders', async ({ page })
   await expect(modal).toContainText('Pane actions');
   await expect(modal).toContainText('Workqueue actions');
   await expect(modal).toContainText('disabled while typing');
-  await expect(modal).toContainText('workspace only');
+  await expect(modal).toContainText('Open or focus Fleet pane');
+  await expect(modal).toContainText('Open Fleet and sort by heartbeat age');
+  await expect(modal).toContainText('Open Workqueue for the active Chat agent');
+  await expect(modal).toContainText('Focus panes 1-9 by visible order');
+
+  const expectedShortcutIds = await page.evaluate(() => window.AppCore.getShortcutIds());
+  const renderedShortcutIds = await modal.locator('[data-shortcut-id]').evaluateAll((rows) =>
+    rows.map((row) => row.getAttribute('data-shortcut-id'))
+  );
+  expect(renderedShortcutIds).toEqual(expectedShortcutIds);
+  expect(new Set(renderedShortcutIds).size).toBe(renderedShortcutIds.length);
 
   await page.keyboard.press('Escape');
   await expect(modal).toHaveAttribute('aria-hidden', 'true');

--- a/tests/unit/app-core.test.js
+++ b/tests/unit/app-core.test.js
@@ -13,7 +13,9 @@ const {
   deriveGlobalConnectionState,
   deriveDisconnectButtonState,
   extractChatText,
-  normalizeHistoryEntries
+  normalizeHistoryEntries,
+  getShortcutGroups,
+  getShortcutIds
 } = require('../../lib/app-core.js');
 
 test('escapeHtml escapes html special chars', () => {
@@ -164,6 +166,23 @@ test('normalizePaneKind handles aliases safely', () => {
   assert.equal(normalizePaneKind('timeline'), 'timeline');
   assert.equal(normalizePaneKind('ti'), 'timeline');
   assert.equal(normalizePaneKind('x'), 'chat');
+});
+
+test('shortcut catalog has stable unique ids and includes fleet shortcuts', () => {
+  const groups = getShortcutGroups();
+  const ids = getShortcutIds();
+  assert.ok(groups.length >= 4);
+  assert.equal(new Set(ids).size, ids.length);
+  assert.ok(ids.includes('fleet.open'));
+  assert.ok(ids.includes('fleet.open-heartbeat-sort'));
+  assert.ok(ids.includes('workqueue.open-active-chat-agent'));
+  assert.ok(
+    groups.some((group) => group.shortcuts.some((shortcut) =>
+      shortcut.id === 'pane.focus.accel-number' &&
+      shortcut.keys.includes('Cmd/Ctrl') &&
+      shortcut.keys.includes('1..9')
+    ))
+  );
 });
 
 test('deriveAuthOverlayState captures auth/role transition flags', () => {


### PR DESCRIPTION
## Summary
- move keyboard shortcut modal rows into a shared AppCore shortcut catalog
- render the modal from that catalog and include missing Fleet / active-chat Workqueue shortcuts
- add unit + Playwright coverage to catch catalog/render drift and duplicate IDs

## Tests
- npm test
- npx playwright test tests/pane.shortcuts.e2e.spec.js --grep "shortcuts overlay"

Closes #343