### PR TITLE
Add composer context send guard

### DIFF
--- a/app.js
+++ b/app.js
@@ -82,6 +82,7 @@ const globalElements = {
   settingsModal: document.getElementById('settingsModal'),
   settingsCloseBtn: document.getElementById('settingsCloseBtn'),
   paneSwitchHudEnabled: document.getElementById('paneSwitchHudEnabled'),
+  composerConfirmGuardEnabled: document.getElementById('composerConfirmGuardEnabled'),
   keybindConflictList: document.getElementById('keybindConflictList'),
   shortcutOverridesList: document.getElementById('shortcutOverridesList'),
   shortcutOverridesSave: document.getElementById('shortcutOverridesSave'),
@@ -295,6 +296,8 @@ const ADMIN_AUTH_DESTINATION_KEY = 'clawnsole.admin.authDestination.v1';
 const ADMIN_AUTH_RESTORE_PENDING_KEY = 'clawnsole.admin.authRestorePending.v1';
 const ADMIN_AUTH_RESTORE_NOTICE_KEY = 'clawnsole.admin.authRestoreNotice.v1';
 const PANE_SWITCH_HUD_ENABLED_KEY = 'clawnsole.admin.paneSwitchHud.enabled';
+const COMPOSER_CONFIRM_GUARD_ENABLED_KEY = 'clawnsole.admin.composerConfirmGuard.enabled';
+const COMPOSER_CONFIRM_GUARD_MS = 5000;
 const KEYBIND_OVERRIDES_KEY = 'clawnsole.admin.keybindOverrides.v1';
 const SHORTCUT_OVERRIDES_KEY = 'clawnsole.admin.shortcutOverrides.v1';
 const ADMIN_AUTH_DESTINATION_TTL_MS = 10 * 60 * 1000;
@@ -1854,6 +1857,9 @@ function openSettings() {
   if (globalElements.paneSwitchHudEnabled) {
     globalElements.paneSwitchHudEnabled.checked = isPaneSwitchHudEnabled();
   }
+  if (globalElements.composerConfirmGuardEnabled) {
+    globalElements.composerConfirmGuardEnabled.checked = isComposerConfirmGuardEnabled();
+  }
   renderKeyboardSettings();
   shortcutOverridesDraft = readShortcutOverrides();
   renderShortcutOverrideSettings();
@@ -2711,6 +2717,10 @@ function isPaneSwitchHudEnabled() {
   return String(storage.get(PANE_SWITCH_HUD_ENABLED_KEY, '1') || '1') !== '0';
 }
 
+function isComposerConfirmGuardEnabled() {
+  return String(storage.get(COMPOSER_CONFIRM_GUARD_ENABLED_KEY, '1') || '1') !== '0';
+}
+
 let paneSwitchHudHideTimer = null;
 
 function ensurePaneSwitchHud() {
@@ -2808,9 +2818,21 @@ function notePaneFocused(pane) {
   if (!key) return;
   const panes = paneManager?.panes || [];
   if (!panes.some((entry) => String(entry?.key || '') === key)) return;
+  const previousKey = paneFocusMruKeys[0] || '';
   paneMruTraversal = null;
   paneMruOrder();
   paneFocusMruKeys = [key, ...paneFocusMruKeys.filter((entry) => entry !== key)];
+  if (pane.kind === 'chat' && previousKey && previousKey !== key) {
+    pane.composerGuard = {
+      ...(pane.composerGuard || {}),
+      focusedAt: Date.now(),
+      typedSinceFocus: false,
+      typedInDraft: Boolean(pane.elements?.input?.value?.trim?.()),
+      confirmPending: false,
+      confirmFor: ''
+    };
+    paneSetDestinationStrip(pane);
+  }
   updateBrowserTitle(pane);
 }
 
@@ -7627,6 +7649,55 @@ function panePumpOutbox(pane) {
 }
 
 
+function paneComposerTargetLabel(pane) {
+  if (!pane) return '';
+  if (pane.kind === 'chat') return paneDisplayTargetLabel(pane);
+  if (pane.kind === 'workqueue') {
+    const scope = String(pane.workqueue?.scopeFilter || 'mine') === 'all' ? 'all' : 'mine';
+    return `${pane.workqueue?.queue || 'dev-team'} · ${scope}`;
+  }
+  if (pane.kind === 'cron') return pane.cronAgentId ? `Agent: ${pane.cronAgentId}` : 'All agents';
+  if (pane.kind === 'timeline') return 'Activity timeline';
+  return paneDisplayTargetLabel(pane);
+}
+
+function paneComposerContextLabel(pane) {
+  return `${paneLabel(pane)} · ${paneComposerTargetLabel(pane) || paneDisplayTargetLabel(pane)}`;
+}
+
+function paneResetComposerConfirm(pane) {
+  if (!pane?.composerGuard) return;
+  pane.composerGuard.confirmPending = false;
+  pane.composerGuard.confirmFor = '';
+  paneSetDestinationStrip(pane);
+}
+
+function paneNeedsComposerConfirm(pane) {
+  if (!pane || pane.kind !== 'chat') return false;
+  if (!isComposerConfirmGuardEnabled()) return false;
+  const guard = pane.composerGuard || {};
+  if (guard.typedInDraft) return false;
+  if (guard.typedSinceFocus) return false;
+  const focusedAt = Number(guard.focusedAt || 0);
+  return focusedAt > 0 && Date.now() - focusedAt <= COMPOSER_CONFIRM_GUARD_MS;
+}
+
+function paneConfirmComposerSend(pane) {
+  const guard = pane.composerGuard || {};
+  const target = paneComposerTargetLabel(pane);
+  if (!paneNeedsComposerConfirm(pane)) {
+    paneResetComposerConfirm(pane);
+    return true;
+  }
+  if (guard.confirmPending && guard.confirmFor === target) {
+    paneResetComposerConfirm(pane);
+    return true;
+  }
+  pane.composerGuard = { ...guard, confirmPending: true, confirmFor: target };
+  paneSetDestinationStrip(pane);
+  return false;
+}
+
 async function paneSendChat(pane) {
   const raw = pane.elements.input.value.trim();
   if (!raw) return;
@@ -7658,6 +7729,8 @@ async function paneSendChat(pane) {
     addFeed('event', 'chat', `reset session (${key})`);
     return;
   }
+
+  if (!paneConfirmComposerSend(pane)) return;
 
   const sessionKey = pane.sessionKey();
   const idempotencyKey = randomId();
@@ -7734,6 +7807,13 @@ async function paneSendChat(pane) {
   panePumpOutbox(pane);
 
   pane.elements.input.value = '';
+  if (pane.composerGuard) {
+    pane.composerGuard.typedSinceFocus = false;
+    pane.composerGuard.typedInDraft = false;
+    pane.composerGuard.confirmPending = false;
+    pane.composerGuard.confirmFor = '';
+    paneSetDestinationStrip(pane);
+  }
   paneUpdateCommandHints(pane);
 }
 
@@ -8164,18 +8244,25 @@ function anyPaneHasDraftChanges(panes) {
 function paneSetDestinationStrip(pane) {
   const strip = pane?.elements?.destinationStrip;
   const valueEl = pane?.elements?.destinationValue;
+  const labelEl = pane?.elements?.destinationLabel;
+  const confirmEl = pane?.elements?.destinationConfirm;
+  const buttonEl = pane?.elements?.destinationButton;
   if (!strip || !valueEl) return;
-  if (pane.kind !== 'chat' || pane.role !== 'admin') {
-    strip.hidden = true;
-    return;
-  }
   strip.hidden = false;
-  const raw = typeof pane.agentId === 'string' ? pane.agentId.trim() : '';
-  const hasSelection = Boolean(raw);
-  const agentId = hasSelection ? normalizeAgentId(raw) : '';
-  const agent = hasSelection ? getAgentRecord(agentId) : null;
-  const displayText = hasSelection ? formatAgentLabel(agent, { includeId: false }) : 'Pick agent…';
-  valueEl.textContent = displayText;
+  const isChatAdmin = pane.kind === 'chat' && pane.role === 'admin';
+  const context = paneComposerContextLabel(pane);
+  const confirmPending = Boolean(isChatAdmin && pane.composerGuard?.confirmPending);
+  strip.classList.toggle('destination-strip-disabled', !isChatAdmin);
+  strip.classList.toggle('destination-strip-confirming', confirmPending);
+  if (labelEl) labelEl.textContent = isChatAdmin ? 'Sending to' : 'Not a chat target';
+  valueEl.textContent = context;
+  if (confirmEl) {
+    confirmEl.textContent = confirmPending ? `Press send again for ${paneComposerTargetLabel(pane)}` : '';
+  }
+  if (buttonEl) {
+    buttonEl.disabled = !isChatAdmin;
+    buttonEl.setAttribute('aria-label', isChatAdmin ? `Change destination (current: ${paneComposerTargetLabel(pane)})` : context);
+  }
 }
 
 function paneSetAgent(pane, nextAgentId, { requireDraftConfirm = true, syncFromPaneKey = '' } = {}) {
@@ -8294,8 +8381,10 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     scrollDownBtn: root.querySelector('[data-pane-scroll-down]'),
     inputRow: root.querySelector('.chat-input-row'),
     destinationStrip: root.querySelector('[data-pane-destination-strip]'),
+    destinationLabel: root.querySelector('[data-pane-destination-label]'),
     destinationButton: root.querySelector('[data-pane-destination-button]'),
     destinationValue: root.querySelector('[data-pane-destination-value]'),
+    destinationConfirm: root.querySelector('[data-pane-destination-confirm]'),
     input: root.querySelector('[data-pane-input]'),
     commandHints: root.querySelector('[data-pane-command-hints]'),
     fileInput: root.querySelector('[data-pane-file-input]'),
@@ -8352,6 +8441,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     abortState: { active: false, requestedAt: 0, targetRunId: null, timer: null, finished: false, canceledRunIds: new Set() },
     attachments: { files: [] },
     pendingSend: null,
+    composerGuard: { focusedAt: 0, typedSinceFocus: false, typedInDraft: false, confirmPending: false, confirmFor: '' },
     catchUp: { active: false, attemptsLeft: 0, timer: null },
     outbox: [],
     inFlight: null,
@@ -8499,7 +8589,6 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     clearPaneUnread(pane);
   });
   elements.root?.addEventListener('pointerdown', () => {
-    notePaneFocused(pane);
     clearPaneUnread(pane);
   });
   renderPaneActivityBadge(pane);
@@ -8507,7 +8596,10 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
   // WORKQUEUE PANE
   if (pane.role === 'admin' && pane.kind === 'workqueue') {
     if (elements.agentWrap) elements.agentWrap.hidden = false;
-    if (elements.inputRow) elements.inputRow.hidden = true;
+    if (elements.inputRow) elements.inputRow.hidden = false;
+    if (elements.input) elements.input.disabled = true;
+    if (elements.sendBtn) elements.sendBtn.disabled = true;
+    if (elements.attachBtn) elements.attachBtn.disabled = true;
     if (elements.scrollDownBtn) elements.scrollDownBtn.hidden = true;
 
     // Header should describe the pane's primary target (queue), not an agent.
@@ -9258,13 +9350,17 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     pane.statusState = 'connected';
     pane.statusMeta = '';
     if (pane.elements?.root) pane.elements.root.dataset.connected = 'true';
+    paneSetDestinationStrip(pane);
     return pane;
   }
 
   // CRON + TIMELINE PANES (admin-only)
   if (pane.role === 'admin' && (pane.kind === 'cron' || pane.kind === 'timeline')) {
     if (elements.agentWrap) elements.agentWrap.hidden = false;
-    if (elements.inputRow) elements.inputRow.hidden = true;
+    if (elements.inputRow) elements.inputRow.hidden = false;
+    if (elements.input) elements.input.disabled = true;
+    if (elements.sendBtn) elements.sendBtn.disabled = true;
+    if (elements.attachBtn) elements.attachBtn.disabled = true;
     if (elements.scrollDownBtn) elements.scrollDownBtn.hidden = true;
 
     const isTimeline = pane.kind === 'timeline';
@@ -9806,6 +9902,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
 
     pane.client = buildClientForPane(pane);
     setStatusPill(elements.status, 'disconnected', '');
+    paneSetDestinationStrip(pane);
     renderPaneIdentity(pane);
     return pane;
   }
@@ -9846,6 +9943,13 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
   });
 
   elements.input.addEventListener('input', () => {
+    if (pane.composerGuard) {
+      pane.composerGuard.typedSinceFocus = true;
+      pane.composerGuard.typedInDraft = Boolean(elements.input.value.trim());
+      pane.composerGuard.confirmPending = false;
+      pane.composerGuard.confirmFor = '';
+      paneSetDestinationStrip(pane);
+    }
     paneUpdateCommandHints(pane);
   });
 
@@ -10626,6 +10730,11 @@ globalElements.settingsModal?.addEventListener('click', (event) => {
 globalElements.paneSwitchHudEnabled?.addEventListener('change', () => {
   storage.set(PANE_SWITCH_HUD_ENABLED_KEY, globalElements.paneSwitchHudEnabled.checked ? '1' : '0');
 });
+globalElements.composerConfirmGuardEnabled?.addEventListener('change', () => {
+  storage.set(COMPOSER_CONFIRM_GUARD_ENABLED_KEY, globalElements.composerConfirmGuardEnabled.checked ? '1' : '0');
+  paneManager?.panes?.forEach?.((pane) => paneResetComposerConfirm(pane));
+});
+
 function handleShortcutOverrideInputKeydown(event) {
   const input = event.target?.closest?.('[data-shortcut-action]');
   if (!input) return;

--- a/app.js
+++ b/app.js
@@ -8045,11 +8045,10 @@ function renderPaneIdentity(pane) {
 
 function paneSetHeaderTarget(pane, { label, value, ariaLabel, onClick } = {}) {
   if (!pane?.elements) return;
-  const { targetLabel, agentButton, agentLabel, agentSelect, agentWarning, destinationValue } = pane.elements;
+  const { targetLabel, agentButton, agentLabel, agentSelect, agentWarning } = pane.elements;
 
   if (targetLabel && typeof label === 'string') targetLabel.textContent = label;
   if (agentLabel && typeof value === 'string') agentLabel.textContent = value;
-  if (destinationValue && typeof value === 'string') destinationValue.textContent = value;
 
   // Non-chat panes use the pill button as a "focus/chooser" affordance.
   if (agentSelect) agentSelect.hidden = true;
@@ -8078,6 +8077,7 @@ function paneSetHeaderTarget(pane, { label, value, ariaLabel, onClick } = {}) {
 
   if (paneManager?.panes?.includes?.(pane)) paneManager.updatePaneLabels();
   else renderPaneIdentity(pane);
+  paneSetDestinationStrip(pane);
 }
 
 function renderPaneAgentIdentity(pane) {

--- a/index.html
+++ b/index.html
@@ -159,10 +159,11 @@
             <div class="chat-input-row">
               <div class="chat-input-stack">
                 <div class="destination-strip" data-pane-destination-strip data-testid="pane-destination-strip">
-                  <span class="destination-strip-label">Sending to</span>
+                  <span class="destination-strip-label" data-pane-destination-label>Context</span>
                   <button class="destination-strip-target" type="button" data-pane-destination-button aria-label="Change destination" data-testid="pane-destination-button">
                     <span data-pane-destination-value data-testid="pane-destination-value">main</span>
                   </button>
+                  <span class="destination-strip-confirm" data-pane-destination-confirm role="status" aria-live="polite"></span>
                 </div>
                 <textarea data-pane-input placeholder="Message..." data-testid="pane-input"></textarea>
                 <div data-pane-command-hints class="command-hints" aria-live="polite"></div>
@@ -507,6 +508,10 @@
             <label class="inline-checkbox">
               <input id="paneSwitchHudEnabled" type="checkbox" checked />
               Show pane-switch HUD
+            </label>
+            <label class="inline-checkbox">
+              <input id="composerConfirmGuardEnabled" type="checkbox" checked />
+              Confirm quick sends after switching panes
             </label>
           </section>
 

--- a/styles.css
+++ b/styles.css
@@ -477,12 +477,11 @@ body::before {
   box-shadow: inset 0 0 0 1px rgba(var(--pane-accent-rgb, 255, 255, 255), 0.14), var(--shadow);
 }
 
-/* Workqueue pane should be full-height: never show chat composer UI in this pane. */
+/* Data panes show composer context, but never expose chat controls. */
 .pane-kind-workqueue {
   --actions-height: 0px;
 }
 
-.pane-kind-workqueue .chat-input-row,
 .pane-kind-workqueue .scroll-down {
   display: none !important;
 }
@@ -493,10 +492,32 @@ body::before {
   --actions-height: 0px;
 }
 
-.pane-kind-cron .chat-input-row,
 .pane-kind-cron .scroll-down,
-.pane-kind-timeline .chat-input-row,
 .pane-kind-timeline .scroll-down {
+  display: none !important;
+}
+
+.pane-kind-workqueue .chat-input-row,
+.pane-kind-cron .chat-input-row,
+.pane-kind-timeline .chat-input-row {
+  grid-template-columns: 1fr;
+}
+
+.pane-kind-workqueue textarea[data-pane-input],
+.pane-kind-workqueue .chat-actions,
+.pane-kind-workqueue .command-hints,
+.pane-kind-workqueue .attachment-row,
+.pane-kind-workqueue .attachment-list,
+.pane-kind-cron textarea[data-pane-input],
+.pane-kind-cron .chat-actions,
+.pane-kind-cron .command-hints,
+.pane-kind-cron .attachment-row,
+.pane-kind-cron .attachment-list,
+.pane-kind-timeline textarea[data-pane-input],
+.pane-kind-timeline .chat-actions,
+.pane-kind-timeline .command-hints,
+.pane-kind-timeline .attachment-row,
+.pane-kind-timeline .attachment-list {
   display: none !important;
 }
 
@@ -3469,6 +3490,15 @@ kbd {
   background: rgba(255, 255, 255, 0.04);
 }
 
+.destination-strip-confirming {
+  border-color: rgba(250, 204, 21, 0.42);
+  background: rgba(250, 204, 21, 0.08);
+}
+
+.destination-strip-disabled {
+  background: rgba(255, 255, 255, 0.025);
+}
+
 .destination-strip-label {
   font-size: 11px;
   text-transform: uppercase;
@@ -3486,8 +3516,25 @@ kbd {
   padding: 4px 8px;
 }
 
+.destination-strip-target:disabled {
+  cursor: default;
+  color: var(--muted);
+}
+
 .destination-strip-target:hover {
   background: rgba(255, 255, 255, 0.08);
+}
+
+.destination-strip-target:disabled:hover {
+  background: transparent;
+}
+
+.destination-strip-confirm {
+  min-width: 0;
+  color: #fde68a;
+  font-size: 12px;
+  font-weight: 700;
+  text-align: right;
 }
 
 .attachment-row {

--- a/styles.css
+++ b/styles.css
@@ -503,6 +503,11 @@ body::before {
   grid-template-columns: 1fr;
 }
 
+.pane-kind-cron .chat-input-row,
+.pane-kind-timeline .chat-input-row {
+  display: none !important;
+}
+
 .pane-kind-workqueue textarea[data-pane-input],
 .pane-kind-workqueue .chat-actions,
 .pane-kind-workqueue .command-hints,

--- a/tests/ui/chat-pane.spec.js
+++ b/tests/ui/chat-pane.spec.js
@@ -88,6 +88,38 @@ test('chat pane: stop button can cancel a running response', async ({ page }) =>
   await expect(pane.locator('.chat-bubble.assistant')).not.toContainText('mock-reply: please stream this', { timeout: 3000 });
 });
 
+test('chat pane: composer context requires confirm after quick pane switch', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Chat pane');
+
+  const panes = page.locator('[data-pane][data-pane-kind="chat"]');
+  const firstPane = panes.first();
+  const secondPane = panes.nth(1);
+
+  await expect(firstPane.locator('[data-pane-send]')).toBeEnabled({ timeout: 90000 });
+  await expect(secondPane.locator('[data-pane-send]')).toBeEnabled({ timeout: 90000 });
+  await expect(firstPane.getByTestId('pane-destination-value')).toHaveText(/Chat · main/);
+
+  await firstPane.locator('[data-pane-input]').focus();
+  await secondPane.locator('[data-pane-input]').focus();
+  await firstPane.locator('[data-pane-input]').focus();
+  await firstPane.locator('[data-pane-input]').evaluate((node) => {
+    node.value = 'guarded send';
+  });
+  await firstPane.locator('[data-pane-input]').press('Enter');
+
+  await expect(firstPane.locator('[data-pane-destination-confirm]')).toContainText(/Press send again for main/);
+  await expect(firstPane.locator('[data-chat-role="user"]')).toHaveCount(0);
+
+  await firstPane.locator('[data-pane-input]').press('Enter');
+  await expect(firstPane.locator('[data-chat-role="user"]').last()).toContainText('guarded send');
+});
+
 test('chat pane: unread badge appears on inactive pane and clears on focus', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);

--- a/tests/ui/pane-add-menu.spec.js
+++ b/tests/ui/pane-add-menu.spec.js
@@ -76,7 +76,7 @@ test('pane add menu: workqueue override is applied before pane opens', async ({ 
 
   const wqPane = page.locator('[data-pane][data-pane-kind="workqueue"]').last();
   await expect(wqPane).toBeVisible();
-  await expect(wqPane.getByTestId('pane-destination-value')).toHaveText('ci-team');
+  await expect(wqPane.getByTestId('pane-destination-value')).toHaveText('Workqueue · ci-team · all');
   await expect(wqPane.locator('[data-wq-scope="all"]')).toHaveAttribute('aria-pressed', 'true');
 });
 

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -278,8 +278,10 @@ test('workqueue pane: renders + has queue dropdown + does not show chat composer
   await page.getByLabel('Refresh agent list').click();
   await expect(wqPane.locator('[data-pane-target-label]')).toHaveText('Queue');
 
-  // Workqueue pane should not render the chat composer UI.
-  await expect(wqPane.locator('.chat-input-row')).toBeHidden();
+  // Workqueue panes keep the context banner visible, but do not render chat input controls.
+  await expect(wqPane.locator('.chat-input-row')).toBeVisible();
+  await expect(wqPane.getByTestId('pane-destination-strip')).toBeVisible();
+  await expect(wqPane.getByTestId('pane-destination-value')).toHaveText(/Workqueue/);
   await expect(wqPane.locator('[data-pane-input]')).toBeHidden();
 });
 


### PR DESCRIPTION
## Summary
- show a composer context strip for chat and non-chat panes
- add a quick-switch send confirmation guard with a settings toggle
- preserve fast sends when the user already typed in the focused pane

Fixes #302

## Tests
- npm run test:syntax
- npx playwright test tests/ui/chat-pane.spec.js tests/ui/pane-add-menu.spec.js --workers=1