### PR TITLE
Fix fleet refresh pause during interaction

### DIFF
--- a/app.js
+++ b/app.js
@@ -38,6 +38,7 @@ const globalElements = {
   agentsSortIndicator: document.getElementById('agentsSortIndicator'),
   agentsActiveMinutes: document.getElementById('agentsActiveMinutes'),
   agentsLastRefreshed: document.getElementById('agentsLastRefreshed'),
+  agentsRefreshPaused: document.getElementById('agentsRefreshPaused'),
   agentsList: document.getElementById('agentsList'),
   agentsEmpty: document.getElementById('agentsEmpty'),
   toastHost: document.getElementById('toastHost'),
@@ -630,6 +631,15 @@ let agentAutoRefreshInterval = null;
 let agentsModalAutoRefreshInterval = null;
 let agentsModalFreshnessTicker = null;
 let agentsLastRefreshedAtMs = 0;
+const agentsModalRefreshLock = {
+  pointerInside: false,
+  focusInside: false,
+  menuOpen: false,
+  deferredRefreshPending: false,
+  lockedAtMs: 0,
+  catchUpTimer: null,
+  handlersInstalled: false
+};
 
 function startAgentAutoRefresh() {
   if (roleState.role !== 'admin') return;
@@ -664,12 +674,107 @@ function renderAgentsLastRefreshed() {
   globalElements.agentsLastRefreshed.textContent = `Last refreshed: ${formatRelativeAge(Date.now() - agentsLastRefreshedAtMs)}`;
 }
 
+function isAgentsModalOpen() {
+  return !!globalElements.agentsModal?.classList?.contains('open');
+}
+
+function isAgentsModalRefreshLocked() {
+  if (!isAgentsModalOpen()) return false;
+  return !!(
+    agentsModalRefreshLock.pointerInside ||
+    agentsModalRefreshLock.focusInside ||
+    agentsModalRefreshLock.menuOpen
+  );
+}
+
+function renderAgentsRefreshPauseState() {
+  const el = globalElements.agentsRefreshPaused;
+  if (!el) return;
+  const locked = isAgentsModalRefreshLocked();
+  if (!locked && !agentsModalRefreshLock.deferredRefreshPending) {
+    el.hidden = true;
+    el.textContent = '';
+    return;
+  }
+  const age = agentsModalRefreshLock.lockedAtMs ? formatRelativeAge(Date.now() - agentsModalRefreshLock.lockedAtMs) : '0s ago';
+  el.hidden = false;
+  el.textContent = locked ? `Refresh paused (${age})` : 'Refresh resuming...';
+}
+
+function setAgentsModalRefreshLock(kind, locked) {
+  if (!agentsModalRefreshLock.lockedAtMs && locked) agentsModalRefreshLock.lockedAtMs = Date.now();
+  if (kind === 'pointer') agentsModalRefreshLock.pointerInside = !!locked;
+  if (kind === 'focus') agentsModalRefreshLock.focusInside = !!locked;
+  if (kind === 'menu') agentsModalRefreshLock.menuOpen = !!locked;
+
+  if (!isAgentsModalRefreshLocked()) {
+    agentsModalRefreshLock.pointerInside = false;
+    agentsModalRefreshLock.focusInside = false;
+    agentsModalRefreshLock.menuOpen = false;
+    agentsModalRefreshLock.lockedAtMs = 0;
+    if (agentsModalRefreshLock.deferredRefreshPending && !agentsModalRefreshLock.catchUpTimer) {
+      agentsModalRefreshLock.catchUpTimer = setTimeout(() => {
+        agentsModalRefreshLock.catchUpTimer = null;
+        if (isAgentsModalRefreshLocked()) return;
+        agentsModalRefreshLock.deferredRefreshPending = false;
+        renderAgentsRefreshPauseState();
+        refreshAgents({ reason: 'fleet_catch_up' }).catch(() => {});
+      }, 200);
+    }
+  }
+
+  renderAgentsRefreshPauseState();
+}
+
+function clearAgentsModalRefreshLock() {
+  agentsModalRefreshLock.pointerInside = false;
+  agentsModalRefreshLock.focusInside = false;
+  agentsModalRefreshLock.menuOpen = false;
+  agentsModalRefreshLock.deferredRefreshPending = false;
+  agentsModalRefreshLock.lockedAtMs = 0;
+  if (agentsModalRefreshLock.catchUpTimer) {
+    clearTimeout(agentsModalRefreshLock.catchUpTimer);
+    agentsModalRefreshLock.catchUpTimer = null;
+  }
+  renderAgentsRefreshPauseState();
+}
+
+function installAgentsModalRefreshLockHandlers() {
+  const root = globalElements.agentsList;
+  if (!root || agentsModalRefreshLock.handlersInstalled) return;
+  agentsModalRefreshLock.handlersInstalled = true;
+
+  root.addEventListener('pointerenter', () => setAgentsModalRefreshLock('pointer', true));
+  root.addEventListener('pointerleave', () => setAgentsModalRefreshLock('pointer', false));
+  root.addEventListener('focusin', () => setAgentsModalRefreshLock('focus', true));
+  root.addEventListener('focusout', () => {
+    setTimeout(() => {
+      const active = document.activeElement;
+      setAgentsModalRefreshLock('focus', !!(active && root.contains(active)));
+    }, 0);
+  });
+}
+
+function requestAgentsRefresh({ reason = 'manual', showSuccessToast = false, manual = false } = {}) {
+  const isManual = manual || reason === 'manual';
+  if (isManual) {
+    clearAgentsModalRefreshLock();
+    return refreshAgents({ reason, showSuccessToast });
+  }
+  if (isAgentsModalRefreshLocked()) {
+    agentsModalRefreshLock.deferredRefreshPending = true;
+    renderAgentsRefreshPauseState();
+    return Promise.resolve(uiState.agents);
+  }
+  return refreshAgents({ reason, showSuccessToast });
+}
+
 function startAgentsModalAutoRefresh() {
   if (agentsModalAutoRefreshInterval) return;
   agentsModalAutoRefreshInterval = setInterval(() => {
-    if (!globalElements.agentsModal?.classList?.contains('open')) return;
+    if (!isAgentsModalOpen()) return;
     if (document.hidden) return;
-    refreshAgents({ reason: 'fleet_auto_refresh' }).catch(() => {});
+    requestAgentsRefresh({ reason: 'fleet_auto_refresh' }).catch(() => {});
   }, 10_000);
 }
 
@@ -682,9 +787,10 @@ function stopAgentsModalAutoRefresh() {
 function startAgentsModalFreshnessTicker() {
   if (agentsModalFreshnessTicker) return;
   agentsModalFreshnessTicker = setInterval(() => {
-    if (!globalElements.agentsModal?.classList?.contains('open')) return;
+    if (!isAgentsModalOpen()) return;
     renderAgentsLastRefreshed();
-    renderAgentsModalList();
+    renderAgentsRefreshPauseState();
+    if (!isAgentsModalRefreshLocked()) renderAgentsModalList();
   }, 1000);
 }
 
@@ -784,7 +890,7 @@ function scheduleAgentRefresh(reason = 'ws_connected') {
   if (agentRefreshTimer) return;
   agentRefreshTimer = setTimeout(() => {
     agentRefreshTimer = null;
-    refreshAgents({ reason }).catch(() => {});
+    requestAgentsRefresh({ reason }).catch(() => {});
   }, 450);
 }
 
@@ -2961,6 +3067,7 @@ function openAgentsModal() {
   if (roleState.role !== 'admin') return;
   globalElements.agentsModal?.classList.add('open');
   globalElements.agentsModal?.setAttribute('aria-hidden', 'false');
+  installAgentsModalRefreshLockHandlers();
 
   // Bootstrap persisted controls.
   const filter = getFleetFilter();
@@ -2982,6 +3089,7 @@ function openAgentsModal() {
 
   renderAgentsModalList();
   renderAgentsLastRefreshed();
+  renderAgentsRefreshPauseState();
   startAgentsModalAutoRefresh();
   startAgentsModalFreshnessTicker();
 
@@ -3011,6 +3119,7 @@ function resetFleetSort() {
 function closeAgentsModal() {
   globalElements.agentsModal?.classList.remove('open');
   globalElements.agentsModal?.setAttribute('aria-hidden', 'true');
+  clearAgentsModalRefreshLock();
   stopAgentsModalAutoRefresh();
   stopAgentsModalFreshnessTicker();
 }
@@ -3408,6 +3517,13 @@ function renderAgentsModalList() {
           else if (action === 'open-chat') openAgentChatFromFleet(id);
           else if (action === 'open-timeline') openAgentTimelineFromFleet(id);
           else if (action === 'open-workqueue') openAgentWorkqueueFromFleet(id);
+        });
+      });
+
+      row.querySelectorAll('.agents-row-actions-overflow').forEach((details) => {
+        details.addEventListener('toggle', () => {
+          const anyOpen = !!root.querySelector('.agents-row-actions-overflow[open]');
+          setAgentsModalRefreshLock('menu', anyOpen);
         });
       });
 
@@ -8940,7 +9056,7 @@ globalElements.recurringPromptRows?.addEventListener('click', (event) => {
 });
 
 globalElements.refreshAgentsBtn?.addEventListener('click', () => {
-  refreshAgents({ reason: 'manual', showSuccessToast: true }).catch(() => {
+  requestAgentsRefresh({ reason: 'manual', showSuccessToast: true, manual: true }).catch(() => {
     showToast('Agent refresh failed.', { kind: 'error', timeoutMs: 3500 });
   });
 });

--- a/index.html
+++ b/index.html
@@ -426,6 +426,7 @@
         <div class="modal-body">
           <div class="agents-toolbar">
             <div id="agentsLastRefreshed" class="agents-last-refreshed" aria-live="polite">Last refreshed: never</div>
+            <div id="agentsRefreshPaused" class="agents-refresh-paused" aria-live="polite" data-testid="agents-refresh-paused" hidden></div>
             <label class="agents-field">
               <span class="agents-label">Search</span>
               <input id="agentsSearch" type="text" placeholder="Filter agents…" />

--- a/styles.css
+++ b/styles.css
@@ -1782,6 +1782,16 @@ button.agents-section-title:hover {
   color: var(--muted);
 }
 
+.agents-refresh-paused {
+  border: 1px solid rgba(255, 199, 70, 0.38);
+  border-radius: 999px;
+  padding: 3px 9px;
+  color: #ffd77a;
+  background: rgba(255, 199, 70, 0.1);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
 .agents-row-actions {
   display: inline-flex;
   align-items: center;

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -74,6 +74,41 @@ test('agents modal shows live refresh freshness indicators', async ({ page, claw
   await expect(page.locator('#agentsList .agents-row-meta').first()).toContainText(/\d+[smhd]/);
 });
 
+test('fleet auto-refresh pauses while interacting and catches up after resume', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  let agents = [{ id: 'alpha', name: 'Alpha', displayName: 'Alpha' }];
+  let agentFetches = 0;
+  await page.route(/\/agents(?:\?|$)/, async (route) => {
+    agentFetches += 1;
+    await route.fulfill({ json: { agents } });
+  });
+
+  await clawnsole.gotoAndLoginAdmin(page);
+  await page.getByRole('button', { name: 'Refresh agent list' }).click();
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsModal')).toHaveClass(/open/);
+  await expect(page.locator('#agentsList .agents-row').filter({ hasText: 'Alpha (alpha)' })).toBeVisible();
+
+  const fetchesBeforeLock = agentFetches;
+  const row = page.locator('#agentsList .agents-row').filter({ hasText: 'Alpha (alpha)' });
+  await row.hover();
+  await page.evaluate(() => window.requestAgentsRefresh({ reason: 'fleet_auto_refresh' }));
+
+  await expect(page.getByTestId('agents-refresh-paused')).toContainText('Refresh paused');
+  await expect(row).toBeVisible();
+  expect(agentFetches).toBe(fetchesBeforeLock);
+
+  agents = [{ id: 'beta', name: 'Beta', displayName: 'Beta' }];
+  const catchUpResponse = page.waitForResponse((res) => res.url().includes('/agents') && res.ok(), { timeout: 5000 });
+  await page.locator('#agentsTitle').hover();
+  await catchUpResponse;
+
+  await expect(page.getByTestId('agents-refresh-paused')).toBeHidden();
+  await expect(page.locator('#agentsList .agents-row').filter({ hasText: 'Beta (beta)' })).toBeVisible();
+  expect(agentFetches).toBe(fetchesBeforeLock + 1);
+});
+
 test('agents modal shows fleet health summary counts and refreshes them', async ({ page, clawnsole }) => {
   if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
 


### PR DESCRIPTION
## Summary
- defer Fleet automatic refreshes while the modal list is hovered, focused, or an overflow action menu is open
- show a small Refresh paused indicator with pause age
- run one catch-up refresh after interaction ends while manual refresh still bypasses the pause

Fixes #303.

## Tests
- npm test
- npx playwright test tests/ui/agents-modal.spec.js -g "fleet auto-refresh pauses" --workers=1