### PR TITLE
Detect risky keyboard shortcut bindings

### DIFF
--- a/app.js
+++ b/app.js
@@ -51,6 +51,7 @@ const globalElements = {
   commandPaletteEmpty: document.getElementById('commandPaletteEmpty'),
   shortcutsModal: document.getElementById('shortcutsModal'),
   shortcutsDialog: document.getElementById('shortcutsDialog'),
+  shortcutsContent: document.getElementById('shortcutsContent'),
   shortcutsCloseBtn: document.getElementById('shortcutsCloseBtn'),
   paneManagerModal: document.getElementById('paneManagerModal'),
   paneManagerCloseBtn: document.getElementById('paneManagerCloseBtn'),
@@ -81,6 +82,7 @@ const globalElements = {
   settingsModal: document.getElementById('settingsModal'),
   settingsCloseBtn: document.getElementById('settingsCloseBtn'),
   paneSwitchHudEnabled: document.getElementById('paneSwitchHudEnabled'),
+  keybindConflictList: document.getElementById('keybindConflictList'),
   rolePill: document.getElementById('rolePill'),
   loginOverlay: document.getElementById('loginOverlay'),
   loginPassword: document.getElementById('loginPassword'),
@@ -278,8 +280,232 @@ const ADMIN_AUTH_DESTINATION_KEY = 'clawnsole.admin.authDestination.v1';
 const ADMIN_AUTH_RESTORE_PENDING_KEY = 'clawnsole.admin.authRestorePending.v1';
 const ADMIN_AUTH_RESTORE_NOTICE_KEY = 'clawnsole.admin.authRestoreNotice.v1';
 const PANE_SWITCH_HUD_ENABLED_KEY = 'clawnsole.admin.paneSwitchHud.enabled';
+const KEYBIND_OVERRIDES_KEY = 'clawnsole.admin.keybindOverrides.v1';
 const ADMIN_AUTH_DESTINATION_TTL_MS = 10 * 60 * 1000;
 const WQ_RECENT_TARGETS_KEY = 'clawnsole.wq.recentTargets';
+
+const KEYBIND_CATALOG = [
+  { id: 'help.shortcuts', group: 'Global', label: 'Open this help overlay', binding: { key: '?', display: '?' } },
+  { id: 'global.escape', group: 'Global', label: 'Close overlay / menus', binding: { key: 'Escape', display: 'Esc' } },
+  {
+    id: 'pane.focusVisible',
+    group: 'Pane focus/navigation',
+    label: 'Focus panes 1-9 by visible order',
+    binding: { alt: true, key: '1..9', display: 'Alt/Option+1..9' },
+    risk: { kind: 'layout', reason: 'Layout-sensitive on some international keyboards', alternative: { accel: true, key: '1..9', display: 'Cmd/Ctrl+1..9' } }
+  },
+  { id: 'pane.focusVisibleAccel', group: 'Pane focus/navigation', label: 'Focus pane 1-9', binding: { accel: true, key: '1..9', display: 'Cmd/Ctrl+1..9' } },
+  { id: 'pane.focusByLetter', group: 'Pane focus/navigation', label: 'Focus pane by visible letter', binding: { chord: ['g', 'a..z'], display: 'g a..z' } },
+  { id: 'pane.manager', group: 'Pane focus/navigation', label: 'Open Pane Manager', binding: { accel: true, key: 'p', display: 'Cmd/Ctrl+P' } },
+  { id: 'pane.next', group: 'Pane focus/navigation', label: 'Focus next pane', binding: { accel: true, shift: true, key: 'k', display: 'Cmd/Ctrl+Shift+K' } },
+  { id: 'pane.prev', group: 'Pane focus/navigation', label: 'Focus previous pane', binding: { accel: true, shift: true, key: 'j', display: 'Cmd/Ctrl+Shift+J' } },
+  { id: 'chat.next', group: 'Pane focus/navigation', label: 'Focus next Chat pane only', binding: { accel: true, alt: true, key: 'k', display: 'Cmd/Ctrl+Alt+K' } },
+  { id: 'chat.prev', group: 'Pane focus/navigation', label: 'Focus previous Chat pane only', binding: { accel: true, alt: true, key: 'j', display: 'Cmd/Ctrl+Alt+J' } },
+  { id: 'chat.return', group: 'Pane focus/navigation', label: 'Return to last active Chat pane', binding: { chord: ['g', 'c'], display: 'g c' } },
+  {
+    id: 'chat.composer',
+    group: 'Pane focus/navigation',
+    label: 'Focus Chat composer',
+    binding: { accel: true, key: 'l', display: 'Cmd/Ctrl+L' },
+    risk: { kind: 'browser', reason: 'Reserved by browser location bar', alternative: { accel: true, shift: true, key: 'm', display: 'Cmd/Ctrl+Shift+M' } }
+  },
+  {
+    id: 'pane.mruNext',
+    group: 'Pane focus/navigation',
+    label: 'Switch panes by most-recent focus order',
+    binding: { ctrlOnly: true, key: 'Tab', display: 'Ctrl+Tab' },
+    risk: { kind: 'browser', reason: 'Reserved by browser tab switching', alternative: { accel: true, alt: true, key: ']', display: 'Cmd/Ctrl+Alt+]' } }
+  },
+  {
+    id: 'pane.mruPrev',
+    group: 'Pane focus/navigation',
+    label: 'Reverse most-recent pane traversal',
+    binding: { ctrlOnly: true, shift: true, key: 'Tab', display: 'Ctrl+Shift+Tab' },
+    risk: { kind: 'browser', reason: 'Reserved by browser tab switching', alternative: { accel: true, alt: true, key: '[', display: 'Cmd/Ctrl+Alt+[' } }
+  },
+  { id: 'pane.unreadNext', group: 'Pane focus/navigation', label: 'Next unread pane', binding: { accel: true, shift: true, key: ']', display: 'Cmd/Ctrl+Shift+]' } },
+  { id: 'pane.unreadPrev', group: 'Pane focus/navigation', label: 'Previous unread pane', binding: { accel: true, shift: true, key: '[', display: 'Cmd/Ctrl+Shift+[' } },
+  { id: 'command.palette', group: 'Pane actions', label: 'Open command palette', binding: { accel: true, key: 'k', display: 'Cmd/Ctrl+K' } },
+  { id: 'pane.addMenu', group: 'Pane actions', label: 'Add pane', binding: { accel: true, shift: true, key: 'n', display: 'Cmd/Ctrl+Shift+N' } },
+  { id: 'pane.addChat', group: 'Pane actions', label: 'Add Chat pane (workspace only)', binding: { accel: true, shift: true, key: 'c', display: 'Cmd/Ctrl+Shift+C' } },
+  { id: 'pane.addWorkqueue', group: 'Pane actions', label: 'Add Workqueue pane (workspace only)', binding: { accel: true, shift: true, key: 'w', display: 'Cmd/Ctrl+Shift+W' } },
+  { id: 'pane.addCron', group: 'Pane actions', label: 'Add Cron pane (workspace only)', binding: { accel: true, shift: true, key: 'r', display: 'Cmd/Ctrl+Shift+R' } },
+  { id: 'pane.addTimeline', group: 'Pane actions', label: 'Add Timeline pane (workspace only)', binding: { accel: true, shift: true, key: 't', display: 'Cmd/Ctrl+Shift+T' } },
+  { id: 'fleet.open', group: 'Pane actions', label: 'Open/focus Fleet pane', binding: { accel: true, shift: true, key: 'f', display: 'Cmd/Ctrl+Shift+F' } },
+  {
+    id: 'agents.refresh',
+    group: 'Pane actions',
+    label: 'Refresh agent list',
+    binding: { accel: true, key: 'r', display: 'Cmd/Ctrl+R' },
+    risk: { kind: 'browser', reason: 'Reserved by browser reload', alternative: { accel: true, shift: true, key: 'y', display: 'Cmd/Ctrl+Shift+Y' } }
+  },
+  { id: 'workqueue.open', group: 'Workqueue actions', label: 'Open Workqueue modal', binding: { chord: ['g', 'w'], display: 'g w' } },
+  { id: 'workqueue.move', group: 'Workqueue actions', label: 'Move selected row in Workqueue keyboard mode', binding: { key: 'j/k', display: 'j/k' } },
+  { id: 'workqueue.inspect', group: 'Workqueue actions', label: 'Inspect selected Workqueue row in keyboard mode', binding: { key: 'Enter', display: 'Enter' } },
+  { id: 'workqueue.edit', group: 'Workqueue actions', label: 'Edit selected Workqueue row in keyboard mode', binding: { key: 'e', display: 'e' } },
+  { id: 'workqueue.status', group: 'Workqueue actions', label: 'Set ready, in progress, blocked, or done in keyboard mode', binding: { key: '1..4', display: '1..4' } }
+];
+
+function readKeybindOverrides() {
+  try {
+    const parsed = JSON.parse(storage.get(KEYBIND_OVERRIDES_KEY, '{}'));
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeKeybindOverrides(overrides) {
+  storage.set(KEYBIND_OVERRIDES_KEY, JSON.stringify(overrides && typeof overrides === 'object' ? overrides : {}));
+}
+
+function keybindEntry(id) {
+  return KEYBIND_CATALOG.find((entry) => entry.id === id) || null;
+}
+
+function keybindFor(id) {
+  const entry = keybindEntry(id);
+  if (!entry) return null;
+  const override = readKeybindOverrides()[id];
+  return override && typeof override === 'object' ? override : entry.binding;
+}
+
+function isKeybindCustomized(id) {
+  return Object.prototype.hasOwnProperty.call(readKeybindOverrides(), id);
+}
+
+function setKeybindOverride(id, binding) {
+  const entry = keybindEntry(id);
+  if (!entry || !binding) return false;
+  const overrides = readKeybindOverrides();
+  overrides[id] = binding;
+  writeKeybindOverrides(overrides);
+  renderKeyboardSettings();
+  renderShortcutsContent();
+  return true;
+}
+
+function resetKeybindOverride(id) {
+  const overrides = readKeybindOverrides();
+  if (!Object.prototype.hasOwnProperty.call(overrides, id)) return false;
+  delete overrides[id];
+  writeKeybindOverrides(overrides);
+  renderKeyboardSettings();
+  renderShortcutsContent();
+  return true;
+}
+
+function shortcutDisplay(id) {
+  const binding = keybindFor(id);
+  return String(binding?.display || keybindEntry(id)?.binding?.display || '');
+}
+
+function renderShortcutKeys(display) {
+  const parts = String(display || '')
+    .split(/(\+|\/|\s+)/)
+    .filter((part) => part !== '');
+  return parts
+    .map((part) => {
+      if (part === '+') return '<span class="shortcut-sep">+</span>';
+      if (part === '/') return '<span class="shortcut-sep">/</span>';
+      if (/^\s+$/.test(part)) return '<span class="shortcut-sep"> </span>';
+      return `<kbd>${escapeHtml(part)}</kbd>`;
+    })
+    .join('');
+}
+
+function renderShortcutsContent() {
+  const root = globalElements.shortcutsContent;
+  if (!root) return;
+  const groups = [];
+  for (const entry of KEYBIND_CATALOG) {
+    let group = groups.find((g) => g.name === entry.group);
+    if (!group) {
+      group = { name: entry.group, entries: [] };
+      groups.push(group);
+    }
+    group.entries.push(entry);
+  }
+  const hint = `
+    <div class="hint" style="margin-bottom: 10px;">
+      Most shortcuts are disabled while typing in inputs, textareas, selects, or contenteditable fields. Global keys like <kbd>Esc</kbd>, <kbd>${escapeHtml(shortcutDisplay('pane.manager'))}</kbd>, and <kbd>${escapeHtml(shortcutDisplay('command.palette'))}</kbd> still work.
+    </div>
+  `;
+  const html = groups.map((group) => `
+    <div class="shortcut-group">
+      <h3 class="shortcut-group-title">${escapeHtml(group.name)}</h3>
+      ${group.entries.map((entry) => `
+        <div class="shortcut-row" data-shortcut-id="${escapeHtml(entry.id)}">
+          <div class="shortcut-keys">${renderShortcutKeys(shortcutDisplay(entry.id))}</div>
+          <div class="shortcut-desc">${escapeHtml(entry.label)}${isKeybindCustomized(entry.id) ? ' <span class="shortcut-custom">custom</span>' : ''}</div>
+        </div>
+      `).join('')}
+    </div>
+  `).join('');
+  root.innerHTML = hint + html;
+}
+
+function renderKeyboardSettings() {
+  const root = globalElements.keybindConflictList;
+  if (!root) return;
+  const conflicted = KEYBIND_CATALOG.filter((entry) => entry.risk && !isKeybindCustomized(entry.id));
+  const customized = KEYBIND_CATALOG.filter((entry) => entry.risk && isKeybindCustomized(entry.id));
+  const rows = [...conflicted, ...customized].map((entry) => {
+    const isCustom = isKeybindCustomized(entry.id);
+    const reason = isCustom ? 'Using app-safe replacement' : entry.risk.reason;
+    const action = isCustom
+      ? `<button type="button" class="secondary keybind-action" data-keybind-reset="${escapeHtml(entry.id)}">Reset</button>`
+      : `<button type="button" class="secondary keybind-action" data-keybind-apply="${escapeHtml(entry.id)}">Use ${escapeHtml(entry.risk.alternative.display)}</button>`;
+    return `
+      <div class="keybind-conflict-row ${isCustom ? 'resolved' : 'warning'}" data-keybind-row="${escapeHtml(entry.id)}">
+        <div class="keybind-conflict-main">
+          <div class="keybind-conflict-title">${escapeHtml(entry.label)}</div>
+          <div class="keybind-conflict-meta">
+            <span class="keybind-chip">${escapeHtml(shortcutDisplay(entry.id))}</span>
+            <span>${escapeHtml(reason)}</span>
+          </div>
+        </div>
+        ${action}
+      </div>
+    `;
+  }).join('');
+  root.innerHTML = rows || '<div class="hint">No risky keyboard shortcuts detected.</div>';
+  root.querySelectorAll('[data-keybind-apply]').forEach((button) => {
+    button.addEventListener('click', () => {
+      const entry = keybindEntry(button.getAttribute('data-keybind-apply'));
+      if (!entry?.risk?.alternative) return;
+      setKeybindOverride(entry.id, entry.risk.alternative);
+      toast(`Updated ${entry.label} shortcut.`, 'ok');
+    });
+  });
+  root.querySelectorAll('[data-keybind-reset]').forEach((button) => {
+    button.addEventListener('click', () => {
+      const id = button.getAttribute('data-keybind-reset');
+      const entry = keybindEntry(id);
+      resetKeybindOverride(id);
+      toast(`Reset ${entry?.label || 'shortcut'}.`, 'info');
+    });
+  });
+}
+
+function matchesKeybind(event, id) {
+  const binding = keybindFor(id);
+  if (!binding || binding.chord) return false;
+  const key = String(event?.key || '');
+  const lower = key.toLowerCase();
+  if (binding.accel && !(event.metaKey || event.ctrlKey)) return false;
+  if (binding.ctrlOnly && !(event.ctrlKey && !event.metaKey)) return false;
+  if (!binding.accel && !binding.ctrlOnly && (event.metaKey || event.ctrlKey)) return false;
+  if (!!binding.shift !== !!event.shiftKey) return false;
+  if (!!binding.alt !== !!event.altKey) return false;
+  const wanted = String(binding.key || '');
+  if (wanted === 'Tab') return key === 'Tab';
+  if (wanted === '1..9') {
+    const n = Number.parseInt(key, 10);
+    return Number.isFinite(n) && n >= 1 && n <= 9;
+  }
+  return lower === wanted.toLowerCase() || key === wanted;
+}
 const WQ_RECENT_ENQUEUE_AGENTS_KEY = 'clawnsole.wq.recentEnqueueAgents';
 const WQ_RECENT_TARGETS_MAX = 6;
 
@@ -1550,6 +1776,7 @@ function openSettings() {
   if (globalElements.paneSwitchHudEnabled) {
     globalElements.paneSwitchHudEnabled.checked = isPaneSwitchHudEnabled();
   }
+  renderKeyboardSettings();
   globalElements.settingsModal.classList.add('open');
   globalElements.settingsModal.setAttribute('aria-hidden', 'false');
 
@@ -1868,6 +2095,7 @@ function getModalFocusableElements(modalEl) {
 function openShortcuts() {
   const modal = globalElements.shortcutsModal;
   if (!modal || modal.classList.contains('open')) return;
+  renderShortcutsContent();
   shortcutsLastFocusedEl = document.activeElement instanceof HTMLElement ? document.activeElement : null;
   modal.classList.add('open');
   modal.setAttribute('aria-hidden', 'false');
@@ -9939,6 +10167,7 @@ function isTypingShortcutExempt(event) {
 
 function isNonTrivialGlobalShortcut(event) {
   if (!event) return false;
+  if (KEYBIND_CATALOG.some((entry) => matchesKeybind(event, entry.id))) return true;
   const key = String(event.key || '');
   const lower = key.toLowerCase();
   const hasMetaCtrl = !!(event.metaKey || event.ctrlKey);
@@ -10248,9 +10477,14 @@ window.addEventListener('keydown', (event) => {
   // Ctrl/Cmd+Shift+T → focus matching timeline target (Alt/Option adds anyway)
   const isAccel = (event.metaKey || event.ctrlKey) && event.shiftKey;
   if (isAccel && roleState.role === 'admin' && !isTypingContext(event.target) && !isAnyOverlayOpen()) {
-    const key = String(event.key || '').toLowerCase();
-    const map = { c: 'chat', w: 'workqueue', r: 'cron', t: 'timeline' };
-    const kind = map[key];
+    const addPaneShortcuts = [
+      ['pane.addChat', 'chat'],
+      ['pane.addWorkqueue', 'workqueue'],
+      ['pane.addCron', 'cron'],
+      ['pane.addTimeline', 'timeline']
+    ];
+    const match = addPaneShortcuts.find(([id]) => matchesKeybind(event, id));
+    const kind = match?.[1] || '';
     if (kind) {
       // Don't hijack add-pane shortcuts while typing or while overlays are active.
       event.preventDefault();
@@ -10261,21 +10495,21 @@ window.addEventListener('keydown', (event) => {
   }
 
   // Cmd/Ctrl+P opens Pane Manager (even while typing).
-  if ((event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey && String(event.key || '').toLowerCase() === 'p') {
+  if (matchesKeybind(event, 'pane.manager')) {
     event.preventDefault();
     openPaneManager();
     return;
   }
 
   // Cmd/Ctrl+K opens command palette (even while typing).
-  if ((event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey && String(event.key || '').toLowerCase() === 'k') {
+  if (matchesKeybind(event, 'command.palette')) {
     event.preventDefault();
     openCommandPalette();
     return;
   }
 
   // Cmd/Ctrl+L focuses the active/most recent Chat composer (even while typing).
-  if ((event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey && String(event.key || '').toLowerCase() === 'l') {
+  if (matchesKeybind(event, 'chat.composer')) {
     event.preventDefault();
     focusChatComposer();
     return;
@@ -10303,10 +10537,10 @@ window.addEventListener('keydown', (event) => {
   const key = String(event.key || '');
 
   // Ctrl+Tab walks panes in most-recently-used order; Shift reverses the traversal.
-  if (event.ctrlKey && !event.metaKey && !event.altKey && key === 'Tab') {
+  if (matchesKeybind(event, 'pane.mruNext') || matchesKeybind(event, 'pane.mruPrev')) {
     if (isTypingContext(document.activeElement) && !paneMruTraversal) return;
     event.preventDefault();
-    switchPaneByMru(event.shiftKey ? -1 : 1);
+    switchPaneByMru(matchesKeybind(event, 'pane.mruPrev') ? -1 : 1);
     return;
   }
 
@@ -10328,7 +10562,7 @@ window.addEventListener('keydown', (event) => {
   }
 
   // Cmd/Ctrl+1..9 focuses panes by visible order (layout-safe fallback to Alt/Option).
-  if ((event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey) {
+  if (matchesKeybind(event, 'pane.focusVisibleAccel')) {
     const n = Number.parseInt(key, 10);
     if (Number.isFinite(n) && n >= 1 && n <= 9) {
       event.preventDefault();
@@ -10338,52 +10572,52 @@ window.addEventListener('keydown', (event) => {
   }
 
   // Cmd/Ctrl+Shift+K cycles focus across panes.
-  if ((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey && key.toLowerCase() === 'k') {
+  if (matchesKeybind(event, 'pane.next')) {
     event.preventDefault();
     cyclePaneFocus();
     return;
   }
 
   // Cmd/Ctrl+Shift+J cycles focus backward across panes.
-  if ((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey && key.toLowerCase() === 'j') {
+  if (matchesKeybind(event, 'pane.prev')) {
     event.preventDefault();
     cyclePaneFocusBackward();
     return;
   }
 
   // Cmd/Ctrl+Alt+K/J cycles only Chat panes, skipping Workqueue/Cron/Timeline/Fleet panes.
-  if ((event.metaKey || event.ctrlKey) && event.altKey && !event.shiftKey && key.toLowerCase() === 'k') {
+  if (matchesKeybind(event, 'chat.next')) {
     event.preventDefault();
     cycleChatPaneFocus(1);
     return;
   }
-  if ((event.metaKey || event.ctrlKey) && event.altKey && !event.shiftKey && key.toLowerCase() === 'j') {
+  if (matchesKeybind(event, 'chat.prev')) {
     event.preventDefault();
     cycleChatPaneFocus(-1);
     return;
   }
 
   // Cmd/Ctrl+Shift+] jumps to next unread pane; Cmd/Ctrl+Shift+[ goes backward.
-  if ((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey && (key === ']' || key === '}')) {
+  if (matchesKeybind(event, 'pane.unreadNext')) {
     event.preventDefault();
     cycleUnreadPaneFocus(1);
     return;
   }
-  if ((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey && (key === '[' || key === '{')) {
+  if (matchesKeybind(event, 'pane.unreadPrev')) {
     event.preventDefault();
     cycleUnreadPaneFocus(-1);
     return;
   }
 
   // Cmd/Ctrl+Shift+N opens Add pane menu.
-  if ((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey && key.toLowerCase() === 'n' && !isAnyOverlayOpen()) {
+  if (matchesKeybind(event, 'pane.addMenu') && !isAnyOverlayOpen()) {
     event.preventDefault();
     paneManager.openAddPaneMenu(globalElements.addPaneBtn);
     return;
   }
 
   // Cmd/Ctrl+Shift+F opens/focuses Fleet pane.
-  if ((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey && key.toLowerCase() === 'f') {
+  if (matchesKeybind(event, 'fleet.open')) {
     event.preventDefault();
     openFleetPane();
     return;
@@ -10401,7 +10635,7 @@ window.addEventListener('keydown', (event) => {
   }
 
   // Cmd/Ctrl+R refreshes agent list (instead of page reload).
-  if ((event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey && key.toLowerCase() === 'r') {
+  if (matchesKeybind(event, 'agents.refresh')) {
     event.preventDefault();
     globalElements.refreshAgentsBtn?.click?.();
     toast('Refreshed agents.', 'info');

--- a/app.js
+++ b/app.js
@@ -506,6 +506,26 @@ function matchesKeybind(event, id) {
   }
   return lower === wanted.toLowerCase() || key === wanted;
 }
+
+function matchesKeybindWithOptionalAlt(event, id) {
+  if (matchesKeybind(event, id)) return true;
+  if (!event?.altKey) return false;
+  return matchesKeybind({
+    key: event.key,
+    metaKey: event.metaKey,
+    ctrlKey: event.ctrlKey,
+    shiftKey: event.shiftKey,
+    altKey: false
+  }, id);
+}
+
+function isGlobalKeybindEntry(entry) {
+  const binding = entry?.binding;
+  if (!binding || binding.chord) return false;
+  if (binding.accel || binding.ctrlOnly || binding.alt || binding.shift) return true;
+  const key = String(binding.key || '');
+  return key === 'Escape' || key === '?';
+}
 const WQ_RECENT_ENQUEUE_AGENTS_KEY = 'clawnsole.wq.recentEnqueueAgents';
 const WQ_RECENT_TARGETS_MAX = 6;
 
@@ -10167,7 +10187,7 @@ function isTypingShortcutExempt(event) {
 
 function isNonTrivialGlobalShortcut(event) {
   if (!event) return false;
-  if (KEYBIND_CATALOG.some((entry) => matchesKeybind(event, entry.id))) return true;
+  if (KEYBIND_CATALOG.some((entry) => isGlobalKeybindEntry(entry) && matchesKeybind(event, entry.id))) return true;
   const key = String(event.key || '');
   const lower = key.toLowerCase();
   const hasMetaCtrl = !!(event.metaKey || event.ctrlKey);
@@ -10483,7 +10503,7 @@ window.addEventListener('keydown', (event) => {
       ['pane.addCron', 'cron'],
       ['pane.addTimeline', 'timeline']
     ];
-    const match = addPaneShortcuts.find(([id]) => matchesKeybind(event, id));
+    const match = addPaneShortcuts.find(([id]) => matchesKeybindWithOptionalAlt(event, id));
     const kind = match?.[1] || '';
     if (kind) {
       // Don't hijack add-pane shortcuts while typing or while overlays are active.

--- a/index.html
+++ b/index.html
@@ -243,53 +243,7 @@
             ✕
           </button>
         </div>
-        <div class="modal-body">
-          <div class="hint" style="margin-bottom: 10px;">
-            Most shortcuts are disabled while typing in inputs, textareas, selects, or contenteditable fields. Global keys like <kbd>Esc</kbd>, <kbd>Cmd/Ctrl+P</kbd>, and <kbd>Cmd/Ctrl+K</kbd> still work.
-          </div>
-
-          <div class="shortcut-group">
-            <h3 class="shortcut-group-title">Global</h3>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>?</kbd></div><div class="shortcut-desc">Open this help overlay</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Esc</kbd></div><div class="shortcut-desc">Close overlay / menus</div></div>
-          </div>
-
-          <div class="shortcut-group">
-            <h3 class="shortcut-group-title">Pane focus/navigation</h3>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Alt</kbd>/<kbd>Option</kbd>+<kbd>1</kbd>..<kbd>9</kbd></div><div class="shortcut-desc">Focus panes 1-9 by visible order</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>1</kbd>..<kbd>4</kbd></div><div class="shortcut-desc">Focus pane 1-4</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>g</kbd> <kbd>a</kbd>..<kbd>z</kbd></div><div class="shortcut-desc">Focus pane by visible letter</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>P</kbd></div><div class="shortcut-desc">Open Pane Manager</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Focus next pane</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd></div><div class="shortcut-desc">Focus previous pane</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Focus next Chat pane only</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>J</kbd></div><div class="shortcut-desc">Focus previous Chat pane only</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>g</kbd> <kbd>c</kbd></div><div class="shortcut-desc">Return to last active Chat pane</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>L</kbd></div><div class="shortcut-desc">Focus Chat composer</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Ctrl</kbd>+<kbd>Tab</kbd></div><div class="shortcut-desc">Switch panes by most-recent focus order</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Tab</kbd></div><div class="shortcut-desc">Reverse most-recent pane traversal</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>]</kbd></div><div class="shortcut-desc">Next unread pane</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>[</kbd></div><div class="shortcut-desc">Previous unread pane</div></div>
-          </div>
-
-          <div class="shortcut-group">
-            <h3 class="shortcut-group-title">Pane actions</h3>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Open command palette</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd></div><div class="shortcut-desc">Add pane</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>C/W/R/T</kbd></div><div class="shortcut-desc">Add Chat/Workqueue/Cron/Timeline pane (workspace only)</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd></div><div class="shortcut-desc">Open/focus Fleet pane</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>R</kbd></div><div class="shortcut-desc">Refresh agent list</div></div>
-          </div>
-
-          <div class="shortcut-group">
-            <h3 class="shortcut-group-title">Workqueue actions</h3>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>g</kbd> <kbd>w</kbd></div><div class="shortcut-desc">Open Workqueue modal</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>j</kbd>/<kbd>k</kbd></div><div class="shortcut-desc">Move selected row in Workqueue keyboard mode</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Enter</kbd></div><div class="shortcut-desc">Inspect selected Workqueue row in keyboard mode</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>e</kbd></div><div class="shortcut-desc">Edit selected Workqueue row in keyboard mode</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>1</kbd>..<kbd>4</kbd></div><div class="shortcut-desc">Set ready, in progress, blocked, or done in keyboard mode</div></div>
-          </div>
-        </div>
+        <div id="shortcutsContent" class="modal-body"></div>
       </div>
     </div>
 
@@ -534,6 +488,11 @@
             </label>
           </section>
 
+          <section class="settings-section" aria-label="Keyboard">
+            <h3>Keyboard</h3>
+            <div id="keybindConflictList" class="keybind-conflict-list" data-testid="keybind-conflict-list"></div>
+          </section>
+
           <section class="settings-section" aria-label="Recurring admin prompts">
             <h3>Recurring admin/system prompts</h3>
             <p class="hint">These run as admin/system prompts via <code>/api/recurring-prompts</code>.</p>
@@ -610,13 +569,6 @@
             </div>
           </section>
 
-          <div class="hint" style="margin-top: 12px;">
-            <div style="font-weight: 600; margin-bottom: 6px;">Keyboard shortcuts (admin)</div>
-            <div>New Chat pane: <code>Ctrl/Cmd</code> + <code>Shift</code> + <code>C</code></div>
-            <div>New Workqueue pane: <code>Ctrl/Cmd</code> + <code>Shift</code> + <code>W</code></div>
-            <div>New Cron pane: <code>Ctrl/Cmd</code> + <code>Shift</code> + <code>R</code></div>
-            <div>New Timeline pane: <code>Ctrl/Cmd</code> + <code>Shift</code> + <code>T</code></div>
-          </div>
         </div>
       </div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -2059,6 +2059,22 @@ button.agents-section-title:hover {
   opacity: 0.9;
 }
 
+.shortcut-sep {
+  align-self: center;
+  opacity: 0.7;
+}
+
+.shortcut-custom {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  border: 1px solid rgba(125, 211, 252, 0.28);
+  color: #bae6fd;
+  font-size: 0.72rem;
+  vertical-align: middle;
+}
+
 kbd {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
   font-size: 0.85rem;
@@ -4088,6 +4104,59 @@ kbd {
 .settings-section h3 {
   margin: 0 0 6px;
   font-size: 0.95rem;
+}
+
+.keybind-conflict-list {
+  display: grid;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.keybind-conflict-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  padding: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.keybind-conflict-row.warning {
+  border-color: rgba(245, 158, 11, 0.38);
+  background: rgba(245, 158, 11, 0.08);
+}
+
+.keybind-conflict-row.resolved {
+  border-color: rgba(34, 197, 94, 0.28);
+  background: rgba(34, 197, 94, 0.06);
+}
+
+.keybind-conflict-title {
+  font-weight: 650;
+}
+
+.keybind-conflict-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  margin-top: 4px;
+  color: rgba(229, 231, 235, 0.78);
+  font-size: 0.82rem;
+}
+
+.keybind-chip {
+  padding: 2px 7px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 999px;
+  color: #e5e7eb;
+  background: rgba(0, 0, 0, 0.22);
+}
+
+.keybind-action {
+  white-space: nowrap;
 }
 
 .settings-rp-form {

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -141,6 +141,32 @@ test('shortcuts modal restores prior focus on close', async ({ page }) => {
   await expect(openBtn).toBeFocused();
 });
 
+test('keyboard settings flags risky shortcuts and updates cheatsheet after applying replacement', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  await page.getByRole('button', { name: 'Open settings' }).click();
+  const conflictList = page.getByTestId('keybind-conflict-list');
+  await expect(conflictList).toContainText('Focus Chat composer');
+  await expect(conflictList).toContainText('Reserved by browser location bar');
+  await conflictList.getByRole('button', { name: 'Use Cmd/Ctrl+Shift+M' }).click();
+  await expect(conflictList).toContainText('Using app-safe replacement');
+
+  await page.keyboard.press('Escape');
+  await page.click('#connectionStatus');
+  await page.keyboard.press('Shift+/');
+  const modal = page.locator('#shortcutsModal');
+  await expect(modal).toHaveAttribute('aria-hidden', 'false');
+  await expect(modal.locator('[data-shortcut-id="chat.composer"]')).toContainText('Cmd/Ctrl+Shift+M');
+});
+
 test('cmd/ctrl+shift+j focuses previous pane with wraparound from unfocused state', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!app?.skipReason, app?.skipReason);


### PR DESCRIPTION
Fixes #349.\n\nSummary:\n- Add a shortcut catalog shared by Settings and the shortcuts help overlay.\n- Flag browser-reserved and layout-sensitive bindings in Settings > Keyboard with recommended app-safe alternatives.\n- Persist one-click replacements and wire the global shortcut handler to honor updated bindings.\n\nValidation:\n- npm run test:syntax\n- npx playwright test tests/pane.shortcuts.e2e.spec.js --workers=1\n\nNo production deploy.