### PR TITLE
Preserve fleet selection across refresh

### DIFF
--- a/app.js
+++ b/app.js
@@ -723,7 +723,8 @@ function clearFleetRefreshLock() {
 const fleetSelectionState = {
   selectedAgentId: '',
   selectedIndex: 0,
-  notice: ''
+  notice: '',
+  missingAgentId: ''
 };
 
 function startAgentAutoRefresh() {
@@ -3620,18 +3621,20 @@ function reconcileFleetSelection(visibleAgents) {
     fleetSelectionState.selectedAgentId = '';
     fleetSelectionState.selectedIndex = 0;
     fleetSelectionState.notice = '';
+    fleetSelectionState.missingAgentId = '';
     return;
   }
   const previousId = String(fleetSelectionState.selectedAgentId || '').trim();
   const existingIndex = previousId ? ids.indexOf(previousId) : -1;
   if (existingIndex >= 0) {
     fleetSelectionState.selectedIndex = existingIndex;
-    fleetSelectionState.notice = '';
+    if (!fleetSelectionState.missingAgentId) fleetSelectionState.notice = '';
     return;
   }
   const fallbackIndex = Math.max(0, Math.min(Number(fleetSelectionState.selectedIndex) || 0, ids.length - 1));
   fleetSelectionState.selectedAgentId = ids[fallbackIndex];
   fleetSelectionState.selectedIndex = fallbackIndex;
+  fleetSelectionState.missingAgentId = previousId;
   fleetSelectionState.notice = previousId ? 'Selected agent no longer in current filter.' : '';
 }
 
@@ -3649,6 +3652,7 @@ function selectFleetAgent(agentId, { focusRow = false } = {}) {
   fleetSelectionState.selectedAgentId = id;
   fleetSelectionState.selectedIndex = ix;
   fleetSelectionState.notice = '';
+  fleetSelectionState.missingAgentId = '';
   rows.forEach((row, index) => row.setAttribute('aria-selected', index === ix ? 'true' : 'false'));
   if (focusRow) {
     try {

--- a/app.js
+++ b/app.js
@@ -27,6 +27,7 @@ const globalElements = {
   refreshAgentsBtn: document.getElementById('refreshAgentsBtn'),
   agentsBtn: document.getElementById('agentsBtn'),
   agentsModal: document.getElementById('agentsModal'),
+  agentsModalRefreshBtn: document.getElementById('agentsModalRefreshBtn'),
   agentsCloseBtn: document.getElementById('agentsCloseBtn'),
   agentsSearch: document.getElementById('agentsSearch'),
   agentsFilterButtons: Array.from(document.querySelectorAll('[data-agents-filter]')),
@@ -104,6 +105,11 @@ const escapeHtml = __appCore.escapeHtml || ((value) => {
     .replace(/\"/g, '&quot;')
     .replace(/'/g, '&#39;');
 });
+function cssEscape(value) {
+  const s = String(value ?? '');
+  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') return CSS.escape(s);
+  return s.replace(/["\\\n\r\f]/g, '\\$&');
+}
 const fmtRemaining = __appCore.fmtRemaining || ((msUntil) => {
   if (!Number.isFinite(msUntil)) return '';
   if (msUntil <= 0) return 'expired';
@@ -713,6 +719,12 @@ function clearFleetRefreshLock() {
   fleetRefreshLock.catchupTimer = null;
   renderFleetRefreshPaused();
 }
+
+const fleetSelectionState = {
+  selectedAgentId: '',
+  selectedIndex: 0,
+  notice: ''
+};
 
 function startAgentAutoRefresh() {
   if (roleState.role !== 'admin') return;
@@ -3296,6 +3308,7 @@ function renderAgentsModalList() {
   const root = globalElements.agentsList;
   if (!root) return;
 
+  const scrollAnchor = captureFleetScrollAnchor(root);
   const search = String(globalElements.agentsSearch?.value || '').trim().toLowerCase();
   const withinMinutes = Math.max(1, Number(globalElements.agentsActiveMinutes?.value) || 10);
   const activeWindowMs = withinMinutes * 60_000;
@@ -3368,6 +3381,8 @@ function renderAgentsModalList() {
   }, { needsTriage: 0, healthy: 0, disconnected: 0 });
   const healthyCollapseDefault = baseAgents.length > ADMIN_AGENT_HEALTHY_COLLAPSE_THRESHOLD;
   const healthyCollapsed = String(storage.get(ADMIN_AGENT_HEALTHY_COLLAPSED_KEY, healthyCollapseDefault ? '1' : '0')) === '1';
+  const visibleAgents = [...pinned, ...needsAttention, ...(healthyCollapsed ? [] : healthy)];
+  reconcileFleetSelection(visibleAgents);
 
   root.innerHTML = '';
 
@@ -3440,6 +3455,10 @@ function renderAgentsModalList() {
       const id = String(agent?.id || '').trim();
       const row = document.createElement('div');
       row.className = 'agents-row';
+      row.tabIndex = 0;
+      row.dataset.agentId = id;
+      row.setAttribute('role', 'option');
+      row.setAttribute('aria-selected', id && id === fleetSelectionState.selectedAgentId ? 'true' : 'false');
 
       const label = formatAgentLabel(agent, { includeId: true });
       const pinnedNow = pins.has(id);
@@ -3495,6 +3514,12 @@ function renderAgentsModalList() {
         paneManager.panes.forEach((p) => renderAgentOptions(p.elements?.agentSelect, p.agentId));
         renderAgentsModalList();
       });
+
+      row.addEventListener('click', (e) => {
+        if (e.target instanceof Element && e.target.closest('button, summary, details')) return;
+        selectFleetAgent(id, { focusRow: true });
+      });
+      row.addEventListener('focus', () => selectFleetAgent(id));
 
       const actionButtons = Array.from(row.querySelectorAll('[data-agent-action]'));
       actionButtons.forEach((btn) => {
@@ -3553,11 +3578,103 @@ function renderAgentsModalList() {
     globalElements.agentsSortIndicator.textContent =
       sortMode === 'heartbeat_age_desc'
         ? 'Sorted by heartbeat age: stale first. Reset sort returns to the prior/default order.'
-        : '';
+        : fleetSelectionState.notice;
   }
 
   const empty = ordered.length === 0;
   if (globalElements.agentsEmpty) globalElements.agentsEmpty.hidden = !empty;
+  restoreFleetScrollAnchor(root, scrollAnchor);
+}
+
+function captureFleetScrollAnchor(root) {
+  if (!root) return null;
+  const rows = Array.from(root.querySelectorAll('.agents-row[data-agent-id]')).filter((row) => row.offsetParent !== null);
+  const top = Number(root.scrollTop) || 0;
+  const anchor = rows.find((row) => row.offsetTop >= top) || rows[0] || null;
+  return {
+    scrollTop: top,
+    agentId: String(anchor?.dataset?.agentId || ''),
+    offset: anchor ? anchor.offsetTop - top : 0
+  };
+}
+
+function restoreFleetScrollAnchor(root, anchor) {
+  if (!root || !anchor) return;
+  const safeScrollTop = Math.max(0, Number(anchor.scrollTop) || 0);
+  if (!anchor.agentId) {
+    root.scrollTop = safeScrollTop;
+    return;
+  }
+  const row = root.querySelector(`.agents-row[data-agent-id="${cssEscape(anchor.agentId)}"]`);
+  if (!row || row.offsetParent === null) {
+    root.scrollTop = safeScrollTop;
+    return;
+  }
+  root.scrollTop = Math.max(0, row.offsetTop - (Number(anchor.offset) || 0));
+}
+
+function reconcileFleetSelection(visibleAgents) {
+  const agents = Array.isArray(visibleAgents) ? visibleAgents : [];
+  const ids = agents.map((agent) => String(agent?.id || '').trim()).filter(Boolean);
+  if (!ids.length) {
+    fleetSelectionState.selectedAgentId = '';
+    fleetSelectionState.selectedIndex = 0;
+    fleetSelectionState.notice = '';
+    return;
+  }
+  const previousId = String(fleetSelectionState.selectedAgentId || '').trim();
+  const existingIndex = previousId ? ids.indexOf(previousId) : -1;
+  if (existingIndex >= 0) {
+    fleetSelectionState.selectedIndex = existingIndex;
+    fleetSelectionState.notice = '';
+    return;
+  }
+  const fallbackIndex = Math.max(0, Math.min(Number(fleetSelectionState.selectedIndex) || 0, ids.length - 1));
+  fleetSelectionState.selectedAgentId = ids[fallbackIndex];
+  fleetSelectionState.selectedIndex = fallbackIndex;
+  fleetSelectionState.notice = previousId ? 'Selected agent no longer in current filter.' : '';
+}
+
+function getFleetSelectableRows() {
+  const root = globalElements.agentsList;
+  if (!root) return [];
+  return Array.from(root.querySelectorAll('.agents-row[data-agent-id]')).filter((row) => row.offsetParent !== null);
+}
+
+function selectFleetAgent(agentId, { focusRow = false } = {}) {
+  const id = String(agentId || '').trim();
+  const rows = getFleetSelectableRows();
+  const ix = rows.findIndex((row) => String(row.dataset.agentId || '') === id);
+  if (ix < 0) return false;
+  fleetSelectionState.selectedAgentId = id;
+  fleetSelectionState.selectedIndex = ix;
+  fleetSelectionState.notice = '';
+  rows.forEach((row, index) => row.setAttribute('aria-selected', index === ix ? 'true' : 'false'));
+  if (focusRow) {
+    try {
+      rows[ix].focus({ preventScroll: true });
+    } catch {}
+  }
+  return true;
+}
+
+function moveFleetSelection(delta) {
+  const rows = getFleetSelectableRows();
+  if (!rows.length) return false;
+  const current = rows.findIndex((row) => String(row.dataset.agentId || '') === String(fleetSelectionState.selectedAgentId || ''));
+  const start = current >= 0 ? current : Math.max(0, Math.min(Number(fleetSelectionState.selectedIndex) || 0, rows.length - 1));
+  const next = Math.max(0, Math.min(start + delta, rows.length - 1));
+  const id = String(rows[next].dataset.agentId || '');
+  if (!selectFleetAgent(id, { focusRow: true })) return false;
+  rows[next].scrollIntoView({ block: 'nearest' });
+  return true;
+}
+
+function runFleetSelectedAgent() {
+  const id = String(fleetSelectionState.selectedAgentId || '').trim();
+  if (!id) return false;
+  openAgentTriageFromFleet(id);
+  return true;
 }
 
 // Workqueue (admin-only)
@@ -9209,6 +9326,11 @@ globalElements.refreshAgentsBtn?.addEventListener('click', () => {
     showToast('Agent refresh failed.', { kind: 'error', timeoutMs: 3500 });
   });
 });
+globalElements.agentsModalRefreshBtn?.addEventListener('click', () => {
+  refreshAgents({ reason: 'manual', showSuccessToast: true }).catch(() => {
+    showToast('Agent refresh failed.', { kind: 'error', timeoutMs: 3500 });
+  });
+});
 
 globalElements.agentsBtn?.addEventListener('click', () => openAgentsModal());
 globalElements.agentsCloseBtn?.addEventListener('click', () => {
@@ -9223,7 +9345,26 @@ globalElements.agentsModal?.addEventListener('click', (event) => {
 });
 globalElements.agentsModal?.addEventListener('keydown', (event) => {
   if (isTypingContext(event.target)) return;
-  if (String(event.key || '').toLowerCase() !== 'h' || event.metaKey || event.ctrlKey || event.altKey) return;
+  const key = String(event.key || '');
+  const lower = key.toLowerCase();
+  if (!event.metaKey && !event.ctrlKey && !event.altKey) {
+    if (key === 'ArrowDown' || lower === 'j') {
+      event.preventDefault();
+      moveFleetSelection(1);
+      return;
+    }
+    if (key === 'ArrowUp' || lower === 'k') {
+      event.preventDefault();
+      moveFleetSelection(-1);
+      return;
+    }
+    if (key === 'Enter') {
+      event.preventDefault();
+      runFleetSelectedAgent();
+      return;
+    }
+  }
+  if (lower !== 'h' || event.metaKey || event.ctrlKey || event.altKey) return;
   event.preventDefault();
   if (event.shiftKey || getFleetSort() !== 'heartbeat_age_desc') setFleetHeartbeatSort();
   else resetFleetSort();

--- a/index.html
+++ b/index.html
@@ -419,9 +419,14 @@
       <div class="modal-card wide" role="dialog" aria-modal="true" aria-labelledby="agentsTitle">
         <div class="modal-header">
           <h2 id="agentsTitle">Agents</h2>
-          <button id="agentsCloseBtn" class="icon-btn" type="button" aria-label="Close agents">
-            ✕
-          </button>
+          <div class="modal-header-actions">
+            <button id="agentsModalRefreshBtn" class="icon-btn" type="button" aria-label="Refresh agent list">
+              ↻
+            </button>
+            <button id="agentsCloseBtn" class="icon-btn" type="button" aria-label="Close agents">
+              ✕
+            </button>
+          </div>
         </div>
         <div class="modal-body">
           <div class="agents-toolbar">

--- a/index.html
+++ b/index.html
@@ -420,7 +420,7 @@
         <div class="modal-header">
           <h2 id="agentsTitle">Agents</h2>
           <div class="modal-header-actions">
-            <button id="agentsModalRefreshBtn" class="icon-btn" type="button" aria-label="Refresh agent list">
+            <button id="agentsModalRefreshBtn" class="icon-btn" type="button" aria-label="Refresh agents modal">
               ↻
             </button>
             <button id="agentsCloseBtn" class="icon-btn" type="button" aria-label="Close agents">

--- a/styles.css
+++ b/styles.css
@@ -1132,6 +1132,12 @@ button.send-btn .btn-icon {
   flex: 0 0 auto;
 }
 
+.modal-header-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .modal-body {
   flex: 1 1 auto;
   min-height: 0;
@@ -1695,6 +1701,16 @@ button.agents-section-title:hover {
   border-radius: 14px;
   padding: 10px 12px;
   background: rgba(255, 255, 255, 0.02);
+}
+
+.agents-row[aria-selected="true"] {
+  border-color: rgba(77, 196, 255, 0.7);
+  background: rgba(77, 196, 255, 0.11);
+}
+
+.agents-row:focus-visible {
+  outline: 2px solid rgba(77, 196, 255, 0.82);
+  outline-offset: 2px;
 }
 
 .agents-row-heatmap {

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -237,6 +237,84 @@ test('agents modal quick filter narrows list and Esc clears it', async ({ page, 
   await expect(rows).toHaveCount(initialCount);
 });
 
+test('fleet refresh preserves selected row and falls back when it disappears', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  let agents = [
+    { id: 'alpha', name: 'Alpha', displayName: 'Alpha' },
+    { id: 'beta', name: 'Beta', displayName: 'Beta' },
+    { id: 'gamma', name: 'Gamma', displayName: 'Gamma' }
+  ];
+  await page.route(/\/agents(?:\?|$)/, async (route) => {
+    await route.fulfill({ json: { agents } });
+  });
+
+  await clawnsole.gotoAndLoginAdmin(page);
+  await page.getByRole('button', { name: 'Refresh agent list' }).click();
+  await page.getByRole('button', { name: 'Open agents' }).click();
+
+  const beta = page.locator('#agentsList .agents-row').filter({ hasText: 'Beta (beta)' });
+  await beta.click();
+  await expect(beta).toHaveAttribute('aria-selected', 'true');
+
+  await page.locator('#agentsModalRefreshBtn').click();
+  await expect(beta).toHaveAttribute('aria-selected', 'true');
+  await expect(page.locator('#agentsSortIndicator')).toHaveText('');
+
+  agents = [
+    { id: 'alpha', name: 'Alpha', displayName: 'Alpha' },
+    { id: 'gamma', name: 'Gamma', displayName: 'Gamma' }
+  ];
+  await page.locator('#agentsModalRefreshBtn').click();
+  await expect(page.locator('#agentsList .agents-row').filter({ hasText: 'Gamma (gamma)' })).toHaveAttribute('aria-selected', 'true');
+  await expect(page.locator('#agentsSortIndicator')).toContainText('Selected agent no longer in current filter');
+});
+
+test('fleet refresh keeps scroll anchor and keyboard triage selection', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  const agents = Array.from({ length: 36 }, (_, index) => {
+    const id = `agent-${String(index + 1).padStart(2, '0')}`;
+    return { id, name: id, displayName: id };
+  });
+  await page.route(/\/agents(?:\?|$)/, async (route) => {
+    await route.fulfill({ json: { agents } });
+  });
+
+  await clawnsole.gotoAndLoginAdmin(page);
+  await page.getByRole('button', { name: 'Refresh agent list' }).click();
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await page.evaluate(() => {
+    const list = document.querySelector('#agentsList');
+    if (!list) return;
+    list.style.maxHeight = '220px';
+    list.style.overflow = 'auto';
+    document.querySelector('.agents-row[data-agent-id="agent-20"]')?.scrollIntoView();
+  });
+  const before = await page.locator('#agentsList').evaluate((el) => el.scrollTop);
+  expect(before).toBeGreaterThan(0);
+
+  await page.locator('#agentsModalRefreshBtn').click();
+  const after = await page.locator('#agentsList').evaluate((el) => el.scrollTop);
+  expect(Math.abs(after - before)).toBeLessThan(24);
+
+  const row20 = page.locator('#agentsList .agents-row[data-agent-id="agent-20"]');
+  await row20.click();
+  await page.keyboard.press('j');
+  await expect(page.locator('#agentsList .agents-row[data-agent-id="agent-21"]')).toHaveAttribute('aria-selected', 'true');
+  await page.keyboard.press('k');
+  await expect(row20).toHaveAttribute('aria-selected', 'true');
+  await page.keyboard.press('Enter');
+  await expect.poll(async () => (
+    page.locator('[data-pane][data-pane-kind="chat"] [data-pane-agent-select]')
+      .evaluateAll((els) => els.map((el) => el.value))
+  )).toContain('agent-20');
+  await expect.poll(async () => (
+    page.locator('[data-pane][data-pane-kind="workqueue"] [data-wq-claim-agent]')
+      .evaluateAll((els) => els.map((el) => el.value))
+  )).toContain('agent-20');
+});
+
 test('fleet attention mode sections healthy agents and keeps filters while expanding', async ({ page, clawnsole }) => {
   if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
 


### PR DESCRIPTION
## Summary
- Preserve selected Fleet agent across refreshes and fall back to nearest visible row when the selected agent disappears
- Preserve the Fleet list scroll anchor across rerenders
- Add modal refresh control plus keyboard row selection/triage affordances

Fixes #293

## Tests
- npm run test:syntax
- npx playwright test tests/ui/agents-modal.spec.js --workers=1