### PR TITLE
Collapse exact duplicate workqueue rows

### DIFF
--- a/app.js
+++ b/app.js
@@ -3188,8 +3188,14 @@ function getActiveChatAgentPane() {
   const focusedKey = focusedPaneKey();
   const fallbackKey = paneMruOrder()[0] || '';
   const originKey = commandPaletteState.open ? String(commandPaletteState.originPaneKey || '') : '';
-  const activeKey = originKey || focusedKey || fallbackKey;
-  return (paneManager?.panes || []).find((pane) => String(pane?.key || '') === activeKey && pane.kind === 'chat') || null;
+  const panes = paneManager?.panes || [];
+  if (originKey) {
+    const origin = panes.find((pane) => String(pane?.key || '') === originKey) || null;
+    return origin?.kind === 'chat' ? origin : null;
+  }
+
+  const activeKey = focusedKey || fallbackKey;
+  return panes.find((pane) => String(pane?.key || '') === activeKey && pane.kind === 'chat') || null;
 }
 
 function openWorkqueueForActiveChatAgent() {
@@ -9049,8 +9055,9 @@ const paneManager = {
         if (event?.preventDefault) event.preventDefault();
         if (event?.stopPropagation) event.stopPropagation();
 
+        const options = getOptions();
         this.closeAddPaneMenu();
-        this.addPane(kind, { ...getOptions(), forceNew: !!event?.altKey });
+        this.addPane(kind, { ...options, forceNew: !!event?.altKey });
 
         queueMicrotask(() => {
           state.menuActionInFlight = false;

--- a/app.js
+++ b/app.js
@@ -122,6 +122,7 @@ const fmtRemaining = __appCore.fmtRemaining || ((msUntil) => {
 });
 const formatWorkqueueIssueTitle = __appCore.formatWorkqueueIssueTitle || ((item) => String(item?.title || ''));
 const sortWorkqueueItems = __appCore.sortWorkqueueItems || ((items, opts) => (Array.isArray(items) ? items.slice() : []));
+const collapseWorkqueueDuplicateRows = __appCore.collapseWorkqueueDuplicateRows || ((items) => (Array.isArray(items) ? items.slice() : []));
 const inferPaneCols = __appCore.inferPaneCols || ((count) => {
   const n = Number(count);
   if (!Number.isFinite(n) || n <= 1) return 1;
@@ -4045,7 +4046,7 @@ function renderWorkqueueItems() {
   const header = listRoot?.querySelector('.wq-list-header');
   if (header) header.style.display = 'none';
 
-  const itemsRaw = Array.isArray(workqueueState.items) ? workqueueState.items : [];
+  const itemsRaw = collapseWorkqueueDuplicateRows(Array.isArray(workqueueState.items) ? workqueueState.items : []);
   const items = sortWorkqueueItems(itemsRaw, { sortKey: workqueueState.sortKey, sortDir: workqueueState.sortDir });
 
   if (!items.length) {
@@ -4119,11 +4120,13 @@ function renderWorkqueueItems() {
       const status = String(it.status || '');
       const age = fmtAge(it.createdAt || it.updatedAt);
       const next = String(it.lastNote || '').trim();
+      const duplicateCount = Number(it.duplicateCount || 0);
 
       card.innerHTML = `
         <div class="wq-card-title">${escapeHtml(formatWorkqueueIssueTitle(it))}</div>
         <div class="wq-card-meta">
           <span class="wq-badge wq-badge-${escapeHtml(status)}">${escapeHtml(status)}</span>
+          ${duplicateCount > 1 ? `<span class="wq-duplicate-count" title="${escapeHtml(`${duplicateCount} exact duplicate rows collapsed`)}">×${escapeHtml(String(duplicateCount))}</span>` : ''}
           ${age ? `<span class="wq-card-chip mono">age ${escapeHtml(age)}</span>` : ''}
           ${leaseLabel ? `<span class="wq-card-chip mono">lease ${escapeHtml(leaseLabel)}</span>` : ''}
         </div>
@@ -4720,11 +4723,12 @@ function appendWorkqueuePaneItemRow(pane, body, item, { child = false } = {}) {
   const leaseLabel = item.leaseUntil ? fmtRemaining(leaseMs) : '';
   const status = String(item.status || '');
   const title = formatWorkqueueIssueTitle(item);
+  const duplicateCount = Number(item.duplicateCount || 0);
   row.title = title;
   row.setAttribute('aria-label', `Workqueue item: ${title}`);
 
   row.innerHTML = `
-    <div class="wq-col title"><span class="wq-title-text" title="${escapeHtml(title)}">${escapeHtml(title)}</span></div>
+    <div class="wq-col title"><span class="wq-title-text" title="${escapeHtml(title)}">${escapeHtml(title)}</span>${duplicateCount > 1 ? `<span class="wq-duplicate-count" title="${escapeHtml(`${duplicateCount} exact duplicate rows collapsed`)}">×${escapeHtml(String(duplicateCount))}</span>` : ''}</div>
     <div class="wq-col status"><span class="wq-badge wq-badge-${escapeHtml(status)}">${escapeHtml(status)}</span></div>
     <div class="wq-col prio mono">${escapeHtml(String(item.priority ?? ''))}</div>
     <div class="wq-col attempts mono">${escapeHtml(String(item.attempts ?? ''))}</div>
@@ -4885,12 +4889,13 @@ function renderWorkqueuePaneItems(pane) {
 
   const scopedItems = filterWorkqueuePaneItemsByScope(pane, pane.workqueue?.items);
   const filteredItems = applyWorkqueueQuickFilters(scopedItems, pane.workqueue?.quickFilters);
-  const items = sortWorkqueueItems(filteredItems, { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
+  const groupMode = normalizeWorkqueueGroupMode(pane.workqueue?.groupMode);
+  const rowItems = groupMode === 'grouped' ? filteredItems : collapseWorkqueueDuplicateRows(filteredItems);
+  const items = sortWorkqueueItems(rowItems, { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
   const totalCount = Array.isArray(pane.workqueue?.countItems) ? pane.workqueue.countItems.length : (Array.isArray(pane.workqueue?.items) ? pane.workqueue.items.length : items.length);
   const statusLine = pane.elements?.thread?.querySelector('[data-wq-statusline]');
   if (statusLine) statusLine.textContent = formatWorkqueueCountText(items.length, totalCount);
   renderWorkqueueFilterSummaryForPane(pane, { shownCount: items.length, totalCount });
-  const groupMode = normalizeWorkqueueGroupMode(pane.workqueue?.groupMode);
   const rows = groupMode === 'grouped' ? summarizeWorkqueueIssueGroups(items) : items.map((item) => ({ kind: 'item', item }));
   const renderLimit = Math.max(
     WORKQUEUE_PANE_INITIAL_RENDER_LIMIT,

--- a/lib/app-core.js
+++ b/lib/app-core.js
@@ -122,6 +122,87 @@
       .map((x) => x.it);
   }
 
+  function normalizeWorkqueueDuplicateText(value) {
+    return String(value || '').trim().replace(/\s+/g, ' ').toLowerCase();
+  }
+
+  function getWorkqueueDuplicateKey(item) {
+    const meta = item?.meta && typeof item.meta === 'object' ? item.meta : {};
+    const dedupeKey = normalizeWorkqueueDuplicateText(meta.dedupeKey || item?.dedupeKey);
+    const title = normalizeWorkqueueDuplicateText(formatWorkqueueIssueTitle(item) || item?.title);
+    const status = normalizeWorkqueueDuplicateText(item?.status || 'ready');
+    if (!title || !status) return '';
+    return dedupeKey ? `dedupe:${dedupeKey}|title:${title}|status:${status}` : `title:${title}|status:${status}`;
+  }
+
+  function workqueueRepresentativeSortValue(item) {
+    const updated = Date.parse(String(item?.updatedAt || ''));
+    if (Number.isFinite(updated)) return updated;
+    const created = Date.parse(String(item?.createdAt || ''));
+    return Number.isFinite(created) ? created : 0;
+  }
+
+  function pickWorkqueueDuplicateRepresentative(items) {
+    let best = null;
+    for (const item of Array.isArray(items) ? items : []) {
+      if (!best) {
+        best = item;
+        continue;
+      }
+      const itemTime = workqueueRepresentativeSortValue(item);
+      const bestTime = workqueueRepresentativeSortValue(best);
+      if (itemTime > bestTime) {
+        best = item;
+        continue;
+      }
+      if (itemTime === bestTime && String(item?.id || '').localeCompare(String(best?.id || '')) > 0) {
+        best = item;
+      }
+    }
+    return best;
+  }
+
+  function collapseWorkqueueDuplicateRows(items) {
+    const source = Array.isArray(items) ? items : [];
+    const groups = new Map();
+    for (const item of source) {
+      const key = getWorkqueueDuplicateKey(item);
+      if (!key) continue;
+      if (!groups.has(key)) groups.set(key, []);
+      groups.get(key).push(item);
+    }
+
+    const representatives = new Map();
+    for (const [key, members] of groups.entries()) {
+      if (members.length <= 1) continue;
+      const representative = pickWorkqueueDuplicateRepresentative(members);
+      if (!representative) continue;
+      representatives.set(key, {
+        representative,
+        duplicateCount: members.length,
+        duplicateMembers: members.slice()
+      });
+    }
+
+    const emitted = new Set();
+    const out = [];
+    for (const item of source) {
+      const key = getWorkqueueDuplicateKey(item);
+      const group = key ? representatives.get(key) : null;
+      if (!group) {
+        out.push(item);
+        continue;
+      }
+      if (emitted.has(key) || item !== group.representative) continue;
+      emitted.add(key);
+      out.push(Object.assign({}, group.representative, {
+        duplicateCount: group.duplicateCount,
+        duplicateMembers: group.duplicateMembers
+      }));
+    }
+    return out;
+  }
+
   function normalizeWorkqueueIssueRepo(value) {
     const s = String(value || '').trim().toLowerCase();
     if (!s || !/^[a-z0-9_.-]+\/[a-z0-9_.-]+$/.test(s)) return '';
@@ -453,6 +534,7 @@
     fmtRemaining,
     formatWorkqueueIssueTitle,
     sortWorkqueueItems,
+    collapseWorkqueueDuplicateRows,
     inferPaneCols,
     normalizePaneKind,
     normalizeAdminDestination,

--- a/styles.css
+++ b/styles.css
@@ -2771,11 +2771,15 @@ kbd {
 }
 
 .wq-col.title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   font-weight: 600;
 }
 
 .wq-title-text {
   display: block;
+  flex: 1;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2804,6 +2808,22 @@ kbd {
 .wq-badge-in_progress { background: rgba(104, 201, 255, 0.12); border-color: rgba(104, 201, 255, 0.25); }
 .wq-badge-done { background: rgba(120, 255, 170, 0.10); border-color: rgba(120, 255, 170, 0.22); }
 .wq-badge-failed { background: rgba(255, 104, 104, 0.10); border-color: rgba(255, 104, 104, 0.22); }
+
+.wq-duplicate-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  padding: 2px 7px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.2;
+  white-space: nowrap;
+}
 
 .wq-col.prio,
 .wq-col.attempts {

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -110,6 +110,48 @@ function seedLegacyIssueTitleVariants(queue) {
   fs.writeFileSync(path.join(dir, 'work-queues.json'), JSON.stringify(data, null, 2));
 }
 
+function seedExactDuplicateWorkqueueItems(queue) {
+  const dir = path.join(env.tempHome, '.openclaw', 'clawnsole');
+  fs.mkdirSync(dir, { recursive: true });
+  const now = new Date();
+  const iso = (offsetMs) => new Date(now.getTime() + offsetMs).toISOString();
+  const mkItem = (id, patch = {}) => ({
+    id,
+    queue,
+    title: '[issue] rmdmattingly/clawnsole#348 exact duplicate collapse',
+    instructions: 'https://github.com/rmdmattingly/clawnsole/issues/348',
+    priority: 10,
+    status: 'ready',
+    claimedBy: '',
+    claimedAt: '',
+    leaseUntil: 0,
+    attempts: 0,
+    lastError: '',
+    createdAt: iso(-60000),
+    updatedAt: iso(-60000),
+    dedupeKey: 'issue:rmdmattingly/clawnsole#348',
+    ...patch
+  });
+
+  const data = {
+    version: 1,
+    queues: { [queue]: { name: queue, createdAt: iso(-120000) } },
+    assignments: {},
+    items: [
+      mkItem('exact-dup-old', { updatedAt: iso(-30000) }),
+      mkItem('exact-dup-new', { updatedAt: iso(-10000), attempts: 2 }),
+      mkItem('exact-dup-other-status', { status: 'pending', updatedAt: iso(-5000) }),
+      mkItem('exact-dup-unrelated', {
+        title: '[issue] rmdmattingly/clawnsole#349 unrelated',
+        instructions: 'https://github.com/rmdmattingly/clawnsole/issues/349',
+        dedupeKey: 'issue:rmdmattingly/clawnsole#349',
+        updatedAt: iso(-20000)
+      })
+    ]
+  };
+  fs.writeFileSync(path.join(dir, 'work-queues.json'), JSON.stringify(data, null, 2));
+}
+
 function seedFilterSummaryWorkqueueItems(queue) {
   const dir = path.join(env.tempHome, '.openclaw', 'clawnsole');
   fs.mkdirSync(dir, { recursive: true });
@@ -682,6 +724,31 @@ test('workqueue pane: duplicate health summary cleans legacy issue duplicates', 
   expect(issue290.filter((it) => it.status !== 'failed')).toHaveLength(1);
   expect(issue290.find((it) => it.id === 'legacy-dup-keep')?.status).toBe('ready');
   expect(issue290.filter((it) => it.status === 'failed').every((it) => String(it.lastError || '').includes('duplicate-cleanup:rmdmattingly/clawnsole#290'))).toBeTruthy();
+});
+
+test('workqueue pane: default rows collapse exact duplicates with count badge', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  const queue = `exact-dupes-${Date.now()}`;
+  seedExactDuplicateWorkqueueItems(queue);
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  const pane = page.locator('[data-pane]').last();
+  await pane.locator('[data-wq-queue-select]').selectOption('__custom__');
+  await pane.locator('[data-wq-queue-custom]').fill(queue);
+  await pane.locator('[data-wq-queue-custom]').press('Enter');
+
+  await expect(pane.locator('[data-wq-statusline]')).toContainText('Showing 3 of 4 items');
+  await expect(pane.locator('.wq-row')).toHaveCount(3);
+  const duplicateRow = pane.locator('.wq-row:has(.wq-duplicate-count)').first();
+  await expect(duplicateRow.locator('.wq-duplicate-count')).toHaveText('×2');
+  await duplicateRow.focus();
+  await page.keyboard.press('Enter');
+  await expect(pane.locator('[data-wq-inspect]')).toContainText('exact-dup-new');
 });
 
 test('workqueue pane: grouped mode collapses duplicate issue rows and expands child actions', async ({ page }) => {

--- a/tests/unit/app-core.test.js
+++ b/tests/unit/app-core.test.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict');
 const {
   escapeHtml,
   fmtRemaining,
+  collapseWorkqueueDuplicateRows,
   formatWorkqueueIssueTitle,
   sortWorkqueueItems,
   inferPaneCols,
@@ -143,6 +144,56 @@ test('sortWorkqueueItems priority sort uses updatedAt desc tie-breaker', () => {
 
   const sorted = sortWorkqueueItems(items, { sortKey: 'priority', sortDir: 'desc' });
   assert.deepEqual(sorted.map((it) => it.id), ['c', 'b', 'a']);
+});
+
+test('collapseWorkqueueDuplicateRows collapses exact duplicate title, status, and dedupe key rows', () => {
+  const items = [
+    {
+      id: 'older',
+      title: 'Duplicate Task',
+      status: 'ready',
+      dedupeKey: 'dupe-1',
+      updatedAt: '2026-01-01T00:00:00Z'
+    },
+    {
+      id: 'newer',
+      title: '  duplicate   task ',
+      status: 'ready',
+      dedupeKey: 'dupe-1',
+      updatedAt: '2026-01-03T00:00:00Z'
+    },
+    {
+      id: 'different-status',
+      title: 'Duplicate Task',
+      status: 'in_progress',
+      dedupeKey: 'dupe-1',
+      updatedAt: '2026-01-04T00:00:00Z'
+    },
+    {
+      id: 'different-title',
+      title: 'Duplicate Task follow-up',
+      status: 'ready',
+      dedupeKey: 'dupe-1',
+      updatedAt: '2026-01-05T00:00:00Z'
+    }
+  ];
+
+  const collapsed = collapseWorkqueueDuplicateRows(items);
+  assert.deepEqual(collapsed.map((it) => it.id), ['newer', 'different-status', 'different-title']);
+  assert.equal(collapsed[0].duplicateCount, 2);
+  assert.deepEqual(collapsed[0].duplicateMembers.map((it) => it.id), ['older', 'newer']);
+});
+
+test('collapseWorkqueueDuplicateRows uses normalized title and status fallback with deterministic tie-break', () => {
+  const items = [
+    { id: 'a', title: 'Fallback task', status: 'pending', updatedAt: '2026-01-01T00:00:00Z' },
+    { id: 'c', title: 'fallback   task', status: 'pending', updatedAt: '2026-01-01T00:00:00Z' },
+    { id: 'b', title: 'Fallback task', status: 'ready', updatedAt: '2026-01-01T00:00:00Z' }
+  ];
+
+  const collapsed = collapseWorkqueueDuplicateRows(items);
+  assert.deepEqual(collapsed.map((it) => it.id), ['c', 'b']);
+  assert.equal(collapsed[0].duplicateCount, 2);
 });
 
 test('inferPaneCols maps pane counts to sensible layout widths', () => {


### PR DESCRIPTION
## Summary
- add a pure Workqueue duplicate-row collapse selector using dedupe key/title/status with newest-row representative selection
- show an xN badge on collapsed Workqueue rows/cards while keeping actions bound to the representative item
- add unit and focused UI regression coverage for exact duplicate collapse

Fixes #348

## Tests
- npm test
- npx playwright test tests/ui/workqueue-pane.spec.js -g "default rows collapse exact duplicates"