### PR TITLE
Disambiguate duplicate pane labels

### DIFF
--- a/app.js
+++ b/app.js
@@ -1785,7 +1785,7 @@ function paneBrowserTitle(pane) {
   if (!pane) return 'Clawnsole';
   const parts = ['Clawnsole', paneLabel(pane)];
   if (pane.kind === 'chat' || pane.kind === 'workqueue') {
-    const target = paneTargetLabel(pane);
+    const target = paneDisplayTargetLabel(pane);
     if (target) parts.push(target);
   }
   return parts.join(' · ');
@@ -1804,7 +1804,7 @@ function updateBrowserTitle(pane = null) {
 function paneIdentityLabel(pane, { includeUnread = false } = {}) {
   const letter = paneHeaderLetter(pane);
   const type = paneLabel(pane);
-  const target = paneTargetLabel(pane);
+  const target = paneDisplayTargetLabel(pane);
   const unread = paneUnreadCount(pane);
   return `${letter} ${type} · ${target}${includeUnread && unread > 0 ? ` • ${unread} unread` : ''}`;
 }
@@ -1866,6 +1866,21 @@ function showPaneSwitchHud(pane) {
 
 function paneDuplicateKey(pane) {
   return `${String(pane?.kind || 'chat')}::${String(paneTargetLabel(pane) || '').trim().toLowerCase()}`;
+}
+
+function paneDuplicateOrdinal(pane) {
+  const panes = Array.isArray(paneManager?.panes) ? paneManager.panes : [];
+  const duplicateKey = paneDuplicateKey(pane);
+  const matching = panes.filter((entry) => paneDuplicateKey(entry) === duplicateKey);
+  if (matching.length <= 1) return { ordinal: 0, total: matching.length };
+  const index = matching.findIndex((entry) => String(entry?.key || '') === String(pane?.key || ''));
+  return { ordinal: index >= 0 ? index + 1 : 0, total: matching.length };
+}
+
+function paneDisplayTargetLabel(pane) {
+  const target = paneTargetLabel(pane);
+  const { ordinal } = paneDuplicateOrdinal(pane);
+  return ordinal > 0 ? `${target} (${ordinal})` : target;
 }
 
 function focusedPaneKey() {
@@ -2419,7 +2434,7 @@ function buildCommandPaletteItems() {
   paneManager.panes.forEach((pane, idx) => {
     const letter = paneHeaderLetter(pane);
     const type = paneLabel(pane);
-    const target = paneTargetLabel(pane);
+    const target = paneDisplayTargetLabel(pane);
     items.push(
       withShortcut(
         {
@@ -6241,7 +6256,7 @@ function renderPaneIdentity(pane) {
   if (!pane?.elements?.name) return;
   const letter = paneHeaderLetter(pane);
   const type = paneLabel(pane);
-  const target = paneTargetLabel(pane);
+  const target = paneDisplayTargetLabel(pane);
   const unread = paneUnreadCount(pane);
   const identity = `${letter} ${type} · ${target}${unread > 0 ? ` • ${unread} unread` : ''}`;
   pane.elements.name.title = paneIdentityLabel(pane, { includeUnread: false });
@@ -6289,7 +6304,8 @@ function paneSetHeaderTarget(pane, { label, value, ariaLabel, onClick } = {}) {
     }
   }
 
-  renderPaneIdentity(pane);
+  if (paneManager?.panes?.includes?.(pane)) paneManager.updatePaneLabels();
+  else renderPaneIdentity(pane);
 }
 
 function renderPaneAgentIdentity(pane) {

--- a/tests/pane.manager.e2e.spec.js
+++ b/tests/pane.manager.e2e.spec.js
@@ -139,8 +139,12 @@ test('pane manager: shows summary + duplicate badge and supports close others', 
   const rows = page.locator('.pane-manager-row');
   await expect(rows).toHaveCount(3);
 
-  const duplicateRows = page.locator('.pane-manager-row', { hasText: 'Chat · main' });
+  const duplicateRows = page.locator('.pane-manager-row', { hasText: /Chat · main \([12]\)/ });
   await expect(duplicateRows).toHaveCount(2);
+  await expect(page.locator('[data-pane][data-pane-kind="chat"]').nth(0).getByTestId('pane-type-label')).toHaveText(/^A Chat · main \(1\)$/);
+  await expect(page.locator('[data-pane][data-pane-kind="chat"]').nth(1).getByTestId('pane-type-label')).toHaveText(/^C Chat · main \(2\)$/);
+  await expect(duplicateRows.nth(0).locator('.pane-manager-kind-label')).toContainText('Chat · main (1)');
+  await expect(duplicateRows.nth(1).locator('.pane-manager-kind-label')).toContainText('Chat · main (2)');
   await expect(duplicateRows.first().getByTestId('pane-manager-duplicate-badge')).toHaveText('duplicate');
 
   const chatRowWithCloseOthers = page.locator('.pane-manager-row', { has: page.getByTestId('pane-manager-close-others') }).first();
@@ -152,6 +156,7 @@ test('pane manager: shows summary + duplicate badge and supports close others', 
   await expect(page.locator('[data-pane][data-pane-kind="chat"]')).toHaveCount(1);
   await expect(page.locator('.pane-manager-row')).toHaveCount(2);
   await expect(page.locator('[data-testid="pane-manager-duplicate-badge"]')).toHaveCount(0);
+  await expect(page.locator('[data-pane][data-pane-kind="chat"]').first().getByTestId('pane-type-label')).toHaveText(/^A Chat · main$/);
 });
 
 test('pane manager: unread-only filter toggle', async ({ page }) => {

--- a/tests/ui/command-palette.spec.js
+++ b/tests/ui/command-palette.spec.js
@@ -82,6 +82,32 @@ test('command palette: keyboard flow can reuse a targeted pane and focus by pane
   await expect(firstChatInput).toBeFocused();
 });
 
+test('command palette: duplicate pane focus actions include stable ordinals', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+  await loginAdmin(page, env.serverPort);
+
+  await page.locator('#addPaneBtn').click();
+  await page.getByTestId('pane-add-menu-chat').click();
+
+  await expect(page.locator('[data-pane][data-pane-kind="chat"]').nth(0).getByTestId('pane-type-label')).toHaveText(/^A Chat · main \(1\)$/);
+  await expect(page.locator('[data-pane][data-pane-kind="chat"]').nth(1).getByTestId('pane-type-label')).toHaveText(/^C Chat · main \(2\)$/);
+
+  await page.keyboard.press('ControlOrMeta+K');
+  const input = page.locator('#commandPaletteInput');
+  await expect(input).toBeVisible();
+  await input.fill('focus chat main');
+
+  const focusChatItems = page.locator('#commandPaletteList [role="option"][data-command-palette-id^="cmd:focus-pane-"]', { hasText: /Focus Chat: main/ });
+  await expect(focusChatItems).toHaveCount(2);
+  await expect(focusChatItems.nth(0).locator('.command-palette-item-label')).toHaveText('Focus Chat: main (1)');
+  await expect(focusChatItems.nth(1).locator('.command-palette-item-label')).toHaveText('Focus Chat: main (2)');
+  await expect(focusChatItems.nth(0).locator('.command-palette-pane-chip')).toContainText(['Chat', 'main (1)', 'focus existing']);
+  await expect(focusChatItems.nth(1).locator('.command-palette-pane-chip')).toContainText(['Chat', 'main (2)', 'focus existing']);
+});
+
 test('command palette: groups core actions and collapses per-agent targets until expanded or searched', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);


### PR DESCRIPTION
## Summary
- append stable ordinal suffixes to duplicate pane identity labels using current pane order
- share the disambiguated label across pane headers, pane manager rows, browser title, and command palette focus actions
- extend pane manager and command palette UI coverage for duplicate labels

## Tests
- npm test -- --runInBand tests/pane.manager.e2e.spec.js tests/ui/command-palette.spec.js
- npm run test:ui -- tests/pane.manager.e2e.spec.js tests/ui/command-palette.spec.js

Fixes #342

Dev pass; ready for 🚢.