### PR TITLE
Add go-to-pane letter shortcut

### DIFF
--- a/app.js
+++ b/app.js
@@ -2445,7 +2445,7 @@ function buildCommandPaletteItems() {
           searchText: `open focus existing pane ${letter} ${type} ${target}`,
           run: () => paneManager.focusPanePrimary(pane)
         },
-        idx < 9 ? `⌘/Ctrl+${idx + 1}` : ''
+        `g ${String(letter || '').toLowerCase()}`
       )
     );
   });
@@ -9056,6 +9056,7 @@ globalElements.wqEnqueueBtn?.addEventListener('click', () => workqueueEnqueueFro
 globalElements.wqClaimBtn?.addEventListener('click', () => workqueueClaimNextFromUi());
 
 let shortcutState = { lastGAtMs: 0, blockedReasonLastShownAt: new Map() };
+const GO_TO_PANE_TIMEOUT_MS = 1200;
 const SHORTCUT_BLOCK_RATE_LIMIT_MS = 5000;
 const SHORTCUT_BLOCK_MESSAGES = {
   typing: 'Shortcut paused while typing',
@@ -9247,6 +9248,15 @@ function focusPaneIndex(idx, { trackMru = true, showHud = false } = {}) {
       }
     }
   }
+}
+
+function focusPaneByHeaderLetter(letter, { showHud = true } = {}) {
+  const wanted = String(letter || '').trim().toUpperCase();
+  if (!/^[A-Z]$/.test(wanted)) return false;
+  const idx = paneManager.panes.findIndex((pane) => paneHeaderLetter(pane).toUpperCase() === wanted);
+  if (idx < 0) return false;
+  focusPaneIndex(idx, { showHud });
+  return true;
 }
 
 function returnToLastActiveChatPane() {
@@ -9477,6 +9487,7 @@ window.addEventListener('keydown', (event) => {
 
   // Never steal focus / override browser shortcuts while typing.
   if (isTypingContext(event.target)) return;
+  if (isAnyOverlayOpen()) return;
 
   const key = String(event.key || '');
 
@@ -9591,19 +9602,25 @@ window.addEventListener('keydown', (event) => {
   if (!event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey) {
     if (key.toLowerCase() === 'g') {
       shortcutState.lastGAtMs = now;
+      event.preventDefault();
       return;
     }
-    if (key.toLowerCase() === 'c' && shortcutState.lastGAtMs && now - shortcutState.lastGAtMs < 1000) {
+    if (shortcutState.lastGAtMs && now - shortcutState.lastGAtMs < GO_TO_PANE_TIMEOUT_MS && /^[a-z]$/i.test(key)) {
       shortcutState.lastGAtMs = 0;
       event.preventDefault();
-      returnToLastActiveChatPane();
+      if (focusPaneByHeaderLetter(key, { showHud: true })) return;
+      if (key.toLowerCase() === 'c') {
+        returnToLastActiveChatPane();
+        return;
+      }
+      if (key.toLowerCase() === 'w') {
+        openTopbarWorkqueueAction();
+        return;
+      }
       return;
     }
-    if (key.toLowerCase() === 'w' && shortcutState.lastGAtMs && now - shortcutState.lastGAtMs < 1000) {
+    if (shortcutState.lastGAtMs && now - shortcutState.lastGAtMs >= GO_TO_PANE_TIMEOUT_MS) {
       shortcutState.lastGAtMs = 0;
-      event.preventDefault();
-      openTopbarWorkqueueAction();
-      return;
     }
   }
 });

--- a/index.html
+++ b/index.html
@@ -254,6 +254,7 @@
             <h3 class="shortcut-group-title">Pane focus/navigation</h3>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Alt</kbd>/<kbd>Option</kbd>+<kbd>1</kbd>..<kbd>9</kbd></div><div class="shortcut-desc">Focus panes 1-9 by visible order</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>1</kbd>..<kbd>4</kbd></div><div class="shortcut-desc">Focus pane 1-4</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>g</kbd> <kbd>a</kbd>..<kbd>z</kbd></div><div class="shortcut-desc">Focus pane by visible letter</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>P</kbd></div><div class="shortcut-desc">Open Pane Manager</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Focus next pane</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd></div><div class="shortcut-desc">Focus previous pane</div></div>

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -288,6 +288,83 @@ test('alt+1..3 and cmd/ctrl+1..3 focus panes by visible order; shortcuts do not 
   await expect.poll(activePaneIndex).toBe(0);
 });
 
+test('g then pane letter focuses matching pane and exits cleanly on misses', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  await page.getByTestId('add-pane-btn').click();
+  await page.getByTestId('pane-add-menu-cron').click();
+  await expect(page.locator('[data-pane]')).toHaveCount(3);
+
+  const activePaneIndex = async () => page.evaluate(() => {
+    const panes = Array.from(document.querySelectorAll('[data-pane]'));
+    const active = document.activeElement;
+    if (!active) return -1;
+    return panes.findIndex((p) => p === active || p.contains(active));
+  });
+
+  await page.click('#connectionStatus');
+  await page.keyboard.press('g');
+  await page.keyboard.press('b');
+  await expect.poll(activePaneIndex).toBe(1);
+
+  await page.keyboard.press('g');
+  await page.keyboard.press('z');
+  await expect.poll(activePaneIndex).toBe(1);
+
+  await page.keyboard.press('b');
+  await expect.poll(activePaneIndex).toBe(1);
+});
+
+test('g then pane letter is suppressed while typing and while modals are active', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  await page.getByTestId('add-pane-btn').click();
+  await page.getByTestId('pane-add-menu-cron').click();
+  await expect(page.locator('[data-pane]')).toHaveCount(3);
+
+  const activePaneIndex = async () => page.evaluate(() => {
+    const panes = Array.from(document.querySelectorAll('[data-pane]')).filter((pane) => pane.getClientRects().length > 0);
+    const active = document.activeElement;
+    if (!active) return -1;
+    return panes.findIndex((p) => p === active || p.contains(active));
+  });
+
+  const firstPaneInput = page.locator('[data-pane][data-pane-kind="chat"]').first().locator('[data-pane-input]');
+  await page.evaluate(() => focusPaneIndex(0));
+  await firstPaneInput.focus();
+  await expect(firstPaneInput).toBeFocused();
+  await expect.poll(activePaneIndex).toBe(0);
+  await page.keyboard.press('g');
+  await page.keyboard.press('b');
+  await expect(firstPaneInput).toHaveValue('gb');
+  await expect.poll(activePaneIndex).toBe(0);
+
+  await page.click('#connectionStatus');
+  await page.keyboard.press('Shift+/');
+  await expect(page.locator('#shortcutsModal')).toHaveAttribute('aria-hidden', 'false');
+  await page.keyboard.press('g');
+  await page.keyboard.press('b');
+  await page.keyboard.press('Escape');
+  await expect(page.locator('#shortcutsModal')).toHaveAttribute('aria-hidden', 'true');
+  await expect.poll(activePaneIndex).not.toBe(1);
+});
+
 test('pane-switch HUD appears for keyboard pane navigation and respects settings', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!app?.skipReason, app?.skipReason);


### PR DESCRIPTION
## Summary
- add short-lived `g` then pane-letter navigation for visible pane identities
- surface `g <letter>` in focus-pane command palette entries and shortcut help
- cover success, no-match, typing suppression, and modal suppression in Playwright

## Tests
- `node --check app.js`
- `npx playwright test tests/pane.shortcuts.e2e.spec.js`
- `npx playwright test tests/ui/command-palette.spec.js`

Closes #334