### PR TITLE
Clarify pane status and manager controls

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,6 +19,7 @@ const globalElements = {
   recurringPromptHistoryRows: document.getElementById('recurringPromptHistoryRows'),
   recurringPromptHistoryEmpty: document.getElementById('recurringPromptHistoryEmpty'),
   status: document.getElementById('connectionStatus'),
+  paneStatusMeta: document.getElementById('paneStatusMeta'),
   paneManagerBtn: document.getElementById('paneManagerBtn'),
   pulseCanvas: document.getElementById('pulseCanvas'),
   workqueueBtn: document.getElementById('workqueueBtn'),
@@ -1395,7 +1396,11 @@ function setStatusPill(el, state, meta = '') {
 function updateGlobalStatus() {
   const status = deriveGlobalConnectionState({ authed: uiState.authed, panes: paneManager.panes });
   setStatusPill(globalElements.status, status.state, status.meta);
-  if (globalElements.paneManagerBtn) globalElements.paneManagerBtn.textContent = status.meta;
+  if (globalElements.paneStatusMeta) {
+    const meta = String(status.meta || '');
+    globalElements.paneStatusMeta.textContent = meta;
+    globalElements.paneStatusMeta.title = meta ? `Pane connection status: ${meta}` : 'Pane connection status';
+  }
 }
 
 function updateConnectionControls() {

--- a/index.html
+++ b/index.html
@@ -32,14 +32,25 @@
         <div class="topbar-actions">
           <div class="status compact">
             <div class="status-pill" id="connectionStatus" data-testid="connection-status">disconnected</div>
-            <button
-              class="status-meta status-meta-btn"
-              id="paneManagerBtn"
-              type="button"
-              aria-label="Open pane manager"
-              data-testid="panes-indicator"
-            ></button>
+            <div
+              class="status-meta pane-status-meta"
+              id="paneStatusMeta"
+              title="Pane connection status"
+              aria-label="Pane connection status"
+              data-testid="panes-status"
+            ></div>
           </div>
+          <button
+            class="icon-btn action-btn pane-manager-action"
+            id="paneManagerBtn"
+            type="button"
+            aria-label="Manage panes"
+            title="Manage panes (Ctrl/Cmd+P)"
+            data-testid="panes-indicator"
+          >
+            <span class="btn-icon" aria-hidden="true">▦</span>
+            <span class="btn-label">Manage panes</span>
+          </button>
           <div id="paneControls" class="pane-controls" hidden>
             <div class="pane-add-wrap">
               <button id="addPaneBtn" class="icon-btn action-btn" type="button" aria-haspopup="menu" aria-expanded="false" aria-label="Add pane" title="Add Pane (Ctrl/Cmd+Shift+N)" data-testid="add-pane-btn">

--- a/styles.css
+++ b/styles.css
@@ -261,6 +261,21 @@ body::before {
   text-overflow: ellipsis;
 }
 
+.pane-status-meta {
+  cursor: default;
+}
+
+.pane-manager-action {
+  border-color: rgba(127, 209, 185, 0.28);
+  background: rgba(9, 12, 16, 0.72);
+}
+
+.pane-manager-action:focus,
+.pane-manager-action:focus-visible {
+  outline: 2px solid rgba(127, 209, 185, 0.9);
+  outline-offset: 2px;
+}
+
 .icon-btn {
   border: 1px solid rgba(255, 255, 255, 0.12);
   background: rgba(9, 12, 16, 0.6);

--- a/tests/pane.manager.e2e.spec.js
+++ b/tests/pane.manager.e2e.spec.js
@@ -23,6 +23,17 @@ test('pane manager: lists panes + focuses via keyboard', async ({ page }) => {
   await page.click('#loginBtn');
   await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
 
+  const panesStatus = page.getByTestId('panes-status');
+  await expect(panesStatus).toContainText(/panes: \d+\/\d+ connected/i);
+  await expect(panesStatus).toHaveAttribute('aria-label', 'Pane connection status');
+  await expect(panesStatus).not.toHaveJSProperty('tagName', 'BUTTON');
+
+  const managePanes = page.getByRole('button', { name: 'Manage panes' });
+  await expect(managePanes).toHaveAttribute('title', /Manage panes/);
+  await managePanes.focus();
+  await expect(managePanes).toBeFocused();
+  await expect(managePanes).toHaveCSS('outline-style', 'solid');
+
   const modal = page.locator('#paneManagerModal');
   await expect(modal).toHaveAttribute('aria-hidden', 'true');
 


### PR DESCRIPTION
## Summary
- Split pane connection status into a non-actionable status readout.
- Add an explicit labeled Manage panes button with title and focus ring.
- Extend pane manager Playwright coverage for status/action role clarity.

Closes #376.

## Tests
- npm run test:syntax
- npx playwright test tests/pane.manager.e2e.spec.js --grep "lists panes" --workers=1