### PR TITLE
Show pane shortcut index badges

### DIFF
--- a/app.js
+++ b/app.js
@@ -1858,6 +1858,7 @@ async function deleteRecurringPrompt(id) {
 }
 
 let shortcutsLastFocusedEl = null;
+let paneShortcutBadgesAltHeld = false;
 
 function getModalFocusableElements(modalEl) {
   if (!modalEl || !modalEl.querySelectorAll) return [];
@@ -1867,10 +1868,15 @@ function getModalFocusableElements(modalEl) {
 
 function openShortcuts() {
   const modal = globalElements.shortcutsModal;
-  if (!modal || modal.classList.contains('open')) return;
+  if (!modal) return;
+  if (modal.classList.contains('open')) {
+    updatePaneShortcutBadges();
+    return;
+  }
   shortcutsLastFocusedEl = document.activeElement instanceof HTMLElement ? document.activeElement : null;
   modal.classList.add('open');
   modal.setAttribute('aria-hidden', 'false');
+  updatePaneShortcutBadges();
   window.setTimeout(() => {
     (globalElements.shortcutsDialog || globalElements.shortcutsCloseBtn || modal).focus?.();
   }, 0);
@@ -1881,6 +1887,7 @@ function closeShortcuts() {
   if (!modal || !modal.classList.contains('open')) return;
   modal.classList.remove('open');
   modal.setAttribute('aria-hidden', 'true');
+  updatePaneShortcutBadges();
   if (shortcutsLastFocusedEl && document.contains(shortcutsLastFocusedEl)) {
     shortcutsLastFocusedEl.focus?.();
   }
@@ -6958,6 +6965,28 @@ function paneHeaderLetter(pane) {
   }
 }
 
+function shouldShowPaneShortcutBadges() {
+  return paneShortcutBadgesAltHeld || isOverlayElementOpen(globalElements.shortcutsModal);
+}
+
+function updatePaneShortcutBadges() {
+  const visible = shouldShowPaneShortcutBadges();
+  (paneManager?.panes || []).forEach((pane, idx) => {
+    const badge = pane?.elements?.indexBadge;
+    if (!badge) return;
+    const shortcutIndex = idx + 1;
+    const supported = shortcutIndex >= 1 && shortcutIndex <= 9;
+    badge.hidden = !visible;
+    badge.classList.toggle('is-visible', visible);
+    badge.classList.toggle('is-excluded', visible && !supported);
+    badge.textContent = supported ? String(shortcutIndex) : '–';
+    badge.setAttribute('aria-hidden', 'true');
+    badge.title = supported
+      ? `Alt/Option+${shortcutIndex} focuses this pane`
+      : 'No direct number shortcut for this pane';
+  });
+}
+
 function renderPaneIdentity(pane) {
   if (!pane?.elements?.name) return;
   const letter = paneHeaderLetter(pane);
@@ -7278,6 +7307,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     name: root.querySelector('[data-pane-name]'),
     nameToken: root.querySelector('[data-pane-name-token]'),
     nameTarget: root.querySelector('[data-pane-name-target]'),
+    indexBadge: root.querySelector('[data-pane-index-badge]'),
     nicknameBtn: root.querySelector('[data-pane-nickname]'),
     typePill: root.querySelector('[data-pane-type-pill]'),
     typeIcon: root.querySelector('[data-pane-type-icon]'),
@@ -9544,6 +9574,7 @@ const paneManager = {
   },
   updatePaneLabels() {
     this.panes.forEach((pane) => renderPaneIdentity(pane));
+    updatePaneShortcutBadges();
     this.updatePaneGridLabel();
   },
   updatePaneGridLabel() {
@@ -10213,6 +10244,11 @@ function isBlockingOverlayOpenForPaneShortcuts() {
 }
 
 window.addEventListener('keydown', (event) => {
+  if (event.key === 'Alt' && !event.metaKey && !event.ctrlKey && !event.shiftKey) {
+    paneShortcutBadgesAltHeld = true;
+    updatePaneShortcutBadges();
+  }
+
   const isEditableTarget = (() => {
     const el = event.target;
     if (!el) return false;
@@ -10434,6 +10470,18 @@ window.addEventListener('keydown', (event) => {
       shortcutState.lastGAtMs = 0;
     }
   }
+});
+
+window.addEventListener('keyup', (event) => {
+  if (event.key !== 'Alt') return;
+  paneShortcutBadgesAltHeld = false;
+  updatePaneShortcutBadges();
+});
+
+window.addEventListener('blur', () => {
+  if (!paneShortcutBadgesAltHeld) return;
+  paneShortcutBadgesAltHeld = false;
+  updatePaneShortcutBadges();
 });
 
 globalElements.disconnectBtn?.addEventListener('click', () => {

--- a/index.html
+++ b/index.html
@@ -91,6 +91,7 @@
         <template id="paneTemplate">
           <section class="chat-panel pane" data-pane data-testid="pane">
             <div class="pane-header">
+              <span class="pane-index-badge" data-pane-index-badge data-testid="pane-index-badge" hidden aria-hidden="true">1</span>
               <div class="pane-header-left">
                 <div class="pane-type-badge pane-type-pill" data-pane-type-pill data-testid="pane-type-pill" aria-label="Pane type">
                   <span class="pane-type-icon" data-pane-type-icon aria-hidden="true">💬</span>

--- a/styles.css
+++ b/styles.css
@@ -464,6 +464,39 @@ body::before {
   z-index: 2;
 }
 
+.pane-index-badge {
+  position: absolute;
+  top: -7px;
+  left: 8px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  background: rgba(14, 18, 26, 0.92);
+  color: #f8fafc;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.25);
+  font-size: 11px;
+  font-weight: 800;
+  line-height: 16px;
+  text-align: center;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-2px);
+  transition: opacity 120ms ease, transform 120ms ease;
+  z-index: 3;
+}
+
+.pane-index-badge.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.pane-index-badge.is-excluded {
+  background: rgba(71, 85, 105, 0.92);
+  color: rgba(248, 250, 252, 0.72);
+}
+
 .pane-header-left {
   display: flex;
   align-items: center;

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -259,6 +259,28 @@ test('alt+1..3 and cmd/ctrl+1..3 focus panes by visible order; shortcuts do not 
   await page.getByTestId('pane-add-menu-cron').click();
   await expect(page.locator('[data-pane]')).toHaveCount(3);
 
+  const badges = page.getByTestId('pane-index-badge');
+  const hiddenBadgeCount = async () => badges.evaluateAll((els) => els.filter((el) => el.hidden).length);
+  await expect(badges).toHaveCount(3);
+  await expect.poll(hiddenBadgeCount).toBe(3);
+
+  const firstLabelXBefore = await page.getByTestId('pane-name-token').first().evaluate((el) => el.getBoundingClientRect().x);
+  await page.keyboard.down('Alt');
+  await expect(badges).toHaveText(['1', '2', '3']);
+  await expect(badges.first()).toBeVisible();
+  const firstLabelXDuring = await page.getByTestId('pane-name-token').first().evaluate((el) => el.getBoundingClientRect().x);
+  expect(firstLabelXDuring).toBe(firstLabelXBefore);
+  await page.keyboard.up('Alt');
+  await expect.poll(hiddenBadgeCount).toBe(3);
+
+  await page.click('#connectionStatus');
+  await page.keyboard.press('Shift+/');
+  await expect(page.locator('#shortcutsModal')).toHaveAttribute('aria-hidden', 'false');
+  await expect(badges.first()).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(page.locator('#shortcutsModal')).toHaveAttribute('aria-hidden', 'true');
+  await expect.poll(hiddenBadgeCount).toBe(3);
+
   const activePaneIndex = async () => page.evaluate(() => {
     const panes = Array.from(document.querySelectorAll('[data-pane]'));
     const active = document.activeElement;


### PR DESCRIPTION
## Summary
- add non-layout-shifting pane index badges for Alt/Option direct-focus shortcuts
- show the same badges while the keyboard shortcuts overlay is open
- update badge labels when pane labels/order refresh

Fixes #364

## Tests
- npm test
- npx playwright test tests/pane.shortcuts.e2e.spec.js --workers=1