### PR TITLE
Sync shortcuts modal with registered actions

### DIFF
--- a/app.js
+++ b/app.js
@@ -49,6 +49,7 @@ const globalElements = {
   shortcutsModal: document.getElementById('shortcutsModal'),
   shortcutsDialog: document.getElementById('shortcutsDialog'),
   shortcutsCloseBtn: document.getElementById('shortcutsCloseBtn'),
+  shortcutGroups: document.getElementById('shortcutGroups'),
   paneManagerModal: document.getElementById('paneManagerModal'),
   paneManagerCloseBtn: document.getElementById('paneManagerCloseBtn'),
   paneManagerSearch: document.getElementById('paneManagerSearch'),
@@ -1699,6 +1700,83 @@ async function deleteRecurringPrompt(id) {
 
 let shortcutsLastFocusedEl = null;
 
+const SHORTCUT_HELP_GROUPS = [
+  {
+    title: 'Global',
+    shortcuts: [
+      { id: 'global.open-shortcuts', keys: ['?'], desc: 'Open this help overlay' },
+      { id: 'global.close-overlay', keys: ['Esc'], desc: 'Close overlay / menus' }
+    ]
+  },
+  {
+    title: 'Pane focus/navigation',
+    shortcuts: [
+      { id: 'pane.focus-alt-1-9', keys: ['Alt/Option', '1..9'], desc: 'Focus panes 1-9 by visible order' },
+      { id: 'pane.focus-accel-1-9', keys: ['Cmd/Ctrl', '1..9'], desc: 'Focus panes 1-9 by visible order' },
+      { id: 'pane.manager', keys: ['Cmd/Ctrl', 'P'], desc: 'Open Pane Manager' },
+      { id: 'pane.next', keys: ['Cmd/Ctrl', 'Shift', 'K'], desc: 'Focus next pane' },
+      { id: 'pane.previous', keys: ['Cmd/Ctrl', 'Shift', 'J'], desc: 'Focus previous pane' },
+      { id: 'pane.chat-next', keys: ['Cmd/Ctrl', 'Alt', 'K'], desc: 'Focus next Chat pane only' },
+      { id: 'pane.chat-previous', keys: ['Cmd/Ctrl', 'Alt', 'J'], desc: 'Focus previous Chat pane only' },
+      { id: 'pane.last-chat', keys: ['g', 'c'], desc: 'Return to last active Chat pane' },
+      { id: 'pane.chat-composer', keys: ['Cmd/Ctrl', 'L'], desc: 'Focus Chat composer' },
+      { id: 'pane.mru-next', keys: ['Ctrl', 'Tab'], desc: 'Switch panes by most-recent focus order' },
+      { id: 'pane.mru-previous', keys: ['Ctrl', 'Shift', 'Tab'], desc: 'Reverse most-recent pane traversal' },
+      { id: 'pane.unread-next', keys: ['Cmd/Ctrl', 'Shift', ']'], desc: 'Next unread pane' },
+      { id: 'pane.unread-previous', keys: ['Cmd/Ctrl', 'Shift', '['], desc: 'Previous unread pane' }
+    ]
+  },
+  {
+    title: 'Pane actions',
+    shortcuts: [
+      { id: 'action.command-palette', keys: ['Cmd/Ctrl', 'K'], desc: 'Open command palette' },
+      { id: 'action.add-pane-menu', keys: ['Cmd/Ctrl', 'Shift', 'N'], desc: 'Open Add pane menu' },
+      { id: 'action.add-chat-pane', keys: ['Cmd/Ctrl', 'Shift', 'C'], desc: 'Add Chat pane (workspace only)' },
+      { id: 'action.add-workqueue-pane', keys: ['Cmd/Ctrl', 'Shift', 'W'], desc: 'Add or focus Workqueue pane (workspace only)' },
+      { id: 'action.add-cron-pane', keys: ['Cmd/Ctrl', 'Shift', 'R'], desc: 'Add or focus Cron pane (workspace only)' },
+      { id: 'action.add-timeline-pane', keys: ['Cmd/Ctrl', 'Shift', 'T'], desc: 'Add or focus Timeline pane (workspace only)' },
+      { id: 'action.workqueue-for-chat', keys: ['Cmd/Ctrl', 'Shift', 'G'], desc: 'Open or focus Workqueue for active Chat agent' },
+      { id: 'action.fleet-pane', keys: ['Cmd/Ctrl', 'Shift', 'F'], desc: 'Open/focus Fleet pane' },
+      { id: 'action.fleet-heartbeat-sort', keys: ['Cmd/Ctrl', 'Shift', 'H'], desc: 'Open Fleet sorted by heartbeat age' },
+      { id: 'action.refresh-agents', keys: ['Cmd/Ctrl', 'R'], desc: 'Refresh agent list' }
+    ]
+  },
+  {
+    title: 'Workqueue actions',
+    shortcuts: [
+      { id: 'workqueue.open-modal', keys: ['g', 'w'], desc: 'Open Workqueue modal' },
+      { id: 'workqueue.row-next-prev', keys: ['j/k', 'Arrow up/down'], desc: 'Move selected row in Workqueue keyboard mode' },
+      { id: 'workqueue.inspect-row', keys: ['Enter'], desc: 'Inspect selected Workqueue row in keyboard mode' },
+      { id: 'workqueue.set-status', keys: ['1..4'], desc: 'Set ready, in progress, blocked, or done in keyboard mode' }
+    ]
+  }
+];
+
+const REGISTERED_SHORTCUT_IDS = SHORTCUT_HELP_GROUPS.flatMap((group) => group.shortcuts.map((shortcut) => shortcut.id));
+
+function shortcutKeyHtml(keys) {
+  return keys
+    .map((key) => `<kbd>${escapeHtml(key)}</kbd>`)
+    .join(' ');
+}
+
+function renderShortcutHelp() {
+  const target = globalElements.shortcutGroups;
+  if (!target) return;
+  target.innerHTML = SHORTCUT_HELP_GROUPS.map((group) => `
+    <div class="shortcut-group" data-shortcut-group="${escapeHtml(group.title)}">
+      <h3 class="shortcut-group-title">${escapeHtml(group.title)}</h3>
+      ${group.shortcuts.map((shortcut) => `
+        <div class="shortcut-row" data-shortcut-id="${escapeHtml(shortcut.id)}">
+          <div class="shortcut-keys">${shortcutKeyHtml(shortcut.keys)}</div>
+          <div class="shortcut-desc">${escapeHtml(shortcut.desc)}</div>
+        </div>
+      `).join('')}
+    </div>
+  `).join('');
+  window.__clawnsoleShortcutIds = REGISTERED_SHORTCUT_IDS.slice();
+}
+
 function getModalFocusableElements(modalEl) {
   if (!modalEl || !modalEl.querySelectorAll) return [];
   return Array.from(modalEl.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'))
@@ -1708,6 +1786,7 @@ function getModalFocusableElements(modalEl) {
 function openShortcuts() {
   const modal = globalElements.shortcutsModal;
   if (!modal || modal.classList.contains('open')) return;
+  renderShortcutHelp();
   shortcutsLastFocusedEl = document.activeElement instanceof HTMLElement ? document.activeElement : null;
   modal.classList.add('open');
   modal.setAttribute('aria-hidden', 'false');

--- a/index.html
+++ b/index.html
@@ -244,45 +244,7 @@
             Most shortcuts are disabled while typing in inputs, textareas, selects, or contenteditable fields. Global keys like <kbd>Esc</kbd>, <kbd>Cmd/Ctrl+P</kbd>, and <kbd>Cmd/Ctrl+K</kbd> still work.
           </div>
 
-          <div class="shortcut-group">
-            <h3 class="shortcut-group-title">Global</h3>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>?</kbd></div><div class="shortcut-desc">Open this help overlay</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Esc</kbd></div><div class="shortcut-desc">Close overlay / menus</div></div>
-          </div>
-
-          <div class="shortcut-group">
-            <h3 class="shortcut-group-title">Pane focus/navigation</h3>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Alt</kbd>/<kbd>Option</kbd>+<kbd>1</kbd>..<kbd>9</kbd></div><div class="shortcut-desc">Focus panes 1-9 by visible order</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>1</kbd>..<kbd>4</kbd></div><div class="shortcut-desc">Focus pane 1-4</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>P</kbd></div><div class="shortcut-desc">Open Pane Manager</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Focus next pane</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd></div><div class="shortcut-desc">Focus previous pane</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Focus next Chat pane only</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>J</kbd></div><div class="shortcut-desc">Focus previous Chat pane only</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>g</kbd> <kbd>c</kbd></div><div class="shortcut-desc">Return to last active Chat pane</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>L</kbd></div><div class="shortcut-desc">Focus Chat composer</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Ctrl</kbd>+<kbd>Tab</kbd></div><div class="shortcut-desc">Switch panes by most-recent focus order</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Tab</kbd></div><div class="shortcut-desc">Reverse most-recent pane traversal</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>]</kbd></div><div class="shortcut-desc">Next unread pane</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>[</kbd></div><div class="shortcut-desc">Previous unread pane</div></div>
-          </div>
-
-          <div class="shortcut-group">
-            <h3 class="shortcut-group-title">Pane actions</h3>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Open command palette</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd></div><div class="shortcut-desc">Add pane</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>C/W/R/T</kbd></div><div class="shortcut-desc">Add Chat/Workqueue/Cron/Timeline pane (workspace only)</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd></div><div class="shortcut-desc">Open/focus Fleet pane</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>R</kbd></div><div class="shortcut-desc">Refresh agent list</div></div>
-          </div>
-
-          <div class="shortcut-group">
-            <h3 class="shortcut-group-title">Workqueue actions</h3>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>g</kbd> <kbd>w</kbd></div><div class="shortcut-desc">Open Workqueue modal</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>j</kbd>/<kbd>k</kbd></div><div class="shortcut-desc">Move selected row in Workqueue keyboard mode</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Enter</kbd></div><div class="shortcut-desc">Inspect selected Workqueue row in keyboard mode</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>1</kbd>..<kbd>4</kbd></div><div class="shortcut-desc">Set ready, in progress, blocked, or done in keyboard mode</div></div>
-          </div>
+          <div id="shortcutGroups" data-testid="shortcut-groups"></div>
         </div>
       </div>
     </div>

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -53,6 +53,24 @@ test('shortcuts overlay: ? opens, Esc closes, content renders', async ({ page })
   await expect(modal).toContainText('Workqueue actions');
   await expect(modal).toContainText('disabled while typing');
   await expect(modal).toContainText('workspace only');
+  await expect(modal).toContainText('Open/focus Fleet pane');
+  await expect(modal).toContainText('Open Fleet sorted by heartbeat age');
+
+  const shortcutCoverage = await page.evaluate(() => {
+    const registered = window.__clawnsoleShortcutIds || [];
+    const rendered = Array.from(document.querySelectorAll('#shortcutsModal [data-shortcut-id]'))
+      .map((el) => el.getAttribute('data-shortcut-id'));
+    const renderedSet = new Set(rendered);
+    return {
+      registered,
+      rendered,
+      missing: registered.filter((id) => !renderedSet.has(id)),
+      duplicates: rendered.filter((id, idx) => rendered.indexOf(id) !== idx)
+    };
+  });
+  expect(shortcutCoverage.missing).toEqual([]);
+  expect(shortcutCoverage.duplicates).toEqual([]);
+  expect(shortcutCoverage.rendered).toHaveLength(shortcutCoverage.registered.length);
 
   await page.keyboard.press('Escape');
   await expect(modal).toHaveAttribute('aria-hidden', 'true');
@@ -529,4 +547,23 @@ test('fleet quick action button + keyboard shortcut focus existing timeline pane
 
   await fleetBtn.click({ modifiers: ['Alt'] });
   await expect(timelinePanes).toHaveCount(2);
+});
+
+test('fleet heartbeat shortcut opens Fleet sorted by heartbeat age', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+  await page.click('#connectionStatus');
+
+  await page.keyboard.press('Control+Shift+H');
+
+  const agentsModal = page.locator('#agentsModal');
+  await expect(agentsModal).toHaveAttribute('aria-hidden', 'false');
+  await expect(page.locator('#agentsSort')).toHaveValue('heartbeat_age_desc');
 });


### PR DESCRIPTION
## Summary\n- Render the keyboard shortcuts modal from a single shortcut registry with stable shortcut IDs.\n- Add missing Fleet entries, including Cmd/Ctrl+Shift+H for heartbeat-age sorting.\n- Add regression coverage that every registered shortcut ID renders exactly once and that the Fleet heartbeat shortcut opens the expected sorted view.\n\n## Tests\n- npm run test:syntax\n- npx playwright test tests/pane.shortcuts.e2e.spec.js --workers=1\n\nFixes #343