### PR TITLE
Pause fleet refresh during row interaction

### DIFF
--- a/app.js
+++ b/app.js
@@ -630,6 +630,89 @@ let agentAutoRefreshInterval = null;
 let agentsModalAutoRefreshInterval = null;
 let agentsModalFreshnessTicker = null;
 let agentsLastRefreshedAtMs = 0;
+const fleetRefreshLock = {
+  lockedAtMs: 0,
+  pointerInsideRow: false,
+  deferredRefreshPending: false,
+  deferredReason: '',
+  catchupTimer: null
+};
+
+function isAgentsModalOpen() {
+  return !!globalElements.agentsModal?.classList?.contains('open');
+}
+
+function getFleetRefreshPausedEl() {
+  return document.getElementById('agentsRefreshPaused');
+}
+
+function renderFleetRefreshPaused() {
+  const el = getFleetRefreshPausedEl();
+  if (!el) return;
+  if (!fleetRefreshLock.lockedAtMs) {
+    el.hidden = true;
+    el.textContent = '';
+    return;
+  }
+  el.hidden = false;
+  el.textContent = `Refresh paused \u2022 ${formatRelativeAge(Date.now() - fleetRefreshLock.lockedAtMs)}`;
+}
+
+function hasFleetRowInteraction() {
+  if (!isAgentsModalOpen()) return false;
+  if (fleetRefreshLock.pointerInsideRow) return true;
+  const active = document.activeElement;
+  if (active && globalElements.agentsList?.contains(active) && active.closest?.('.agents-row')) return true;
+  return !!globalElements.agentsList?.querySelector?.('.agents-row-actions-overflow[open]');
+}
+
+function setFleetRefreshLock(locked) {
+  const nextLocked = !!locked && isAgentsModalOpen();
+  if (nextLocked) {
+    if (!fleetRefreshLock.lockedAtMs) fleetRefreshLock.lockedAtMs = Date.now();
+    renderFleetRefreshPaused();
+    return;
+  }
+  if (hasFleetRowInteraction()) return;
+  if (!fleetRefreshLock.lockedAtMs) {
+    renderFleetRefreshPaused();
+    return;
+  }
+  fleetRefreshLock.lockedAtMs = 0;
+  renderFleetRefreshPaused();
+  if (!fleetRefreshLock.deferredRefreshPending) return;
+  fleetRefreshLock.deferredRefreshPending = false;
+  const reason = fleetRefreshLock.deferredReason || 'fleet_interaction_resume';
+  fleetRefreshLock.deferredReason = '';
+  clearTimeout(fleetRefreshLock.catchupTimer);
+  fleetRefreshLock.catchupTimer = setTimeout(() => {
+    fleetRefreshLock.catchupTimer = null;
+    if (hasFleetRowInteraction()) {
+      fleetRefreshLock.deferredRefreshPending = true;
+      fleetRefreshLock.deferredReason = reason;
+      setFleetRefreshLock(true);
+      return;
+    }
+    refreshAgents({ reason }).catch(() => {});
+  }, 250);
+}
+
+function deferFleetRefresh(reason) {
+  fleetRefreshLock.deferredRefreshPending = true;
+  fleetRefreshLock.deferredReason = String(reason || fleetRefreshLock.deferredReason || 'fleet_interaction_resume');
+  setFleetRefreshLock(true);
+  return uiState.agents;
+}
+
+function clearFleetRefreshLock() {
+  fleetRefreshLock.pointerInsideRow = false;
+  fleetRefreshLock.lockedAtMs = 0;
+  fleetRefreshLock.deferredRefreshPending = false;
+  fleetRefreshLock.deferredReason = '';
+  clearTimeout(fleetRefreshLock.catchupTimer);
+  fleetRefreshLock.catchupTimer = null;
+  renderFleetRefreshPaused();
+}
 
 function startAgentAutoRefresh() {
   if (roleState.role !== 'admin') return;
@@ -667,7 +750,7 @@ function renderAgentsLastRefreshed() {
 function startAgentsModalAutoRefresh() {
   if (agentsModalAutoRefreshInterval) return;
   agentsModalAutoRefreshInterval = setInterval(() => {
-    if (!globalElements.agentsModal?.classList?.contains('open')) return;
+    if (!isAgentsModalOpen()) return;
     if (document.hidden) return;
     refreshAgents({ reason: 'fleet_auto_refresh' }).catch(() => {});
   }, 10_000);
@@ -682,8 +765,10 @@ function stopAgentsModalAutoRefresh() {
 function startAgentsModalFreshnessTicker() {
   if (agentsModalFreshnessTicker) return;
   agentsModalFreshnessTicker = setInterval(() => {
-    if (!globalElements.agentsModal?.classList?.contains('open')) return;
+    if (!isAgentsModalOpen()) return;
     renderAgentsLastRefreshed();
+    renderFleetRefreshPaused();
+    if (fleetRefreshLock.lockedAtMs) return;
     renderAgentsModalList();
   }, 1000);
 }
@@ -697,6 +782,7 @@ function stopAgentsModalFreshnessTicker() {
 async function refreshAgents({ reason = 'manual', showSuccessToast = false } = {}) {
   if (roleState.role !== 'admin') return uiState.agents;
   if (!uiState.authed) return uiState.agents;
+  if (reason !== 'manual' && hasFleetRowInteraction()) return deferFleetRefresh(reason);
 
   if (agentRefreshInFlight) return agentRefreshInFlight;
 
@@ -2982,6 +3068,7 @@ function openAgentsModal() {
 
   renderAgentsModalList();
   renderAgentsLastRefreshed();
+  renderFleetRefreshPaused();
   startAgentsModalAutoRefresh();
   startAgentsModalFreshnessTicker();
 
@@ -3009,6 +3096,7 @@ function resetFleetSort() {
 }
 
 function closeAgentsModal() {
+  clearFleetRefreshLock();
   globalElements.agentsModal?.classList.remove('open');
   globalElements.agentsModal?.setAttribute('aria-hidden', 'true');
   stopAgentsModalAutoRefresh();
@@ -3408,6 +3496,25 @@ function renderAgentsModalList() {
           else if (action === 'open-chat') openAgentChatFromFleet(id);
           else if (action === 'open-timeline') openAgentTimelineFromFleet(id);
           else if (action === 'open-workqueue') openAgentWorkqueueFromFleet(id);
+        });
+      });
+
+      row.addEventListener('mouseenter', () => {
+        fleetRefreshLock.pointerInsideRow = true;
+        setFleetRefreshLock(true);
+      });
+      row.addEventListener('mouseleave', () => {
+        fleetRefreshLock.pointerInsideRow = false;
+        setTimeout(() => setFleetRefreshLock(false), 80);
+      });
+      row.addEventListener('focusin', () => setFleetRefreshLock(true));
+      row.addEventListener('focusout', () => {
+        setTimeout(() => setFleetRefreshLock(false), 80);
+      });
+      row.querySelectorAll('.agents-row-actions-overflow').forEach((details) => {
+        details.addEventListener('toggle', () => {
+          setFleetRefreshLock(details.open);
+          if (!details.open) setTimeout(() => setFleetRefreshLock(false), 80);
         });
       });
 
@@ -4090,6 +4197,7 @@ async function renderWorkqueuePane(rootEl, { queue = '' } = {}) {
 // In DevTools: window.__debug.renderWorkqueuePane(document.querySelector('#someRoot'), { queue: 'dev-team' })
 window.__debug = window.__debug || {};
 window.__debug.renderWorkqueuePane = renderWorkqueuePane;
+window.__debug.refreshAgents = refreshAgents;
 
 function getWorkqueueItemRepo(item) {
   const repo = String(item?.meta?.repo || '').trim();
@@ -8940,15 +9048,22 @@ globalElements.recurringPromptRows?.addEventListener('click', (event) => {
 });
 
 globalElements.refreshAgentsBtn?.addEventListener('click', () => {
+  clearFleetRefreshLock();
   refreshAgents({ reason: 'manual', showSuccessToast: true }).catch(() => {
     showToast('Agent refresh failed.', { kind: 'error', timeoutMs: 3500 });
   });
 });
 
 globalElements.agentsBtn?.addEventListener('click', () => openAgentsModal());
-globalElements.agentsCloseBtn?.addEventListener('click', () => closeAgentsModal());
+globalElements.agentsCloseBtn?.addEventListener('click', () => {
+  clearFleetRefreshLock();
+  closeAgentsModal();
+});
 globalElements.agentsModal?.addEventListener('click', (event) => {
-  if (event.target === globalElements.agentsModal) closeAgentsModal();
+  if (event.target === globalElements.agentsModal) {
+    clearFleetRefreshLock();
+    closeAgentsModal();
+  }
 });
 globalElements.agentsModal?.addEventListener('keydown', (event) => {
   if (isTypingContext(event.target)) return;
@@ -9010,13 +9125,13 @@ globalElements.agentsActiveMinutes?.addEventListener('change', () => {
 });
 
 document.addEventListener('visibilitychange', () => {
-  if (!globalElements.agentsModal?.classList?.contains('open')) return;
+  if (!isAgentsModalOpen()) return;
   if (document.hidden) return;
   refreshAgents({ reason: 'fleet_visibility_resume' }).catch(() => {});
 });
 
 window.addEventListener('focus', () => {
-  if (!globalElements.agentsModal?.classList?.contains('open')) return;
+  if (!isAgentsModalOpen()) return;
   if (document.hidden) return;
   refreshAgents({ reason: 'fleet_focus_resume' }).catch(() => {});
 });

--- a/index.html
+++ b/index.html
@@ -424,7 +424,10 @@
         </div>
         <div class="modal-body">
           <div class="agents-toolbar">
-            <div id="agentsLastRefreshed" class="agents-last-refreshed" aria-live="polite">Last refreshed: never</div>
+            <div class="agents-refresh-state">
+              <span id="agentsLastRefreshed" class="agents-last-refreshed" aria-live="polite">Last refreshed: never</span>
+              <span id="agentsRefreshPaused" class="agents-refresh-paused" aria-live="polite" hidden></span>
+            </div>
             <label class="agents-field">
               <span class="agents-label">Search</span>
               <input id="agentsSearch" type="text" placeholder="Filter agents…" />

--- a/styles.css
+++ b/styles.css
@@ -1464,10 +1464,33 @@ button.send-btn .btn-icon {
   margin-bottom: 14px;
 }
 
-.agents-last-refreshed {
+.agents-refresh-state {
   grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.agents-last-refreshed {
   font-size: 12px;
   color: var(--muted);
+}
+
+.agents-refresh-paused {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  border: 1px solid rgba(255, 203, 107, 0.34);
+  border-radius: 999px;
+  padding: 2px 8px;
+  background: rgba(255, 203, 107, 0.1);
+  color: var(--text);
+  font-size: 12px;
+}
+
+.agents-refresh-paused[hidden] {
+  display: none;
 }
 
 .agents-field {

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -74,6 +74,64 @@ test('agents modal shows live refresh freshness indicators', async ({ page, claw
   await expect(page.locator('#agentsList .agents-row-meta').first()).toContainText(/\d+[smhd]/);
 });
 
+test('agents modal defers auto-refresh while a fleet row is active, then catches up once', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  let agents = [{ id: 'alpha', name: 'Alpha', displayName: 'Alpha' }];
+  await page.route(/\/agents(?:\?|$)/, async (route) => {
+    await route.fulfill({ json: { agents } });
+  });
+
+  await clawnsole.gotoAndLoginAdmin(page);
+  await page.getByRole('button', { name: 'Refresh agent list' }).click();
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsModal')).toHaveClass(/open/);
+
+  const row = page.locator('#agentsList .agents-row').filter({ hasText: 'Alpha (alpha)' });
+  await expect(row).toBeVisible();
+  await row.locator('[data-agent-action="open-chat"]').first().focus();
+
+  agents = [{ id: 'beta', name: 'Beta', displayName: 'Beta' }];
+  await page.evaluate(() => window.__debug.refreshAgents({ reason: 'fleet_auto_refresh' }));
+
+  await expect(page.locator('#agentsRefreshPaused')).toContainText('Refresh paused');
+  await expect(row).toBeVisible();
+  await expect(page.locator('#agentsList')).not.toContainText('Beta (beta)');
+
+  await page.locator('#agentsSearch').focus();
+  await expect(page.locator('#agentsRefreshPaused')).toBeHidden();
+  await expect(page.locator('#agentsList')).toContainText('Beta (beta)');
+  await expect(page.locator('#agentsList')).not.toContainText('Alpha (alpha)');
+});
+
+test('agents modal keeps an open row menu stable during a paused refresh', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  let agents = [{ id: 'alpha', name: 'Alpha', displayName: 'Alpha' }];
+  await page.route(/\/agents(?:\?|$)/, async (route) => {
+    await route.fulfill({ json: { agents } });
+  });
+
+  await clawnsole.gotoAndLoginAdmin(page);
+  await page.getByRole('button', { name: 'Refresh agent list' }).click();
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsModal')).toHaveClass(/open/);
+
+  await page.evaluate(() => {
+    const details = document.querySelector('#agentsList .agents-row-actions-overflow');
+    details.open = true;
+    details.dispatchEvent(new Event('toggle', { bubbles: true }));
+  });
+
+  agents = [{ id: 'beta', name: 'Beta', displayName: 'Beta' }];
+  await page.evaluate(() => window.__debug.refreshAgents({ reason: 'fleet_auto_refresh' }));
+
+  await expect(page.locator('#agentsRefreshPaused')).toContainText('Refresh paused');
+  await expect(page.locator('#agentsList .agents-row-actions-overflow').first()).toHaveAttribute('open', '');
+  await expect(page.locator('#agentsList')).toContainText('Alpha (alpha)');
+  await expect(page.locator('#agentsList')).not.toContainText('Beta (beta)');
+});
+
 test('agents modal shows fleet health summary counts and refreshes them', async ({ page, clawnsole }) => {
   if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
 


### PR DESCRIPTION
## Summary
- Add an interaction-aware Fleet refresh lock for active rows and open row menus.
- Show an inline refresh-paused age indicator and run one debounced catch-up refresh after interaction ends.
- Keep manual refresh immediate and add Playwright coverage for row/menu preservation.

Fixes #303

## Tests
- npm test
- npx playwright test tests/ui/agents-modal.spec.js --workers=1

Requesting ship sign-off.