### PR TITLE
Collapse exact duplicate Workqueue rows by default

### DIFF
--- a/app.js
+++ b/app.js
@@ -121,6 +121,7 @@ const fmtRemaining = __appCore.fmtRemaining || ((msUntil) => {
   return `${sec}s`;
 });
 const formatWorkqueueIssueTitle = __appCore.formatWorkqueueIssueTitle || ((item) => String(item?.title || ''));
+const collapseWorkqueueDuplicateItems = __appCore.collapseWorkqueueDuplicateItems || ((items) => (Array.isArray(items) ? items : []).map((item) => ({ kind: 'item', item, duplicateCount: 1, duplicateMembers: [item] })));
 const sortWorkqueueItems = __appCore.sortWorkqueueItems || ((items, opts) => (Array.isArray(items) ? items.slice() : []));
 const inferPaneCols = __appCore.inferPaneCols || ((count) => {
   const n = Number(count);
@@ -4709,7 +4710,7 @@ function summarizeWorkqueueIssueGroups(items) {
   return out;
 }
 
-function appendWorkqueuePaneItemRow(pane, body, item, { child = false } = {}) {
+function appendWorkqueuePaneItemRow(pane, body, item, { child = false, duplicateCount = 1, duplicateMembers = null } = {}) {
   const row = document.createElement('button');
   row.type = 'button';
   row.className = child ? 'wq-row wq-row-child' : 'wq-row';
@@ -4720,11 +4721,24 @@ function appendWorkqueuePaneItemRow(pane, body, item, { child = false } = {}) {
   const leaseLabel = item.leaseUntil ? fmtRemaining(leaseMs) : '';
   const status = String(item.status || '');
   const title = formatWorkqueueIssueTitle(item);
+  const duplicateIds = (Array.isArray(duplicateMembers) ? duplicateMembers : [])
+    .map((member) => String(member?.id || '').trim())
+    .filter(Boolean);
+  const duplicateTitle = duplicateCount > 1
+    ? `Collapsed ${duplicateCount} exact duplicate rows. Representative is newest member ${item.id || 'unknown'}${duplicateIds.length ? `; members: ${duplicateIds.join(', ')}` : ''}.`
+    : title;
   row.title = title;
   row.setAttribute('aria-label', `Workqueue item: ${title}`);
+  if (duplicateCount > 1) {
+    row.setAttribute('data-wq-duplicate-count', String(duplicateCount));
+    row.title = duplicateTitle;
+  }
 
   row.innerHTML = `
-    <div class="wq-col title"><span class="wq-title-text" title="${escapeHtml(title)}">${escapeHtml(title)}</span></div>
+    <div class="wq-col title">
+      <span class="wq-title-text" title="${escapeHtml(title)}">${escapeHtml(title)}</span>
+      ${duplicateCount > 1 ? `<span class="wq-duplicate-count" title="${escapeHtml(duplicateTitle)}">×${escapeHtml(String(duplicateCount))}</span>` : ''}
+    </div>
     <div class="wq-col status"><span class="wq-badge wq-badge-${escapeHtml(status)}">${escapeHtml(status)}</span></div>
     <div class="wq-col prio mono">${escapeHtml(String(item.priority ?? ''))}</div>
     <div class="wq-col attempts mono">${escapeHtml(String(item.attempts ?? ''))}</div>
@@ -4885,13 +4899,16 @@ function renderWorkqueuePaneItems(pane) {
 
   const scopedItems = filterWorkqueuePaneItemsByScope(pane, pane.workqueue?.items);
   const filteredItems = applyWorkqueueQuickFilters(scopedItems, pane.workqueue?.quickFilters);
-  const items = sortWorkqueueItems(filteredItems, { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
+  const groupMode = normalizeWorkqueueGroupMode(pane.workqueue?.groupMode);
+  const collapsedRows = groupMode === 'rows' ? collapseWorkqueueDuplicateItems(filteredItems) : [];
+  const sortableItems = groupMode === 'rows' ? collapsedRows.map((entry) => entry.item).filter(Boolean) : filteredItems;
+  const items = sortWorkqueueItems(sortableItems, { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
   const totalCount = Array.isArray(pane.workqueue?.countItems) ? pane.workqueue.countItems.length : (Array.isArray(pane.workqueue?.items) ? pane.workqueue.items.length : items.length);
   const statusLine = pane.elements?.thread?.querySelector('[data-wq-statusline]');
   if (statusLine) statusLine.textContent = formatWorkqueueCountText(items.length, totalCount);
   renderWorkqueueFilterSummaryForPane(pane, { shownCount: items.length, totalCount });
-  const groupMode = normalizeWorkqueueGroupMode(pane.workqueue?.groupMode);
-  const rows = groupMode === 'grouped' ? summarizeWorkqueueIssueGroups(items) : items.map((item) => ({ kind: 'item', item }));
+  const collapsedById = new Map(collapsedRows.map((entry) => [entry.item?.id, entry]));
+  const rows = groupMode === 'grouped' ? summarizeWorkqueueIssueGroups(items) : items.map((item) => collapsedById.get(item?.id) || { kind: 'item', item });
   const renderLimit = Math.max(
     WORKQUEUE_PANE_INITIAL_RENDER_LIMIT,
     Number(pane.workqueue?.renderLimit || WORKQUEUE_PANE_INITIAL_RENDER_LIMIT)
@@ -4939,7 +4956,10 @@ function renderWorkqueuePaneItems(pane) {
 
   for (const entry of visibleRows) {
     if (entry.kind === 'item') {
-      appendWorkqueuePaneItemRow(pane, body, entry.item);
+      appendWorkqueuePaneItemRow(pane, body, entry.item, {
+        duplicateCount: entry.duplicateCount,
+        duplicateMembers: entry.duplicateMembers
+      });
       continue;
     }
 

--- a/lib/app-core.js
+++ b/lib/app-core.js
@@ -122,6 +122,63 @@
       .map((x) => x.it);
   }
 
+  function normalizeWorkqueueDuplicateText(value) {
+    return String(value || '').trim().replace(/\s+/g, ' ').toLowerCase();
+  }
+
+  function getWorkqueueDuplicateKey(item) {
+    const meta = item?.meta && typeof item.meta === 'object' ? item.meta : {};
+    const dedupeKey = normalizeWorkqueueDuplicateText(meta.dedupeKey || item?.dedupeKey);
+    const title = normalizeWorkqueueDuplicateText(formatWorkqueueIssueTitle(item));
+    const status = normalizeWorkqueueDuplicateText(item?.status);
+    if (!title || !status) return '';
+    return dedupeKey ? `dedupe:${dedupeKey}|title:${title}|status:${status}` : `title:${title}|status:${status}`;
+  }
+
+  function compareWorkqueueRepresentative(a, b) {
+    const timeOr0 = (v) => {
+      if (!v) return 0;
+      const n = Date.parse(String(v));
+      return Number.isFinite(n) ? n : 0;
+    };
+    const at = timeOr0(a?.updatedAt || a?.createdAt);
+    const bt = timeOr0(b?.updatedAt || b?.createdAt);
+    if (at !== bt) return bt - at;
+    return String(a?.id || '').localeCompare(String(b?.id || ''));
+  }
+
+  function collapseWorkqueueDuplicateItems(items) {
+    const groups = new Map();
+    const order = [];
+    for (const item of Array.isArray(items) ? items : []) {
+      const key = getWorkqueueDuplicateKey(item);
+      if (!key) {
+        const uniqueKey = `item:${order.length}`;
+        groups.set(uniqueKey, [item]);
+        order.push(uniqueKey);
+        continue;
+      }
+      if (!groups.has(key)) {
+        groups.set(key, []);
+        order.push(key);
+      }
+      groups.get(key).push(item);
+    }
+
+    return order.map((key) => {
+      const members = groups.get(key) || [];
+      const sortedMembers = members.slice().sort(compareWorkqueueRepresentative);
+      const representative = sortedMembers[0] || members[0] || null;
+      return {
+        kind: 'item',
+        item: representative,
+        duplicateKey: key,
+        duplicateCount: members.length,
+        duplicateMembers: sortedMembers
+      };
+    });
+  }
+
   function normalizeWorkqueueIssueRepo(value) {
     const s = String(value || '').trim().toLowerCase();
     if (!s || !/^[a-z0-9_.-]+\/[a-z0-9_.-]+$/.test(s)) return '';
@@ -452,6 +509,7 @@
     escapeHtml,
     fmtRemaining,
     formatWorkqueueIssueTitle,
+    collapseWorkqueueDuplicateItems,
     sortWorkqueueItems,
     inferPaneCols,
     normalizePaneKind,

--- a/styles.css
+++ b/styles.css
@@ -2771,15 +2771,33 @@ kbd {
 }
 
 .wq-col.title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   font-weight: 600;
 }
 
 .wq-title-text {
   display: block;
+  flex: 1 1 auto;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.wq-duplicate-count {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  padding: 2px 7px;
+  border: 1px solid rgba(255, 212, 104, 0.28);
+  border-radius: 999px;
+  color: rgb(255, 224, 142);
+  background: rgba(255, 212, 104, 0.10);
+  font-size: 11px;
+  line-height: 1.2;
+  font-weight: 700;
 }
 
 .wq-col.mono {

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -75,6 +75,51 @@ function seedLegacyDuplicateWorkqueueItems(queue) {
   fs.writeFileSync(path.join(dir, 'work-queues.json'), JSON.stringify(data, null, 2));
 }
 
+function seedExactDuplicateWorkqueueItems(queue) {
+  const dir = path.join(env.tempHome, '.openclaw', 'clawnsole');
+  fs.mkdirSync(dir, { recursive: true });
+  const now = new Date();
+  const iso = (offsetMs) => new Date(now.getTime() + offsetMs).toISOString();
+  const mkItem = (id, offsetMs) => ({
+    id,
+    queue,
+    title: '[issue] rmdmattingly/clawnsole#348 collapse exact duplicates',
+    instructions: 'Repo: rmdmattingly/clawnsole\nIssue: https://github.com/rmdmattingly/clawnsole/issues/348',
+    priority: 10,
+    status: 'ready',
+    claimedBy: '',
+    claimedAt: '',
+    leaseUntil: 0,
+    attempts: 0,
+    lastError: '',
+    createdAt: iso(-60000),
+    updatedAt: iso(offsetMs),
+    dedupeKey: 'issue:rmdmattingly/clawnsole#348'
+  });
+
+  const data = {
+    version: 1,
+    queues: { [queue]: { name: queue, createdAt: iso(-120000) } },
+    assignments: {},
+    items: [
+      mkItem('exact-dup-old', -30000),
+      mkItem('exact-dup-newest', -10000),
+      mkItem('exact-dup-middle', -20000),
+      {
+        ...mkItem('exact-dup-blocked', -5000),
+        status: 'blocked'
+      },
+      {
+        ...mkItem('exact-unrelated', -40000),
+        title: 'unrelated',
+        dedupeKey: 'exact-unrelated',
+        priority: 1
+      }
+    ]
+  };
+  fs.writeFileSync(path.join(dir, 'work-queues.json'), JSON.stringify(data, null, 2));
+}
+
 function seedLegacyIssueTitleVariants(queue) {
   const dir = path.join(env.tempHome, '.openclaw', 'clawnsole');
   fs.mkdirSync(dir, { recursive: true });
@@ -716,6 +761,35 @@ test('workqueue pane: grouped mode collapses duplicate issue rows and expands ch
   await child.focus();
   await page.keyboard.press('Enter');
   await expect(pane.locator('[data-wq-inspect]')).toContainText('legacy-dup');
+});
+
+test('workqueue pane: rows mode auto-collapses exact duplicate rows with count badge', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  const queue = `exact-duplicates-${Date.now()}`;
+  seedExactDuplicateWorkqueueItems(queue);
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  const pane = page.locator('[data-pane]').last();
+  await pane.locator('[data-wq-queue-select]').selectOption('__custom__');
+  await pane.locator('[data-wq-queue-custom]').fill(queue);
+  await pane.locator('[data-wq-queue-custom]').press('Enter');
+
+  const rows = pane.locator('[data-wq-list-body] .wq-row');
+  await expect(rows).toHaveCount(3);
+
+  const collapsed = pane.locator('[data-wq-duplicate-count="3"]');
+  await expect(collapsed).toHaveCount(1);
+  await expect(collapsed.locator('.wq-duplicate-count')).toHaveText('×3');
+
+  await collapsed.focus();
+  await page.keyboard.press('Enter');
+  await expect(pane.locator('[data-wq-inspect]')).toContainText('exact-dup-newest');
+  await expect(pane.locator('[data-wq-inspect]')).not.toContainText('exact-dup-old');
 });
 
 test('workqueue pane: controls toolbar is sticky and list scrolls independently', async ({ page }) => {

--- a/tests/unit/app-core.test.js
+++ b/tests/unit/app-core.test.js
@@ -5,6 +5,7 @@ const {
   escapeHtml,
   fmtRemaining,
   formatWorkqueueIssueTitle,
+  collapseWorkqueueDuplicateItems,
   sortWorkqueueItems,
   inferPaneCols,
   normalizePaneKind,
@@ -85,6 +86,57 @@ test('sortWorkqueueItems supports explicit sort keys and stable ordering fallbac
   // For ties without timestamps, preserve input order.
   const byPrio = sortWorkqueueItems(items, { sortKey: 'priority', sortDir: 'desc' });
   assert.deepEqual(byPrio.map((it) => it.id), ['a', 'b', 'c']);
+});
+
+test('collapseWorkqueueDuplicateItems collapses exact dedupeKey title status matches', () => {
+  const items = [
+    {
+      id: 'old',
+      title: 'Duplicate task',
+      status: 'ready',
+      dedupeKey: 'issue:1',
+      updatedAt: '2026-01-01T00:00:00Z'
+    },
+    {
+      id: 'new',
+      title: 'Duplicate task',
+      status: 'ready',
+      dedupeKey: 'issue:1',
+      updatedAt: '2026-01-03T00:00:00Z'
+    },
+    {
+      id: 'different-status',
+      title: 'Duplicate task',
+      status: 'blocked',
+      dedupeKey: 'issue:1',
+      updatedAt: '2026-01-04T00:00:00Z'
+    },
+    {
+      id: 'different-title',
+      title: 'Other task',
+      status: 'ready',
+      dedupeKey: 'issue:1',
+      updatedAt: '2026-01-05T00:00:00Z'
+    }
+  ];
+
+  const rows = collapseWorkqueueDuplicateItems(items);
+  assert.equal(rows.length, 3);
+  assert.equal(rows[0].item.id, 'new');
+  assert.equal(rows[0].duplicateCount, 2);
+  assert.deepEqual(rows[0].duplicateMembers.map((it) => it.id), ['new', 'old']);
+  assert.deepEqual(rows.slice(1).map((row) => row.item.id), ['different-status', 'different-title']);
+});
+
+test('collapseWorkqueueDuplicateItems uses normalized title and status fallback', () => {
+  const rows = collapseWorkqueueDuplicateItems([
+    { id: 'b', title: '  Same   Task ', status: 'READY', updatedAt: '2026-01-02T00:00:00Z' },
+    { id: 'a', title: 'same task', status: 'ready', updatedAt: '2026-01-02T00:00:00Z' }
+  ]);
+
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].item.id, 'a');
+  assert.equal(rows[0].duplicateCount, 2);
 });
 
 test('formatWorkqueueIssueTitle normalizes mixed legacy issue prefixes', () => {


### PR DESCRIPTION
## Summary
- add a pure Workqueue row selector that collapses exact duplicates by dedupe key/title/status
- render collapsed default rows with a count badge and newest-member representative
- add unit and pane-level regression coverage

## Tests
- npm test
- npx playwright test tests/ui/workqueue-pane.spec.js -g "rows mode auto-collapses exact duplicate rows" --workers=1

Closes #348