### PR TITLE
Make keyboard shortcuts searchable

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,6 +44,10 @@ const globalElements = {
   shortcutsModal: document.getElementById('shortcutsModal'),
   shortcutsDialog: document.getElementById('shortcutsDialog'),
   shortcutsCloseBtn: document.getElementById('shortcutsCloseBtn'),
+  shortcutsSearch: document.getElementById('shortcutsSearch'),
+  shortcutsEmpty: document.getElementById('shortcutsEmpty'),
+  shortcutsFilterButtons: Array.from(document.querySelectorAll('[data-shortcut-filter]')),
+  shortcutGroups: Array.from(document.querySelectorAll('[data-shortcut-category]')),
   paneManagerModal: document.getElementById('paneManagerModal'),
   paneManagerCloseBtn: document.getElementById('paneManagerCloseBtn'),
   paneManagerSearch: document.getElementById('paneManagerSearch'),
@@ -1292,6 +1296,19 @@ async function deleteRecurringPrompt(id) {
 }
 
 let shortcutsLastFocusedEl = null;
+let shortcutsActiveFilter = 'all';
+
+function shortcutsEl(id) {
+  return document.getElementById(id);
+}
+
+function shortcutFilterButtons() {
+  return Array.from(document.querySelectorAll('[data-shortcut-filter]'));
+}
+
+function shortcutGroups() {
+  return Array.from(document.querySelectorAll('[data-shortcut-category]'));
+}
 
 function getModalFocusableElements(modalEl) {
   if (!modalEl || !modalEl.querySelectorAll) return [];
@@ -1299,19 +1316,65 @@ function getModalFocusableElements(modalEl) {
     .filter((el) => !el.disabled && !el.hidden && el.getAttribute('aria-hidden') !== 'true');
 }
 
+function shortcutGroupMatches(group, query, filter) {
+  const categories = String(group?.dataset?.shortcutCategory || '')
+    .split(/\s+/)
+    .filter(Boolean);
+  if (filter && filter !== 'all' && !categories.includes(filter)) return false;
+  if (!query) return true;
+  const searchable = `${categories.join(' ')} ${group.textContent || ''}`.toLowerCase();
+  return searchable.includes(query);
+}
+
+function renderShortcutsFilters() {
+  const query = String(shortcutsEl('shortcutsSearch')?.value || '').trim().toLowerCase();
+  let visibleCount = 0;
+  shortcutFilterButtons().forEach((btn) => {
+    const filter = btn.getAttribute('data-shortcut-filter') || 'all';
+    const active = filter === shortcutsActiveFilter;
+    btn.classList.toggle('active', active);
+    btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+  });
+  shortcutGroups().forEach((group) => {
+    const visible = shortcutGroupMatches(group, query, shortcutsActiveFilter);
+    group.hidden = !visible;
+    if (visible) visibleCount += 1;
+  });
+  const empty = shortcutsEl('shortcutsEmpty');
+  if (empty) empty.hidden = visibleCount > 0;
+}
+
+function resetShortcutsFilters() {
+  shortcutsActiveFilter = 'all';
+  const search = shortcutsEl('shortcutsSearch');
+  if (search) search.value = '';
+  renderShortcutsFilters();
+}
+
+function focusShortcutsSearch() {
+  const search = shortcutsEl('shortcutsSearch');
+  const target = search || shortcutsEl('shortcutsDialog') || shortcutsEl('shortcutsCloseBtn') || shortcutsEl('shortcutsModal');
+  if (!target) return;
+  target.focus?.({ preventScroll: true });
+  if (target === search) target.select?.();
+}
+
 function openShortcuts() {
-  const modal = globalElements.shortcutsModal;
+  const modal = shortcutsEl('shortcutsModal') || globalElements.shortcutsModal;
   if (!modal || modal.classList.contains('open')) return;
   shortcutsLastFocusedEl = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  resetShortcutsFilters();
   modal.classList.add('open');
   modal.setAttribute('aria-hidden', 'false');
-  window.setTimeout(() => {
-    (globalElements.shortcutsDialog || globalElements.shortcutsCloseBtn || modal).focus?.();
-  }, 0);
+  focusShortcutsSearch();
+  window.requestAnimationFrame?.(() => focusShortcutsSearch());
+  window.setTimeout(() => focusShortcutsSearch(), 0);
+  window.setTimeout(() => focusShortcutsSearch(), 50);
+  window.setTimeout(() => focusShortcutsSearch(), 150);
 }
 
 function closeShortcuts() {
-  const modal = globalElements.shortcutsModal;
+  const modal = shortcutsEl('shortcutsModal') || globalElements.shortcutsModal;
   if (!modal || !modal.classList.contains('open')) return;
   modal.classList.remove('open');
   modal.setAttribute('aria-hidden', 'true');
@@ -7005,6 +7068,14 @@ globalElements.settingsModal?.addEventListener('click', (event) => {
 
 globalElements.shortcutsBtn?.addEventListener('click', () => openShortcuts());
 globalElements.shortcutsCloseBtn?.addEventListener('click', () => closeShortcuts());
+globalElements.shortcutsSearch?.addEventListener('input', () => renderShortcutsFilters());
+globalElements.shortcutsFilterButtons?.forEach((btn) => {
+  btn.addEventListener('click', () => {
+    shortcutsActiveFilter = btn.getAttribute('data-shortcut-filter') || 'all';
+    renderShortcutsFilters();
+    focusShortcutsSearch();
+  });
+});
 globalElements.shortcutsModal?.addEventListener('click', (event) => {
   if (event.target === globalElements.shortcutsModal) closeShortcuts();
 });

--- a/index.html
+++ b/index.html
@@ -240,13 +240,28 @@
             Most shortcuts are disabled while typing in inputs, textareas, selects, or contenteditable fields. Global keys like <kbd>Esc</kbd>, <kbd>Cmd/Ctrl+P</kbd>, and <kbd>Cmd/Ctrl+K</kbd> still work.
           </div>
 
-          <div class="shortcut-group">
+          <div class="shortcut-tools" aria-label="Filter keyboard shortcuts">
+            <label class="shortcut-search-label" for="shortcutsSearch">Search shortcuts</label>
+            <input id="shortcutsSearch" class="shortcut-search" type="search" placeholder="Search keys, actions, categories" autocomplete="off" data-testid="shortcuts-search" />
+            <div class="shortcut-filter-chips" role="group" aria-label="Shortcut category filters">
+              <button type="button" class="shortcut-filter-chip active" data-shortcut-filter="all" aria-pressed="true">All</button>
+              <button type="button" class="shortcut-filter-chip" data-shortcut-filter="global" aria-pressed="false">Global</button>
+              <button type="button" class="shortcut-filter-chip" data-shortcut-filter="chat" aria-pressed="false">Chat</button>
+              <button type="button" class="shortcut-filter-chip" data-shortcut-filter="pane" aria-pressed="false">Pane</button>
+              <button type="button" class="shortcut-filter-chip" data-shortcut-filter="workqueue" aria-pressed="false">Workqueue</button>
+              <button type="button" class="shortcut-filter-chip" data-shortcut-filter="fleet" aria-pressed="false">Fleet</button>
+            </div>
+          </div>
+
+          <div class="shortcut-empty" id="shortcutsEmpty" hidden>No shortcuts match.</div>
+
+          <div class="shortcut-group" data-shortcut-category="global">
             <h3 class="shortcut-group-title">Global</h3>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>?</kbd></div><div class="shortcut-desc">Open this help overlay</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Esc</kbd></div><div class="shortcut-desc">Close overlay / menus</div></div>
           </div>
 
-          <div class="shortcut-group">
+          <div class="shortcut-group" data-shortcut-category="pane">
             <h3 class="shortcut-group-title">Pane focus/navigation</h3>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Alt</kbd>/<kbd>Option</kbd>+<kbd>1</kbd>..<kbd>9</kbd></div><div class="shortcut-desc">Focus panes 1-9 by visible order</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>1</kbd>..<kbd>4</kbd></div><div class="shortcut-desc">Focus pane 1-4</div></div>
@@ -257,7 +272,7 @@
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>[</kbd></div><div class="shortcut-desc">Previous unread pane</div></div>
           </div>
 
-          <div class="shortcut-group">
+          <div class="shortcut-group" data-shortcut-category="pane fleet">
             <h3 class="shortcut-group-title">Pane actions</h3>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Open command palette</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd></div><div class="shortcut-desc">Add pane</div></div>
@@ -265,7 +280,13 @@
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>R</kbd></div><div class="shortcut-desc">Refresh agent list</div></div>
           </div>
 
-          <div class="shortcut-group">
+          <div class="shortcut-group" data-shortcut-category="chat">
+            <h3 class="shortcut-group-title">Chat actions</h3>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Enter</kbd></div><div class="shortcut-desc">Send chat message from the composer</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Shift</kbd>+<kbd>Enter</kbd></div><div class="shortcut-desc">Insert a new line in the composer</div></div>
+          </div>
+
+          <div class="shortcut-group" data-shortcut-category="workqueue">
             <h3 class="shortcut-group-title">Workqueue actions</h3>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>g</kbd> <kbd>w</kbd></div><div class="shortcut-desc">Open Workqueue modal</div></div>
           </div>

--- a/styles.css
+++ b/styles.css
@@ -1590,6 +1590,67 @@ button.agents-section-title:hover {
 
 /* Shortcuts modal */
 
+.shortcut-tools {
+  display: grid;
+  gap: 10px;
+  margin: 0 0 14px 0;
+}
+
+.shortcut-search-label {
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  opacity: 0.88;
+}
+
+.shortcut-search {
+  width: 100%;
+  min-height: 40px;
+  padding: 9px 11px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(5, 10, 20, 0.58);
+  color: var(--text);
+}
+
+.shortcut-filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.shortcut-filter-chip {
+  min-height: 32px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text);
+  padding: 6px 10px;
+  cursor: pointer;
+}
+
+.shortcut-filter-chip:hover,
+.shortcut-filter-chip:focus-visible {
+  border-color: rgba(125, 211, 252, 0.62);
+}
+
+.shortcut-filter-chip.active {
+  background: rgba(56, 189, 248, 0.18);
+  border-color: rgba(125, 211, 252, 0.72);
+}
+
+.shortcut-empty {
+  border: 1px dashed rgba(255, 255, 255, 0.16);
+  border-radius: 8px;
+  padding: 14px;
+  margin-bottom: 12px;
+  color: var(--muted);
+}
+
+.shortcut-empty[hidden] {
+  display: none;
+}
+
 .shortcut-group {
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 12px;

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -36,10 +36,49 @@ test('shortcuts overlay: ? opens, Esc closes, content renders', async ({ page })
   await expect(modal).toContainText('Pane focus/navigation');
   await expect(modal).toContainText('Pane actions');
   await expect(modal).toContainText('Workqueue actions');
+  await expect(page.locator('#shortcutsSearch')).toBeFocused();
   await expect(modal).toContainText('disabled while typing');
 
   await page.keyboard.press('Escape');
   await expect(modal).toHaveAttribute('aria-hidden', 'true');
+});
+
+test('shortcuts modal supports search, category chips, and empty state', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const modal = page.locator('#shortcutsModal');
+  const search = page.locator('#shortcutsSearch');
+
+  await page.locator('#connectionStatus').click();
+  await page.keyboard.press('Shift+/');
+  await expect(modal).toHaveAttribute('aria-hidden', 'false');
+  await expect(search).toBeFocused();
+
+  await search.fill('fleet');
+  await expect(modal.locator('.shortcut-group:visible')).toHaveCount(1);
+  await expect(modal.locator('.shortcut-group:visible')).toContainText('Open/focus Fleet pane');
+
+  await modal.locator('[data-shortcut-filter="workqueue"]').click();
+  await expect(search).toBeFocused();
+  await expect(modal.locator('.shortcut-group:visible')).toHaveCount(0);
+  await expect(page.locator('#shortcutsEmpty')).toBeVisible();
+
+  await search.fill('');
+  await expect(modal.locator('.shortcut-group:visible')).toHaveCount(1);
+  await expect(modal.locator('.shortcut-group:visible')).toContainText('Workqueue actions');
+
+  await modal.locator('[data-shortcut-filter="chat"]').click();
+  await search.fill('enter');
+  await expect(modal.locator('.shortcut-group:visible')).toHaveCount(1);
+  await expect(modal.locator('.shortcut-group:visible')).toContainText('Chat actions');
 });
 
 test('shortcuts modal restores prior focus on close', async ({ page }) => {


### PR DESCRIPTION
## Summary\n- add an autofocus search field and category filter chips to the keyboard shortcuts modal\n- filter shortcuts by key combo, action label, and category text\n- show an empty state when filters hide all shortcuts\n\nCloses #338\n\n## Tests\n- npm test\n- npx playwright test tests/pane.shortcuts.e2e.spec.js --workers=1