### PR TITLE
Clarify pane topbar affordances

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,6 +19,7 @@ const globalElements = {
   recurringPromptHistoryRows: document.getElementById('recurringPromptHistoryRows'),
   recurringPromptHistoryEmpty: document.getElementById('recurringPromptHistoryEmpty'),
   status: document.getElementById('connectionStatus'),
+  paneConnectionSummary: document.getElementById('paneConnectionSummary'),
   paneManagerBtn: document.getElementById('paneManagerBtn'),
   pulseCanvas: document.getElementById('pulseCanvas'),
   workqueueBtn: document.getElementById('workqueueBtn'),
@@ -1395,7 +1396,10 @@ function setStatusPill(el, state, meta = '') {
 function updateGlobalStatus() {
   const status = deriveGlobalConnectionState({ authed: uiState.authed, panes: paneManager.panes });
   setStatusPill(globalElements.status, status.state, status.meta);
-  if (globalElements.paneManagerBtn) globalElements.paneManagerBtn.textContent = status.meta;
+  if (globalElements.paneConnectionSummary) {
+    globalElements.paneConnectionSummary.textContent = status.meta;
+    globalElements.paneConnectionSummary.title = status.meta ? `Pane connection status: ${status.meta}` : 'Pane connection status';
+  }
 }
 
 function updateConnectionControls() {

--- a/index.html
+++ b/index.html
@@ -32,13 +32,22 @@
         <div class="topbar-actions">
           <div class="status compact">
             <div class="status-pill" id="connectionStatus" data-testid="connection-status">disconnected</div>
-            <button
-              class="status-meta status-meta-btn"
-              id="paneManagerBtn"
-              type="button"
-              aria-label="Open pane manager"
-              data-testid="panes-indicator"
-            ></button>
+            <div class="pane-summary-row">
+              <span
+                class="status-meta pane-summary"
+                id="paneConnectionSummary"
+                data-testid="pane-connection-summary"
+                title="Pane connection status"
+              ></span>
+              <button
+                class="secondary pane-manager-topbar-btn"
+                id="paneManagerBtn"
+                type="button"
+                aria-label="Manage panes"
+                title="Manage panes"
+                data-testid="panes-indicator"
+              >Manage panes</button>
+            </div>
           </div>
           <div id="paneControls" class="pane-controls" hidden>
             <div class="pane-add-wrap">

--- a/styles.css
+++ b/styles.css
@@ -261,6 +261,14 @@ body::before {
   text-overflow: ellipsis;
 }
 
+.pane-summary-row {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  max-width: 360px;
+}
+
 .icon-btn {
   border: 1px solid rgba(255, 255, 255, 0.12);
   background: rgba(9, 12, 16, 0.6);
@@ -1326,15 +1334,14 @@ button.send-btn .btn-icon {
 
 /* Pane Manager */
 
-.status-meta-btn {
-  background: transparent;
-  border: none;
-  padding: 0;
-  cursor: pointer;
+.pane-summary {
+  cursor: default;
 }
 
-.status-meta-btn:hover {
-  color: var(--text);
+.pane-manager-topbar-btn {
+  min-height: 28px;
+  padding: 5px 10px;
+  white-space: nowrap;
 }
 
 .pane-manager-search-wrap {

--- a/tests/pane.manager.e2e.spec.js
+++ b/tests/pane.manager.e2e.spec.js
@@ -50,6 +50,32 @@ test('pane manager: lists panes + focuses via keyboard', async ({ page }) => {
   expect(focusedPaneIndex).toBe(1);
 });
 
+test('topbar panes controls: status summary and manage action have distinct roles', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const paneSummary = page.getByTestId('pane-connection-summary');
+  await expect(paneSummary).toHaveText(/^panes: \d+\/\d+ connected$/);
+  await expect(paneSummary).toHaveAttribute('title', /^Pane connection status: panes: \d+\/\d+ connected$/);
+
+  const managePanes = page.getByRole('button', { name: 'Manage panes' });
+  await expect(managePanes).toBeVisible();
+  await expect(managePanes).toHaveText('Manage panes');
+  await expect(managePanes).toHaveAttribute('title', 'Manage panes');
+
+  await managePanes.focus();
+  await expect(managePanes).toBeFocused();
+  await managePanes.press('Enter');
+  await expect(page.getByTestId('pane-manager-modal')).toHaveAttribute('aria-hidden', 'false');
+});
+
 test('pane header: identity line uses "[Letter] [Type] · [Target]" across pane kinds', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!app?.skipReason, app?.skipReason);


### PR DESCRIPTION
## Summary
- split the topbar pane connection summary from the manage-panes action
- relabel the pane manager trigger as an explicit `Manage panes` button with tooltip/focusable button semantics
- add Playwright coverage for the distinct status/action roles

Closes #376

## Tests
- npm run test:syntax
- npx playwright test tests/pane.manager.e2e.spec.js --workers=1