### PR TITLE
Add Pane Manager quick search

### DIFF
--- a/app.js
+++ b/app.js
@@ -2039,14 +2039,73 @@ function markPaneUnread(pane, increment = 1, kind = 'chat') {
 }
 
 function paneSearchText(pane) {
+  const kind = String(pane?.kind || 'chat');
+  const type = paneLabel(pane);
+  const letter = paneHeaderLetter(pane);
+  const target =
+    kind === 'workqueue'
+      ? String(pane?.workqueue?.queue || 'dev-team')
+      : kind === 'cron' || kind === 'timeline'
+        ? 'gateway'
+        : String(pane?.agentId || 'main');
   return [
-    paneSummaryLabel(pane),
-    paneLabel(pane),
-    paneTargetLabel(pane),
-    pane?.kind || ''
+    letter,
+    `${letter} ${type}`,
+    `${letter} ${type} ${target}`,
+    type,
+    target,
+    kind
   ]
     .join(' ')
     .toLowerCase();
+}
+
+function paneManagerSearchTokens() {
+  return String(paneManagerUiState.query || '')
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+function paneMatchesSearch(pane, tokens) {
+  if (!tokens.length) return true;
+  const haystack = paneSearchText(pane);
+  return tokens.every((token) => haystack.includes(token));
+}
+
+function highlightPaneManagerMatches(value, tokens) {
+  const text = String(value || '');
+  const filteredTokens = Array.from(new Set((tokens || []).filter(Boolean))).sort((a, b) => b.length - a.length);
+  if (!text || !filteredTokens.length) return escapeHtml(text);
+
+  const lower = text.toLowerCase();
+  const ranges = [];
+  filteredTokens.forEach((token) => {
+    let start = 0;
+    while (start < lower.length) {
+      const idx = lower.indexOf(token, start);
+      if (idx < 0) break;
+      const end = idx + token.length;
+      if (!ranges.some((range) => idx < range.end && end > range.start)) {
+        ranges.push({ start: idx, end });
+      }
+      start = end;
+    }
+  });
+
+  if (!ranges.length) return escapeHtml(text);
+  ranges.sort((a, b) => a.start - b.start);
+
+  let html = '';
+  let pos = 0;
+  ranges.forEach((range) => {
+    html += escapeHtml(text.slice(pos, range.start));
+    html += `<mark class="pane-manager-mark">${escapeHtml(text.slice(range.start, range.end))}</mark>`;
+    pos = range.end;
+  });
+  html += escapeHtml(text.slice(pos));
+  return html;
 }
 
 function paneGroupOrder(kind) {
@@ -2104,10 +2163,11 @@ function renderPaneManager() {
   const empty = globalElements.paneManagerEmpty;
   if (!list || !empty) return;
 
-  const query = String(paneManagerUiState.query || '').trim().toLowerCase();
+  const query = String(paneManagerUiState.query || '').trim();
+  const tokens = paneManagerSearchTokens();
   const filtered = panes.filter((pane) => {
     if (paneManagerUiState.unreadOnly && paneUnreadCount(pane) <= 0) return false;
-    return !query || paneSearchText(pane).includes(query);
+    return paneMatchesSearch(pane, tokens);
   });
 
   const grouped = new Map();
@@ -2132,6 +2192,7 @@ function renderPaneManager() {
 
   list.innerHTML = '';
   empty.hidden = filtered.length > 0;
+  empty.textContent = query ? `No panes match ${query}` : 'No panes match this filter.';
   if (!filtered.length) return;
 
   const maxIndex = Math.max(0, visibleKeys.length - 1);
@@ -2177,13 +2238,14 @@ function renderPaneManager() {
         const isDuplicate = duplicateCount > 1;
         const unreadCount = paneUnreadCount(pane);
         const paneIdentity = paneSummaryLabel(pane);
+        const paneId = String(pane?.key || '');
 
         row.innerHTML = `
           <div class="pane-manager-main">
             <div class="pane-manager-kind" title="${escapeHtml(paneIdentity)}">
               ${paneTypeBadgeMarkup(pane, { extraClass: 'pane-manager-type-badge', testId: 'pane-manager-type-badge' })}
-              <span class="pane-manager-kind-label">${escapeHtml(paneIdentity)}</span>
-              <span class="pane-manager-pane-id" title="Internal pane id">${escapeHtml(String(pane?.key || ''))}</span>
+              <span class="pane-manager-kind-label">${highlightPaneManagerMatches(paneIdentity, tokens)}</span>
+              <span class="pane-manager-pane-id" title="Internal pane id">${highlightPaneManagerMatches(paneId, tokens)}</span>
               ${isDuplicate ? `<span class="pane-manager-duplicate-badge" data-testid="pane-manager-duplicate-badge" title="${escapeHtml(`${duplicateCount} duplicate panes`)}">duplicate</span>` : ''}
               ${unreadCount > 0 ? `<span class="pane-manager-unread-badge" data-testid="pane-manager-unread-badge" title="${escapeHtml(`${unreadCount} unread`)}">${escapeHtml(String(unreadCount))}</span>` : ''}
             </div>
@@ -2308,13 +2370,31 @@ function closePaneManager({ restoreFocus = true } = {}) {
 function paneManagerHandleKeydown(event) {
   if (!isPaneManagerOpen()) return false;
   const panes = paneManager?.panes || [];
+  const key = String(event.key || '');
+  const activeEl = document.activeElement;
+  if (
+    (key === '/' && activeEl !== globalElements.paneManagerSearch && !event.metaKey && !event.ctrlKey && !event.altKey) ||
+    ((event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey && key.toLowerCase() === 'f')
+  ) {
+    event.preventDefault();
+    globalElements.paneManagerSearch?.focus?.();
+    globalElements.paneManagerSearch?.select?.();
+    return true;
+  }
   if (event.key === 'Escape') {
     event.preventDefault();
+    if (String(globalElements.paneManagerSearch?.value || '').trim()) {
+      globalElements.paneManagerSearch.value = '';
+      paneManagerUiState.query = '';
+      paneManagerUiState.selectedIndex = 0;
+      renderPaneManager();
+      globalElements.paneManagerSearch?.focus?.();
+      return true;
+    }
     closePaneManager();
     return true;
   }
 
-  const activeEl = document.activeElement;
   if (activeEl === globalElements.paneManagerSearch && (event.key === 'ArrowLeft' || event.key === 'ArrowRight')) {
     return false;
   }
@@ -9556,6 +9636,9 @@ window.addEventListener('keydown', (event) => {
     return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
   })();
 
+  // If Pane Manager is open, it gets first dibs on keys.
+  if (paneManagerHandleKeydown(event)) return;
+
   if (event.key === 'Escape') {
     const closedOverlay = closeTopmostOverlay();
     if (closedOverlay || !isEditableTarget) {
@@ -9564,9 +9647,6 @@ window.addEventListener('keydown', (event) => {
     if (closedOverlay) event.stopPropagation();
     return;
   }
-
-  // If Pane Manager is open, it gets first dibs on keys.
-  if (paneManagerHandleKeydown(event)) return;
 
   const blockedReason = blockedGlobalShortcutReason(event);
   if (blockedReason) {

--- a/index.html
+++ b/index.html
@@ -301,7 +301,7 @@
           </div>
           <label class="pane-manager-search-wrap" for="paneManagerSearch">
             <span class="pane-manager-search-label">Quick find</span>
-            <input id="paneManagerSearch" class="pane-manager-search" type="search" placeholder="Filter by title, type, or target" autocomplete="off" data-testid="pane-manager-search" />
+            <input id="paneManagerSearch" class="pane-manager-search" type="search" placeholder="Find pane (A, Workqueue, dev-agent...)" autocomplete="off" data-testid="pane-manager-search" />
           </label>
           <label class="pane-manager-unread-only"><input id="paneManagerUnreadOnly" type="checkbox" data-testid="pane-manager-unread-only" /> Unread only</label>
           <div id="paneManagerList" class="pane-manager-list" role="listbox" aria-label="Open panes" data-testid="pane-manager-list"></div>

--- a/styles.css
+++ b/styles.css
@@ -1403,6 +1403,12 @@ button.send-btn .btn-icon {
   white-space: nowrap;
 }
 
+.pane-manager-mark {
+  border-radius: 4px;
+  background: rgba(251, 191, 36, 0.22);
+  color: var(--text);
+}
+
 .pane-manager-pane-id {
   font-size: 11px;
   color: var(--muted);

--- a/tests/pane.manager.e2e.spec.js
+++ b/tests/pane.manager.e2e.spec.js
@@ -109,13 +109,45 @@ test('pane manager: quick-find filters and groups by kind', async ({ page }) => 
   await expect(page.locator('.pane-manager-group-header').nth(2)).toContainText('Cron (1)');
 
   const search = page.getByTestId('pane-manager-search');
+  await expect(search).toHaveAttribute('placeholder', 'Find pane (A, Workqueue, dev-agent...)');
   await search.fill('cron');
   await expect(page.locator('.pane-manager-row')).toHaveCount(1);
   await expect(page.locator('.pane-manager-row').first()).toContainText('Cron');
+  await expect(page.locator('.pane-manager-mark').first()).toHaveText(/Cron/i);
 
   await search.fill('B');
   await expect(page.locator('.pane-manager-row')).toHaveCount(1);
   await expect(page.locator('.pane-manager-row').first()).toContainText('Workqueue');
+
+  await search.fill('dev-team');
+  await expect(page.locator('.pane-manager-row')).toHaveCount(1);
+  await expect(page.locator('.pane-manager-row').first()).toContainText('Workqueue');
+
+  await page.keyboard.press('Enter');
+  await expect(modal).toHaveAttribute('aria-hidden', 'true');
+  const focusedPaneKind = await page.evaluate(() => document.activeElement?.closest?.('[data-pane]')?.dataset?.paneKind || '');
+  expect(focusedPaneKind).toBe('workqueue');
+
+  await page.keyboard.press('Control+P');
+  await expect(modal).toHaveAttribute('aria-hidden', 'false');
+  await page.keyboard.press('/');
+  await expect(search).toBeFocused();
+
+  await search.fill('does-not-exist');
+  await expect(page.locator('.pane-manager-row')).toHaveCount(0);
+  await expect(page.getByText('No panes match does-not-exist')).toBeVisible();
+
+  await page.keyboard.press('Escape');
+  await expect(modal).toHaveAttribute('aria-hidden', 'false');
+  await expect(search).toHaveValue('');
+
+  await page.keyboard.press('Control+F');
+  await expect(search).toBeFocused();
+  await search.fill('cron');
+  await page.keyboard.press('Escape');
+  await expect(search).toHaveValue('');
+  await page.keyboard.press('Escape');
+  await expect(modal).toHaveAttribute('aria-hidden', 'true');
 });
 
 test('pane manager: shows summary + duplicate badge and supports close others', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Add Pane Manager search matching for pane letters, types, target identities, and workqueue queue names.
- Add slash / Cmd-Ctrl+F search focus, Enter-to-focus, two-step Esc clearing/closing, and lightweight match highlights.
- Update Pane Manager E2E coverage for filtering, highlighting, Enter focus, and Esc behavior.

Fixes #304

## Tests
- npm test
- npx playwright test tests/pane.manager.e2e.spec.js --workers=1