### PR TITLE
Add sticky fleet selection summary

### DIFF
--- a/app.js
+++ b/app.js
@@ -43,6 +43,7 @@ const globalElements = {
   agentsLastRefreshed: document.getElementById('agentsLastRefreshed'),
   agentsList: document.getElementById('agentsList'),
   agentsEmpty: document.getElementById('agentsEmpty'),
+  agentsSelectionBar: document.getElementById('agentsSelectionBar'),
   toastHost: document.getElementById('toastHost'),
   commandPaletteModal: document.getElementById('commandPaletteModal'),
   commandPaletteCloseBtn: document.getElementById('commandPaletteCloseBtn'),
@@ -3443,6 +3444,85 @@ function openAgentTriageFromFleet(agentId) {
   openAgentWorkqueueFromFleet(target);
 }
 
+function renderFleetSelectionBar({ classify = null, lastSeenMap = null } = {}) {
+  const bar = globalElements.agentsSelectionBar;
+  if (!bar) return;
+
+  const id = String(fleetSelectionState.selectedAgentId || '').trim();
+  const visibleRows = getFleetSelectableRows();
+  const selectedVisible = id && visibleRows.some((row) => String(row.dataset.agentId || '') === id);
+  if (!id || !selectedVisible) {
+    bar.hidden = true;
+    bar.dataset.agentId = '';
+    bar.innerHTML = '';
+    return;
+  }
+
+  const agent = getAgentRecord(id);
+  const label = formatAgentLabel(agent, { includeId: true });
+  const map = lastSeenMap || getAgentLastSeenMap();
+  const heartbeatTs = Number(map[id]) || 0;
+  const heartbeatAge = heartbeatTs > 0 ? formatRelativeAge(Date.now() - heartbeatTs) : 'unknown';
+  const triage = typeof classify === 'function'
+    ? classify(id)
+    : (() => {
+        const withinMinutes = Math.max(1, Number(globalElements.agentsActiveMinutes?.value) || 10);
+        const paneState = getAgentPaneStateMap()[id] || 'unknown';
+        const ageMs = heartbeatTs > 0 ? Math.max(0, Date.now() - heartbeatTs) : Number.POSITIVE_INFINITY;
+        const ageBucket = heartbeatAgeBucket(ageMs, { activeWindowMs: withinMinutes * 60_000, paneState });
+        if (paneState === 'error' || paneState === 'offline' || !Number.isFinite(ageMs)) return { bucket: 'offline_error', ageBucket };
+        return { bucket: ageMs <= withinMinutes * 60_000 ? 'active' : 'stale', ageBucket };
+      })();
+  const healthLabel = triage.bucket === 'offline_error'
+    ? 'Offline/Error'
+    : triage.bucket === 'stale'
+      ? 'Stale'
+      : 'Healthy';
+
+  bar.hidden = false;
+  if (String(bar.dataset.agentId || '') !== id) {
+    bar.dataset.agentId = id;
+    bar.innerHTML = `
+      <div class="agents-selection-main">
+        <div class="agents-selection-title" data-agents-selection-title></div>
+        <div class="agents-selection-meta">
+          <span class="agents-health-state-chip" data-agents-selection-health></span>
+          <span class="agents-age-chip" data-agents-selection-age></span>
+        </div>
+      </div>
+      <div class="agents-selection-actions" role="group" aria-label="Selected agent actions">
+        <button type="button" class="secondary agents-action-btn" data-agent-action="open-chat" data-agent-id="${escapeHtml(id)}">Open Chat</button>
+        <button type="button" class="secondary agents-action-btn" data-agent-action="open-workqueue" data-agent-id="${escapeHtml(id)}">Open Workqueue</button>
+        <button type="button" class="secondary agents-action-btn" data-agent-action="open-timeline" data-agent-id="${escapeHtml(id)}">Open Timeline</button>
+      </div>
+    `;
+
+    bar.querySelectorAll('[data-agent-action]').forEach((btn) => {
+      btn.addEventListener('click', (e) => {
+        e.preventDefault();
+        const action = String(btn.getAttribute('data-agent-action') || '').trim();
+        const target = String(btn.getAttribute('data-agent-id') || '').trim();
+        if (action === 'open-chat') openAgentChatFromFleet(target);
+        else if (action === 'open-timeline') openAgentTimelineFromFleet(target);
+        else if (action === 'open-workqueue') openAgentWorkqueueFromFleet(target);
+      });
+    });
+  }
+
+  const titleEl = bar.querySelector('[data-agents-selection-title]');
+  const healthEl = bar.querySelector('[data-agents-selection-health]');
+  const ageEl = bar.querySelector('[data-agents-selection-age]');
+  if (titleEl) titleEl.textContent = label;
+  if (healthEl) {
+    healthEl.textContent = healthLabel;
+    healthEl.dataset.healthState = triage.bucket;
+  }
+  if (ageEl) {
+    ageEl.textContent = heartbeatAge;
+    ageEl.dataset.heartbeatBucket = triage.ageBucket || '';
+  }
+}
+
 function findActivePaneFromFocus() {
   const active = document.activeElement;
   if (!active) return null;
@@ -3786,6 +3866,7 @@ function renderAgentsModalList() {
   const empty = ordered.length === 0;
   if (globalElements.agentsEmpty) globalElements.agentsEmpty.hidden = !empty;
   restoreFleetScrollAnchor(root, scrollAnchor);
+  renderFleetSelectionBar({ classify, lastSeenMap });
   if (focusedAgentId) {
     try {
       root.querySelector(`.agents-row[data-agent-id="${CSS.escape(focusedAgentId)}"]`)?.focus?.({ preventScroll: true });
@@ -3828,6 +3909,7 @@ function reconcileFleetSelection(visibleAgents) {
     fleetSelectionState.selectedIndex = 0;
     fleetSelectionState.notice = '';
     fleetSelectionState.missingAgentId = '';
+    renderFleetSelectionBar();
     return;
   }
   const previousId = String(fleetSelectionState.selectedAgentId || '').trim();
@@ -3860,6 +3942,7 @@ function selectFleetAgent(agentId, { focusRow = false } = {}) {
   fleetSelectionState.notice = '';
   fleetSelectionState.missingAgentId = '';
   rows.forEach((row, index) => row.setAttribute('aria-selected', index === ix ? 'true' : 'false'));
+  renderFleetSelectionBar();
   if (focusRow) {
     try {
       rows[ix].focus({ preventScroll: true });
@@ -9744,6 +9827,7 @@ globalElements.agentsModal?.addEventListener('click', (event) => {
 });
 globalElements.agentsModal?.addEventListener('keydown', (event) => {
   if (isTypingContext(event.target)) return;
+  if (event.target instanceof Element && event.target.closest('button, a, input, select, textarea, summary')) return;
   const key = String(event.key || '');
   const lower = key.toLowerCase();
   if (!event.metaKey && !event.ctrlKey && !event.altKey) {

--- a/index.html
+++ b/index.html
@@ -493,6 +493,7 @@
 
           <div id="agentsList" class="agents-list" aria-label="Agent list"></div>
           <div id="agentsEmpty" class="hint" hidden>No agents match.</div>
+          <div id="agentsSelectionBar" class="agents-selection-bar" aria-live="polite" hidden></div>
         </div>
       </div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -1964,6 +1964,51 @@ button.agents-section-title:hover {
   gap: 6px;
 }
 
+.agents-selection-bar {
+  position: sticky;
+  bottom: 0;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 10px;
+  padding: 10px 12px;
+  border: 1px solid rgba(77, 196, 255, 0.28);
+  border-radius: 12px;
+  background: rgba(12, 16, 22, 0.96);
+  box-shadow: 0 -10px 24px rgba(0, 0, 0, 0.28);
+}
+
+.agents-selection-bar[hidden] {
+  display: none;
+}
+
+.agents-selection-main {
+  min-width: 0;
+}
+
+.agents-selection-title {
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 700;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agents-selection-meta,
+.agents-selection-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.agents-selection-meta {
+  margin-top: 4px;
+}
+
 .agents-action-btn {
   padding: 5px 9px;
   font-size: 12px;

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -315,6 +315,47 @@ test('fleet refresh keeps scroll anchor and keyboard triage selection', async ({
   )).toContain('agent-20');
 });
 
+test('agents modal keeps selected agent summary sticky with keyboard actions', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  let agents = [
+    { id: 'alpha', name: 'Alpha', displayName: 'Alpha' },
+    { id: 'beta', name: 'Beta', displayName: 'Beta' }
+  ];
+  await page.route(/\/agents(?:\?|$)/, async (route) => {
+    await route.fulfill({ json: { agents } });
+  });
+
+  await clawnsole.gotoAndLoginAdmin(page);
+  await page.evaluate(() => {
+    const now = Date.now();
+    localStorage.setItem('clawnsole.admin.agentLastSeenAtMs', JSON.stringify({ alpha: now, beta: now - 70 * 60 * 1000 }));
+  });
+  await page.getByRole('button', { name: 'Refresh agent list' }).click();
+  await page.getByRole('button', { name: 'Open agents' }).click();
+
+  const beta = page.locator('#agentsList .agents-row[data-agent-id="beta"]');
+  await beta.click();
+
+  const bar = page.locator('#agentsSelectionBar');
+  await expect(bar).toBeVisible();
+  await expect(bar).toContainText('Beta (beta)');
+  await expect(bar).toContainText('Stale');
+  await expect(bar).toContainText('1h ago');
+
+  const openTimeline = bar.getByRole('button', { name: 'Open Timeline' });
+  await openTimeline.focus();
+  await expect(openTimeline).toBeFocused();
+  await page.keyboard.press('Enter');
+  await expect(page.locator('[data-pane][data-pane-kind="timeline"]')).toHaveCount(1);
+
+  agents = [{ id: 'alpha', name: 'Alpha', displayName: 'Alpha' }];
+  await page.locator('#agentsModalRefreshBtn').click();
+  await expect(bar).toBeVisible();
+  await expect(bar).toContainText('Alpha (alpha)');
+  await expect(bar).not.toContainText('Beta (beta)');
+});
+
 test('fleet attention mode sections healthy agents and keeps filters while expanding', async ({ page, clawnsole }) => {
   if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
 


### PR DESCRIPTION
## Summary
- Add a sticky Fleet selected-agent summary footer with health and heartbeat age.
- Wire footer actions for Open Chat, Open Workqueue, and Open Timeline.
- Preserve native keyboard activation for focused controls in the Fleet modal.

## Tests
- npm run test:syntax
- npx playwright test tests/ui/agents-modal.spec.js --grep "selected agent summary|fleet refresh keeps scroll anchor" --workers=1

Fixes #366