### PR TITLE
Show workqueue queue in pane identity

### DIFF
--- a/app.js
+++ b/app.js
@@ -1860,11 +1860,16 @@ function paneTypeBadgeMarkup(pane, { extraClass = '', testId = '' } = {}) {
 
 function paneTargetLabel(pane) {
   if (!pane) return '';
+  if (pane.kind === 'workqueue') return formatWorkqueuePaneQueueLabel(pane);
   const current = String(pane?.elements?.agentLabel?.textContent || '').trim();
   if (current) return current;
-  if (pane.kind === 'workqueue') return String(pane.workqueue?.queue || 'dev-team');
   if (pane.kind === 'timeline' || pane.kind === 'cron') return 'gateway';
   return String(pane.agentId || 'main');
+}
+
+function formatWorkqueuePaneQueueLabel(pane) {
+  const queue = String(pane?.workqueue?.queue || '').trim();
+  return queue || 'No queue';
 }
 
 function paneBrowserTitle(pane) {
@@ -7029,8 +7034,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     // Header should describe the pane's primary target (queue), not an agent.
     paneSetHeaderTarget(pane, {
       label: 'Queue',
-      value: String(pane.workqueue.queue || 'dev-team'),
-      ariaLabel: `Change queue (current: ${String(pane.workqueue.queue || 'dev-team')})`
+      value: formatWorkqueuePaneQueueLabel(pane),
+      ariaLabel: `Change queue (current: ${formatWorkqueuePaneQueueLabel(pane)})`
     });
 
     // Replace thread with workqueue list + inspect.
@@ -7190,8 +7195,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     // Make header pill focus the queue selector in the body (no duplicated selector state).
     paneSetHeaderTarget(pane, {
       label: 'Queue',
-      value: String(pane.workqueue.queue || 'dev-team'),
-      ariaLabel: `Change queue (current: ${String(pane.workqueue.queue || 'dev-team')})`,
+      value: formatWorkqueuePaneQueueLabel(pane),
+      ariaLabel: `Change queue (current: ${formatWorkqueuePaneQueueLabel(pane)})`,
       onClick: () => {
         try {
           queueSelectEl?.focus?.();
@@ -7335,8 +7340,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       rememberRecentWorkqueueTarget(q);
       paneSetHeaderTarget(pane, {
         label: 'Queue',
-        value: String(q),
-        ariaLabel: `Change queue (current: ${String(q)})`,
+        value: formatWorkqueuePaneQueueLabel(pane),
+        ariaLabel: `Change queue (current: ${formatWorkqueuePaneQueueLabel(pane)})`,
         onClick: () => {
           try {
             queueSelectEl?.focus?.();

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -154,6 +154,31 @@ function seedFilterSummaryWorkqueueItems(queue) {
   fs.writeFileSync(path.join(dir, 'work-queues.json'), JSON.stringify(data, null, 2));
 }
 
+test('workqueue pane: queue switch updates pane identity everywhere', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  const queue = `identity-${Date.now()}`;
+  await loginAdmin(page, env.serverPort);
+
+  const pane = page.locator('[data-pane][data-pane-kind="workqueue"]').first();
+  await expect(pane.getByTestId('pane-type-label')).toHaveText(/^B Workqueue · dev-team$/);
+
+  await pane.locator('[data-wq-queue-select]').selectOption('__custom__');
+  await pane.locator('[data-wq-queue-custom]').fill(queue);
+  await pane.locator('[data-wq-queue-custom]').press('Enter');
+
+  await expect(pane.getByTestId('pane-type-label')).toHaveText(`B Workqueue · ${queue}`);
+  await expect(pane.getByTestId('pane-name-target')).toHaveText(` · ${queue}`);
+
+  await page.keyboard.press('Control+P');
+  const managerRow = page.locator('.pane-manager-row[data-pane-kind="workqueue"]').first();
+  await expect(managerRow.locator('.pane-manager-kind-label')).toHaveText(`B Workqueue · ${queue}`);
+  await expect(managerRow).not.toContainText('main');
+});
+
 function seedKeyboardTriageWorkqueueItems(queue) {
   const dir = path.join(env.tempHome, '.openclaw', 'clawnsole');
   fs.mkdirSync(dir, { recursive: true });


### PR DESCRIPTION
## Summary
- make Workqueue pane identity resolve from the pane queue before any header label text
- add an explicit `No queue` fallback for missing Workqueue queue state
- cover queue switching updating header and pane manager identity

Fixes #339

## Tests
- npm run test:syntax
- npx playwright test tests/ui/workqueue-pane.spec.js -g "queue switch updates pane identity everywhere"