### PR TITLE
Add Pane Manager quick search keyboard flow

### DIFF
--- a/app.js
+++ b/app.js
@@ -2039,14 +2039,57 @@ function markPaneUnread(pane, increment = 1, kind = 'chat') {
 }
 
 function paneSearchText(pane) {
+  const kind = String(pane?.kind || 'chat');
   return [
+    paneHeaderLetter(pane),
     paneSummaryLabel(pane),
     paneLabel(pane),
     paneTargetLabel(pane),
-    pane?.kind || ''
+    kind === 'workqueue' ? pane?.workqueue?.queue || '' : '',
+    kind === 'chat' || kind === 'workqueue' ? pane?.agentId || '' : '',
+    kind === 'cron' || kind === 'timeline' ? pane?.cronAgentId || '' : '',
+    kind
   ]
     .join(' ')
     .toLowerCase();
+}
+
+function paneManagerSearchTerms() {
+  return String(paneManagerUiState.query || '')
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+function paneMatchesSearch(pane, terms) {
+  if (!Array.isArray(terms) || !terms.length) return true;
+  const searchText = paneSearchText(pane);
+  return terms.every((term) => searchText.includes(term));
+}
+
+function highlightPaneManagerMatch(value, terms) {
+  const raw = String(value || '');
+  if (!Array.isArray(terms) || !terms.length) return escapeHtml(raw);
+  const normalizedTerms = Array.from(new Set(terms.map((term) => String(term || '').trim().toLowerCase()).filter(Boolean)))
+    .sort((a, b) => b.length - a.length);
+  if (!normalizedTerms.length) return escapeHtml(raw);
+
+  let html = '';
+  let i = 0;
+  while (i < raw.length) {
+    const lower = raw.slice(i).toLowerCase();
+    const term = normalizedTerms.find((entry) => lower.startsWith(entry));
+    if (term) {
+      const match = raw.slice(i, i + term.length);
+      html += `<mark class="pane-manager-match">${escapeHtml(match)}</mark>`;
+      i += term.length;
+    } else {
+      html += escapeHtml(raw[i]);
+      i += 1;
+    }
+  }
+  return html;
 }
 
 function paneGroupOrder(kind) {
@@ -2104,10 +2147,11 @@ function renderPaneManager() {
   const empty = globalElements.paneManagerEmpty;
   if (!list || !empty) return;
 
-  const query = String(paneManagerUiState.query || '').trim().toLowerCase();
+  const query = String(paneManagerUiState.query || '').trim();
+  const terms = paneManagerSearchTerms();
   const filtered = panes.filter((pane) => {
     if (paneManagerUiState.unreadOnly && paneUnreadCount(pane) <= 0) return false;
-    return !query || paneSearchText(pane).includes(query);
+    return paneMatchesSearch(pane, terms);
   });
 
   const grouped = new Map();
@@ -2132,6 +2176,7 @@ function renderPaneManager() {
 
   list.innerHTML = '';
   empty.hidden = filtered.length > 0;
+  empty.textContent = query ? `No panes match "${query}"` : 'No panes match this filter.';
   if (!filtered.length) return;
 
   const maxIndex = Math.max(0, visibleKeys.length - 1);
@@ -2182,7 +2227,7 @@ function renderPaneManager() {
           <div class="pane-manager-main">
             <div class="pane-manager-kind" title="${escapeHtml(paneIdentity)}">
               ${paneTypeBadgeMarkup(pane, { extraClass: 'pane-manager-type-badge', testId: 'pane-manager-type-badge' })}
-              <span class="pane-manager-kind-label">${escapeHtml(paneIdentity)}</span>
+              <span class="pane-manager-kind-label">${highlightPaneManagerMatch(paneIdentity, terms)}</span>
               <span class="pane-manager-pane-id" title="Internal pane id">${escapeHtml(String(pane?.key || ''))}</span>
               ${isDuplicate ? `<span class="pane-manager-duplicate-badge" data-testid="pane-manager-duplicate-badge" title="${escapeHtml(`${duplicateCount} duplicate panes`)}">duplicate</span>` : ''}
               ${unreadCount > 0 ? `<span class="pane-manager-unread-badge" data-testid="pane-manager-unread-badge" title="${escapeHtml(`${unreadCount} unread`)}">${escapeHtml(String(unreadCount))}</span>` : ''}
@@ -2308,13 +2353,34 @@ function closePaneManager({ restoreFocus = true } = {}) {
 function paneManagerHandleKeydown(event) {
   if (!isPaneManagerOpen()) return false;
   const panes = paneManager?.panes || [];
-  if (event.key === 'Escape') {
+  const activeEl = document.activeElement;
+  const isAccelFind = (event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey && String(event.key || '').toLowerCase() === 'f';
+  if (isAccelFind || (event.key === '/' && activeEl !== globalElements.paneManagerSearch)) {
     event.preventDefault();
-    closePaneManager();
+    event.stopPropagation();
+    try {
+      globalElements.paneManagerSearch?.focus?.();
+      globalElements.paneManagerSearch?.select?.();
+    } catch {}
     return true;
   }
 
-  const activeEl = document.activeElement;
+  if (event.key === 'Escape') {
+    event.preventDefault();
+    if (String(paneManagerUiState.query || '').trim()) {
+      paneManagerUiState.query = '';
+      if (globalElements.paneManagerSearch) globalElements.paneManagerSearch.value = '';
+      paneManagerUiState.selectedIndex = 0;
+      renderPaneManager();
+      try {
+        globalElements.paneManagerSearch?.focus?.();
+      } catch {}
+    } else {
+      closePaneManager();
+    }
+    return true;
+  }
+
   if (activeEl === globalElements.paneManagerSearch && (event.key === 'ArrowLeft' || event.key === 'ArrowRight')) {
     return false;
   }
@@ -9390,6 +9456,9 @@ window.addEventListener('keydown', (event) => {
     return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
   })();
 
+  // If Pane Manager is open, it gets first dibs on keys, including Esc clear-then-close.
+  if (paneManagerHandleKeydown(event)) return;
+
   if (event.key === 'Escape') {
     const closedOverlay = closeTopmostOverlay();
     if (closedOverlay || !isEditableTarget) {
@@ -9398,9 +9467,6 @@ window.addEventListener('keydown', (event) => {
     if (closedOverlay) event.stopPropagation();
     return;
   }
-
-  // If Pane Manager is open, it gets first dibs on keys.
-  if (paneManagerHandleKeydown(event)) return;
 
   const blockedReason = blockedGlobalShortcutReason(event);
   if (blockedReason) {

--- a/index.html
+++ b/index.html
@@ -299,7 +299,7 @@
           </div>
           <label class="pane-manager-search-wrap" for="paneManagerSearch">
             <span class="pane-manager-search-label">Quick find</span>
-            <input id="paneManagerSearch" class="pane-manager-search" type="search" placeholder="Filter by title, type, or target" autocomplete="off" data-testid="pane-manager-search" />
+            <input id="paneManagerSearch" class="pane-manager-search" type="search" placeholder="Find pane (A, Workqueue, dev-agent...)" autocomplete="off" data-testid="pane-manager-search" />
           </label>
           <label class="pane-manager-unread-only"><input id="paneManagerUnreadOnly" type="checkbox" data-testid="pane-manager-unread-only" /> Unread only</label>
           <div id="paneManagerList" class="pane-manager-list" role="listbox" aria-label="Open panes" data-testid="pane-manager-list"></div>

--- a/styles.css
+++ b/styles.css
@@ -1409,6 +1409,13 @@ button.send-btn .btn-icon {
   opacity: 0.7;
 }
 
+.pane-manager-match {
+  color: var(--text);
+  background: rgba(251, 191, 36, 0.24);
+  border-radius: 4px;
+  padding: 0 2px;
+}
+
 .pane-manager-duplicate-badge {
   display: inline-flex;
   align-items: center;

--- a/tests/pane.manager.e2e.spec.js
+++ b/tests/pane.manager.e2e.spec.js
@@ -109,13 +109,43 @@ test('pane manager: quick-find filters and groups by kind', async ({ page }) => 
   await expect(page.locator('.pane-manager-group-header').nth(2)).toContainText('Cron (1)');
 
   const search = page.getByTestId('pane-manager-search');
+  await expect(search).toHaveAttribute('placeholder', 'Find pane (A, Workqueue, dev-agent...)');
   await search.fill('cron');
   await expect(page.locator('.pane-manager-row')).toHaveCount(1);
   await expect(page.locator('.pane-manager-row').first()).toContainText('Cron');
+  await expect(page.locator('.pane-manager-row mark.pane-manager-match').first()).toContainText(/cron/i);
 
   await search.fill('B');
   await expect(page.locator('.pane-manager-row')).toHaveCount(1);
   await expect(page.locator('.pane-manager-row').first()).toContainText('Workqueue');
+
+  await search.fill('dev-team');
+  await expect(page.locator('.pane-manager-row')).toHaveCount(1);
+  await expect(page.locator('.pane-manager-row').first()).toContainText('Workqueue');
+
+  await search.fill('zzz-no-pane');
+  await expect(page.locator('.pane-manager-row')).toHaveCount(0);
+  await expect(page.locator('#paneManagerEmpty')).toHaveText('No panes match "zzz-no-pane"');
+
+  await page.keyboard.press('Escape');
+  await expect(search).toHaveValue('');
+  await expect(modal).toHaveAttribute('aria-hidden', 'false');
+
+  await page.keyboard.press('/');
+  await expect(search).toBeFocused();
+
+  await search.fill('cron');
+  await page.keyboard.press('Control+F');
+  await expect(search).toBeFocused();
+  await page.keyboard.press('Enter');
+  await expect(modal).toHaveAttribute('aria-hidden', 'true');
+  const focusedPaneKind = await page.evaluate(() => {
+    const panes = Array.from(document.querySelectorAll('[data-pane]'));
+    const active = document.activeElement;
+    const pane = panes.find((entry) => entry === active || (active && entry.contains(active)));
+    return pane?.getAttribute('data-pane-kind') || '';
+  });
+  expect(focusedPaneKind).toBe('cron');
 });
 
 test('pane manager: shows summary + duplicate badge and supports close others', async ({ page }) => {


### PR DESCRIPTION
Fixes #304\n\n## Summary\n- updates Pane Manager quick-find placeholder and matching fields for letter, type, target identity, and Workqueue queue\n- adds inline match highlighting plus explicit empty-state copy for queries\n- supports / and Cmd/Ctrl+F focus, Enter-to-focus, and Esc clear-then-close behavior\n- expands Pane Manager Playwright coverage for filtering, highlighting, queue matching, empty state, keyboard focus, Enter, and Esc\n\n## Tests\n- npm test\n- npx playwright test tests/pane.manager.e2e.spec.js --workers=1\n\nNo prod deploy.