### PR TITLE
Add Settings shortcut overrides

### DIFF
--- a/app.js
+++ b/app.js
@@ -81,6 +81,10 @@ const globalElements = {
   settingsModal: document.getElementById('settingsModal'),
   settingsCloseBtn: document.getElementById('settingsCloseBtn'),
   paneSwitchHudEnabled: document.getElementById('paneSwitchHudEnabled'),
+  shortcutOverridesList: document.getElementById('shortcutOverridesList'),
+  shortcutOverridesSave: document.getElementById('shortcutOverridesSave'),
+  shortcutOverridesResetAll: document.getElementById('shortcutOverridesResetAll'),
+  shortcutOverridesError: document.getElementById('shortcutOverridesError'),
   rolePill: document.getElementById('rolePill'),
   loginOverlay: document.getElementById('loginOverlay'),
   loginPassword: document.getElementById('loginPassword'),
@@ -278,6 +282,7 @@ const ADMIN_AUTH_DESTINATION_KEY = 'clawnsole.admin.authDestination.v1';
 const ADMIN_AUTH_RESTORE_PENDING_KEY = 'clawnsole.admin.authRestorePending.v1';
 const ADMIN_AUTH_RESTORE_NOTICE_KEY = 'clawnsole.admin.authRestoreNotice.v1';
 const PANE_SWITCH_HUD_ENABLED_KEY = 'clawnsole.admin.paneSwitchHud.enabled';
+const SHORTCUT_OVERRIDES_KEY = 'clawnsole.admin.shortcutOverrides.v1';
 const ADMIN_AUTH_DESTINATION_TTL_MS = 10 * 60 * 1000;
 const WQ_RECENT_TARGETS_KEY = 'clawnsole.wq.recentTargets';
 const WQ_RECENT_ENQUEUE_AGENTS_KEY = 'clawnsole.wq.recentEnqueueAgents';
@@ -1550,6 +1555,8 @@ function openSettings() {
   if (globalElements.paneSwitchHudEnabled) {
     globalElements.paneSwitchHudEnabled.checked = isPaneSwitchHudEnabled();
   }
+  shortcutOverridesDraft = readShortcutOverrides();
+  renderShortcutOverrideSettings();
   globalElements.settingsModal.classList.add('open');
   globalElements.settingsModal.setAttribute('aria-hidden', 'false');
 
@@ -1562,6 +1569,252 @@ function openSettings() {
 function closeSettings() {
   globalElements.settingsModal.classList.remove('open');
   globalElements.settingsModal.setAttribute('aria-hidden', 'true');
+  shortcutOverridesDraft = null;
+}
+
+const SHORTCUT_OVERRIDE_ACTIONS = [
+  {
+    id: 'pane-next',
+    label: 'Focus next pane',
+    defaultCombo: { accel: true, shift: true, alt: false, key: 'k' },
+    run: () => cyclePaneFocus()
+  },
+  {
+    id: 'pane-previous',
+    label: 'Focus previous pane',
+    defaultCombo: { accel: true, shift: true, alt: false, key: 'j' },
+    run: () => cyclePaneFocusBackward()
+  },
+  {
+    id: 'pane-manager',
+    label: 'Open pane manager',
+    defaultCombo: { accel: true, shift: false, alt: false, key: 'p' },
+    run: () => openPaneManager(),
+    typingExempt: true
+  },
+  {
+    id: 'workqueue-open',
+    label: 'Open workqueue',
+    defaultCombo: { sequence: ['g', 'w'] },
+    run: () => openTopbarWorkqueueAction()
+  },
+  {
+    id: 'fleet-open',
+    label: 'Open fleet/agents',
+    defaultCombo: { accel: true, shift: true, alt: false, key: 'f' },
+    run: () => openFleetPane()
+  }
+];
+const SHORTCUT_OVERRIDE_ACTION_BY_ID = new Map(SHORTCUT_OVERRIDE_ACTIONS.map((action) => [action.id, action]));
+let shortcutOverridesDraft = null;
+
+function normalizeShortcutKey(key) {
+  const raw = String(key || '').trim();
+  if (!raw) return '';
+  const lower = raw.toLowerCase();
+  if (lower === ' ') return 'space';
+  if (lower === 'escape') return 'esc';
+  if (lower === 'arrowup') return 'up';
+  if (lower === 'arrowdown') return 'down';
+  if (lower === 'arrowleft') return 'left';
+  if (lower === 'arrowright') return 'right';
+  if (lower.length === 1) return lower;
+  return lower;
+}
+
+function normalizeShortcutCombo(combo) {
+  if (!combo || typeof combo !== 'object') return '';
+  if (Array.isArray(combo.sequence) && combo.sequence.length) {
+    return combo.sequence.map((part) => normalizeShortcutKey(part)).filter(Boolean).join(' ');
+  }
+  const key = normalizeShortcutKey(combo.key);
+  if (!key) return '';
+  const parts = [];
+  if (combo.accel) parts.push('accel');
+  if (combo.ctrl) parts.push('ctrl');
+  if (combo.meta) parts.push('meta');
+  if (combo.alt) parts.push('alt');
+  if (combo.shift) parts.push('shift');
+  parts.push(key);
+  return parts.join('+');
+}
+
+function shortcutComboEquals(a, b) {
+  return normalizeShortcutCombo(a) === normalizeShortcutCombo(b);
+}
+
+function shortcutComboFromEvent(event) {
+  const key = normalizeShortcutKey(event?.key);
+  if (!key || ['control', 'shift', 'alt', 'meta'].includes(key)) return null;
+  return {
+    accel: !!(event.metaKey || event.ctrlKey),
+    alt: !!event.altKey,
+    shift: !!event.shiftKey,
+    key
+  };
+}
+
+function shortcutComboLabel(combo) {
+  if (!combo || typeof combo !== 'object') return '';
+  if (Array.isArray(combo.sequence) && combo.sequence.length) {
+    return combo.sequence.map((part) => normalizeShortcutKey(part).toUpperCase()).join(' ');
+  }
+  const key = normalizeShortcutKey(combo.key);
+  if (!key) return '';
+  const parts = [];
+  if (combo.accel) parts.push('Cmd/Ctrl');
+  if (combo.ctrl) parts.push('Ctrl');
+  if (combo.meta) parts.push('Cmd');
+  if (combo.alt) parts.push('Alt/Option');
+  if (combo.shift) parts.push('Shift');
+  parts.push(key.length === 1 ? key.toUpperCase() : key.replace(/\b\w/g, (m) => m.toUpperCase()));
+  return parts.join('+');
+}
+
+function shortcutComboHtml(combo) {
+  const label = shortcutComboLabel(combo);
+  if (!label) return '';
+  if (Array.isArray(combo?.sequence)) {
+    return label.split(/\s+/).map((part) => `<kbd>${escapeHtml(part)}</kbd>`).join(' ');
+  }
+  return label.split('+').map((part) => `<kbd>${escapeHtml(part)}</kbd>`).join('+');
+}
+
+function cleanShortcutOverrides(value) {
+  const source = value && typeof value === 'object' ? value : {};
+  const cleaned = {};
+  for (const action of SHORTCUT_OVERRIDE_ACTIONS) {
+    const combo = source[action.id];
+    if (!combo || typeof combo !== 'object') continue;
+    if (shortcutComboEquals(combo, action.defaultCombo)) continue;
+    if (normalizeShortcutCombo(combo)) cleaned[action.id] = combo;
+  }
+  return cleaned;
+}
+
+function readShortcutOverrides() {
+  return cleanShortcutOverrides(readJsonFromStorage(SHORTCUT_OVERRIDES_KEY, {}));
+}
+
+function activeShortcutCombo(actionId, source = null) {
+  const action = SHORTCUT_OVERRIDE_ACTION_BY_ID.get(actionId);
+  if (!action) return null;
+  const overrides = source || readShortcutOverrides();
+  return overrides[actionId] || action.defaultCombo;
+}
+
+function validateShortcutOverrides(overrides) {
+  const seen = new Map();
+  for (const action of SHORTCUT_OVERRIDE_ACTIONS) {
+    const combo = activeShortcutCombo(action.id, overrides);
+    const normalized = normalizeShortcutCombo(combo);
+    if (!normalized) return { ok: false, message: `${action.label}: press a shortcut combo.` };
+    if (seen.has(normalized)) {
+      return { ok: false, message: `${action.label} conflicts with ${seen.get(normalized)}. Pick a different combo.` };
+    }
+    seen.set(normalized, action.label);
+    if (!Array.isArray(combo.sequence) && !combo.accel && !combo.alt && !combo.ctrl && !combo.meta) {
+      return { ok: false, message: `${action.label}: use Cmd/Ctrl, Alt/Option, or a g-chord style default to avoid normal typing keys.` };
+    }
+  }
+  const reserved = [
+    ['accel+q', 'Cmd/Ctrl+Q is usually reserved by the browser or OS. Try Cmd/Ctrl+Shift+K.'],
+    ['accel+w', 'Cmd/Ctrl+W closes tabs. Try Cmd/Ctrl+Shift+W with another action free.'],
+    ['accel+n', 'Cmd/Ctrl+N opens a new window. Try Cmd/Ctrl+Shift+N only if Add pane is not needed.'],
+    ['accel+t', 'Cmd/Ctrl+T opens a new tab. Try Cmd/Ctrl+Alt+T.']
+  ];
+  for (const action of SHORTCUT_OVERRIDE_ACTIONS) {
+    const normalized = normalizeShortcutCombo(activeShortcutCombo(action.id, overrides));
+    const hit = reserved.find(([combo]) => combo === normalized);
+    if (hit) return { ok: false, message: `${action.label}: ${hit[1]}` };
+  }
+  const fixedConflicts = new Map([
+    ['accel+k', 'Open command palette'],
+    ['accel+l', 'Focus Chat composer'],
+    ['accel+r', 'Refresh agent list'],
+    ['accel+shift+n', 'Add pane menu'],
+    ['accel+shift+c', 'New Chat pane'],
+    ['accel+shift+w', 'New Workqueue pane'],
+    ['accel+shift+r', 'New Cron pane'],
+    ['accel+shift+t', 'New Timeline pane']
+  ]);
+  for (const action of SHORTCUT_OVERRIDE_ACTIONS) {
+    const normalized = normalizeShortcutCombo(activeShortcutCombo(action.id, overrides));
+    if (shortcutComboEquals(activeShortcutCombo(action.id, overrides), action.defaultCombo)) continue;
+    if (fixedConflicts.has(normalized)) {
+      return { ok: false, message: `${action.label} conflicts with ${fixedConflicts.get(normalized)}. Try ${shortcutComboLabel(action.defaultCombo)} or another combo.` };
+    }
+  }
+  return { ok: true, message: '' };
+}
+
+function renderShortcutHelpLabels() {
+  for (const action of SHORTCUT_OVERRIDE_ACTIONS) {
+    document.querySelectorAll(`[data-shortcut-help="${action.id}"]`).forEach((el) => {
+      el.innerHTML = shortcutComboHtml(activeShortcutCombo(action.id));
+    });
+  }
+}
+
+function renderShortcutOverrideSettings() {
+  const list = globalElements.shortcutOverridesList;
+  if (!list) return;
+  const overrides = shortcutOverridesDraft || readShortcutOverrides();
+  list.innerHTML = '';
+  for (const action of SHORTCUT_OVERRIDE_ACTIONS) {
+    const combo = activeShortcutCombo(action.id, overrides);
+    const row = document.createElement('div');
+    row.className = 'shortcut-override-row';
+    row.innerHTML = `
+      <div>
+        <div class="shortcut-override-label">${escapeHtml(action.label)}</div>
+        <div class="shortcut-override-default">Default: ${escapeHtml(shortcutComboLabel(action.defaultCombo))}</div>
+      </div>
+      <input class="shortcut-override-input" data-shortcut-action="${escapeHtml(action.id)}" type="text" value="${escapeHtml(shortcutComboLabel(combo))}" readonly aria-label="${escapeHtml(`${action.label} shortcut`)}" />
+      <button class="secondary" type="button" data-shortcut-reset="${escapeHtml(action.id)}">Reset</button>
+    `;
+    list.appendChild(row);
+  }
+  const validation = validateShortcutOverrides(overrides);
+  setShortcutOverridesError(validation.ok ? '' : validation.message);
+}
+
+function setShortcutOverridesError(message) {
+  const el = globalElements.shortcutOverridesError;
+  if (!el) return;
+  const text = String(message || '').trim();
+  el.textContent = text;
+  el.hidden = !text;
+}
+
+function saveShortcutOverridesFromSettings() {
+  const overrides = cleanShortcutOverrides(shortcutOverridesDraft || readShortcutOverrides());
+  const validation = validateShortcutOverrides(overrides);
+  if (!validation.ok) {
+    setShortcutOverridesError(validation.message);
+    return false;
+  }
+  writeJsonToStorage(SHORTCUT_OVERRIDES_KEY, overrides);
+  shortcutOverridesDraft = null;
+  renderShortcutHelpLabels();
+  renderShortcutOverrideSettings();
+  showToast('Shortcut overrides saved.', { kind: 'info', timeoutMs: 2200 });
+  return true;
+}
+
+function resetShortcutOverride(actionId) {
+  const overrides = cleanShortcutOverrides(shortcutOverridesDraft || readShortcutOverrides());
+  delete overrides[actionId];
+  shortcutOverridesDraft = overrides;
+  renderShortcutOverrideSettings();
+}
+
+function resetAllShortcutOverrides() {
+  shortcutOverridesDraft = {};
+  storage.remove(SHORTCUT_OVERRIDES_KEY);
+  renderShortcutHelpLabels();
+  renderShortcutOverrideSettings();
+  showToast('Shortcut overrides reset.', { kind: 'info', timeoutMs: 2200 });
 }
 
 const recurringPromptState = {
@@ -9602,6 +9855,7 @@ const paneManager = {
 };
 
 // Global event wiring
+renderShortcutHelpLabels();
 
 globalElements.settingsBtn?.addEventListener('click', () => openSettings());
 globalElements.settingsCloseBtn?.addEventListener('click', () => closeSettings());
@@ -9611,6 +9865,33 @@ globalElements.settingsModal?.addEventListener('click', (event) => {
 globalElements.paneSwitchHudEnabled?.addEventListener('change', () => {
   storage.set(PANE_SWITCH_HUD_ENABLED_KEY, globalElements.paneSwitchHudEnabled.checked ? '1' : '0');
 });
+function handleShortcutOverrideInputKeydown(event) {
+  const input = event.target?.closest?.('[data-shortcut-action]');
+  if (!input) return;
+  const combo = shortcutComboFromEvent(event);
+  if (!combo) return;
+  event.preventDefault();
+  event.stopPropagation();
+  const actionId = String(input.dataset.shortcutAction || '');
+  const overrides = cleanShortcutOverrides(shortcutOverridesDraft || readShortcutOverrides());
+  const action = SHORTCUT_OVERRIDE_ACTION_BY_ID.get(actionId);
+  if (!action) return;
+  if (shortcutComboEquals(combo, action.defaultCombo)) delete overrides[actionId];
+  else overrides[actionId] = combo;
+  shortcutOverridesDraft = overrides;
+  renderShortcutOverrideSettings();
+  const nextInput = globalElements.shortcutOverridesList?.querySelector?.(`[data-shortcut-action="${CSS.escape(actionId)}"]`);
+  nextInput?.focus?.();
+  nextInput?.select?.();
+}
+window.addEventListener('keydown', handleShortcutOverrideInputKeydown, true);
+globalElements.shortcutOverridesList?.addEventListener('click', (event) => {
+  const resetBtn = event.target?.closest?.('[data-shortcut-reset]');
+  if (!resetBtn) return;
+  resetShortcutOverride(String(resetBtn.dataset.shortcutReset || ''));
+});
+globalElements.shortcutOverridesSave?.addEventListener('click', () => saveShortcutOverridesFromSettings());
+globalElements.shortcutOverridesResetAll?.addEventListener('click', () => resetAllShortcutOverrides());
 
 globalElements.shortcutsBtn?.addEventListener('click', () => openShortcuts());
 globalElements.shortcutsCloseBtn?.addEventListener('click', () => closeShortcuts());
@@ -9934,11 +10215,14 @@ function hasPaneNumberLayoutMismatch(event) {
 
 function isTypingShortcutExempt(event) {
   const key = String(event?.key || '').toLowerCase();
+  const override = matchingShortcutOverrideAction(event);
+  if (override?.typingExempt) return true;
   return (event?.metaKey || event?.ctrlKey) && !event.shiftKey && !event.altKey && (key === 'p' || key === 'k' || key === 'l');
 }
 
 function isNonTrivialGlobalShortcut(event) {
   if (!event) return false;
+  if (matchingShortcutOverrideAction(event)) return true;
   const key = String(event.key || '');
   const lower = key.toLowerCase();
   const hasMetaCtrl = !!(event.metaKey || event.ctrlKey);
@@ -9963,6 +10247,27 @@ function blockedGlobalShortcutReason(event) {
   if (isTypingContext(event.target) && !isTypingShortcutExempt(event)) return 'typing';
   if (hasPaneNumberLayoutMismatch(event)) return 'layout';
   return '';
+}
+
+function isShortcutOverrideEvent(event, combo) {
+  if (!combo || Array.isArray(combo.sequence)) return false;
+  if (normalizeShortcutKey(event?.key) !== normalizeShortcutKey(combo.key)) return false;
+  if (!!combo.accel !== !!(event.metaKey || event.ctrlKey)) return false;
+  if (!!combo.shift !== !!event.shiftKey) return false;
+  if (!!combo.alt !== !!event.altKey) return false;
+  if (combo.ctrl !== undefined && !!combo.ctrl !== !!event.ctrlKey) return false;
+  if (combo.meta !== undefined && !!combo.meta !== !!event.metaKey) return false;
+  return true;
+}
+
+function matchingShortcutOverrideAction(event) {
+  if (isAnyOverlayOpen()) return null;
+  for (const action of SHORTCUT_OVERRIDE_ACTIONS) {
+    const combo = activeShortcutCombo(action.id);
+    if (Array.isArray(combo?.sequence)) continue;
+    if (isShortcutOverrideEvent(event, combo)) return action;
+  }
+  return null;
 }
 
 function closeTopmostOverlay() {
@@ -10238,6 +10543,13 @@ window.addEventListener('keydown', (event) => {
     event.preventDefault();
     event.stopPropagation();
     reportBlockedShortcut(blockedReason);
+    return;
+  }
+
+  const overrideAction = matchingShortcutOverrideAction(event);
+  if (overrideAction && (!isTypingContext(event.target) || overrideAction.typingExempt)) {
+    event.preventDefault();
+    overrideAction.run();
     return;
   }
 

--- a/index.html
+++ b/index.html
@@ -259,9 +259,9 @@
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Alt</kbd>/<kbd>Option</kbd>+<kbd>1</kbd>..<kbd>9</kbd></div><div class="shortcut-desc">Focus panes 1-9 by visible order</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>1</kbd>..<kbd>4</kbd></div><div class="shortcut-desc">Focus pane 1-4</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>g</kbd> <kbd>a</kbd>..<kbd>z</kbd></div><div class="shortcut-desc">Focus pane by visible letter</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>P</kbd></div><div class="shortcut-desc">Open Pane Manager</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Focus next pane</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd></div><div class="shortcut-desc">Focus previous pane</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys" data-shortcut-help="pane-manager"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>P</kbd></div><div class="shortcut-desc">Open Pane Manager</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys" data-shortcut-help="pane-next"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Focus next pane</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys" data-shortcut-help="pane-previous"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd></div><div class="shortcut-desc">Focus previous pane</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Focus next Chat pane only</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>J</kbd></div><div class="shortcut-desc">Focus previous Chat pane only</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>g</kbd> <kbd>c</kbd></div><div class="shortcut-desc">Return to last active Chat pane</div></div>
@@ -277,13 +277,13 @@
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Open command palette</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd></div><div class="shortcut-desc">Add pane</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>C/W/R/T</kbd></div><div class="shortcut-desc">Add Chat/Workqueue/Cron/Timeline pane (workspace only)</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd></div><div class="shortcut-desc">Open/focus Fleet pane</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys" data-shortcut-help="fleet-open"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd></div><div class="shortcut-desc">Open/focus Fleet pane</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>R</kbd></div><div class="shortcut-desc">Refresh agent list</div></div>
           </div>
 
           <div class="shortcut-group">
             <h3 class="shortcut-group-title">Workqueue actions</h3>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>g</kbd> <kbd>w</kbd></div><div class="shortcut-desc">Open Workqueue modal</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys" data-shortcut-help="workqueue-open"><kbd>g</kbd> <kbd>w</kbd></div><div class="shortcut-desc">Open Workqueue modal</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>j</kbd>/<kbd>k</kbd></div><div class="shortcut-desc">Move selected row in Workqueue keyboard mode</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Enter</kbd></div><div class="shortcut-desc">Inspect selected Workqueue row in keyboard mode</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>e</kbd></div><div class="shortcut-desc">Edit selected Workqueue row in keyboard mode</div></div>
@@ -532,6 +532,19 @@
               <input id="paneSwitchHudEnabled" type="checkbox" checked />
               Show pane-switch HUD
             </label>
+          </section>
+
+          <section class="settings-section" aria-label="Shortcut overrides">
+            <div class="settings-section-head">
+              <h3>Shortcut overrides</h3>
+              <button id="shortcutOverridesResetAll" type="button" class="secondary">Reset all</button>
+            </div>
+            <p class="hint">Click a shortcut field, press a key combo, then save changes.</p>
+            <div id="shortcutOverridesList" class="shortcut-overrides-list"></div>
+            <div id="shortcutOverridesError" class="settings-error" role="alert" hidden></div>
+            <div class="button-row">
+              <button id="shortcutOverridesSave" type="button">Save shortcuts</button>
+            </div>
           </section>
 
           <section class="settings-section" aria-label="Recurring admin prompts">

--- a/styles.css
+++ b/styles.css
@@ -4090,6 +4090,51 @@ kbd {
   font-size: 0.95rem;
 }
 
+.settings-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.settings-section-head h3 {
+  margin-bottom: 0;
+}
+
+.shortcut-overrides-list {
+  display: grid;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.shortcut-override-row {
+  display: grid;
+  grid-template-columns: minmax(140px, 1fr) minmax(150px, 190px) auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.shortcut-override-label {
+  font-weight: 600;
+}
+
+.shortcut-override-default {
+  margin-top: 2px;
+  color: rgba(230, 238, 246, 0.62);
+  font-size: 0.8rem;
+}
+
+.shortcut-override-input {
+  cursor: pointer;
+  text-align: center;
+}
+
+.settings-error {
+  margin-top: 8px;
+  color: #ffb4b4;
+  font-size: 0.85rem;
+}
+
 .settings-rp-form {
   display: grid;
   gap: 8px;

--- a/tests/ui/settings-recurring-prompts.spec.js
+++ b/tests/ui/settings-recurring-prompts.spec.js
@@ -1,5 +1,40 @@
 const { test, expect } = require('./fixtures');
 
+test('settings: shortcut overrides validate, persist, and update help', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  await clawnsole.gotoAndLoginAdmin(page);
+
+  await page.getByRole('button', { name: 'Open settings' }).click();
+  await expect(page.locator('#settingsModal')).toHaveAttribute('aria-hidden', 'false');
+
+  const nextShortcut = page.locator('[data-shortcut-action="pane-next"]');
+  const prevShortcut = page.locator('[data-shortcut-action="pane-previous"]');
+
+  await nextShortcut.click();
+  await page.keyboard.press('Control+Alt+Y');
+  await expect(nextShortcut).toHaveValue('Cmd/Ctrl+Alt/Option+Y');
+
+  await prevShortcut.click();
+  await page.keyboard.press('Control+Alt+Y');
+  await page.locator('#shortcutOverridesSave').click();
+  await expect(page.locator('#shortcutOverridesError')).toContainText('conflicts');
+
+  await prevShortcut.click();
+  await page.keyboard.press('Control+Alt+U');
+  await page.locator('#shortcutOverridesSave').click();
+  await expect(page.locator('#shortcutOverridesError')).toBeHidden();
+
+  await page.locator('#settingsCloseBtn').click();
+  await page.getByRole('button', { name: 'Open keyboard shortcuts' }).click();
+  await expect(page.locator('[data-shortcut-help="pane-next"]')).toContainText('Cmd/Ctrl+Alt/Option+Y');
+
+  await page.reload();
+  await clawnsole.waitForAdminUiReady(page);
+  await page.getByRole('button', { name: 'Open keyboard shortcuts' }).click();
+  await expect(page.locator('[data-shortcut-help="pane-next"]')).toContainText('Cmd/Ctrl+Alt/Option+Y');
+});
+
 test('settings: recurring admin/system prompts list + create + toggle + history filter', async ({ page, clawnsole }) => {
   if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
 


### PR DESCRIPTION
## Summary
- add Settings shortcut override controls for pane next/previous, pane manager, workqueue, and fleet actions
- persist validated overrides in localStorage and update the shortcuts help modal from active bindings
- add UI coverage for validation, persistence, and help rendering

Fixes #372

## Tests
- npm test
- npx playwright test tests/ui/settings-recurring-prompts.spec.js --workers=1