### PR TITLE
Add fleet column visibility controls

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,6 +32,8 @@ const globalElements = {
   agentsSearch: document.getElementById('agentsSearch'),
   agentsFilterButtons: Array.from(document.querySelectorAll('[data-agents-filter]')),
   agentsDensityButtons: Array.from(document.querySelectorAll('[data-agents-density]')),
+  agentsColumnPicker: document.getElementById('agentsColumnPicker'),
+  agentsColumnOptions: document.getElementById('agentsColumnOptions'),
   agentsSort: document.getElementById('agentsSort'),
   agentsHeatmapToggle: document.getElementById('agentsHeatmapToggle'),
   agentsHeartbeatSortBtn: document.getElementById('agentsHeartbeatSortBtn'),
@@ -258,8 +260,19 @@ const ADMIN_AGENT_PRE_HEARTBEAT_SORT_KEY = 'clawnsole.admin.agents.preHeartbeatS
 const ADMIN_AGENT_HEATMAP_KEY = 'clawnsole.admin.agents.heartbeatHeatmap';
 const ADMIN_AGENT_ACTIVE_MINUTES_KEY = 'clawnsole.admin.agents.activeMinutes';
 const ADMIN_AGENT_DENSITY_KEY = 'clawnsole.admin.agents.density';
+const ADMIN_AGENT_COLUMNS_KEY = 'clawnsole.admin.agents.columns';
 const ADMIN_AGENT_HEALTHY_COLLAPSED_KEY = 'clawnsole.admin.agents.healthyCollapsed';
 const ADMIN_AGENT_HEALTHY_COLLAPSE_THRESHOLD = 10;
+const FLEET_COLUMN_DEFS = [
+  { key: 'id', label: 'Agent id', defaultVisible: true },
+  { key: 'health', label: 'Health', defaultVisible: true },
+  { key: 'heartbeat', label: 'Heartbeat age', defaultVisible: true },
+  { key: 'heartbeatDetail', label: 'Heartbeat detail', defaultVisible: true },
+  { key: 'status', label: 'Status detail', defaultVisible: true },
+  { key: 'model', label: 'Model', defaultVisible: false },
+  { key: 'host', label: 'Host', defaultVisible: false },
+  { key: 'actions', label: 'Actions', defaultVisible: true }
+];
 const ADMIN_AUTH_DESTINATION_KEY = 'clawnsole.admin.authDestination.v1';
 const ADMIN_AUTH_RESTORE_PENDING_KEY = 'clawnsole.admin.authRestorePending.v1';
 const ADMIN_AUTH_RESTORE_NOTICE_KEY = 'clawnsole.admin.authRestoreNotice.v1';
@@ -492,6 +505,50 @@ function getFleetHeatmapEnabled() {
 
 function getFleetDensity() {
   return String(storage.get(ADMIN_AGENT_DENSITY_KEY, 'comfortable') || 'comfortable') === 'compact' ? 'compact' : 'comfortable';
+}
+
+function getFleetColumns() {
+  const defaults = {};
+  FLEET_COLUMN_DEFS.forEach((col) => {
+    defaults[col.key] = !!col.defaultVisible;
+  });
+  const saved = readJsonFromStorage(ADMIN_AGENT_COLUMNS_KEY, {});
+  if (!saved || typeof saved !== 'object' || Array.isArray(saved)) return defaults;
+  FLEET_COLUMN_DEFS.forEach((col) => {
+    if (typeof saved[col.key] === 'boolean') defaults[col.key] = saved[col.key];
+  });
+  return defaults;
+}
+
+function setFleetColumn(key, visible) {
+  const allowed = new Set(FLEET_COLUMN_DEFS.map((col) => col.key));
+  if (!allowed.has(key)) return;
+  const next = getFleetColumns();
+  next[key] = !!visible;
+  writeJsonToStorage(ADMIN_AGENT_COLUMNS_KEY, next);
+}
+
+function renderFleetColumnPicker() {
+  const root = globalElements.agentsColumnOptions;
+  if (!root) return;
+  const visible = getFleetColumns();
+  root.innerHTML = '';
+  FLEET_COLUMN_DEFS.forEach((col) => {
+    const id = `agentsColumn_${col.key}`;
+    const label = document.createElement('label');
+    label.className = 'agents-column-option';
+    label.setAttribute('for', id);
+    label.innerHTML = `
+      <input id="${id}" type="checkbox" data-agents-column="${escapeHtml(col.key)}" ${visible[col.key] ? 'checked' : ''} />
+      <span>${escapeHtml(col.label)}</span>
+    `;
+    label.querySelector('input')?.addEventListener('change', (event) => {
+      const input = event.currentTarget;
+      setFleetColumn(col.key, !!input.checked);
+      renderAgentsModalList();
+    });
+    root.appendChild(label);
+  });
 }
 
 function syncFleetDensityControl() {
@@ -1250,7 +1307,9 @@ async function fetchAgents() {
         id: typeof agent?.id === 'string' ? agent.id : '',
         name: typeof agent?.name === 'string' ? agent.name : '',
         displayName: typeof agent?.displayName === 'string' ? agent.displayName : '',
-        emoji: typeof agent?.emoji === 'string' ? agent.emoji : ''
+        emoji: typeof agent?.emoji === 'string' ? agent.emoji : '',
+        model: typeof agent?.model === 'string' ? agent.model : '',
+        host: typeof agent?.host === 'string' ? agent.host : ''
       }))
       .filter((agent) => agent.id);
   } catch {
@@ -3137,6 +3196,7 @@ function openAgentsModal() {
     globalElements.agentsActiveMinutes.value = String(Math.max(1, minutes));
   }
   syncFleetDensityControl();
+  renderFleetColumnPicker();
 
   renderAgentsModalList();
   renderAgentsLastRefreshed();
@@ -3369,12 +3429,16 @@ function renderAgentsModalList() {
   if (!root) return;
 
   const scrollAnchor = captureFleetScrollAnchor(root);
+  const focusedAgentId = document.activeElement instanceof Element
+    ? String(document.activeElement.closest?.('.agents-row')?.dataset?.agentId || '')
+    : '';
   const search = String(globalElements.agentsSearch?.value || '').trim().toLowerCase();
   const withinMinutes = Math.max(1, Number(globalElements.agentsActiveMinutes?.value) || 10);
   const activeWindowMs = withinMinutes * 60_000;
   const filterMode = getFleetFilter();
   const sortMode = getFleetSort();
   const heatmapEnabled = getFleetHeatmapEnabled();
+  const visibleColumns = getFleetColumns();
   syncFleetDensityControl();
 
   const pins = getPinnedAgentIds();
@@ -3532,22 +3596,19 @@ function renderAgentsModalList() {
           : 'Healthy';
       const heatBucketLabel = heartbeatAgeBucketLabel(triage.ageBucket);
       const statusSnippet = String(statusSnippetMap[id] || '').trim();
-      const statusSnippetHtml = statusSnippet ? ` · <span class="agents-status-snippet">${escapeHtml(statusSnippet)}</span>` : '';
-      row.dataset.heartbeatBucket = triage.ageBucket;
-      row.dataset.healthState = triage.bucket;
-      row.classList.toggle('agents-row-heatmap', heatmapEnabled);
-
-      row.innerHTML = `
-        <button type="button" class="agents-pin" aria-label="${pinnedNow ? 'Unpin agent' : 'Pin agent'}" aria-pressed="${pinnedNow ? 'true' : 'false'}" data-agent-pin="${escapeHtml(id)}">${pinnedNow ? '★' : '☆'}</button>
-        <div class="agents-row-main">
-          <div class="agents-row-title">${escapeHtml(label)}</div>
-          <div class="agents-row-meta">
-            <span class="agents-row-id">${escapeHtml(id)}</span>
-            <span class="agents-health-state-chip" data-health-state="${escapeHtml(triage.bucket)}">${escapeHtml(healthLabel)}</span>
-            <span class="agents-age-chip" data-heartbeat-bucket="${escapeHtml(triage.ageBucket)}" title="Heartbeat age: ${escapeHtml(heartbeatAge)} (${escapeHtml(heatBucketLabel)})">${escapeHtml(heartbeatAge)}</span>
-            <span class="agents-age-label">${escapeHtml(heatBucketLabel)}</span>${statusSnippetHtml}
-          </div>
-        </div>
+      const statusSnippetHtml = visibleColumns.status && statusSnippet
+        ? `<span class="agents-status-snippet" data-fleet-column="status">${escapeHtml(statusSnippet)}</span>`
+        : '';
+      const model = String(agent?.model || '').trim();
+      const host = String(agent?.host || '').trim();
+      const modelHtml = visibleColumns.model && model
+        ? `<span class="agents-optional-chip" data-fleet-column="model" title="Model">${escapeHtml(model)}</span>`
+        : '';
+      const hostHtml = visibleColumns.host && host
+        ? `<span class="agents-optional-chip" data-fleet-column="host" title="Host">${escapeHtml(host)}</span>`
+        : '';
+      const rowActionsHtml = visibleColumns.actions
+        ? `
         <div class="agents-row-actions agents-row-actions-inline" role="group" aria-label="Quick actions for ${escapeHtml(label)}">
           <button type="button" class="secondary agents-action-btn" data-agent-action="triage" data-agent-id="${escapeHtml(id)}" title="Open Chat and Workqueue" aria-label="Triage agent ${escapeHtml(label)}">Triage</button>
           <button type="button" class="secondary agents-action-btn" data-agent-action="open-chat" data-agent-id="${escapeHtml(id)}" title="Open Chat" aria-label="Open Chat for ${escapeHtml(label)}">Chat</button>
@@ -3563,6 +3624,25 @@ function renderAgentsModalList() {
             <button type="button" class="secondary agents-action-btn" data-agent-action="open-workqueue" data-agent-id="${escapeHtml(id)}" title="Open Workqueue" aria-label="Open Workqueue">Open Workqueue</button>
           </div>
         </details>
+      `
+        : '';
+      row.dataset.heartbeatBucket = triage.ageBucket;
+      row.dataset.healthState = triage.bucket;
+      row.classList.toggle('agents-row-heatmap', heatmapEnabled);
+      row.classList.toggle('agents-row-no-actions', !visibleColumns.actions);
+
+      row.innerHTML = `
+        <button type="button" class="agents-pin" aria-label="${pinnedNow ? 'Unpin agent' : 'Pin agent'}" aria-pressed="${pinnedNow ? 'true' : 'false'}" data-agent-pin="${escapeHtml(id)}">${pinnedNow ? '★' : '☆'}</button>
+        <div class="agents-row-main">
+          <div class="agents-row-title">${escapeHtml(label)}</div>
+          <div class="agents-row-meta">
+            ${visibleColumns.id ? `<span class="agents-row-id" data-fleet-column="id">${escapeHtml(id)}</span>` : ''}
+            ${visibleColumns.health ? `<span class="agents-health-state-chip" data-fleet-column="health" data-health-state="${escapeHtml(triage.bucket)}">${escapeHtml(healthLabel)}</span>` : ''}
+            ${visibleColumns.heartbeat ? `<span class="agents-age-chip" data-fleet-column="heartbeat" data-heartbeat-bucket="${escapeHtml(triage.ageBucket)}" title="Heartbeat age: ${escapeHtml(heartbeatAge)} (${escapeHtml(heatBucketLabel)})">${escapeHtml(heartbeatAge)}</span>` : ''}
+            ${visibleColumns.heartbeatDetail ? `<span class="agents-age-label" data-fleet-column="heartbeatDetail">${escapeHtml(heatBucketLabel)}</span>` : ''}${statusSnippetHtml}${modelHtml}${hostHtml}
+          </div>
+        </div>
+        ${rowActionsHtml}
       `;
 
       const pinBtn = row.querySelector('[data-agent-pin]');
@@ -3644,6 +3724,11 @@ function renderAgentsModalList() {
   const empty = ordered.length === 0;
   if (globalElements.agentsEmpty) globalElements.agentsEmpty.hidden = !empty;
   restoreFleetScrollAnchor(root, scrollAnchor);
+  if (focusedAgentId) {
+    try {
+      root.querySelector(`.agents-row[data-agent-id="${CSS.escape(focusedAgentId)}"]`)?.focus?.({ preventScroll: true });
+    } catch {}
+  }
 }
 
 function captureFleetScrollAnchor(root) {

--- a/index.html
+++ b/index.html
@@ -478,6 +478,13 @@
                 <button type="button" class="agents-chip" data-agents-density="compact" aria-pressed="false">Compact</button>
               </div>
             </div>
+            <div class="agents-field agents-columns">
+              <span class="agents-label">Columns</span>
+              <details id="agentsColumnPicker" class="agents-column-picker">
+                <summary class="agents-chip">Columns</summary>
+                <div id="agentsColumnOptions" class="agents-column-options" role="group" aria-label="Fleet columns"></div>
+              </details>
+            </div>
           </div>
 
           <div id="agentsList" class="agents-list" aria-label="Agent list"></div>

--- a/styles.css
+++ b/styles.css
@@ -1561,6 +1561,49 @@ button.send-btn .btn-icon {
   align-items: center;
 }
 
+.agents-column-picker {
+  position: relative;
+}
+
+.agents-column-picker > summary {
+  list-style: none;
+  cursor: pointer;
+}
+
+.agents-column-picker > summary::-webkit-details-marker {
+  display: none;
+}
+
+.agents-column-options {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 6px);
+  z-index: 8;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(130px, 1fr));
+  gap: 6px;
+  min-width: 290px;
+  padding: 10px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(13, 17, 23, 0.98);
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.38);
+}
+
+.agents-column-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 28px;
+  color: var(--text);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.agents-column-option input {
+  accent-color: #4dc4ff;
+}
+
 .agents-chip {
   border: 1px solid rgba(255, 255, 255, 0.16);
   background: rgba(255, 255, 255, 0.03);
@@ -1715,6 +1758,10 @@ button.agents-section-title:hover {
   background: rgba(77, 196, 255, 0.11);
 }
 
+.agents-row-no-actions {
+  grid-template-columns: 42px 1fr;
+}
+
 .agents-row:focus-visible {
   outline: 2px solid rgba(77, 196, 255, 0.82);
   outline-offset: 2px;
@@ -1749,6 +1796,10 @@ button.agents-section-title:hover {
   gap: 8px;
   border-radius: 10px;
   padding: 3px 8px;
+}
+
+.agents-list.compact .agents-row-no-actions {
+  grid-template-columns: 32px minmax(0, 1fr);
 }
 
 .agents-pin {
@@ -1856,8 +1907,17 @@ button.agents-section-title:hover {
   color: var(--muted);
 }
 
-.agents-status-snippet {
+.agents-status-snippet,
+.agents-optional-chip {
   color: var(--muted);
+}
+
+.agents-optional-chip {
+  display: inline-block;
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .agents-row-actions {

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -540,3 +540,51 @@ test('agents modal compact density tightens rows and persists', async ({ page, c
   await expect(page.locator('#agentsList')).toHaveClass(/compact/);
   await expect(page.getByRole('button', { name: 'Compact' })).toHaveAttribute('aria-pressed', 'true');
 });
+
+test('agents modal column picker hides optional metadata and preserves row selection', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  const agents = [
+    { id: 'alpha', name: 'Alpha', displayName: 'Alpha', model: 'gpt-alpha', host: 'mini-1' },
+    { id: 'beta', name: 'Beta', displayName: 'Beta', model: 'gpt-beta', host: 'mini-2' }
+  ];
+  await page.route(/\/agents(?:\?|$)/, async (route) => {
+    await route.fulfill({ json: { agents } });
+  });
+
+  await clawnsole.gotoAndLoginAdmin(page);
+  await page.evaluate(() => {
+    const now = Date.now();
+    localStorage.setItem('clawnsole.admin.agentLastSeenAtMs', JSON.stringify({ alpha: now, beta: now }));
+    localStorage.removeItem('clawnsole.admin.agents.columns');
+  });
+  await page.getByRole('button', { name: 'Refresh agent list' }).click();
+
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  const beta = page.locator('#agentsList .agents-row').filter({ hasText: 'Beta (beta)' });
+  await beta.click();
+  await expect(beta).toHaveAttribute('aria-selected', 'true');
+
+  await page.locator('#agentsColumnPicker summary').click();
+  await page.locator('#agentsColumn_model').check();
+  await page.locator('#agentsColumn_host').check();
+  await expect(beta).toHaveAttribute('aria-selected', 'true');
+  await expect(beta.locator('[data-fleet-column="model"]')).toHaveText('gpt-beta');
+  await expect(beta.locator('[data-fleet-column="host"]')).toHaveText('mini-2');
+
+  await page.locator('#agentsColumn_id').uncheck();
+  await expect(beta).toHaveAttribute('aria-selected', 'true');
+  await expect(beta.locator('[data-fleet-column="id"]')).toHaveCount(0);
+
+  await page.getByRole('button', { name: 'Compact' }).click();
+  await expect(beta).toHaveAttribute('aria-selected', 'true');
+  await expect(page.locator('#agentsList')).toHaveClass(/compact/);
+
+  await page.reload();
+  await clawnsole.waitForAdminUiReady(page);
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsColumn_model')).toBeChecked();
+  await expect(page.locator('#agentsColumn_host')).toBeChecked();
+  await expect(page.locator('#agentsColumn_id')).not.toBeChecked();
+  await expect(page.locator('#agentsList .agents-row').filter({ hasText: 'Beta' }).locator('[data-fleet-column="model"]')).toHaveText('gpt-beta');
+});


### PR DESCRIPTION
## Summary
- add a persisted Fleet column picker for agent id, health, heartbeat, status, model, host, and actions metadata
- keep the existing comfortable/compact density presets while preserving selected row focus across Fleet rerenders
- extend agent modal coverage for column persistence and selection stability

Fixes #350

## Tests
- npm run test:syntax
- npx playwright test tests/ui/agents-modal.spec.js --workers=1