### PR TITLE
Add pane pinning guardrail

### DIFF
--- a/app.js
+++ b/app.js
@@ -2666,6 +2666,7 @@ function paneSearchFields(pane) {
     { key: 'target', value: paneTargetLabel(pane) },
     { key: 'targetDisplay', value: paneDisplayTargetLabel(pane) },
     { key: 'nickname', value: paneNickname(pane) },
+    { key: 'pinned', value: pane?.pinned ? 'pinned pin' : '' },
     { key: 'queue', value: queue },
     { key: 'paneId', value: pane?.key || '' }
   ].map((field) => ({ ...field, value: String(field.value || '') })).filter((field) => field.value);
@@ -2814,6 +2815,7 @@ function renderPaneManager() {
         const duplicateCount = duplicateCounts.get(paneDuplicateKey(pane)) || 0;
         const isDuplicate = duplicateCount > 1;
         const unreadCount = paneUnreadCount(pane);
+        const isPinned = !!pane.pinned;
         const paneIdentity = paneSummaryLabel(pane);
         const nickname = paneNickname(pane);
 
@@ -2826,6 +2828,7 @@ function renderPaneManager() {
               <span class="pane-manager-kind-label">${paneManagerHighlightHtml(paneIdentity, query)}</span>
               ${nickname ? `<span class="pane-manager-nickname" data-testid="pane-manager-nickname" title="${escapeHtml(`Pane nickname: ${nickname}`)}">${paneManagerHighlightHtml(nickname, query)}</span>` : ''}
               <span class="pane-manager-pane-id" title="Internal pane id">${paneManagerHighlightHtml(String(pane?.key || ''), query)}</span>
+              ${isPinned ? '<span class="pane-manager-pin-badge" data-testid="pane-manager-pin-badge">pinned</span>' : ''}
               ${isDuplicate ? `<span class="pane-manager-duplicate-badge" data-testid="pane-manager-duplicate-badge" title="${escapeHtml(`${duplicateCount} duplicate panes`)}">duplicate</span>` : ''}
               ${unreadCount > 0 ? `<span class="pane-manager-unread-badge" data-testid="pane-manager-unread-badge" title="${escapeHtml(`${unreadCount} unread`)}">${escapeHtml(String(unreadCount))}</span>` : ''}
             </div>
@@ -2836,6 +2839,7 @@ function renderPaneManager() {
             <button class="secondary pane-manager-down" type="button" data-action="move-down" data-testid="pane-manager-move-down" title="${lockDisabled ? 'Layout is locked' : 'Move pane down'}" aria-label="Move pane down" ${(visibleIdx === visibleKeys.length - 1 || lockDisabled) ? 'disabled' : ''}>↓</button>
             ${isDuplicate ? '<button class="secondary pane-manager-close-others" type="button" data-action="close-others" data-testid="pane-manager-close-others">Close others</button>' : ''}
             <button class="secondary pane-manager-nickname-action" type="button" data-action="nickname" data-testid="pane-manager-nickname-action">Nickname</button>
+            <button class="secondary pane-manager-pin" type="button" data-action="pin" data-testid="pane-manager-pin" aria-pressed="${isPinned ? 'true' : 'false'}">${isPinned ? 'Unpin' : 'Pin'}</button>
             <button class="secondary pane-manager-focus" type="button" data-action="focus">Focus</button>
             <button class="secondary pane-manager-close" type="button" data-action="close">Close</button>
           </div>
@@ -2867,6 +2871,11 @@ function renderPaneManager() {
             try {
               paneManager.removePane(pane.key, { source: 'manager' });
             } catch {}
+            renderPaneManager();
+            return;
+          }
+          if (action === 'pin') {
+            paneManager.togglePanePinned(pane.key);
             renderPaneManager();
             return;
           }
@@ -7762,7 +7771,7 @@ function normalizeWorkqueueGroupMode(value) {
   return String(value || '').trim().toLowerCase() === 'grouped' ? 'grouped' : 'rows';
 }
 
-function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, scopeFilter, quickFilters, groupMode, sortKey, sortDir, cronAgentId, nickname, closable = true } = {}) {
+function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, scopeFilter, quickFilters, groupMode, sortKey, sortDir, cronAgentId, nickname, closable = true, pinned = false } = {}) {
   const template = globalElements.paneTemplate;
   const root = template.content.firstElementChild.cloneNode(true);
   const elements = {
@@ -7785,6 +7794,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     activityBadge: root.querySelector('[data-pane-activity-badge]'),
     helpDetails: root.querySelector('[data-pane-help]'),
     helpPopover: root.querySelector('[data-pane-help-popover]'),
+    pinBtn: root.querySelector('[data-pane-pin]'),
     closeBtn: root.querySelector('[data-pane-close]'),
     thread: root.querySelector('[data-pane-thread]'),
     scrollDownBtn: root.querySelector('[data-pane-scroll-down]'),
@@ -7837,6 +7847,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     connected: false,
     statusState: 'disconnected',
     statusMeta: '',
+    pinned: !!pinned,
     elements,
     chat: { runs: new Map(), history: [] },
     unreadCount: 0,
@@ -7861,6 +7872,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
   try {
     elements.root.dataset.paneKind = pane.kind;
     elements.root.dataset.paneAccentKind = pane.kind;
+    elements.root.dataset.panePinned = pane.pinned ? 'true' : 'false';
     elements.root.classList.add(`pane-kind-${pane.kind}`);
   } catch {}
 
@@ -7978,6 +7990,20 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       paneManager.removePane(pane.key);
     });
   }
+
+  const renderPanePinButton = () => {
+    if (!elements.pinBtn) return;
+    elements.pinBtn.hidden = role !== 'admin';
+    if (role !== 'admin') return;
+    elements.pinBtn.setAttribute('aria-pressed', pane.pinned ? 'true' : 'false');
+    elements.pinBtn.setAttribute('aria-label', pane.pinned ? 'Unpin pane' : 'Pin pane');
+    elements.pinBtn.setAttribute('title', pane.pinned ? 'Pinned: click to unpin' : 'Pin pane');
+    elements.pinBtn.textContent = pane.pinned ? '📌' : '📍';
+  };
+  renderPanePinButton();
+  elements.pinBtn?.addEventListener('click', () => {
+    paneManager.togglePanePinned(pane.key);
+  });
 
   if (elements.stopBtn) {
     elements.stopBtn.addEventListener('click', (e) => {
@@ -9403,6 +9429,7 @@ const paneManager = {
         sortKey: cfg.sortKey,
         sortDir: cfg.sortDir,
         nickname: cfg.nickname,
+        pinned: !!cfg.pinned,
         closable: true
       })
     );
@@ -9479,13 +9506,13 @@ const paneManager = {
           const sortKey = typeof item.sortKey === 'string' ? item.sortKey : 'priority';
           const sortDir = item.sortDir === 'asc' ? 'asc' : 'desc';
           const groupMode = normalizeWorkqueueGroupMode(item.groupMode);
-          return { key, kind, agentId, queue, statusFilter, scopeFilter, quickFilters, groupMode, sortKey, sortDir, nickname };
+          return { key, kind, agentId, queue, statusFilter, scopeFilter, quickFilters, groupMode, sortKey, sortDir, nickname, pinned: !!item.pinned };
         }
         if (kind === 'cron' || kind === 'timeline') {
-          return { key, kind, nickname };
+          return { key, kind, nickname, pinned: !!item.pinned };
         }
         const agentId = normalizeAgentId(typeof item.agentId === 'string' ? item.agentId : defaultAgent);
-        return { key, kind: 'chat', agentId, nickname };
+        return { key, kind: 'chat', agentId, nickname, pinned: !!item.pinned };
       }
       // Super-legacy format: ['pabc','pdef'] (treat as chat panes)
       if (typeof item === 'string' && item) {
@@ -9529,15 +9556,36 @@ const paneManager = {
           groupMode: normalizeWorkqueueGroupMode(pane.workqueue?.groupMode),
           sortKey: pane.workqueue?.sortKey || 'priority',
           sortDir: pane.workqueue?.sortDir || 'desc',
-          nickname: paneNickname(pane)
+          nickname: paneNickname(pane),
+          pinned: !!pane.pinned
         };
       }
       if (pane.kind === 'cron' || pane.kind === 'timeline') {
-        return { key: pane.key, kind: pane.kind, nickname: paneNickname(pane) };
+        return { key: pane.key, kind: pane.kind, nickname: paneNickname(pane), pinned: !!pane.pinned };
       }
-      return { key: pane.key, kind: 'chat', agentId: pane.agentId || 'main', nickname: paneNickname(pane) };
+      return { key: pane.key, kind: 'chat', agentId: pane.agentId || 'main', nickname: paneNickname(pane), pinned: !!pane.pinned };
     });
     storage.set(ADMIN_PANES_KEY, JSON.stringify(payload));
+  },
+  togglePanePinned(key) {
+    if (roleState.role !== 'admin') return false;
+    const pane = this.panes.find((entry) => entry.key === key);
+    if (!pane) return false;
+    pane.pinned = !pane.pinned;
+    try {
+      pane.elements.root.dataset.panePinned = pane.pinned ? 'true' : 'false';
+      if (pane.elements.pinBtn) {
+        pane.elements.pinBtn.setAttribute('aria-pressed', pane.pinned ? 'true' : 'false');
+        pane.elements.pinBtn.setAttribute('aria-label', pane.pinned ? 'Unpin pane' : 'Pin pane');
+        pane.elements.pinBtn.setAttribute('title', pane.pinned ? 'Pinned: click to unpin' : 'Pin pane');
+        pane.elements.pinBtn.textContent = pane.pinned ? '📌' : '📍';
+      }
+    } catch {}
+    this.updateCloseButtons();
+    this.persistAdminPanes();
+    renderPaneManager();
+    showToast(pane.pinned ? 'Pane pinned' : 'Pane unpinned', { kind: 'info', timeoutMs: 1500 });
+    return true;
   },
   hasUnsentDrafts() {
     return anyPaneHasDraftChanges(this.panes);
@@ -9978,17 +10026,30 @@ const paneManager = {
     if (roleState.role !== 'admin') return null;
     const idx = this.panes.findIndex((pane) => pane.key === key);
     if (idx < 0) return null;
+    const pane = this.panes[idx];
+    if (pane?.pinned) {
+      const ok = window.confirm('Replace pinned pane? This pane is pinned to protect it from accidental layout changes.');
+      if (!ok) return null;
+    }
     const targetKind = isAnchorPaneKind(kind) ? kind : 'chat';
-    const removed = this.removePane(key, { skipAnchorGuard: true, focusFallback: false });
+    const removed = this.removePane(key, { skipAnchorGuard: true, focusFallback: false, allowPinned: true, source: 'replace' });
     if (!removed) return null;
     return this.addPane(targetKind, { ...options, forceNew: true });
   },
-  removePane(key, { skipAnchorGuard = false, focusFallback = true, source = 'unknown' } = {}) {
+  removePane(key, { skipAnchorGuard = false, focusFallback = true, source = 'unknown', allowPinned = false } = {}) {
     if (roleState.role !== 'admin') return;
     if (this.panes.length <= 1) return;
     const idx = this.panes.findIndex((pane) => pane.key === key);
     if (idx < 0) return;
     const candidate = this.panes[idx];
+    if (candidate?.pinned && !allowPinned) {
+      if (source === 'manager-keyboard') {
+        showToast('This pane is pinned. Unpin it before closing.', { kind: 'info', timeoutMs: 2600 });
+        return;
+      }
+      const ok = window.confirm('Close pinned pane? This pane is pinned to protect it from accidental layout changes.');
+      if (!ok) return;
+    }
     if (!skipAnchorGuard && this.maybeOfferAnchorReplace(candidate, { source })) return;
     const [pane] = this.panes.splice(idx, 1);
     forgetFocusedPaneKey(pane?.key || key);

--- a/index.html
+++ b/index.html
@@ -124,6 +124,7 @@
 
                 <div class="pane-activity-badge" data-pane-activity-badge data-testid="pane-activity-badge" hidden aria-live="polite" aria-label="No unread activity">•</div>
                 <div class="status-pill pane-status" data-pane-status data-testid="pane-connection-status">disconnected</div>
+                <button class="icon-btn pane-pin" data-pane-pin type="button" aria-label="Pin pane" aria-pressed="false" title="Pin pane" data-testid="pane-pin">📍</button>
                 <button class="icon-btn pane-close" data-pane-close type="button" aria-label="Close pane" data-testid="pane-close">
                   ✕
                 </button>

--- a/styles.css
+++ b/styles.css
@@ -1509,6 +1509,22 @@ button.send-btn .btn-icon {
   text-transform: uppercase;
 }
 
+.pane-manager-pin-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 18px;
+  padding: 0 7px;
+  border-radius: 999px;
+  border: 1px solid rgba(77, 196, 255, 0.42);
+  background: rgba(77, 196, 255, 0.12);
+  color: #b7ecff;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
 .pane-manager-unread-badge {
   display: inline-flex;
   align-items: center;

--- a/tests/pane.manager.e2e.spec.js
+++ b/tests/pane.manager.e2e.spec.js
@@ -4,6 +4,15 @@ const { startClawnsoleTestApp } = require('./helpers/pw-app');
 
 let app;
 
+async function openPaneManager(page) {
+  const modal = page.locator('#paneManagerModal');
+  await page.keyboard.press('Control+P');
+  if ((await modal.getAttribute('aria-hidden')) !== 'false') {
+    await page.click('#paneManagerBtn');
+  }
+  await expect(modal).toHaveAttribute('aria-hidden', 'false');
+}
+
 test.beforeAll(async () => {
   app = await startClawnsoleTestApp();
 });
@@ -373,4 +382,35 @@ test('pane layout lock disables pane reordering controls', async ({ page }) => {
   await page.keyboard.press('Control+P');
   const movableRow = page.locator('.pane-manager-row', { hasText: 'Workqueue' }).first();
   await expect(movableRow.getByTestId('pane-manager-move-down')).toBeDisabled();
+});
+
+test('pane manager: pins panes, blocks keyboard close, and persists pin state', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  await openPaneManager(page);
+
+  const workqueueRow = page.locator('.pane-manager-row', { hasText: 'Workqueue' }).first();
+  await workqueueRow.getByTestId('pane-manager-pin').click();
+  await expect(workqueueRow.getByTestId('pane-manager-pin')).toHaveAttribute('aria-pressed', 'true');
+  await expect(workqueueRow.getByTestId('pane-manager-pin-badge')).toBeVisible();
+
+  await page.keyboard.press('Delete');
+  await expect(page.getByTestId('toast').last()).toContainText('This pane is pinned. Unpin it before closing.');
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
+
+  await page.reload();
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+  await openPaneManager(page);
+
+  const persistedWorkqueueRow = page.locator('.pane-manager-row', { hasText: 'Workqueue' }).first();
+  await expect(persistedWorkqueueRow.getByTestId('pane-manager-pin')).toHaveAttribute('aria-pressed', 'true');
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"]').first().getByTestId('pane-pin')).toHaveAttribute('aria-pressed', 'true');
 });


### PR DESCRIPTION
Fixes #345.

## Summary
- Add pane-level pin/unpin controls in headers and Pane Manager.
- Persist pinned state in admin pane layout storage across reloads.
- Guard pinned pane close/replace actions with confirmation, and block keyboard close with an explanatory toast.

## Tests
- npm test
- npx playwright test tests/pane.manager.e2e.spec.js --workers=1
