### PR TITLE
Default agent-targeted Workqueue panes to assigned scope

### DIFF
--- a/app.js
+++ b/app.js
@@ -138,6 +138,16 @@ const normalizePaneKind = __appCore.normalizePaneKind || ((rawKind) => {
             ? 'timeline'
             : 'chat';
 });
+const normalizeWorkqueueScope = __appCore.normalizeWorkqueueScope || ((scope) => {
+  const s = String(scope || '').trim().toLowerCase();
+  return s === 'assigned' || s === 'unassigned' ? s : 'all';
+});
+const deriveDefaultWorkqueueScope = __appCore.deriveDefaultWorkqueueScope || (({ explicitScope, explicitAgentId, storedDefault = 'unassigned' } = {}) => {
+  if (explicitScope !== undefined && explicitScope !== null && String(explicitScope).trim()) {
+    return normalizeWorkqueueScope(explicitScope);
+  }
+  return String(explicitAgentId || '').trim() ? 'assigned' : normalizeWorkqueueScope(storedDefault || 'unassigned');
+});
 const normalizeAdminDestination = __appCore.normalizeAdminDestination || ((candidate, { origin = '', now = Date.now(), ttlMs = 10 * 60 * 1000 } = {}) => {
   const value = candidate && typeof candidate === 'object' ? candidate : {};
   const href = typeof value.href === 'string' ? value.href.trim() : '';
@@ -339,9 +349,10 @@ function buildDefaultAdminPanes(defaultAgent = 'main') {
     {
       key: `p${randomId().slice(0, 8)}`,
       kind: 'workqueue',
+      agentId,
       queue: 'dev-team',
       statusFilter: ['ready', 'pending', 'blocked', 'claimed', 'in_progress'],
-      scopeFilter: getDefaultWorkqueueScope(),
+      scopeFilter: getInitialWorkqueueScope({ explicitAgentId: agentId }),
       sortKey: 'priority',
       sortDir: 'desc'
     }
@@ -5291,13 +5302,17 @@ const ADMIN_LAYOUT_MODE_KEY = 'clawnsole.admin.layoutMode';
 const ADMIN_DEFAULT_AGENT_KEY = 'clawnsole.admin.agentId';
 const WORKQUEUE_SCOPE_PREF_KEY = 'clawnsole.admin.workqueue.scope.v1';
 
-function normalizeWorkqueueScope(scope) {
-  return scope === 'assigned' || scope === 'unassigned' ? scope : 'all';
-}
-
 function getDefaultWorkqueueScope() {
   // Low-noise triage default: focus on unassigned work first.
   return normalizeWorkqueueScope(storage.get(WORKQUEUE_SCOPE_PREF_KEY, 'unassigned'));
+}
+
+function getInitialWorkqueueScope({ explicitScope, explicitAgentId } = {}) {
+  return deriveDefaultWorkqueueScope({
+    explicitScope,
+    explicitAgentId,
+    storedDefault: storage.get(WORKQUEUE_SCOPE_PREF_KEY, 'unassigned')
+  });
 }
 
 function computeBaseDeviceLabel() {
@@ -6735,7 +6750,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     workqueue: {
       queue: (queue || 'dev-team').trim() || 'dev-team',
       statusFilter: Array.isArray(statusFilter) ? statusFilter : ['ready', 'pending', 'blocked', 'claimed', 'in_progress'],
-      scopeFilter: normalizeWorkqueueScope(scopeFilter ?? getDefaultWorkqueueScope()),
+      scopeFilter: getInitialWorkqueueScope({ explicitScope: scopeFilter, explicitAgentId: agentId }),
       quickFilters: {
         sources: Array.isArray(quickFilters?.sources) ? quickFilters.sources.map((s) => String(s || '').trim()).filter(Boolean) : [],
         repos: Array.isArray(quickFilters?.repos) ? quickFilters.repos.map((s) => String(s || '').trim()).filter(Boolean) : [],
@@ -8356,7 +8371,10 @@ const paneManager = {
           const statusFilter = Array.isArray(item.statusFilter)
             ? item.statusFilter.map((s) => String(s || '').trim()).filter(Boolean)
             : ['ready', 'pending', 'blocked', 'claimed', 'in_progress'];
-          const scopeFilter = normalizeWorkqueueScope(item.scopeFilter ?? getDefaultWorkqueueScope());
+          const scopeFilter = getInitialWorkqueueScope({
+            explicitScope: item.scopeFilter,
+            explicitAgentId: item.agentId
+          });
           const quickFilters = {
             sources: Array.isArray(item?.quickFilters?.sources) ? item.quickFilters.sources.map((s) => String(s || '').trim()).filter(Boolean) : [],
             repos: Array.isArray(item?.quickFilters?.repos) ? item.quickFilters.repos.map((s) => String(s || '').trim()).filter(Boolean) : [],
@@ -8455,7 +8473,10 @@ const paneManager = {
     const nextQueue = String(options?.queue || 'dev-team').trim() || 'dev-team';
     const nextAgentId = normalizeAgentId(options?.agentId || storage.get(ADMIN_DEFAULT_AGENT_KEY, 'main'));
     const nextCronAgentId = String(options?.cronAgentId || '').trim();
-    const nextScopeFilter = normalizeWorkqueueScope(options?.scopeFilter ?? getDefaultWorkqueueScope());
+    const nextScopeFilter = getInitialWorkqueueScope({
+      explicitScope: options?.scopeFilter,
+      explicitAgentId: Object.prototype.hasOwnProperty.call(options || {}, 'agentId') ? options?.agentId : ''
+    });
     const forceNew = Boolean(options?.forceNew);
 
     const findMatchingPane = () => {

--- a/lib/app-core.js
+++ b/lib/app-core.js
@@ -235,6 +235,22 @@
               : 'chat';
   }
 
+  function normalizeWorkqueueScope(scope) {
+    const s = String(scope || '').trim().toLowerCase();
+    return s === 'assigned' || s === 'unassigned' ? s : 'all';
+  }
+
+  function deriveDefaultWorkqueueScope({ explicitScope, explicitAgentId, storedDefault = 'unassigned' } = {}) {
+    if (explicitScope !== undefined && explicitScope !== null && String(explicitScope).trim()) {
+      return normalizeWorkqueueScope(explicitScope);
+    }
+
+    const agent = String(explicitAgentId || '').trim();
+    if (agent) return 'assigned';
+
+    return normalizeWorkqueueScope(storedDefault || 'unassigned');
+  }
+
   function normalizeAdminDestination(candidate, { origin = '', now = Date.now(), ttlMs = 10 * 60 * 1000 } = {}) {
     const value = candidate && typeof candidate === 'object' ? candidate : {};
     const href = typeof value.href === 'string' ? value.href.trim() : '';
@@ -455,6 +471,8 @@
     sortWorkqueueItems,
     inferPaneCols,
     normalizePaneKind,
+    normalizeWorkqueueScope,
+    deriveDefaultWorkqueueScope,
     normalizeAdminDestination,
     deriveAuthOverlayState,
     deriveGlobalConnectionState,

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -291,6 +291,7 @@ test('agents modal quick actions open/reuse chat, timeline, and workqueue contex
   await firstRow.locator('[data-agent-action="open-workqueue"]').first().click();
   await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
   await expect(page.locator('[data-pane][data-pane-kind="workqueue"] [data-wq-claim-agent]')).toHaveValue(agentId || 'main');
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"] [data-wq-scope="assigned"]')).toHaveAttribute('aria-pressed', 'true');
 });
 
 test('agents modal triage action opens chat and workqueue from non-chat layout', async ({ page, clawnsole }) => {
@@ -322,6 +323,7 @@ test('agents modal triage action opens chat and workqueue from non-chat layout',
   await expect(page.locator('[data-pane][data-pane-kind="chat"] [data-pane-agent-select]')).toHaveValue('alpha');
   const wqPane = page.locator('[data-pane][data-pane-kind="workqueue"]').first();
   await expect(wqPane.locator('[data-wq-claim-agent]')).toHaveValue('alpha');
+  await expect(wqPane.locator('[data-wq-scope="assigned"]')).toHaveAttribute('aria-pressed', 'true');
   await expect(wqPane.locator('[data-wq-queue-select]')).toBeFocused();
 });
 

--- a/tests/unit/app-core.test.js
+++ b/tests/unit/app-core.test.js
@@ -8,6 +8,8 @@ const {
   sortWorkqueueItems,
   inferPaneCols,
   normalizePaneKind,
+  normalizeWorkqueueScope,
+  deriveDefaultWorkqueueScope,
   normalizeAdminDestination,
   deriveAuthOverlayState,
   deriveGlobalConnectionState,
@@ -164,6 +166,25 @@ test('normalizePaneKind handles aliases safely', () => {
   assert.equal(normalizePaneKind('timeline'), 'timeline');
   assert.equal(normalizePaneKind('ti'), 'timeline');
   assert.equal(normalizePaneKind('x'), 'chat');
+});
+
+test('deriveDefaultWorkqueueScope prefers assigned for explicit workqueue agent targets', () => {
+  assert.equal(normalizeWorkqueueScope('assigned'), 'assigned');
+  assert.equal(normalizeWorkqueueScope('UNASSIGNED'), 'unassigned');
+  assert.equal(normalizeWorkqueueScope('unknown'), 'all');
+
+  assert.equal(
+    deriveDefaultWorkqueueScope({ explicitAgentId: 'hop', storedDefault: 'unassigned' }),
+    'assigned'
+  );
+  assert.equal(
+    deriveDefaultWorkqueueScope({ explicitAgentId: '', storedDefault: 'unassigned' }),
+    'unassigned'
+  );
+  assert.equal(
+    deriveDefaultWorkqueueScope({ explicitAgentId: 'hop', explicitScope: 'all', storedDefault: 'unassigned' }),
+    'all'
+  );
 });
 
 test('deriveAuthOverlayState captures auth/role transition flags', () => {


### PR DESCRIPTION
## Summary
- derive Workqueue initial scope from explicit pane agent targets
- default reset/admin baseline Workqueue panes to the assigned scope for the selected default agent
- keep explicit user scope overrides working, including All

Fixes #381

## Verification
- npm run test:syntax
- node --test tests/unit/app-core.test.js
- npx playwright test tests/ui/agents-modal.spec.js --workers=1