### PR TITLE
Add sticky fleet header and identity columns

### DIFF
--- a/app.js
+++ b/app.js
@@ -3633,6 +3633,19 @@ function renderAgentsModalList() {
     }
     section.appendChild(header);
 
+    const columnHeader = document.createElement('div');
+    columnHeader.className = 'agents-table-header';
+    columnHeader.setAttribute('role', 'presentation');
+    columnHeader.innerHTML = `
+      <div class="agents-table-header-pin" aria-hidden="true"></div>
+      <div class="agents-table-header-identity" data-fleet-column-header="identity">
+        <span>Agent</span>
+        ${visibleColumns.health ? '<span>Health</span>' : ''}
+      </div>
+      ${visibleColumns.actions ? '<div class="agents-table-header-actions">Actions</div>' : ''}
+    `;
+    section.appendChild(columnHeader);
+
     const list = document.createElement('div');
     list.className = 'agents-rows';
     if (collapsible && collapsed) list.hidden = true;

--- a/styles.css
+++ b/styles.css
@@ -1616,7 +1616,7 @@ button.send-btn .btn-icon {
   position: absolute;
   right: 0;
   top: calc(100% + 6px);
-  z-index: 8;
+  z-index: 30;
   display: grid;
   grid-template-columns: repeat(2, minmax(130px, 1fr));
   gap: 6px;
@@ -1667,6 +1667,8 @@ button.send-btn .btn-icon {
   display: flex;
   flex-direction: column;
   gap: 12px;
+  overflow: auto;
+  scrollbar-gutter: stable both-edges;
 }
 
 .agents-list.compact {
@@ -1766,6 +1768,56 @@ button.agents-section-title:hover {
   color: var(--text);
 }
 
+.agents-section {
+  min-width: 780px;
+}
+
+.agents-table-header {
+  position: sticky;
+  top: 0;
+  z-index: 9;
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  min-width: 780px;
+  min-height: 28px;
+  margin-bottom: 6px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(13, 17, 23, 0.98);
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.agents-table-header-pin,
+.agents-table-header-identity {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  z-index: 10;
+  background: rgba(13, 17, 23, 0.98);
+}
+
+.agents-table-header-pin {
+  left: 0;
+  width: 42px;
+}
+
+.agents-table-header-identity {
+  left: 52px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 250px;
+}
+
+.agents-table-header-actions {
+  justify-self: end;
+  padding-right: 8px;
+}
+
 .agents-rows {
   display: flex;
   flex-direction: column;
@@ -1785,6 +1837,7 @@ button.agents-section-title:hover {
   grid-template-columns: 42px 1fr auto;
   gap: 10px;
   align-items: center;
+  min-width: 780px;
   border: 1px solid rgba(255, 255, 255, 0.09);
   border-radius: 14px;
   padding: 10px 12px;
@@ -1841,6 +1894,9 @@ button.agents-section-title:hover {
 }
 
 .agents-pin {
+  position: sticky;
+  left: 0;
+  z-index: 5;
   width: 36px;
   height: 36px;
   border-radius: 12px;
@@ -1861,6 +1917,28 @@ button.agents-section-title:hover {
 .agents-pin[aria-pressed="true"] {
   border-color: rgba(255, 179, 71, 0.55);
   background: rgba(255, 179, 71, 0.12);
+}
+
+.agents-row-main {
+  position: sticky;
+  left: 52px;
+  z-index: 4;
+  min-width: 250px;
+  padding: 2px 8px;
+  border-radius: 8px;
+  background: rgba(13, 17, 23, 0.96);
+}
+
+.agents-list.compact .agents-row-main {
+  left: 40px;
+}
+
+.agents-list.compact .agents-table-header-identity {
+  left: 40px;
+}
+
+.agents-list.compact .agents-table-header {
+  grid-template-columns: 32px minmax(0, 1fr) auto;
 }
 
 .agents-row-title {
@@ -1999,7 +2077,7 @@ button.agents-section-title:hover {
   position: absolute;
   right: 0;
   top: calc(100% + 6px);
-  z-index: 6;
+  z-index: 24;
   display: flex;
   flex-direction: column;
   gap: 6px;

--- a/styles.css
+++ b/styles.css
@@ -1937,6 +1937,10 @@ button.agents-section-title:hover {
   left: 40px;
 }
 
+.agents-list.compact .agents-table-header-pin {
+  width: 32px;
+}
+
 .agents-list.compact .agents-table-header {
   grid-template-columns: 32px minmax(0, 1fr) auto;
 }

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -315,6 +315,90 @@ test('fleet refresh keeps scroll anchor and keyboard triage selection', async ({
   )).toContain('agent-20');
 });
 
+test('fleet list keeps header and identity columns sticky while scanning', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  const agents = Array.from({ length: 40 }, (_, index) => {
+    const id = `scan-agent-${String(index + 1).padStart(2, '0')}`;
+    return { id, name: id, displayName: id, model: `model-${index + 1}`, host: `host-${index + 1}` };
+  });
+  await page.route(/\/agents(?:\?|$)/, async (route) => {
+    await route.fulfill({ json: { agents } });
+  });
+
+  await clawnsole.gotoAndLoginAdmin(page);
+  await page.evaluate(() => {
+    const now = Date.now();
+    const lastSeen = {};
+    for (let index = 1; index <= 40; index += 1) {
+      lastSeen[`scan-agent-${String(index).padStart(2, '0')}`] = now;
+    }
+    localStorage.setItem('clawnsole.admin.agentLastSeenAtMs', JSON.stringify(lastSeen));
+    localStorage.setItem('clawnsole.admin.agents.healthyCollapsed', '0');
+    localStorage.removeItem('clawnsole.admin.agents.columns');
+  });
+  await page.getByRole('button', { name: 'Refresh agent list' }).click();
+
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await page.locator('#agentsColumnPicker summary').click();
+  await page.locator('#agentsColumn_model').check();
+  await page.locator('#agentsColumn_host').check();
+  await page.locator('#agentsColumnPicker').evaluate((el) => { el.open = false; });
+
+  await page.locator('#agentsList').evaluate((el) => {
+    el.style.maxHeight = '260px';
+    el.style.maxWidth = '520px';
+    el.scrollTop = 260;
+    el.scrollLeft = 260;
+  });
+
+  const header = page.locator('#agentsList .agents-table-header').last();
+  const identityHeader = header.locator('[data-fleet-column-header="identity"]');
+  const row20 = page.locator('#agentsList .agents-row[data-agent-id="scan-agent-20"]');
+  await row20.scrollIntoViewIfNeeded();
+
+  await expect(header).toBeVisible();
+  await expect(identityHeader).toBeVisible();
+  await expect(row20.locator('.agents-row-title')).toHaveText('scan-agent-20');
+  await expect(row20.locator('.agents-health-state-chip')).toHaveText('Healthy');
+
+  const metrics = await page.locator('#agentsList').evaluate((list) => {
+    const headers = Array.from(list.querySelectorAll('.agents-table-header'));
+    const headerEl = headers[headers.length - 1] || null;
+    const identityEl = headerEl?.querySelector('[data-fleet-column-header="identity"]') || null;
+    const rowMain = list.querySelector('.agents-row[data-agent-id="scan-agent-20"] .agents-row-main');
+    const style = (el) => el ? getComputedStyle(el) : null;
+    const bounds = (el) => el ? el.getBoundingClientRect() : null;
+    const listBounds = list.getBoundingClientRect();
+    const beforeIdentityLeft = bounds(identityEl)?.left || 0;
+    const beforeRowMainLeft = bounds(rowMain)?.left || 0;
+    list.scrollLeft += 120;
+    const afterIdentityLeft = bounds(identityEl)?.left || 0;
+    const afterRowMainLeft = bounds(rowMain)?.left || 0;
+    return {
+      scrollTop: list.scrollTop,
+      scrollLeft: list.scrollLeft,
+      headerPosition: style(headerEl)?.position,
+      identityPosition: style(identityEl)?.position,
+      rowMainPosition: style(rowMain)?.position,
+      headerTopDelta: Math.abs((bounds(headerEl)?.top || 0) - list.getBoundingClientRect().top),
+      rowMainVisible: (bounds(rowMain)?.left || 0) >= listBounds.left && (bounds(rowMain)?.right || 0) <= listBounds.right,
+      identityHorizontalDrift: Math.abs(afterIdentityLeft - beforeIdentityLeft),
+      rowMainHorizontalDrift: Math.abs(afterRowMainLeft - beforeRowMainLeft)
+    };
+  });
+
+  expect(metrics.scrollTop).toBeGreaterThan(0);
+  expect(metrics.scrollLeft).toBeGreaterThan(0);
+  expect(metrics.headerPosition).toBe('sticky');
+  expect(metrics.identityPosition).toBe('absolute');
+  expect(metrics.rowMainPosition).toBe('sticky');
+  expect(metrics.headerTopDelta).toBeLessThan(4);
+  expect(metrics.rowMainVisible).toBeTruthy();
+  expect(metrics.identityHorizontalDrift).toBeLessThan(4);
+  expect(metrics.rowMainHorizontalDrift).toBeLessThan(4);
+});
+
 test('fleet attention mode sections healthy agents and keeps filters while expanding', async ({ page, clawnsole }) => {
   if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
 

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -345,58 +345,70 @@ test('fleet list keeps header and identity columns sticky while scanning', async
   await page.locator('#agentsColumn_host').check();
   await page.locator('#agentsColumnPicker').evaluate((el) => { el.open = false; });
 
-  await page.locator('#agentsList').evaluate((el) => {
-    el.style.maxHeight = '260px';
-    el.style.maxWidth = '520px';
-    el.scrollTop = 260;
-    el.scrollLeft = 260;
-  });
+  const assertStickyFleetScan = async (density) => {
+    if (density === 'compact') {
+      await page.getByRole('button', { name: 'Compact' }).click();
+    }
 
-  const header = page.locator('#agentsList .agents-table-header').last();
-  const identityHeader = header.locator('[data-fleet-column-header="identity"]');
-  const row20 = page.locator('#agentsList .agents-row[data-agent-id="scan-agent-20"]');
-  await row20.scrollIntoViewIfNeeded();
+    await page.locator('#agentsList').evaluate((el) => {
+      el.style.maxHeight = '260px';
+      el.style.maxWidth = '520px';
+      el.scrollTop = 260;
+      el.scrollLeft = 260;
+    });
 
-  await expect(header).toBeVisible();
-  await expect(identityHeader).toBeVisible();
-  await expect(row20.locator('.agents-row-title')).toHaveText('scan-agent-20');
-  await expect(row20.locator('.agents-health-state-chip')).toHaveText('Healthy');
+    const header = page.locator('#agentsList .agents-table-header').last();
+    const identityHeader = header.locator('[data-fleet-column-header="identity"]');
+    const row20 = page.locator('#agentsList .agents-row[data-agent-id="scan-agent-20"]');
+    await row20.scrollIntoViewIfNeeded();
 
-  const metrics = await page.locator('#agentsList').evaluate((list) => {
-    const headers = Array.from(list.querySelectorAll('.agents-table-header'));
-    const headerEl = headers[headers.length - 1] || null;
-    const identityEl = headerEl?.querySelector('[data-fleet-column-header="identity"]') || null;
-    const rowMain = list.querySelector('.agents-row[data-agent-id="scan-agent-20"] .agents-row-main');
-    const style = (el) => el ? getComputedStyle(el) : null;
-    const bounds = (el) => el ? el.getBoundingClientRect() : null;
-    const listBounds = list.getBoundingClientRect();
-    const beforeIdentityLeft = bounds(identityEl)?.left || 0;
-    const beforeRowMainLeft = bounds(rowMain)?.left || 0;
-    list.scrollLeft += 120;
-    const afterIdentityLeft = bounds(identityEl)?.left || 0;
-    const afterRowMainLeft = bounds(rowMain)?.left || 0;
-    return {
-      scrollTop: list.scrollTop,
-      scrollLeft: list.scrollLeft,
-      headerPosition: style(headerEl)?.position,
-      identityPosition: style(identityEl)?.position,
-      rowMainPosition: style(rowMain)?.position,
-      headerTopDelta: Math.abs((bounds(headerEl)?.top || 0) - list.getBoundingClientRect().top),
-      rowMainVisible: (bounds(rowMain)?.left || 0) >= listBounds.left && (bounds(rowMain)?.right || 0) <= listBounds.right,
-      identityHorizontalDrift: Math.abs(afterIdentityLeft - beforeIdentityLeft),
-      rowMainHorizontalDrift: Math.abs(afterRowMainLeft - beforeRowMainLeft)
-    };
-  });
+    await expect(header).toBeVisible();
+    await expect(identityHeader).toBeVisible();
+    await expect(row20.locator('.agents-row-title')).toHaveText('scan-agent-20');
+    await expect(row20.locator('.agents-health-state-chip')).toHaveText('Healthy');
 
-  expect(metrics.scrollTop).toBeGreaterThan(0);
-  expect(metrics.scrollLeft).toBeGreaterThan(0);
-  expect(metrics.headerPosition).toBe('sticky');
-  expect(metrics.identityPosition).toBe('absolute');
-  expect(metrics.rowMainPosition).toBe('sticky');
-  expect(metrics.headerTopDelta).toBeLessThan(4);
-  expect(metrics.rowMainVisible).toBeTruthy();
-  expect(metrics.identityHorizontalDrift).toBeLessThan(4);
-  expect(metrics.rowMainHorizontalDrift).toBeLessThan(4);
+    const metrics = await page.locator('#agentsList').evaluate((list) => {
+      const headers = Array.from(list.querySelectorAll('.agents-table-header'));
+      const headerEl = headers[headers.length - 1] || null;
+      const identityEl = headerEl?.querySelector('[data-fleet-column-header="identity"]') || null;
+      const pinEl = headerEl?.querySelector('.agents-table-header-pin') || null;
+      const rowMain = list.querySelector('.agents-row[data-agent-id="scan-agent-20"] .agents-row-main');
+      const style = (el) => el ? getComputedStyle(el) : null;
+      const bounds = (el) => el ? el.getBoundingClientRect() : null;
+      const listBounds = list.getBoundingClientRect();
+      const beforeIdentityLeft = bounds(identityEl)?.left || 0;
+      const beforeRowMainLeft = bounds(rowMain)?.left || 0;
+      list.scrollLeft += 120;
+      const afterIdentityLeft = bounds(identityEl)?.left || 0;
+      const afterRowMainLeft = bounds(rowMain)?.left || 0;
+      return {
+        scrollTop: list.scrollTop,
+        scrollLeft: list.scrollLeft,
+        headerPosition: style(headerEl)?.position,
+        identityPosition: style(identityEl)?.position,
+        pinWidth: Math.round(bounds(pinEl)?.width || 0),
+        rowMainPosition: style(rowMain)?.position,
+        headerTopDelta: Math.abs((bounds(headerEl)?.top || 0) - list.getBoundingClientRect().top),
+        rowMainVisible: (bounds(rowMain)?.left || 0) >= listBounds.left && (bounds(rowMain)?.right || 0) <= listBounds.right,
+        identityHorizontalDrift: Math.abs(afterIdentityLeft - beforeIdentityLeft),
+        rowMainHorizontalDrift: Math.abs(afterRowMainLeft - beforeRowMainLeft)
+      };
+    });
+
+    expect(metrics.scrollTop).toBeGreaterThan(0);
+    expect(metrics.scrollLeft).toBeGreaterThan(0);
+    expect(metrics.headerPosition).toBe('sticky');
+    expect(metrics.identityPosition).toBe('absolute');
+    expect(metrics.pinWidth).toBe(density === 'compact' ? 32 : 42);
+    expect(metrics.rowMainPosition).toBe('sticky');
+    expect(metrics.headerTopDelta).toBeLessThan(4);
+    expect(metrics.rowMainVisible).toBeTruthy();
+    expect(metrics.identityHorizontalDrift).toBeLessThan(4);
+    expect(metrics.rowMainHorizontalDrift).toBeLessThan(4);
+  };
+
+  await assertStickyFleetScan('comfortable');
+  await assertStickyFleetScan('compact');
 });
 
 test('fleet attention mode sections healthy agents and keeps filters while expanding', async ({ page, clawnsole }) => {

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -359,8 +359,12 @@ test('fleet list keeps header and identity columns sticky while scanning', async
 
     const header = page.locator('#agentsList .agents-table-header').last();
     const identityHeader = header.locator('[data-fleet-column-header="identity"]');
+    await expect(page.locator('#agentsList .agents-row[data-agent-id="scan-agent-20"]')).toHaveCount(1);
+    await page.locator('#agentsList').evaluate((list) => {
+      const row = list.querySelector('.agents-row[data-agent-id="scan-agent-20"]');
+      row?.scrollIntoView({ block: 'center', inline: 'nearest' });
+    });
     const row20 = page.locator('#agentsList .agents-row[data-agent-id="scan-agent-20"]');
-    await row20.scrollIntoViewIfNeeded();
 
     await expect(header).toBeVisible();
     await expect(identityHeader).toBeVisible();


### PR DESCRIPTION
Fixes #356.

Summary:
- Add sticky Fleet section headers with Agent/Health/Actions context.
- Make Fleet identity controls stay visible during horizontal scans.
- Align compact sticky header pin width with compact Fleet rows.
- Add Playwright coverage for sticky header/identity behavior in comfortable and compact density.

Verification:
- npm run test:syntax
- npx playwright test tests/ui/agents-modal.spec.js -g "fleet list keeps header and identity columns sticky while scanning" --workers=1

CI:
- GitHub Actions test is running on the latest push.