### PR TITLE
Collapse exact duplicate workqueue rows

### DIFF
--- a/app.js
+++ b/app.js
@@ -116,6 +116,12 @@ const fmtRemaining = __appCore.fmtRemaining || ((msUntil) => {
 });
 const formatWorkqueueIssueTitle = __appCore.formatWorkqueueIssueTitle || ((item) => String(item?.title || ''));
 const sortWorkqueueItems = __appCore.sortWorkqueueItems || ((items, opts) => (Array.isArray(items) ? items.slice() : []));
+const collapseWorkqueueDuplicateItems = __appCore.collapseWorkqueueDuplicateItems || ((items) => (Array.isArray(items) ? items.map((it) => ({
+  representative: it,
+  members: [it],
+  duplicates: [],
+  duplicateCount: 1
+})) : []));
 const inferPaneCols = __appCore.inferPaneCols || ((count) => {
   const n = Number(count);
   if (!Number.isFinite(n) || n <= 1) return 1;
@@ -3761,18 +3767,20 @@ function renderWorkqueueItems() {
 
   const itemsRaw = Array.isArray(workqueueState.items) ? workqueueState.items : [];
   const items = sortWorkqueueItems(itemsRaw, { sortKey: workqueueState.sortKey, sortDir: workqueueState.sortDir });
+  const duplicateGroups = collapseWorkqueueDuplicateItems(items);
+  const visibleItems = duplicateGroups.map((group) => group.representative);
 
-  if (!items.length) {
+  if (!visibleItems.length) {
     globalElements.wqListEmpty.hidden = false;
   } else {
     globalElements.wqListEmpty.hidden = true;
   }
 
   const cols = getWorkqueueBoardColumns();
-  const itemsByStatus = items.reduce((acc, it) => {
-    const st = String(it?.status || 'ready');
+  const groupsByStatus = duplicateGroups.reduce((acc, group) => {
+    const st = String(group?.representative?.status || 'ready');
     if (!acc[st]) acc[st] = [];
-    acc[st].push(it);
+    acc[st].push(group);
     return acc;
   }, {});
 
@@ -3782,13 +3790,13 @@ function renderWorkqueueItems() {
     col.className = 'wq-board-col';
     col.setAttribute('data-wq-col', colDef.status);
 
-    const colItems = Array.isArray(itemsByStatus[colDef.status]) ? itemsByStatus[colDef.status] : [];
+    const colGroups = Array.isArray(groupsByStatus[colDef.status]) ? groupsByStatus[colDef.status] : [];
 
     const head = document.createElement('div');
     head.className = 'wq-board-col-header';
     head.innerHTML = `
       <div class="wq-board-col-title">${escapeHtml(colDef.label)}</div>
-      <div class="wq-board-col-count mono">${escapeHtml(String(colItems.length))}</div>
+      <div class="wq-board-col-count mono">${escapeHtml(String(colGroups.length))}</div>
     `;
 
     const lane = document.createElement('div');
@@ -3813,11 +3821,19 @@ function renderWorkqueueItems() {
       }
     });
 
-    for (const it of colItems) {
+    for (const group of colGroups) {
+      const it = group.representative;
+      const duplicates = Array.isArray(group.duplicates) ? group.duplicates : [];
+      const duplicateCount = Number(group.duplicateCount || 1);
+      const isSelected = [it, ...duplicates].some((entry) => entry?.id && entry.id === workqueueState.selectedItemId);
+
+      const cardWrap = document.createElement('div');
+      cardWrap.className = 'wq-card-wrap';
+
       const card = document.createElement('button');
       card.type = 'button';
       card.className = 'wq-card';
-      if (it.id && it.id === workqueueState.selectedItemId) card.classList.add('selected');
+      if (isSelected) card.classList.add('selected');
       if (it.id) card.setAttribute('data-wq-item', it.id);
 
       // Allow dragging the whole card.
@@ -3840,6 +3856,7 @@ function renderWorkqueueItems() {
           <span class="wq-badge wq-badge-${escapeHtml(status)}">${escapeHtml(status)}</span>
           ${age ? `<span class="wq-card-chip mono">age ${escapeHtml(age)}</span>` : ''}
           ${leaseLabel ? `<span class="wq-card-chip mono">lease ${escapeHtml(leaseLabel)}</span>` : ''}
+          ${duplicateCount > 1 ? `<span class="wq-card-chip mono" title="${escapeHtml(`${duplicateCount} exact duplicate rows`)}">×${escapeHtml(String(duplicateCount))}</span>` : ''}
         </div>
         <div class="wq-card-fields">
           <div class="wq-card-field"><span class="k">prio</span> <span class="v mono">${escapeHtml(String(it.priority ?? ''))}</span></div>
@@ -3855,7 +3872,38 @@ function renderWorkqueueItems() {
         renderWorkqueueInspect(it);
       });
 
-      lane.appendChild(card);
+      cardWrap.appendChild(card);
+
+      if (duplicates.length) {
+        const details = document.createElement('details');
+        details.className = 'wq-duplicates';
+
+        const summary = document.createElement('summary');
+        summary.className = 'wq-duplicates-summary mono';
+        summary.textContent = `Show ${duplicates.length} duplicate${duplicates.length === 1 ? '' : 's'}`;
+
+        const list = document.createElement('div');
+        list.className = 'wq-duplicates-list';
+
+        for (const dup of duplicates) {
+          const btn = document.createElement('button');
+          btn.type = 'button';
+          btn.className = 'wq-duplicate-btn';
+          btn.textContent = `${dup.id || ''} · prio ${dup.priority ?? ''} · ${dup.status || ''}`;
+          btn.addEventListener('click', () => {
+            workqueueState.selectedItemId = dup.id || null;
+            renderWorkqueueItems();
+            renderWorkqueueInspect(dup);
+          });
+          list.appendChild(btn);
+        }
+
+        details.appendChild(summary);
+        details.appendChild(list);
+        cardWrap.appendChild(details);
+      }
+
+      lane.appendChild(cardWrap);
     }
 
     col.appendChild(head);
@@ -4422,11 +4470,17 @@ function summarizeWorkqueueIssueGroups(items) {
   return out;
 }
 
-function appendWorkqueuePaneItemRow(pane, body, item, { child = false } = {}) {
+function appendWorkqueuePaneItemRow(pane, body, item, { child = false, duplicateGroup = null } = {}) {
+  const duplicates = Array.isArray(duplicateGroup?.duplicates) ? duplicateGroup.duplicates : [];
+  const duplicateCount = Number(duplicateGroup?.duplicateCount || 1);
+  const isSelected = [item, ...duplicates].some((entry) => entry?.id && entry.id === pane.workqueue.selectedItemId);
+  const wrap = duplicates.length && !child ? document.createElement('div') : null;
+  if (wrap) wrap.className = 'wq-row-group';
+
   const row = document.createElement('button');
   row.type = 'button';
   row.className = child ? 'wq-row wq-row-child' : 'wq-row';
-  if (item.id && item.id === pane.workqueue.selectedItemId) row.classList.add('selected');
+  if (isSelected) row.classList.add('selected');
   if (item.id) row.setAttribute('data-wq-item', item.id);
 
   const leaseMs = item.leaseUntil ? Number(item.leaseUntil) - Date.now() : NaN;
@@ -4437,7 +4491,7 @@ function appendWorkqueuePaneItemRow(pane, body, item, { child = false } = {}) {
   row.setAttribute('aria-label', `Workqueue item: ${title}`);
 
   row.innerHTML = `
-    <div class="wq-col title"><span class="wq-title-text" title="${escapeHtml(title)}">${escapeHtml(title)}</span></div>
+    <div class="wq-col title"><span class="wq-title-text" title="${escapeHtml(title)}">${escapeHtml(title)}</span>${duplicateCount > 1 ? ` <span class="wq-card-chip mono" title="${escapeHtml(`${duplicateCount} exact duplicate rows`)}">×${escapeHtml(String(duplicateCount))}</span>` : ''}</div>
     <div class="wq-col status"><span class="wq-badge wq-badge-${escapeHtml(status)}">${escapeHtml(status)}</span></div>
     <div class="wq-col prio mono">${escapeHtml(String(item.priority ?? ''))}</div>
     <div class="wq-col attempts mono">${escapeHtml(String(item.attempts ?? ''))}</div>
@@ -4451,7 +4505,39 @@ function appendWorkqueuePaneItemRow(pane, body, item, { child = false } = {}) {
     renderWorkqueuePaneInspect(pane, item);
   });
 
-  body.appendChild(row);
+  if (wrap) {
+    wrap.appendChild(row);
+
+    const details = document.createElement('details');
+    details.className = 'wq-duplicates';
+
+    const summary = document.createElement('summary');
+    summary.className = 'wq-duplicates-summary mono';
+    summary.textContent = `+${duplicates.length} duplicate${duplicates.length === 1 ? '' : 's'}`;
+
+    const list = document.createElement('div');
+    list.className = 'wq-duplicates-list';
+
+    for (const dup of duplicates) {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'wq-duplicate-btn';
+      btn.textContent = `${dup.id || ''} · prio ${dup.priority ?? ''} · ${dup.status || ''}`;
+      btn.addEventListener('click', () => {
+        pane.workqueue.selectedItemId = dup.id || null;
+        renderWorkqueuePaneItems(pane);
+        renderWorkqueuePaneInspect(pane, dup);
+      });
+      list.appendChild(btn);
+    }
+
+    details.appendChild(summary);
+    details.appendChild(list);
+    wrap.appendChild(details);
+    body.appendChild(wrap);
+  } else {
+    body.appendChild(row);
+  }
   return row;
 }
 
@@ -4599,12 +4685,17 @@ function renderWorkqueuePaneItems(pane) {
   const scopedItems = filterWorkqueuePaneItemsByScope(pane, pane.workqueue?.items);
   const filteredItems = applyWorkqueueQuickFilters(scopedItems, pane.workqueue?.quickFilters);
   const items = sortWorkqueueItems(filteredItems, { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
+  const duplicateGroups = collapseWorkqueueDuplicateItems(items);
+  const collapsedItems = duplicateGroups.map((group) => group.representative);
   const totalCount = Array.isArray(pane.workqueue?.countItems) ? pane.workqueue.countItems.length : (Array.isArray(pane.workqueue?.items) ? pane.workqueue.items.length : items.length);
   const statusLine = pane.elements?.thread?.querySelector('[data-wq-statusline]');
-  if (statusLine) statusLine.textContent = formatWorkqueueCountText(items.length, totalCount);
-  renderWorkqueueFilterSummaryForPane(pane, { shownCount: items.length, totalCount });
   const groupMode = normalizeWorkqueueGroupMode(pane.workqueue?.groupMode);
-  const rows = groupMode === 'grouped' ? summarizeWorkqueueIssueGroups(items) : items.map((item) => ({ kind: 'item', item }));
+  const rows = groupMode === 'grouped'
+    ? summarizeWorkqueueIssueGroups(items)
+    : duplicateGroups.map((group) => ({ kind: 'item', item: group.representative, duplicateGroup: group }));
+  const shownCount = groupMode === 'grouped' ? rows.length : collapsedItems.length;
+  if (statusLine) statusLine.textContent = formatWorkqueueCountText(shownCount, totalCount);
+  renderWorkqueueFilterSummaryForPane(pane, { shownCount, totalCount });
   const renderLimit = Math.max(
     WORKQUEUE_PANE_INITIAL_RENDER_LIMIT,
     Number(pane.workqueue?.renderLimit || WORKQUEUE_PANE_INITIAL_RENDER_LIMIT)
@@ -4652,7 +4743,7 @@ function renderWorkqueuePaneItems(pane) {
 
   for (const entry of visibleRows) {
     if (entry.kind === 'item') {
-      appendWorkqueuePaneItemRow(pane, body, entry.item);
+      appendWorkqueuePaneItemRow(pane, body, entry.item, { duplicateGroup: entry.duplicateGroup });
       continue;
     }
 

--- a/lib/app-core.js
+++ b/lib/app-core.js
@@ -122,6 +122,84 @@
       .map((x) => x.it);
   }
 
+  function normalizeWorkqueueDuplicateText(value) {
+    return String(value || '').trim().toLowerCase().replace(/\s+/g, ' ');
+  }
+
+  function getWorkqueueDedupeIdentity(item) {
+    const key = String(item?.dedupeKey || item?.meta?.dedupeKey || '').trim().toLowerCase();
+    if (!key) return '';
+    const queue = String(item?.queue || '').trim() || '__default__';
+    return `${queue}::dedupe::${key}`;
+  }
+
+  function getWorkqueueExactDuplicateIdentity(item) {
+    const dedupeIdentity = getWorkqueueDedupeIdentity(item);
+    if (dedupeIdentity) return dedupeIdentity;
+
+    const title = normalizeWorkqueueDuplicateText(item?.title);
+    const status = normalizeWorkqueueDuplicateText(item?.status);
+    if (!title || !status) return '';
+
+    const queue = String(item?.queue || '').trim() || '__default__';
+    return `${queue}::exact::${title}::${status}`;
+  }
+
+  function workqueueItemUpdatedAtMs(item) {
+    const t = Date.parse(String(item?.updatedAt || item?.createdAt || ''));
+    return Number.isFinite(t) ? t : 0;
+  }
+
+  function pickWorkqueueDuplicateRepresentative(a, b) {
+    const at = workqueueItemUpdatedAtMs(a);
+    const bt = workqueueItemUpdatedAtMs(b);
+    if (bt > at) return b;
+    if (bt < at) return a;
+    return String(b?.id || '').localeCompare(String(a?.id || '')) > 0 ? b : a;
+  }
+
+  function collapseWorkqueueDuplicateItems(items) {
+    const groups = [];
+    const byIdentity = new Map();
+
+    for (const item of Array.isArray(items) ? items : []) {
+      const identity = getWorkqueueExactDuplicateIdentity(item);
+      if (!identity) {
+        groups.push({ representative: item, members: [item], duplicateCount: 1, duplicates: [], identity: '' });
+        continue;
+      }
+
+      let group = byIdentity.get(identity);
+      if (!group) {
+        group = { representative: item, members: [], duplicateCount: 0, duplicates: [], identity };
+        byIdentity.set(identity, group);
+        groups.push(group);
+      }
+
+      group.members.push(item);
+      group.duplicateCount = group.members.length;
+      group.representative = pickWorkqueueDuplicateRepresentative(group.representative, item);
+    }
+
+    for (const group of groups) {
+      group.duplicates = group.members
+        .filter((it) => it !== group.representative)
+        .sort((a, b) => {
+          const recency = workqueueItemUpdatedAtMs(b) - workqueueItemUpdatedAtMs(a);
+          if (recency) return recency;
+          return String(b?.id || '').localeCompare(String(a?.id || ''));
+        });
+    }
+
+    groups.sort((a, b) => {
+      const recency = workqueueItemUpdatedAtMs(b.representative) - workqueueItemUpdatedAtMs(a.representative);
+      if (recency) return recency;
+      return String(b.representative?.id || '').localeCompare(String(a.representative?.id || ''));
+    });
+
+    return groups;
+  }
+
   function normalizeWorkqueueIssueRepo(value) {
     const s = String(value || '').trim().toLowerCase();
     if (!s || !/^[a-z0-9_.-]+\/[a-z0-9_.-]+$/.test(s)) return '';
@@ -453,6 +531,9 @@
     fmtRemaining,
     formatWorkqueueIssueTitle,
     sortWorkqueueItems,
+    getWorkqueueDedupeIdentity,
+    getWorkqueueExactDuplicateIdentity,
+    collapseWorkqueueDuplicateItems,
     inferPaneCols,
     normalizePaneKind,
     normalizeAdminDestination,

--- a/styles.css
+++ b/styles.css
@@ -2579,6 +2579,11 @@ kbd {
   outline-offset: -2px;
 }
 
+.wq-card-wrap,
+.wq-row-group {
+  min-width: 0;
+}
+
 .wq-card {
   border: 1px solid rgba(255, 255, 255, 0.10);
   border-radius: 12px;
@@ -2651,6 +2656,37 @@ kbd {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.wq-duplicates {
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.wq-duplicates-summary {
+  cursor: pointer;
+  padding: 4px 8px;
+}
+
+.wq-duplicates-list {
+  display: grid;
+  gap: 4px;
+  padding: 0 8px 8px;
+}
+
+.wq-duplicate-btn {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text);
+  text-align: left;
+  padding: 6px 8px;
+  cursor: pointer;
+}
+
+.wq-duplicate-btn:hover {
+  background: rgba(255, 255, 255, 0.06);
 }
 
 .wq-row {

--- a/tests/pane.workqueue.e2e.spec.js
+++ b/tests/pane.workqueue.e2e.spec.js
@@ -156,6 +156,62 @@ test('pane: workqueue golden path (list + inspect)', async ({ page }) => {
   await expect(wqPane.locator('[data-wq-inspect]')).toContainText(instructions);
 });
 
+test('pane: workqueue default view auto-collapses exact title/status duplicates', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  await page.getByTestId('add-pane-btn').click();
+  await page.getByTestId('pane-add-menu-workqueue').click();
+
+  const wqPane = page.locator('[data-pane]').last();
+  await expect(wqPane).toHaveAttribute('data-pane-kind', 'workqueue');
+
+  const queue = `pw-dedupe-default-${Date.now()}`;
+  await wqPane.locator('[data-wq-queue-select]').selectOption('__custom__');
+  await wqPane.locator('[data-wq-queue-custom]').fill(queue);
+  await wqPane.locator('[data-wq-queue-custom]').press('Enter');
+
+  await wqPane.locator('details.wq-enqueue > summary').click();
+
+  const title = `default dedupe collapse ${Date.now()}`;
+  for (let i = 0; i < 2; i += 1) {
+    await wqPane.locator('[data-wq-enqueue-title]').fill(title);
+    await wqPane.locator('[data-wq-enqueue-instructions]').fill(`dedupe-default-test ${i}`);
+    await wqPane.locator('[data-wq-enqueue-priority]').fill('5');
+    await wqPane.locator('[data-wq-enqueue-dedupe]').fill('');
+    const enqueueResP = page.waitForResponse(
+      (res) => res.url().includes('/api/workqueue/enqueue') && res.request().method() === 'POST',
+      { timeout: 15000 }
+    );
+    await wqPane.locator('[data-wq-enqueue-submit]').click();
+    const enqueueRes = await enqueueResP;
+    expect(enqueueRes.ok()).toBeTruthy();
+    await expect(wqPane.locator('[data-wq-enqueue-status]')).toContainText('Queued');
+  }
+
+  await wqPane.locator('details.wq-enqueue > summary').click();
+
+  const refreshResP = page.waitForResponse((res) => res.url().includes('/api/workqueue/items') && res.ok(), { timeout: 15000 });
+  await wqPane.locator('[data-wq-refresh]').click();
+  await refreshResP;
+
+  const groupedRow = wqPane.locator('.wq-row', { hasText: title });
+  await expect(groupedRow).toHaveCount(1);
+  await expect(groupedRow).toContainText('×2');
+
+  const details = wqPane.locator('.wq-row-group', { hasText: title }).locator('details.wq-duplicates');
+  await expect(details.locator('summary')).toContainText('+1 duplicate');
+  await details.locator('summary').click();
+  await expect(details.locator('.wq-duplicate-btn')).toHaveCount(1);
+});
+
 test('pane: workqueue scope filter toggles deterministic row counts', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!app?.skipReason, app?.skipReason);

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -234,22 +234,24 @@ test('workqueue pane: keyboard mode navigates rows and updates status', async ({
   await pane.locator('[data-wq-queue-custom]').press('Enter');
 
   const rows = pane.locator('[data-wq-list-body] .wq-row');
+  const alphaRow = pane.locator('[data-wq-item="keyboard-triage-a"]');
+  const betaRow = pane.locator('[data-wq-item="keyboard-triage-b"]');
   await expect(rows).toHaveCount(2);
   await pane.locator('[data-wq-keyboard-mode]').click();
   await expect(pane.locator('[data-wq-keyboard-mode]')).toHaveAttribute('aria-pressed', 'true');
-  await expect(rows.nth(0)).toHaveClass(/selected/);
+  await expect(alphaRow).toHaveClass(/selected/);
 
   await page.keyboard.press('j');
-  await expect(rows.nth(1)).toHaveClass(/selected/);
+  await expect(betaRow).toHaveClass(/selected/);
 
   await page.keyboard.press('Enter');
   await expect(pane.locator('[data-wq-inspect]')).toContainText('keyboard triage beta');
 
   await page.keyboard.press('2');
-  await expect(rows.nth(1).locator('.wq-col.status')).toContainText('in_progress');
+  await expect(betaRow.locator('.wq-col.status')).toContainText('in_progress');
 
   await page.keyboard.press('3');
-  await expect(rows.nth(1).locator('.wq-col.status')).toContainText('blocked');
+  await expect(betaRow.locator('.wq-col.status')).toContainText('blocked');
 
   let editPromptMessage = '';
   page.once('dialog', async (dialog) => {
@@ -261,7 +263,7 @@ test('workqueue pane: keyboard mode navigates rows and updates status', async ({
 
   await pane.locator('[data-wq-queue-search]').fill('triage');
   await page.keyboard.press('k');
-  await expect(rows.nth(1)).toHaveClass(/selected/);
+  await expect(betaRow).toHaveClass(/selected/);
 
   const res = await page.request.get(`http://127.0.0.1:${env.serverPort}/api/workqueue/items?queue=${encodeURIComponent(queue)}&status=ready,blocked,in_progress`);
   expect(res.ok()).toBeTruthy();

--- a/tests/unit/app-core.test.js
+++ b/tests/unit/app-core.test.js
@@ -6,6 +6,9 @@ const {
   fmtRemaining,
   formatWorkqueueIssueTitle,
   sortWorkqueueItems,
+  getWorkqueueDedupeIdentity,
+  getWorkqueueExactDuplicateIdentity,
+  collapseWorkqueueDuplicateItems,
   inferPaneCols,
   normalizePaneKind,
   normalizeAdminDestination,
@@ -143,6 +146,49 @@ test('sortWorkqueueItems priority sort uses updatedAt desc tie-breaker', () => {
 
   const sorted = sortWorkqueueItems(items, { sortKey: 'priority', sortDir: 'desc' });
   assert.deepEqual(sorted.map((it) => it.id), ['c', 'b', 'a']);
+});
+
+test('getWorkqueueExactDuplicateIdentity groups dedupe keys and exact title/status fallbacks', () => {
+  const deduped = getWorkqueueExactDuplicateIdentity({
+    queue: 'dev-team',
+    dedupeKey: ' Issue: RMDMATTINGLY/CLAWNSOLE#171 ',
+    title: 'old title',
+    status: 'ready'
+  });
+  assert.equal(
+    getWorkqueueExactDuplicateIdentity({
+      queue: 'dev-team',
+      meta: { dedupeKey: 'issue: rmdmattingly/clawnsole#171' },
+      title: 'new title',
+      status: 'failed'
+    }),
+    deduped
+  );
+
+  const exact = getWorkqueueExactDuplicateIdentity({
+    queue: 'dev-team',
+    title: '  Repeat   Task ',
+    status: 'READY'
+  });
+  assert.equal(exact, 'dev-team::exact::repeat task::ready');
+  assert.notEqual(getWorkqueueExactDuplicateIdentity({ queue: 'dev-team', title: 'Repeat Task', status: 'done' }), exact);
+  assert.notEqual(getWorkqueueExactDuplicateIdentity({ queue: 'ops', title: 'Repeat Task', status: 'ready' }), exact);
+  assert.equal(getWorkqueueDedupeIdentity({ queue: 'dev-team' }), '');
+  assert.equal(getWorkqueueExactDuplicateIdentity({ queue: 'dev-team', title: 'Repeat Task' }), '');
+});
+
+test('collapseWorkqueueDuplicateItems picks newest representative and count badge data', () => {
+  const groups = collapseWorkqueueDuplicateItems([
+    { id: 'older', queue: 'dev-team', title: 'Same', status: 'ready', updatedAt: '2026-01-01T00:00:00Z' },
+    { id: 'single', queue: 'dev-team', title: 'Single', status: 'ready', updatedAt: '2026-01-03T00:00:00Z' },
+    { id: 'newer', queue: 'dev-team', title: ' same ', status: 'READY', updatedAt: '2026-01-04T00:00:00Z' },
+    { id: 'tie-b', queue: 'dev-team', title: 'Tie', status: 'ready', updatedAt: '2026-01-02T00:00:00Z' },
+    { id: 'tie-a', queue: 'dev-team', title: 'Tie', status: 'ready', updatedAt: '2026-01-02T00:00:00Z' }
+  ]);
+
+  assert.deepEqual(groups.map((g) => g.representative.id), ['newer', 'single', 'tie-b']);
+  assert.deepEqual(groups.map((g) => g.duplicateCount), [2, 1, 2]);
+  assert.deepEqual(groups[0].duplicates.map((it) => it.id), ['older']);
 });
 
 test('inferPaneCols maps pane counts to sensible layout widths', () => {


### PR DESCRIPTION
## Summary
- add a shared workqueue duplicate-collapse selector using dedupeKey or exact queue/title/status identity
- render one representative modal card or pane row with a ×N badge and duplicate detail controls
- keep actions bound to the newest representative item with deterministic id tie-breaks

## Tests
- npm run test:syntax
- node --test tests/unit/app-core.test.js
- npx playwright test tests/pane.workqueue.e2e.spec.js -g "auto-collapses exact title/status" --workers=1

Closes #348