### PR TITLE
UX: add Settings shortcut overrides

### DIFF
--- a/app.js
+++ b/app.js
@@ -81,6 +81,9 @@ const globalElements = {
   settingsModal: document.getElementById('settingsModal'),
   settingsCloseBtn: document.getElementById('settingsCloseBtn'),
   paneSwitchHudEnabled: document.getElementById('paneSwitchHudEnabled'),
+  shortcutOverridesRows: document.getElementById('shortcutOverridesRows'),
+  shortcutOverridesError: document.getElementById('shortcutOverridesError'),
+  shortcutOverridesResetAllBtn: document.getElementById('shortcutOverridesResetAllBtn'),
   rolePill: document.getElementById('rolePill'),
   loginOverlay: document.getElementById('loginOverlay'),
   loginPassword: document.getElementById('loginPassword'),
@@ -278,6 +281,7 @@ const ADMIN_AUTH_DESTINATION_KEY = 'clawnsole.admin.authDestination.v1';
 const ADMIN_AUTH_RESTORE_PENDING_KEY = 'clawnsole.admin.authRestorePending.v1';
 const ADMIN_AUTH_RESTORE_NOTICE_KEY = 'clawnsole.admin.authRestoreNotice.v1';
 const PANE_SWITCH_HUD_ENABLED_KEY = 'clawnsole.admin.paneSwitchHud.enabled';
+const SHORTCUT_OVERRIDES_KEY = 'clawnsole.admin.shortcutOverrides.v1';
 const ADMIN_AUTH_DESTINATION_TTL_MS = 10 * 60 * 1000;
 const WQ_RECENT_TARGETS_KEY = 'clawnsole.wq.recentTargets';
 const WQ_RECENT_ENQUEUE_AGENTS_KEY = 'clawnsole.wq.recentEnqueueAgents';
@@ -291,6 +295,214 @@ function readJsonFromStorage(key, fallback) {
   } catch {
     return fallback;
   }
+}
+
+const SHORTCUT_OVERRIDE_ACTIONS = [
+  { id: 'focusNextPane', label: 'Focus next pane', default: 'Ctrl/Cmd+Shift+K', suggest: 'Ctrl/Cmd+Shift+Y' },
+  { id: 'focusPreviousPane', label: 'Focus previous pane', default: 'Ctrl/Cmd+Shift+J', suggest: 'Ctrl/Cmd+Shift+U' },
+  { id: 'paneManager', label: 'Open pane manager', default: 'Ctrl/Cmd+P', suggest: 'Ctrl/Cmd+Shift+P' },
+  { id: 'openWorkqueue', label: 'Open workqueue', default: 'g w', suggest: 'Ctrl/Cmd+Shift+O' },
+  { id: 'openAgents', label: 'Open fleet/agents', default: 'Ctrl/Cmd+Shift+F', suggest: 'Ctrl/Cmd+Shift+A' }
+];
+const SHORTCUT_OVERRIDE_BY_ID = new Map(SHORTCUT_OVERRIDE_ACTIONS.map((action) => [action.id, action]));
+const SHORTCUT_RESERVED_CANONICAL = new Set([
+  'accel+r',
+  'accel+shift+r',
+  'accel+w',
+  'accel+shift+w',
+  'accel+t',
+  'accel+shift+t',
+  'accel+n',
+  'accel+shift+n',
+  'accel+shift+c',
+  'accel+shift+h',
+  'accel+l',
+  'accel+q'
+]);
+
+function normalizeShortcutComboText(value) {
+  return String(value || '')
+    .trim()
+    .replace(/\s*\+\s*/g, '+')
+    .replace(/\s+/g, ' ');
+}
+
+function parseShortcutCombo(value) {
+  const raw = normalizeShortcutComboText(value);
+  if (!raw) return null;
+  const chordParts = raw.split(' ').filter(Boolean);
+  if (chordParts.length > 2) return null;
+  if (chordParts.length === 2) {
+    const first = chordParts[0].toLowerCase();
+    const second = chordParts[1].toLowerCase();
+    if (!/^[a-z]$/.test(first) || !/^[a-z]$/.test(second)) return null;
+    return { kind: 'chord', keys: [first, second], canonical: `${first} ${second}`, display: `${first} ${second}` };
+  }
+
+  const tokens = chordParts[0].split('+').filter(Boolean);
+  let accel = false;
+  let ctrl = false;
+  let meta = false;
+  let shift = false;
+  let alt = false;
+  let key = '';
+  for (const tokenRaw of tokens) {
+    const token = tokenRaw.toLowerCase();
+    if (token === 'ctrl/cmd' || token === 'cmd/ctrl' || token === 'accel') accel = true;
+    else if (token === 'ctrl' || token === 'control') ctrl = true;
+    else if (token === 'cmd' || token === 'command' || token === 'meta') meta = true;
+    else if (token === 'shift') shift = true;
+    else if (token === 'alt' || token === 'option') alt = true;
+    else if (!key) key = token.length === 1 ? token : token;
+    else return null;
+  }
+  if (!key) return null;
+  const modifiers = [accel ? 'accel' : '', ctrl ? 'ctrl' : '', meta ? 'meta' : '', shift ? 'shift' : '', alt ? 'alt' : ''].filter(Boolean);
+  if (!modifiers.length) return null;
+  const canonical = [...modifiers, key].join('+');
+  const displayParts = [
+    accel ? 'Ctrl/Cmd' : '',
+    ctrl ? 'Ctrl' : '',
+    meta ? 'Cmd' : '',
+    shift ? 'Shift' : '',
+    alt ? 'Alt/Option' : '',
+    key.length === 1 ? key.toUpperCase() : key
+  ].filter(Boolean);
+  return { kind: 'combo', accel, ctrl, meta, shift, alt, key, canonical, display: displayParts.join('+') };
+}
+
+function readShortcutOverrides() {
+  const raw = readJsonFromStorage(SHORTCUT_OVERRIDES_KEY, {});
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+  const next = {};
+  for (const action of SHORTCUT_OVERRIDE_ACTIONS) {
+    const value = normalizeShortcutComboText(raw[action.id] || '');
+    if (value) next[action.id] = value;
+  }
+  return next;
+}
+
+function activeShortcutText(actionId) {
+  const action = SHORTCUT_OVERRIDE_BY_ID.get(actionId);
+  if (!action) return '';
+  const overrides = readShortcutOverrides();
+  return normalizeShortcutComboText(overrides[actionId] || action.default);
+}
+
+function activeShortcut(actionId) {
+  return parseShortcutCombo(activeShortcutText(actionId));
+}
+
+function eventMatchesShortcut(event, actionId) {
+  const shortcut = activeShortcut(actionId);
+  if (!shortcut || shortcut.kind !== 'combo') return false;
+  const key = String(event?.key || '').toLowerCase();
+  const shortcutKey = String(shortcut.key || '').toLowerCase();
+  const accelOk = shortcut.accel ? !!(event.metaKey || event.ctrlKey) : true;
+  return accelOk &&
+    !!event.shiftKey === !!shortcut.shift &&
+    !!event.altKey === !!shortcut.alt &&
+    (!shortcut.ctrl || !!event.ctrlKey) &&
+    (!shortcut.meta || !!event.metaKey) &&
+    key === shortcutKey;
+}
+
+function activeChordSecondKey(actionId) {
+  const shortcut = activeShortcut(actionId);
+  if (!shortcut || shortcut.kind !== 'chord') return '';
+  return shortcut.keys[0] === 'g' ? shortcut.keys[1] : '';
+}
+
+function shortcutHelpHtml(actionId) {
+  const parsed = activeShortcut(actionId);
+  const display = parsed?.display || activeShortcutText(actionId);
+  return String(display || '').split(/(\+| )/).filter((part) => part && part !== '+').map((part) => {
+    if (part === ' ') return ' ';
+    return `<kbd>${escapeHtml(part)}</kbd>`;
+  }).join('');
+}
+
+function renderShortcutHelpOverrides() {
+  document.querySelectorAll('[data-shortcut-help]').forEach((el) => {
+    const actionId = el.getAttribute('data-shortcut-help');
+    el.innerHTML = shortcutHelpHtml(actionId);
+  });
+}
+
+function validateShortcutOverrides(values) {
+  const seen = new Map();
+  for (const action of SHORTCUT_OVERRIDE_ACTIONS) {
+    const text = normalizeShortcutComboText(values[action.id] || action.default);
+    const parsed = parseShortcutCombo(text);
+    if (!parsed) return { ok: false, actionId: action.id, message: `${action.label}: enter a shortcut such as ${action.suggest}.` };
+    const defaultCanonical = parseShortcutCombo(action.default)?.canonical || '';
+    if (parsed.canonical !== defaultCanonical && SHORTCUT_RESERVED_CANONICAL.has(parsed.canonical)) {
+      return { ok: false, actionId: action.id, message: `${action.label}: ${parsed.display} is browser-reserved. Try ${action.suggest}.` };
+    }
+    if (seen.has(parsed.canonical)) {
+      return { ok: false, actionId: action.id, message: `${action.label}: conflicts with ${seen.get(parsed.canonical)}. Try ${action.suggest}.` };
+    }
+    seen.set(parsed.canonical, action.label);
+  }
+  return { ok: true };
+}
+
+function renderShortcutOverrideSettings() {
+  const root = globalElements.shortcutOverridesRows;
+  if (!root) return;
+  const overrides = readShortcutOverrides();
+  root.innerHTML = '';
+  for (const action of SHORTCUT_OVERRIDE_ACTIONS) {
+    const row = document.createElement('div');
+    row.className = 'settings-shortcut-row';
+    row.innerHTML = `
+      <label for="shortcutOverride_${escapeHtml(action.id)}">
+        <span>${escapeHtml(action.label)}</span>
+        <span class="settings-shortcut-default">Default: ${escapeHtml(action.default)}</span>
+      </label>
+      <input id="shortcutOverride_${escapeHtml(action.id)}" data-shortcut-override="${escapeHtml(action.id)}" type="text" value="${escapeHtml(overrides[action.id] || action.default)}" autocomplete="off" spellcheck="false" />
+      <button type="button" class="secondary" data-shortcut-reset="${escapeHtml(action.id)}">Reset</button>
+    `;
+    root.appendChild(row);
+  }
+  const error = globalElements.shortcutOverridesError;
+  if (error) {
+    error.hidden = true;
+    error.textContent = '';
+  }
+}
+
+function persistShortcutOverrideSettings() {
+  const root = globalElements.shortcutOverridesRows;
+  if (!root) return false;
+  const values = {};
+  root.querySelectorAll('[data-shortcut-override]').forEach((input) => {
+    values[input.dataset.shortcutOverride] = normalizeShortcutComboText(input.value);
+    input.removeAttribute('aria-invalid');
+  });
+  const validation = validateShortcutOverrides(values);
+  const error = globalElements.shortcutOverridesError;
+  if (!validation.ok) {
+    const input = root.querySelector(`[data-shortcut-override="${CSS.escape(validation.actionId)}"]`);
+    input?.setAttribute('aria-invalid', 'true');
+    if (error) {
+      error.textContent = validation.message;
+      error.hidden = false;
+    }
+    return false;
+  }
+  const next = {};
+  for (const action of SHORTCUT_OVERRIDE_ACTIONS) {
+    const value = normalizeShortcutComboText(values[action.id]);
+    if (value && value !== action.default) next[action.id] = value;
+  }
+  storage.set(SHORTCUT_OVERRIDES_KEY, JSON.stringify(next));
+  if (error) {
+    error.hidden = true;
+    error.textContent = '';
+  }
+  renderShortcutHelpOverrides();
+  return true;
 }
 
 function writeJsonToStorage(key, value) {
@@ -1550,6 +1762,7 @@ function openSettings() {
   if (globalElements.paneSwitchHudEnabled) {
     globalElements.paneSwitchHudEnabled.checked = isPaneSwitchHudEnabled();
   }
+  renderShortcutOverrideSettings();
   globalElements.settingsModal.classList.add('open');
   globalElements.settingsModal.setAttribute('aria-hidden', 'false');
 
@@ -1868,6 +2081,7 @@ function getModalFocusableElements(modalEl) {
 function openShortcuts() {
   const modal = globalElements.shortcutsModal;
   if (!modal || modal.classList.contains('open')) return;
+  renderShortcutHelpOverrides();
   shortcutsLastFocusedEl = document.activeElement instanceof HTMLElement ? document.activeElement : null;
   modal.classList.add('open');
   modal.setAttribute('aria-hidden', 'false');
@@ -9611,6 +9825,30 @@ globalElements.settingsModal?.addEventListener('click', (event) => {
 globalElements.paneSwitchHudEnabled?.addEventListener('change', () => {
   storage.set(PANE_SWITCH_HUD_ENABLED_KEY, globalElements.paneSwitchHudEnabled.checked ? '1' : '0');
 });
+globalElements.shortcutOverridesRows?.addEventListener('change', (event) => {
+  if (event.target?.matches?.('[data-shortcut-override]')) persistShortcutOverrideSettings();
+});
+globalElements.shortcutOverridesRows?.addEventListener('keydown', (event) => {
+  if (event.key === 'Enter' && event.target?.matches?.('[data-shortcut-override]')) {
+    event.preventDefault();
+    persistShortcutOverrideSettings();
+  }
+});
+globalElements.shortcutOverridesRows?.addEventListener('click', (event) => {
+  const actionId = event.target?.dataset?.shortcutReset;
+  if (!actionId) return;
+  const action = SHORTCUT_OVERRIDE_BY_ID.get(actionId);
+  const input = globalElements.shortcutOverridesRows?.querySelector(`[data-shortcut-override="${CSS.escape(actionId)}"]`);
+  if (action && input) {
+    input.value = action.default;
+    persistShortcutOverrideSettings();
+  }
+});
+globalElements.shortcutOverridesResetAllBtn?.addEventListener('click', () => {
+  storage.remove(SHORTCUT_OVERRIDES_KEY);
+  renderShortcutOverrideSettings();
+  renderShortcutHelpOverrides();
+});
 
 globalElements.shortcutsBtn?.addEventListener('click', () => openShortcuts());
 globalElements.shortcutsCloseBtn?.addEventListener('click', () => closeShortcuts());
@@ -9934,11 +10172,13 @@ function hasPaneNumberLayoutMismatch(event) {
 
 function isTypingShortcutExempt(event) {
   const key = String(event?.key || '').toLowerCase();
-  return (event?.metaKey || event?.ctrlKey) && !event.shiftKey && !event.altKey && (key === 'p' || key === 'k' || key === 'l');
+  return eventMatchesShortcut(event, 'paneManager') ||
+    ((event?.metaKey || event?.ctrlKey) && !event.shiftKey && !event.altKey && (key === 'k' || key === 'l'));
 }
 
 function isNonTrivialGlobalShortcut(event) {
   if (!event) return false;
+  if (SHORTCUT_OVERRIDE_ACTIONS.some((action) => eventMatchesShortcut(event, action.id))) return true;
   const key = String(event.key || '');
   const lower = key.toLowerCase();
   const hasMetaCtrl = !!(event.metaKey || event.ctrlKey);
@@ -10260,8 +10500,8 @@ window.addEventListener('keydown', (event) => {
     }
   }
 
-  // Cmd/Ctrl+P opens Pane Manager (even while typing).
-  if ((event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey && String(event.key || '').toLowerCase() === 'p') {
+  // Pane Manager shortcut opens even while typing.
+  if (eventMatchesShortcut(event, 'paneManager')) {
     event.preventDefault();
     openPaneManager();
     return;
@@ -10285,6 +10525,12 @@ window.addEventListener('keydown', (event) => {
   if ((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey && String(event.key || '').toLowerCase() === 'g' && roleState.role === 'admin') {
     event.preventDefault();
     openWorkqueueForActiveChatAgent();
+    return;
+  }
+
+  if (eventMatchesShortcut(event, 'openWorkqueue')) {
+    event.preventDefault();
+    openTopbarWorkqueueAction();
     return;
   }
 
@@ -10337,15 +10583,15 @@ window.addEventListener('keydown', (event) => {
     }
   }
 
-  // Cmd/Ctrl+Shift+K cycles focus across panes.
-  if ((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey && key.toLowerCase() === 'k') {
+  // Cycle focus across panes.
+  if (eventMatchesShortcut(event, 'focusNextPane')) {
     event.preventDefault();
     cyclePaneFocus();
     return;
   }
 
-  // Cmd/Ctrl+Shift+J cycles focus backward across panes.
-  if ((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey && key.toLowerCase() === 'j') {
+  // Cycle focus backward across panes.
+  if (eventMatchesShortcut(event, 'focusPreviousPane')) {
     event.preventDefault();
     cyclePaneFocusBackward();
     return;
@@ -10382,8 +10628,8 @@ window.addEventListener('keydown', (event) => {
     return;
   }
 
-  // Cmd/Ctrl+Shift+F opens/focuses Fleet pane.
-  if ((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey && key.toLowerCase() === 'f') {
+  // Open/focus Fleet pane.
+  if (eventMatchesShortcut(event, 'openAgents')) {
     event.preventDefault();
     openFleetPane();
     return;
@@ -10424,7 +10670,7 @@ window.addEventListener('keydown', (event) => {
         returnToLastActiveChatPane();
         return;
       }
-      if (key.toLowerCase() === 'w') {
+      if (key.toLowerCase() === activeChordSecondKey('openWorkqueue')) {
         openTopbarWorkqueueAction();
         return;
       }

--- a/index.html
+++ b/index.html
@@ -259,9 +259,9 @@
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Alt</kbd>/<kbd>Option</kbd>+<kbd>1</kbd>..<kbd>9</kbd></div><div class="shortcut-desc">Focus panes 1-9 by visible order</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>1</kbd>..<kbd>4</kbd></div><div class="shortcut-desc">Focus pane 1-4</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>g</kbd> <kbd>a</kbd>..<kbd>z</kbd></div><div class="shortcut-desc">Focus pane by visible letter</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>P</kbd></div><div class="shortcut-desc">Open Pane Manager</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Focus next pane</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd></div><div class="shortcut-desc">Focus previous pane</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys" data-shortcut-help="paneManager"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>P</kbd></div><div class="shortcut-desc">Open Pane Manager</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys" data-shortcut-help="focusNextPane"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Focus next pane</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys" data-shortcut-help="focusPreviousPane"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd></div><div class="shortcut-desc">Focus previous pane</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Focus next Chat pane only</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>J</kbd></div><div class="shortcut-desc">Focus previous Chat pane only</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>g</kbd> <kbd>c</kbd></div><div class="shortcut-desc">Return to last active Chat pane</div></div>
@@ -277,13 +277,13 @@
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>K</kbd></div><div class="shortcut-desc">Open command palette</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd></div><div class="shortcut-desc">Add pane</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>C/W/R/T</kbd></div><div class="shortcut-desc">Add Chat/Workqueue/Cron/Timeline pane (workspace only)</div></div>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd></div><div class="shortcut-desc">Open/focus Fleet pane</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys" data-shortcut-help="openAgents"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd></div><div class="shortcut-desc">Open/focus Fleet pane</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>R</kbd></div><div class="shortcut-desc">Refresh agent list</div></div>
           </div>
 
           <div class="shortcut-group">
             <h3 class="shortcut-group-title">Workqueue actions</h3>
-            <div class="shortcut-row"><div class="shortcut-keys"><kbd>g</kbd> <kbd>w</kbd></div><div class="shortcut-desc">Open Workqueue modal</div></div>
+            <div class="shortcut-row"><div class="shortcut-keys" data-shortcut-help="openWorkqueue"><kbd>g</kbd> <kbd>w</kbd></div><div class="shortcut-desc">Open Workqueue modal</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>j</kbd>/<kbd>k</kbd></div><div class="shortcut-desc">Move selected row in Workqueue keyboard mode</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>Enter</kbd></div><div class="shortcut-desc">Inspect selected Workqueue row in keyboard mode</div></div>
             <div class="shortcut-row"><div class="shortcut-keys"><kbd>e</kbd></div><div class="shortcut-desc">Edit selected Workqueue row in keyboard mode</div></div>
@@ -532,6 +532,17 @@
               <input id="paneSwitchHudEnabled" type="checkbox" checked />
               Show pane-switch HUD
             </label>
+            <div class="settings-shortcuts" aria-label="Shortcut overrides">
+              <div class="settings-shortcuts-head">
+                <div>
+                  <div class="settings-shortcuts-title">Shortcut overrides</div>
+                  <div class="hint">Use tokens like <code>Ctrl/Cmd+Shift+K</code> or <code>g w</code>.</div>
+                </div>
+                <button id="shortcutOverridesResetAllBtn" type="button" class="secondary">Reset all</button>
+              </div>
+              <div id="shortcutOverridesRows" class="settings-shortcuts-rows"></div>
+              <div id="shortcutOverridesError" class="settings-shortcuts-error" role="alert" hidden></div>
+            </div>
           </section>
 
           <section class="settings-section" aria-label="Recurring admin prompts">

--- a/styles.css
+++ b/styles.css
@@ -4090,6 +4090,65 @@ kbd {
   font-size: 0.95rem;
 }
 
+.settings-shortcuts {
+  display: grid;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.settings-shortcuts-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: start;
+}
+
+.settings-shortcuts-title {
+  font-weight: 700;
+}
+
+.settings-shortcuts-rows {
+  display: grid;
+  gap: 8px;
+}
+
+.settings-shortcut-row {
+  display: grid;
+  grid-template-columns: minmax(150px, 1fr) minmax(170px, 220px) auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.settings-shortcut-row label {
+  display: grid;
+  gap: 2px;
+}
+
+.settings-shortcut-default {
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.settings-shortcut-row input[aria-invalid="true"] {
+  border-color: rgba(255, 116, 116, 0.85);
+  box-shadow: 0 0 0 2px rgba(255, 116, 116, 0.12);
+}
+
+.settings-shortcuts-error {
+  color: #ffb7b7;
+  font-size: 0.86rem;
+}
+
+@media (max-width: 720px) {
+  .settings-shortcuts-head {
+    flex-direction: column;
+  }
+
+  .settings-shortcut-row {
+    grid-template-columns: 1fr;
+  }
+}
+
 .settings-rp-form {
   display: grid;
   gap: 8px;

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -179,6 +179,62 @@ test('cmd/ctrl+shift+j focuses previous pane with wraparound from unfocused stat
   await expect.poll(activePaneIndex).toBe(2);
 });
 
+test('settings shortcut overrides persist, validate conflicts, and update help', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  await page.getByTestId('add-pane-btn').click();
+  await page.getByTestId('pane-add-menu-cron').click();
+  await expect(page.locator('[data-pane]')).toHaveCount(3);
+
+  await page.getByRole('button', { name: 'Open settings' }).click();
+  await page.locator('[data-shortcut-override="focusNextPane"]').fill('Ctrl/Cmd+Shift+Y');
+  await page.locator('[data-shortcut-override="focusNextPane"]').press('Enter');
+  await expect(page.locator('#shortcutOverridesError')).toBeHidden();
+
+  await page.locator('[data-shortcut-override="focusPreviousPane"]').fill('Ctrl/Cmd+Shift+Y');
+  await page.locator('[data-shortcut-override="focusPreviousPane"]').press('Enter');
+  await expect(page.locator('#shortcutOverridesError')).toContainText('conflicts with Focus next pane');
+  await page.locator('[data-shortcut-reset="focusPreviousPane"]').click();
+  await page.keyboard.press('Escape');
+
+  const activePaneIndex = async () => page.evaluate(() => {
+    const panes = Array.from(document.querySelectorAll('[data-pane]'));
+    const active = document.activeElement;
+    if (!active) return -1;
+    return panes.findIndex((p) => p === active || p.contains(active));
+  });
+  const triggerShortcut = async (key) => page.evaluate((nextKey) => {
+    window.dispatchEvent(new KeyboardEvent('keydown', {
+      key: nextKey,
+      ctrlKey: true,
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true
+    }));
+  }, key);
+
+  await page.click('#connectionStatus');
+  await page.evaluate(() => focusPaneIndex(0));
+  await triggerShortcut('K');
+  await expect.poll(activePaneIndex).toBe(0);
+  await triggerShortcut('Y');
+  await expect.poll(activePaneIndex).toBe(1);
+
+  await page.reload();
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+  await page.click('#connectionStatus');
+  await page.keyboard.press('Shift+/');
+  await expect(page.locator('[data-shortcut-help="focusNextPane"]')).toContainText('Y');
+});
+
 test('cmd/ctrl+alt+j/k cycles chat panes only and keeps typing guard', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!app?.skipReason, app?.skipReason);


### PR DESCRIPTION
## Summary
- add a Settings shortcut override section for core pane/navigation actions
- persist validated overrides in localStorage and apply them in the global shortcut handler
- update the keyboard shortcuts modal to reflect active bindings

## Tests
- npm test
- npx playwright test tests/pane.shortcuts.e2e.spec.js --grep "settings shortcut overrides" --workers=1

Closes #372