### PR TITLE
Collapse exact duplicate workqueue rows

### DIFF
--- a/app.js
+++ b/app.js
@@ -121,6 +121,7 @@ const fmtRemaining = __appCore.fmtRemaining || ((msUntil) => {
   return `${sec}s`;
 });
 const formatWorkqueueIssueTitle = __appCore.formatWorkqueueIssueTitle || ((item) => String(item?.title || ''));
+const summarizeExactWorkqueueDuplicateRows = __appCore.summarizeExactWorkqueueDuplicateRows || ((items) => (Array.isArray(items) ? items : []).map((item) => ({ kind: 'item', item })));
 const sortWorkqueueItems = __appCore.sortWorkqueueItems || ((items, opts) => (Array.isArray(items) ? items.slice() : []));
 const inferPaneCols = __appCore.inferPaneCols || ((count) => {
   const n = Number(count);

--- a/lib/app-core.js
+++ b/lib/app-core.js
@@ -210,6 +210,61 @@
     return `[ISSUE] ${ref.repo}#${ref.issueNumber}${displayTitle ? ` - ${displayTitle}` : ''}`;
   }
 
+  function getWorkqueueDedupeKey(item) {
+    const meta = item?.meta && typeof item.meta === 'object' ? item.meta : {};
+    return String(meta.dedupeKey || item?.dedupeKey || '').trim();
+  }
+
+  function summarizeExactWorkqueueDuplicateRows(items) {
+    const source = Array.isArray(items) ? items : [];
+    const grouped = new Map();
+    for (const item of source) {
+      const dedupeKey = getWorkqueueDedupeKey(item);
+      if (!dedupeKey) continue;
+      const title = formatWorkqueueIssueTitle(item).trim();
+      const status = String(item?.status || '').trim();
+      const key = JSON.stringify([dedupeKey, title, status]);
+      if (!grouped.has(key)) grouped.set(key, { key, dedupeKey, title, status, items: [] });
+      grouped.get(key).items.push(item);
+    }
+
+    const duplicateGroups = Array.from(grouped.values())
+      .filter((group) => group.items.length > 1)
+      .map((group) => ({
+        kind: 'exact_duplicate',
+        key: `exact:${group.key}`,
+        dedupeKey: group.dedupeKey,
+        items: group.items,
+        representative: group.items[0],
+        title: group.title,
+        status: group.status,
+        count: group.items.length
+      }));
+
+    const byKey = new Map(duplicateGroups.map((group) => [group.key, group]));
+    const itemToGroupKey = new Map();
+    for (const group of duplicateGroups) {
+      for (const item of group.items) {
+        if (item?.id) itemToGroupKey.set(String(item.id), group.key);
+      }
+    }
+
+    const rows = [];
+    const emitted = new Set();
+    for (const item of source) {
+      const groupKey = item?.id ? itemToGroupKey.get(String(item.id)) : '';
+      if (!groupKey) {
+        rows.push({ kind: 'item', item });
+        continue;
+      }
+      if (emitted.has(groupKey)) continue;
+      const group = byKey.get(groupKey);
+      if (group) rows.push(group);
+      emitted.add(groupKey);
+    }
+    return rows;
+  }
+
   function inferPaneCols(count) {
     const n = Number(count);
     if (!Number.isFinite(n) || n <= 1) return 1;
@@ -452,6 +507,7 @@
     escapeHtml,
     fmtRemaining,
     formatWorkqueueIssueTitle,
+    summarizeExactWorkqueueDuplicateRows,
     sortWorkqueueItems,
     inferPaneCols,
     normalizePaneKind,

--- a/lib/app-core.js
+++ b/lib/app-core.js
@@ -215,31 +215,45 @@
     return String(meta.dedupeKey || item?.dedupeKey || '').trim();
   }
 
+  function normalizeWorkqueueDuplicateTitle(title) {
+    return String(title || '').trim().replace(/\s+/g, ' ').toLowerCase();
+  }
+
+  function compareWorkqueueDuplicateRepresentative(a, b) {
+    const updated = String(b?.updatedAt || '').localeCompare(String(a?.updatedAt || ''));
+    if (updated !== 0) return updated;
+    return String(a?.id || '').localeCompare(String(b?.id || ''));
+  }
+
   function summarizeExactWorkqueueDuplicateRows(items) {
     const source = Array.isArray(items) ? items : [];
     const grouped = new Map();
     for (const item of source) {
       const dedupeKey = getWorkqueueDedupeKey(item);
-      if (!dedupeKey) continue;
       const title = formatWorkqueueIssueTitle(item).trim();
       const status = String(item?.status || '').trim();
-      const key = JSON.stringify([dedupeKey, title, status]);
+      const normalizedTitle = normalizeWorkqueueDuplicateTitle(title);
+      if (!dedupeKey && !normalizedTitle) continue;
+      const key = JSON.stringify([dedupeKey || `title:${normalizedTitle}`, normalizedTitle, status]);
       if (!grouped.has(key)) grouped.set(key, { key, dedupeKey, title, status, items: [] });
       grouped.get(key).items.push(item);
     }
 
     const duplicateGroups = Array.from(grouped.values())
       .filter((group) => group.items.length > 1)
-      .map((group) => ({
-        kind: 'exact_duplicate',
-        key: `exact:${group.key}`,
-        dedupeKey: group.dedupeKey,
-        items: group.items,
-        representative: group.items[0],
-        title: group.title,
-        status: group.status,
-        count: group.items.length
-      }));
+      .map((group) => {
+        const sortedItems = group.items.slice().sort(compareWorkqueueDuplicateRepresentative);
+        return {
+          kind: 'exact_duplicate',
+          key: `exact:${group.key}`,
+          dedupeKey: group.dedupeKey,
+          items: sortedItems,
+          representative: sortedItems[0],
+          title: group.title,
+          status: group.status,
+          count: group.items.length
+        };
+      });
 
     const byKey = new Map(duplicateGroups.map((group) => [group.key, group]));
     const itemToGroupKey = new Map();

--- a/styles.css
+++ b/styles.css
@@ -2738,6 +2738,10 @@ kbd {
   font-weight: 600;
 }
 
+.wq-duplicate-row {
+  background: rgba(255, 255, 255, 0.028);
+}
+
 .wq-row-child {
   padding-left: 28px;
   background: rgba(0, 0, 0, 0.1);

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -452,6 +452,40 @@ test('workqueue pane: filter summary chips show counts and remove filters', asyn
   await expect(wqPane.locator('[data-wq-queue-custom]')).toHaveValue(queue);
 });
 
+test('workqueue pane: default rows collapse exact duplicates with expandable members', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  const queue = `exact-duplicates-${Date.now()}`;
+  seedExactDuplicateWorkqueueItems(queue);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  const wqPane = page.locator('[data-pane]').last();
+  await wqPane.locator('[data-wq-queue-select]').selectOption('__custom__');
+  await wqPane.locator('[data-wq-queue-custom]').fill(queue);
+  await wqPane.locator('[data-wq-queue-custom]').press('Enter');
+  await wqPane.locator('[data-wq-scope="all"]').click();
+
+  const rows = wqPane.locator('[data-wq-list-body] .wq-row');
+  const duplicateRow = wqPane.locator('[data-wq-duplicate-row]').first();
+
+  await expect(wqPane.locator('[data-wq-group-mode="rows"]')).toHaveAttribute('aria-pressed', 'true');
+  await expect(wqPane.locator('[data-wq-statusline]')).toContainText('Showing 4 items');
+  await expect(rows).toHaveCount(3);
+  await expect(duplicateRow).toContainText('x2');
+  await expect(duplicateRow).toContainText('duplicate collapse');
+  await expect(duplicateRow).toHaveAttribute('data-wq-item', 'exact-dup-latest');
+  await expect(wqPane.locator('[data-wq-list-body] .wq-row-child')).toHaveCount(0);
+
+  await duplicateRow.press('Enter');
+  await expect(duplicateRow).toHaveAttribute('aria-expanded', 'true');
+  await expect(wqPane.locator('[data-wq-list-body] .wq-row-child')).toHaveCount(2);
+});
+
 test('workqueue pane: queue target supports search + recent persistence', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);

--- a/tests/unit/app-core.test.js
+++ b/tests/unit/app-core.test.js
@@ -152,12 +152,14 @@ test('summarizeExactWorkqueueDuplicateRows collapses same dedupe key title and s
       id: 'a',
       title: 'Open issue: Duplicate health',
       status: 'ready',
+      updatedAt: '2026-01-01T00:00:00Z',
       meta: { dedupeKey: 'rmdmattingly/clawnsole#348', repo: 'rmdmattingly/clawnsole', issueNumber: 348 }
     },
     {
       id: 'b',
       title: '[issue] rmdmattingly/clawnsole#348 Duplicate health',
       status: 'ready',
+      updatedAt: '2026-01-02T00:00:00Z',
       meta: { dedupeKey: 'rmdmattingly/clawnsole#348', repo: 'rmdmattingly/clawnsole', issueNumber: 348 }
     },
     {
@@ -181,10 +183,42 @@ test('summarizeExactWorkqueueDuplicateRows collapses same dedupe key title and s
 
   const rows = summarizeExactWorkqueueDuplicateRows(items);
   assert.deepEqual(rows.map((row) => row.kind), ['exact_duplicate', 'item', 'item', 'item']);
-  assert.deepEqual(rows[0].items.map((item) => item.id), ['a', 'b']);
+  assert.deepEqual(rows[0].items.map((item) => item.id), ['b', 'a']);
+  assert.equal(rows[0].representative.id, 'b');
   assert.equal(rows[0].count, 2);
   assert.equal(rows[0].dedupeKey, 'rmdmattingly/clawnsole#348');
   assert.deepEqual(rows.slice(1).map((row) => row.item.id), ['c', 'd', 'e']);
+});
+
+test('summarizeExactWorkqueueDuplicateRows falls back to normalized title and status', () => {
+  const items = [
+    {
+      id: 'a',
+      title: '  Repeat   title  ',
+      status: 'ready',
+      updatedAt: '2026-01-01T00:00:00Z'
+    },
+    {
+      id: 'b',
+      title: 'repeat title',
+      status: 'ready',
+      updatedAt: '2026-01-01T00:00:00Z'
+    },
+    {
+      id: 'c',
+      title: 'repeat title',
+      status: 'done',
+      updatedAt: '2026-01-03T00:00:00Z'
+    }
+  ];
+
+  const rows = summarizeExactWorkqueueDuplicateRows(items);
+  assert.deepEqual(rows.map((row) => row.kind), ['exact_duplicate', 'item']);
+  assert.deepEqual(rows[0].items.map((item) => item.id), ['a', 'b']);
+  assert.equal(rows[0].representative.id, 'a');
+  assert.equal(rows[0].count, 2);
+  assert.equal(rows[0].dedupeKey, '');
+  assert.equal(rows[1].item.id, 'c');
 });
 
 test('inferPaneCols maps pane counts to sensible layout widths', () => {

--- a/tests/unit/app-core.test.js
+++ b/tests/unit/app-core.test.js
@@ -5,6 +5,7 @@ const {
   escapeHtml,
   fmtRemaining,
   formatWorkqueueIssueTitle,
+  summarizeExactWorkqueueDuplicateRows,
   sortWorkqueueItems,
   inferPaneCols,
   normalizePaneKind,
@@ -143,6 +144,47 @@ test('sortWorkqueueItems priority sort uses updatedAt desc tie-breaker', () => {
 
   const sorted = sortWorkqueueItems(items, { sortKey: 'priority', sortDir: 'desc' });
   assert.deepEqual(sorted.map((it) => it.id), ['c', 'b', 'a']);
+});
+
+test('summarizeExactWorkqueueDuplicateRows collapses same dedupe key title and status only', () => {
+  const items = [
+    {
+      id: 'a',
+      title: 'Open issue: Duplicate health',
+      status: 'ready',
+      meta: { dedupeKey: 'rmdmattingly/clawnsole#348', repo: 'rmdmattingly/clawnsole', issueNumber: 348 }
+    },
+    {
+      id: 'b',
+      title: '[issue] rmdmattingly/clawnsole#348 Duplicate health',
+      status: 'ready',
+      meta: { dedupeKey: 'rmdmattingly/clawnsole#348', repo: 'rmdmattingly/clawnsole', issueNumber: 348 }
+    },
+    {
+      id: 'c',
+      title: 'Open issue: Duplicate health',
+      status: 'claimed',
+      meta: { dedupeKey: 'rmdmattingly/clawnsole#348', repo: 'rmdmattingly/clawnsole', issueNumber: 348 }
+    },
+    {
+      id: 'd',
+      title: 'Open issue: Different title',
+      status: 'ready',
+      meta: { dedupeKey: 'rmdmattingly/clawnsole#348', repo: 'rmdmattingly/clawnsole', issueNumber: 348 }
+    },
+    {
+      id: 'e',
+      title: 'No dedupe key',
+      status: 'ready'
+    }
+  ];
+
+  const rows = summarizeExactWorkqueueDuplicateRows(items);
+  assert.deepEqual(rows.map((row) => row.kind), ['exact_duplicate', 'item', 'item', 'item']);
+  assert.deepEqual(rows[0].items.map((item) => item.id), ['a', 'b']);
+  assert.equal(rows[0].count, 2);
+  assert.equal(rows[0].dedupeKey, 'rmdmattingly/clawnsole#348');
+  assert.deepEqual(rows.slice(1).map((row) => row.item.id), ['c', 'd', 'e']);
 });
 
 test('inferPaneCols maps pane counts to sensible layout widths', () => {


### PR DESCRIPTION
## Summary
- Collapse exact duplicate workqueue pane rows in the default rows view using dedupe key + normalized title + status.
- Render a single expandable row with an xN count badge, while preserving the existing broader grouped mode.
- Add unit and focused UI regression coverage for exact duplicate grouping boundaries.

Fixes #348

## Tests
- npm run test:syntax
- npm run test:unit
- npx playwright test tests/ui/workqueue-pane.spec.js -g "default rows collapse exact duplicates"
