### PR TITLE
Add workqueue bulk archive action

### DIFF
--- a/app.js
+++ b/app.js
@@ -4292,7 +4292,7 @@ function runFleetSelectedAgent() {
 
 // Workqueue (admin-only)
 
-const WORKQUEUE_STATUSES = ['ready', 'pending', 'blocked', 'claimed', 'in_progress', 'done', 'failed'];
+const WORKQUEUE_STATUSES = ['ready', 'pending', 'blocked', 'claimed', 'in_progress', 'done', 'failed', 'archived'];
 const WORKQUEUE_PANE_INITIAL_RENDER_LIMIT = 100;
 const WORKQUEUE_PANE_RENDER_CHUNK_SIZE = 100;
 const WORKQUEUE_ALL_SCOPE_GUARD_THRESHOLD_KEY = 'clawnsole.admin.workqueue.allScopeGuardThreshold';
@@ -5548,6 +5548,61 @@ async function cleanWorkqueueDuplicatesForPane(pane) {
   if (audit) audit.textContent = message;
   addFeed('ok', 'workqueue', message);
   await fetchAndRenderWorkqueueItemsForPane(pane);
+}
+
+async function bulkArchiveTerminalItemsForPane(pane) {
+  const statusEl = pane?.elements?.thread?.querySelector?.('[data-wq-bulk-archive-status]');
+  const setStatus = (text) => {
+    if (statusEl) statusEl.textContent = String(text || '');
+  };
+  const queue = String(pane?.workqueue?.queue || '').trim() || 'dev-team';
+  const raw = prompt('Archive done/failed items older than how many days?', '30');
+  if (raw === null) return;
+
+  const olderThanDays = Number.parseInt(String(raw || '').trim(), 10);
+  if (!Number.isFinite(olderThanDays) || olderThanDays <= 0) {
+    setStatus('Enter a positive day threshold.');
+    return;
+  }
+
+  const requestArchive = async (dryRun) => {
+    const res = await fetch('/api/workqueue/archive-terminal', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ queue, olderThanDays, dryRun })
+    });
+    const data = await res.json().catch(() => null);
+    if (!res.ok || !data?.ok) throw new Error(String(data?.error || res.status));
+    return data.result || {};
+  };
+
+  try {
+    setStatus('Previewing bulk archive...');
+    const preview = await requestArchive(true);
+    const count = Number(preview.count || 0);
+    if (!count) {
+      setStatus(`No done/failed items older than ${olderThanDays} days.`);
+      return;
+    }
+
+    const ok = confirm(
+      `Archive ${count} done/failed workqueue item${count === 1 ? '' : 's'} in ${queue} older than ${olderThanDays} days?\n\n` +
+        'Ready, pending, blocked, claimed, and in-progress items will not be touched.'
+    );
+    if (!ok) {
+      setStatus('Bulk archive canceled.');
+      return;
+    }
+
+    const result = await requestArchive(false);
+    const archived = Number(result.count || 0);
+    setStatus(`Archived ${archived} terminal item${archived === 1 ? '' : 's'}.`);
+    addFeed('ok', 'workqueue', `Archived ${archived} terminal item${archived === 1 ? '' : 's'} from ${queue}`);
+    await fetchAndRenderWorkqueueItemsForPane(pane);
+  } catch (err) {
+    setStatus(`Bulk archive failed: ${String(err)}`);
+  }
 }
 
 function renderWorkqueuePaneItems(pane) {
@@ -8056,6 +8111,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
           <button data-wq-preset-clawnsole class="secondary" type="button">Clawnsole only</button>
           <button data-wq-clear-quick class="secondary" type="button">Clear filters</button>
           <button data-wq-refresh class="secondary" type="button">Refresh</button>
+          <button data-wq-bulk-archive class="secondary danger" type="button">Bulk archive</button>
           <button data-wq-keyboard-mode class="secondary wq-keyboard-toggle" type="button" aria-pressed="false">Keyboard mode</button>
 
           <div class="wq-sort" role="group" aria-label="Sort workqueue items">
@@ -8118,6 +8174,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         </details>
 
         <div class="hint" data-wq-statusline></div>
+        <div class="hint" data-wq-bulk-archive-status aria-live="polite"></div>
         <div class="hint wq-keyboard-hint" data-wq-keyboard-hint hidden>j/k move, Enter inspect, e edit, 1 ready, 2 in progress, 3 blocked, 4 done</div>
         <div class="wq-filter-summary" data-wq-filter-summary aria-live="polite" hidden></div>
         <div class="wq-duplicate-health" data-wq-duplicate-health aria-live="polite" hidden></div>
@@ -8171,6 +8228,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     const clearQuickBtn = elements.thread.querySelector('[data-wq-clear-quick]');
     const searchEl = elements.thread.querySelector('[data-wq-search]');
     const refreshBtn = elements.thread.querySelector('[data-wq-refresh]');
+    const bulkArchiveBtn = elements.thread.querySelector('[data-wq-bulk-archive]');
     const keyboardModeBtn = elements.thread.querySelector('[data-wq-keyboard-mode]');
     const keyboardHint = elements.thread.querySelector('[data-wq-keyboard-hint]');
 
@@ -8487,6 +8545,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     populateQueueSelect().then(() => doRefresh());
 
     refreshBtn?.addEventListener('click', () => doRefresh());
+    bulkArchiveBtn?.addEventListener('click', () => bulkArchiveTerminalItemsForPane(pane));
     queueCustomEl?.addEventListener('keydown', (e) => {
       if (e.key === 'Enter') doRefresh();
     });

--- a/clawnsole-server.js
+++ b/clawnsole-server.js
@@ -1137,6 +1137,44 @@ function createClawnsoleServer(options = {}) {
       return;
     }
 
+    if (req.url === '/api/workqueue/archive-terminal') {
+      if (!requireAuth(req, res)) return;
+      if (req.clawnsoleRole !== 'admin') {
+        sendJson(res, 403, { error: 'forbidden' });
+        return;
+      }
+      if (req.method !== 'POST') {
+        sendJson(res, 405, { error: 'method_not_allowed' });
+        return;
+      }
+
+      (async () => {
+        const payload = await readJsonBody(req, res);
+        if (!payload) return;
+        const queue = String(payload.queue || '').trim();
+        const olderThanDays = Number(payload.olderThanDays);
+        const dryRun = Boolean(payload.dryRun);
+
+        try {
+          const { bulkArchiveTerminalItems } = require('./lib/workqueue');
+          const result = bulkArchiveTerminalItems(null, { queue, olderThanDays, dryRun });
+          sendJson(res, 200, { ok: true, result });
+        } catch (err) {
+          const code = err && err.code;
+          if (code === 'QUEUE_REQUIRED') {
+            sendJson(res, 400, { error: 'queue_required' });
+            return;
+          }
+          if (code === 'INVALID_THRESHOLD') {
+            sendJson(res, 400, { error: 'invalid_threshold' });
+            return;
+          }
+          sendJson(res, 500, { error: 'workqueue_error' });
+        }
+      })();
+      return;
+    }
+
     if (req.url === '/api/workqueue/assignments') {
       if (!requireAuth(req, res)) return;
       if (req.clawnsoleRole !== 'admin') {

--- a/lib/workqueue.js
+++ b/lib/workqueue.js
@@ -171,7 +171,8 @@ function createItem({ queue, title, instructions, priority, meta }) {
 
 
 
-const TERMINAL_STATUSES = new Set(['done', 'failed']);
+const TERMINAL_STATUSES = new Set(['done', 'failed', 'archived']);
+const BULK_ARCHIVE_SOURCE_STATUSES = new Set(['done', 'failed']);
 
 function normalizeIssueRepoName(repo) {
   return String(repo || '').trim().toLowerCase().replace(/\s+/g, '');
@@ -589,7 +590,7 @@ function updateItem(rootDir, { itemId, patch } = {}) {
   const p = patch && typeof patch === 'object' ? patch : {};
   if (!id) throw new Error('itemId required');
 
-  const allowedStatuses = new Set(['ready', 'pending', 'blocked', 'claimed', 'in_progress', 'done', 'failed']);
+  const allowedStatuses = new Set(['ready', 'pending', 'blocked', 'claimed', 'in_progress', 'done', 'failed', 'archived']);
 
   return withFileLock(lockFile, () => {
     const state = loadState(rootDir);
@@ -633,6 +634,58 @@ function updateItem(rootDir, { itemId, patch } = {}) {
   });
 }
 
+function bulkArchiveTerminalItems(rootDir, { queue, olderThanDays, dryRun = false, now = nowMs() } = {}) {
+  const q = String(queue || '').trim();
+  const days = Number(olderThanDays);
+  if (!q) {
+    const e = new Error('queue required');
+    e.code = 'QUEUE_REQUIRED';
+    throw e;
+  }
+  if (!Number.isFinite(days) || days <= 0) {
+    const e = new Error('olderThanDays must be positive');
+    e.code = 'INVALID_THRESHOLD';
+    throw e;
+  }
+
+  const cutoffMs = Number(now) - (days * 24 * 60 * 60 * 1000);
+  const cutoffIso = new Date(cutoffMs).toISOString();
+  const { lockFile } = statePaths(rootDir);
+
+  return withFileLock(lockFile, () => {
+    const state = loadState(rootDir);
+    const matches = [];
+    for (const item of state.items) {
+      if (!item || item.queue !== q) continue;
+      const status = String(item.status || '').trim();
+      if (!BULK_ARCHIVE_SOURCE_STATUSES.has(status)) continue;
+      const itemMs = Date.parse(String(item.updatedAt || item.createdAt || ''));
+      if (!Number.isFinite(itemMs) || itemMs >= cutoffMs) continue;
+      matches.push(item);
+    }
+
+    if (!dryRun) {
+      const archivedAt = new Date(Number(now)).toISOString();
+      for (const item of matches) {
+        item.status = 'archived';
+        item.updatedAt = archivedAt;
+        item.lastNote = `bulk archived terminal item older than ${days} days`;
+        item.leaseUntil = 0;
+      }
+      saveState(rootDir, state);
+    }
+
+    return {
+      queue: q,
+      olderThanDays: days,
+      cutoffIso,
+      dryRun: Boolean(dryRun),
+      count: matches.length,
+      itemIds: matches.map((item) => item.id).filter(Boolean)
+    };
+  });
+}
+
 function deleteItem(rootDir, { itemId } = {}) {
   const { lockFile } = statePaths(rootDir);
   const id = String(itemId || '').trim();
@@ -662,6 +715,7 @@ module.exports = {
   transitionItem,
   updateItem,
   deleteItem,
+  bulkArchiveTerminalItems,
   listAssignments,
   setAssignments,
   resolveClaimQueues,

--- a/styles.css
+++ b/styles.css
@@ -2960,6 +2960,7 @@ kbd {
 .wq-badge-in_progress { background: rgba(104, 201, 255, 0.12); border-color: rgba(104, 201, 255, 0.25); }
 .wq-badge-done { background: rgba(120, 255, 170, 0.10); border-color: rgba(120, 255, 170, 0.22); }
 .wq-badge-failed { background: rgba(255, 104, 104, 0.10); border-color: rgba(255, 104, 104, 0.22); }
+.wq-badge-archived { background: rgba(180, 190, 205, 0.10); border-color: rgba(180, 190, 205, 0.22); }
 
 .wq-col.prio,
 .wq-col.attempts {

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -837,6 +837,7 @@ test('workqueue pane: controls toolbar is sticky and list scrolls independently'
   const listBody = wqPane.locator('.wq-pane [data-wq-list-body]').first();
 
   await expect(toolbar).toBeVisible();
+  await expect(toolbar.locator('[data-wq-bulk-archive]')).toHaveText('Bulk archive');
   await expect(listBody).toHaveCount(1);
 
   const itemsResP = page.waitForResponse((res) => res.url().includes('/api/workqueue/items') && res.ok(), { timeout: 15000 });

--- a/tests/unit/workqueue-api.test.js
+++ b/tests/unit/workqueue-api.test.js
@@ -6,7 +6,7 @@ const path = require('node:path');
 const http = require('node:http');
 
 const { createClawnsoleServer } = require('../../clawnsole-server');
-const { enqueueItem } = require('../../lib/workqueue');
+const { enqueueItem, loadState, saveState } = require('../../lib/workqueue');
 
 function mkTempEnv() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'clawnsole-wq-api-'));
@@ -306,6 +306,43 @@ test('workqueue API: update edits item fields', async () => {
     assert.equal(res.json?.item?.title, 'new');
     assert.equal(res.json?.item?.priority, 5);
     assert.equal(res.json?.item?.status, 'pending');
+  } finally {
+    server.close();
+  }
+});
+
+test('workqueue API: archive-terminal dry-runs then archives only terminal rows', async () => {
+  const { openclawHome } = mkTempEnv();
+  fs.mkdirSync(openclawHome, { recursive: true });
+  fs.writeFileSync(path.join(openclawHome, 'clawnsole.json'), JSON.stringify({ adminPassword: 'admin', authVersion: 'test' }));
+
+  const oldDone = enqueueItem(null, { queue: 'dev-team', title: 'old done', instructions: '', priority: 1 });
+  const oldReady = enqueueItem(null, { queue: 'dev-team', title: 'old ready', instructions: '', priority: 1 });
+  const state = loadState(null);
+  Object.assign(state.items.find((it) => it.id === oldDone.id), { status: 'done', updatedAt: '2026-06-01T00:00:00.000Z' });
+  Object.assign(state.items.find((it) => it.id === oldReady.id), { status: 'ready', updatedAt: '2026-06-01T00:00:00.000Z' });
+  saveState(null, state);
+
+  const { server, port } = await startServer({ openclawHome });
+  try {
+    const cookie = Buffer.from('admin::test', 'utf8').toString('base64');
+    const headers = { Cookie: 'clawnsole_auth=' + cookie + '; clawnsole_role=admin' };
+    const url = 'http://127.0.0.1:' + port + '/api/workqueue/archive-terminal';
+
+    const preview = await httpPostJson(url, { queue: 'dev-team', olderThanDays: 14, dryRun: true }, headers);
+    assert.equal(preview.status, 200);
+    assert.equal(preview.json?.ok, true);
+    assert.equal(preview.json?.result?.count, 1);
+    assert.equal(loadState(null).items.find((it) => it.id === oldDone.id).status, 'done');
+
+    const apply = await httpPostJson(url, { queue: 'dev-team', olderThanDays: 14 }, headers);
+    assert.equal(apply.status, 200);
+    assert.equal(apply.json?.ok, true);
+    assert.equal(apply.json?.result?.count, 1);
+
+    const next = loadState(null);
+    assert.equal(next.items.find((it) => it.id === oldDone.id).status, 'archived');
+    assert.equal(next.items.find((it) => it.id === oldReady.id).status, 'ready');
   } finally {
     server.close();
   }

--- a/tests/unit/workqueue.test.js
+++ b/tests/unit/workqueue.test.js
@@ -10,6 +10,7 @@ const {
   loadState,
   saveState,
   transitionItem,
+  bulkArchiveTerminalItems,
   collapseCanonicalIssueDuplicates,
   canonicalizeIssueDedupeKey
 } = require('../../lib/workqueue');
@@ -217,6 +218,42 @@ test('workqueue: progress/terminal transitions require an explicit claim', () =>
     () => transitionItem(root, { itemId: item.id, agentId: 'agent-1', status: 'failed', error: 'nope' }),
     (err) => err && err.code === 'NOT_CLAIMED'
   );
+});
+
+test('workqueue: bulk archive previews and archives only old done/failed items', () => {
+  withFakeNow(Date.parse('2026-07-27T00:00:00.000Z'), () => {
+    const root = tempRoot();
+    const oldDone = enqueueItem(root, { queue: 'dev', title: 'old done', instructions: '', priority: 0 });
+    const oldFailed = enqueueItem(root, { queue: 'dev', title: 'old failed', instructions: '', priority: 0 });
+    const recentDone = enqueueItem(root, { queue: 'dev', title: 'recent done', instructions: '', priority: 0 });
+    const oldReady = enqueueItem(root, { queue: 'dev', title: 'old ready', instructions: '', priority: 0 });
+    const otherQueue = enqueueItem(root, { queue: 'other', title: 'old other', instructions: '', priority: 0 });
+
+    let state = loadState(root);
+    const set = (id, fields) => Object.assign(state.items.find((it) => it.id === id), fields);
+    set(oldDone.id, { status: 'done', updatedAt: '2026-06-01T00:00:00.000Z' });
+    set(oldFailed.id, { status: 'failed', updatedAt: '2026-06-01T00:00:00.000Z' });
+    set(recentDone.id, { status: 'done', updatedAt: '2026-07-20T00:00:00.000Z' });
+    set(oldReady.id, { status: 'ready', updatedAt: '2026-06-01T00:00:00.000Z' });
+    set(otherQueue.id, { status: 'done', updatedAt: '2026-06-01T00:00:00.000Z' });
+    saveState(root, state);
+
+    const preview = bulkArchiveTerminalItems(root, { queue: 'dev', olderThanDays: 14, dryRun: true });
+    assert.equal(preview.count, 2);
+
+    state = loadState(root);
+    assert.equal(state.items.find((it) => it.id === oldDone.id).status, 'done');
+
+    const result = bulkArchiveTerminalItems(root, { queue: 'dev', olderThanDays: 14 });
+    assert.equal(result.count, 2);
+
+    state = loadState(root);
+    assert.equal(state.items.find((it) => it.id === oldDone.id).status, 'archived');
+    assert.equal(state.items.find((it) => it.id === oldFailed.id).status, 'archived');
+    assert.equal(state.items.find((it) => it.id === recentDone.id).status, 'done');
+    assert.equal(state.items.find((it) => it.id === oldReady.id).status, 'ready');
+    assert.equal(state.items.find((it) => it.id === otherQueue.id).status, 'done');
+  });
 });
 
 test('workqueue: claim-next treats pending as ready', () => {


### PR DESCRIPTION
## Summary
- add an admin workqueue API to dry-run/apply archiving old done/failed rows
- add a Workqueue pane Bulk archive action with threshold prompt and preview confirmation
- add archived status display plus library/API/UI coverage

Fixes #378

## Tests
- npm test
- npx playwright test tests/ui/workqueue-pane.spec.js --workers=1

No production deploy performed.