### PR TITLE
Fix workqueue pane queue identity

### DIFF
--- a/app.js
+++ b/app.js
@@ -1772,11 +1772,15 @@ function paneTypeBadgeMarkup(pane, { extraClass = '', testId = '' } = {}) {
   return `<span class="${escapeHtml(classes)}" data-pane-type-badge data-pane-accent="${escapeHtml(kind)}"${testAttr} aria-label="${escapeHtml(`Pane type: ${label}`)}"><span class="pane-type-icon" aria-hidden="true">${escapeHtml(icon)}</span><span class="pane-type-text">${escapeHtml(label)}</span></span>`;
 }
 
+function paneWorkqueueTargetLabel(pane) {
+  return String(pane?.workqueue?.queue || '').trim() || 'No queue';
+}
+
 function paneTargetLabel(pane) {
   if (!pane) return '';
+  if (pane.kind === 'workqueue') return paneWorkqueueTargetLabel(pane);
   const current = String(pane?.elements?.agentLabel?.textContent || '').trim();
   if (current) return current;
-  if (pane.kind === 'workqueue') return String(pane.workqueue?.queue || 'dev-team');
   if (pane.kind === 'timeline' || pane.kind === 'cron') return 'gateway';
   return String(pane.agentId || 'main');
 }
@@ -6911,8 +6915,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     // Header should describe the pane's primary target (queue), not an agent.
     paneSetHeaderTarget(pane, {
       label: 'Queue',
-      value: String(pane.workqueue.queue || 'dev-team'),
-      ariaLabel: `Change queue (current: ${String(pane.workqueue.queue || 'dev-team')})`
+      value: paneWorkqueueTargetLabel(pane),
+      ariaLabel: `Change queue (current: ${paneWorkqueueTargetLabel(pane)})`
     });
 
     // Replace thread with workqueue list + inspect.
@@ -7072,8 +7076,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     // Make header pill focus the queue selector in the body (no duplicated selector state).
     paneSetHeaderTarget(pane, {
       label: 'Queue',
-      value: String(pane.workqueue.queue || 'dev-team'),
-      ariaLabel: `Change queue (current: ${String(pane.workqueue.queue || 'dev-team')})`,
+      value: paneWorkqueueTargetLabel(pane),
+      ariaLabel: `Change queue (current: ${paneWorkqueueTargetLabel(pane)})`,
       onClick: () => {
         try {
           queueSelectEl?.focus?.();
@@ -7217,8 +7221,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       rememberRecentWorkqueueTarget(q);
       paneSetHeaderTarget(pane, {
         label: 'Queue',
-        value: String(q),
-        ariaLabel: `Change queue (current: ${String(q)})`,
+        value: paneWorkqueueTargetLabel(pane),
+        ariaLabel: `Change queue (current: ${paneWorkqueueTargetLabel(pane)})`,
         onClick: () => {
           try {
             queueSelectEl?.focus?.();

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -207,10 +207,31 @@ test('workqueue pane: renders + has queue dropdown + does not show chat composer
 
   // Header target should describe queue context (not agent).
   await expect(wqPane.locator('[data-pane-target-label]')).toHaveText('Queue');
+  await expect(wqPane.locator('[data-pane-name]')).toContainText('Workqueue · dev-team');
+  await expect(wqPane.locator('[data-pane-agent-label]')).toHaveText('dev-team');
 
   // Refreshing agent list should not flip the workqueue header back to Agent.
   await page.getByLabel('Refresh agent list').click();
   await expect(wqPane.locator('[data-pane-target-label]')).toHaveText('Queue');
+  await expect(wqPane.locator('[data-pane-name]')).toContainText('Workqueue · dev-team');
+
+  await page.keyboard.press('Control+P');
+  const manager = page.getByTestId('pane-manager-modal');
+  await expect(manager).toHaveAttribute('aria-hidden', 'false');
+  await expect(manager.locator('.pane-manager-row[data-pane-kind="workqueue"] .pane-manager-kind-label')).toContainText('Workqueue · dev-team');
+  await page.keyboard.press('Escape');
+
+  const nextQueue = `issue-339-${Date.now()}`;
+  await wqPane.locator('[data-wq-queue-select]').selectOption('__custom__');
+  await wqPane.locator('[data-wq-queue-custom]').fill(nextQueue);
+  await wqPane.locator('[data-wq-queue-custom]').press('Enter');
+  await expect(wqPane.locator('[data-pane-name]')).toContainText(`Workqueue · ${nextQueue}`);
+  await expect(wqPane.locator('[data-pane-agent-label]')).toHaveText(nextQueue);
+
+  await page.keyboard.press('Control+P');
+  await expect(manager).toHaveAttribute('aria-hidden', 'false');
+  await expect(manager.locator('.pane-manager-row[data-pane-kind="workqueue"] .pane-manager-kind-label')).toContainText(`Workqueue · ${nextQueue}`);
+  await page.keyboard.press('Escape');
 
   // Workqueue pane should not render the chat composer UI.
   await expect(wqPane.locator('.chat-input-row')).toBeHidden();


### PR DESCRIPTION
## Summary\n- make Workqueue pane identity resolve from the queue before any agent header text\n- show an explicit `No queue` fallback when a Workqueue pane has no queue target\n- extend UI coverage for queue identity in the pane header and Pane Manager before/after queue switches\n\nFixes #339\n\n## Tests\n- npm run test:syntax\n- npx playwright test tests/ui/workqueue-pane.spec.js -g "renders \+ has queue dropdown" --workers=1