### PR TITLE
Add sticky Fleet header and frozen identity columns

### DIFF
--- a/app.js
+++ b/app.js
@@ -4015,6 +4015,20 @@ function renderAgentsModalList() {
     root.appendChild(summary);
   };
 
+  const renderFleetHeader = () => {
+    const header = document.createElement('div');
+    header.className = 'agents-table-header';
+    header.setAttribute('role', 'presentation');
+    header.innerHTML = `
+      <span class="agents-table-pin-label" aria-hidden="true">Pin</span>
+      <span class="agents-table-agent-label">Agent</span>
+      <span class="agents-table-health-label">Health</span>
+      <span class="agents-table-details-label">Details</span>
+      ${visibleColumns.actions ? '<span class="agents-table-actions-label">Actions</span>' : ''}
+    `;
+    root.appendChild(header);
+  };
+
   const renderSection = (title, agents, { collapsible = false, collapsed = false } = {}) => {
     const section = document.createElement('div');
     section.className = 'agents-section';
@@ -4098,14 +4112,16 @@ function renderAgentsModalList() {
 
       row.innerHTML = `
         <button type="button" class="agents-pin" aria-label="${pinnedNow ? 'Unpin agent' : 'Pin agent'}" aria-pressed="${pinnedNow ? 'true' : 'false'}" data-agent-pin="${escapeHtml(id)}">${pinnedNow ? '★' : '☆'}</button>
-        <div class="agents-row-main">
+        <div class="agents-row-identity">
           <div class="agents-row-title">${escapeHtml(label)}</div>
-          <div class="agents-row-meta">
-            ${visibleColumns.id ? `<span class="agents-row-id" data-fleet-column="id">${escapeHtml(id)}</span>` : ''}
-            ${visibleColumns.health ? `<span class="agents-health-state-chip" data-fleet-column="health" data-health-state="${escapeHtml(triage.bucket)}">${escapeHtml(healthLabel)}</span>` : ''}
+          ${visibleColumns.id ? `<div class="agents-row-id" data-fleet-column="id">${escapeHtml(id)}</div>` : ''}
+        </div>
+        <div class="agents-row-health">
+          ${visibleColumns.health ? `<span class="agents-health-state-chip" data-fleet-column="health" data-health-state="${escapeHtml(triage.bucket)}">${escapeHtml(healthLabel)}</span>` : ''}
+        </div>
+        <div class="agents-row-meta">
             ${visibleColumns.heartbeat ? `<span class="agents-age-chip" data-fleet-column="heartbeat" data-heartbeat-bucket="${escapeHtml(triage.ageBucket)}" title="Heartbeat age: ${escapeHtml(heartbeatAge)} (${escapeHtml(heatBucketLabel)})">${escapeHtml(heartbeatAge)}</span>` : ''}
             ${visibleColumns.heartbeatDetail ? `<span class="agents-age-label" data-fleet-column="heartbeatDetail">${escapeHtml(heatBucketLabel)}</span>` : ''}${statusSnippetHtml}${modelHtml}${hostHtml}
-          </div>
         </div>
         ${rowActionsHtml}
       `;
@@ -4166,6 +4182,7 @@ function renderAgentsModalList() {
   };
 
   renderSummary();
+  renderFleetHeader();
   if (pinned.length > 0) renderSection('Pinned', pinned);
   renderSection('Needs attention', needsAttention);
   renderSection('Healthy', healthy, { collapsible: true, collapsed: healthyCollapsed });

--- a/styles.css
+++ b/styles.css
@@ -1697,12 +1697,27 @@ button.send-btn .btn-icon {
 }
 
 .agents-list {
-  display: flex;
-  flex-direction: column;
+  --agents-pin-col: 42px;
+  --agents-agent-col: 250px;
+  --agents-health-col: 132px;
+  --agents-details-col: minmax(360px, 1fr);
+  --agents-actions-col: minmax(280px, auto);
+  --agents-row-pad: 12px;
+  --agents-sticky-bg: rgba(16, 20, 27, 0.98);
+  display: block;
   gap: 12px;
+  max-height: min(62vh, 620px);
+  overflow: auto;
+  overscroll-behavior: contain;
+  padding-right: 2px;
+  scrollbar-gutter: stable;
 }
 
 .agents-list.compact {
+  --agents-pin-col: 32px;
+  --agents-agent-col: 230px;
+  --agents-health-col: 118px;
+  --agents-row-pad: 8px;
   gap: 6px;
 }
 
@@ -1781,7 +1796,38 @@ button.send-btn .btn-icon {
   letter-spacing: 0.1em;
   color: var(--muted);
   margin-bottom: 8px;
+  margin-top: 12px;
   text-align: left;
+}
+
+.agents-table-header {
+  position: sticky;
+  top: 0;
+  z-index: 9;
+  display: grid;
+  grid-template-columns: var(--agents-pin-col) var(--agents-agent-col) var(--agents-health-col) var(--agents-details-col) var(--agents-actions-col);
+  gap: 10px;
+  align-items: center;
+  min-width: 1120px;
+  margin-top: 12px;
+  margin-bottom: 8px;
+  padding: 7px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  background: var(--agents-sticky-bg);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.28);
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.agents-list.compact .agents-table-header {
+  gap: 8px;
+  min-width: 1040px;
+  padding: 5px 8px;
+  border-radius: 8px;
 }
 
 button.agents-section-title {
@@ -1803,10 +1849,12 @@ button.agents-section-title:hover {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  min-width: 1120px;
 }
 
 .agents-list.compact .agents-rows {
   gap: 4px;
+  min-width: 1040px;
 }
 
 .agents-rows[hidden] {
@@ -1815,13 +1863,14 @@ button.agents-section-title:hover {
 
 .agents-row {
   display: grid;
-  grid-template-columns: 42px 1fr auto;
+  grid-template-columns: var(--agents-pin-col) var(--agents-agent-col) var(--agents-health-col) var(--agents-details-col) var(--agents-actions-col);
   gap: 10px;
   align-items: center;
   border: 1px solid rgba(255, 255, 255, 0.09);
   border-radius: 14px;
   padding: 10px 12px;
   background: rgba(255, 255, 255, 0.02);
+  min-width: 1120px;
 }
 
 .agents-row[aria-selected="true"] {
@@ -1830,7 +1879,7 @@ button.agents-section-title:hover {
 }
 
 .agents-row-no-actions {
-  grid-template-columns: 42px 1fr;
+  grid-template-columns: var(--agents-pin-col) var(--agents-agent-col) var(--agents-health-col) var(--agents-details-col);
 }
 
 .agents-row:focus-visible {
@@ -1863,14 +1912,10 @@ button.agents-section-title:hover {
 }
 
 .agents-list.compact .agents-row {
-  grid-template-columns: 32px minmax(0, 1fr) auto;
   gap: 8px;
   border-radius: 10px;
   padding: 3px 8px;
-}
-
-.agents-list.compact .agents-row-no-actions {
-  grid-template-columns: 32px minmax(0, 1fr);
+  min-width: 1040px;
 }
 
 .agents-pin {
@@ -1896,7 +1941,15 @@ button.agents-section-title:hover {
   background: rgba(255, 179, 71, 0.12);
 }
 
+.agents-row-identity,
+.agents-row-health {
+  min-width: 0;
+}
+
 .agents-row-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   font-size: 14px;
   font-weight: 600;
   color: var(--text);
@@ -1908,7 +1961,6 @@ button.agents-section-title:hover {
 }
 
 .agents-row-meta {
-  margin-top: 2px;
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -1918,7 +1970,6 @@ button.agents-section-title:hover {
 }
 
 .agents-list.compact .agents-row-meta {
-  margin-top: 0;
   font-size: 11px;
   line-height: 1.05;
   white-space: nowrap;
@@ -1927,9 +1978,19 @@ button.agents-section-title:hover {
 }
 
 .agents-row-id {
+  margin-top: 2px;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.agents-list.compact .agents-row-id {
+  margin-top: 0;
+  font-size: 11px;
+  line-height: 1.05;
 }
 
 .agents-health-state-chip,
@@ -2032,7 +2093,7 @@ button.agents-section-title:hover {
   position: absolute;
   right: 0;
   top: calc(100% + 6px);
-  z-index: 6;
+  z-index: 14;
   display: flex;
   flex-direction: column;
   gap: 6px;
@@ -2043,9 +2104,70 @@ button.agents-section-title:hover {
   min-width: 150px;
 }
 
+@media (min-width: 861px) {
+  .agents-table-pin-label,
+  .agents-table-agent-label,
+  .agents-table-health-label,
+  .agents-pin,
+  .agents-row-identity,
+  .agents-row-health {
+    position: sticky;
+    background: var(--agents-sticky-bg);
+  }
+
+  .agents-table-pin-label,
+  .agents-pin {
+    left: var(--agents-row-pad);
+    z-index: 5;
+  }
+
+  .agents-table-agent-label,
+  .agents-row-identity {
+    left: calc(var(--agents-row-pad) + var(--agents-pin-col) + 10px);
+    z-index: 5;
+  }
+
+  .agents-table-health-label,
+  .agents-row-health {
+    left: calc(var(--agents-row-pad) + var(--agents-pin-col) + var(--agents-agent-col) + 20px);
+    z-index: 5;
+  }
+
+  .agents-table-pin-label,
+  .agents-table-agent-label,
+  .agents-table-health-label {
+    z-index: 11;
+  }
+
+  .agents-row[aria-selected="true"] .agents-pin,
+  .agents-row[aria-selected="true"] .agents-row-identity,
+  .agents-row[aria-selected="true"] .agents-row-health {
+    background: rgb(16, 35, 45);
+  }
+}
+
 @media (max-width: 860px) {
+  .agents-list {
+    max-height: none;
+    overflow-x: auto;
+  }
+
+  .agents-table-header {
+    grid-template-columns: 42px minmax(200px, 1fr) 118px minmax(240px, 1fr) auto;
+    min-width: 720px;
+  }
+
   .agents-row {
-    grid-template-columns: 42px 1fr auto;
+    grid-template-columns: 42px minmax(200px, 1fr) 118px minmax(240px, 1fr) auto;
+    min-width: 720px;
+  }
+
+  .agents-row-no-actions {
+    grid-template-columns: 42px minmax(200px, 1fr) 118px minmax(240px, 1fr);
+  }
+
+  .agents-rows {
+    min-width: 720px;
   }
 
   .agents-row-actions-inline {

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -315,6 +315,76 @@ test('fleet refresh keeps scroll anchor and keyboard triage selection', async ({
   )).toContain('agent-20');
 });
 
+test('fleet list keeps header and identity columns visible while scrolling', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  const agents = Array.from({ length: 40 }, (_, index) => {
+    const id = `agent-${String(index + 1).padStart(2, '0')}`;
+    return {
+      id,
+      name: id,
+      displayName: id,
+      model: `gpt-${String(index + 1).padStart(2, '0')}`,
+      host: `host-${String(index + 1).padStart(2, '0')}`
+    };
+  });
+  await page.route(/\/agents(?:\?|$)/, async (route) => {
+    await route.fulfill({ json: { agents } });
+  });
+
+  await clawnsole.gotoAndLoginAdmin(page);
+  await page.getByRole('button', { name: 'Refresh agent list' }).click();
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await page.locator('#agentsColumnPicker summary').click();
+  await page.locator('#agentsColumn_model').check();
+  await page.locator('#agentsColumn_host').check();
+  await page.locator('#agentsColumnPicker').evaluate((el) => {
+    el.open = false;
+  });
+
+  const list = page.locator('#agentsList');
+  await list.evaluate((el) => {
+    el.style.maxHeight = '240px';
+  });
+  await expect(page.locator('#agentsList .agents-row[data-agent-id="agent-30"]')).toBeVisible();
+
+  const header = page.locator('#agentsList .agents-table-header');
+  await list.evaluate((el) => {
+    el.scrollTop = 260;
+  });
+  const stickyHeader = await header.evaluate((el) => {
+    const headerRect = el.getBoundingClientRect();
+    const listRect = el.closest('#agentsList').getBoundingClientRect();
+    return {
+      topDelta: Math.abs(headerRect.top - listRect.top),
+      position: getComputedStyle(el).position
+    };
+  });
+  expect(stickyHeader.position).toBe('sticky');
+  expect(stickyHeader.topDelta).toBeLessThan(2);
+
+  const row = page.locator('#agentsList .agents-row[data-agent-id="agent-30"]');
+  const before = await row.evaluate((el) => ({
+    identityLeft: el.querySelector('.agents-row-identity').getBoundingClientRect().left,
+    detailsLeft: el.querySelector('.agents-row-meta').getBoundingClientRect().left
+  }));
+  await list.evaluate((el) => {
+    el.scrollLeft = 260;
+  });
+  const after = await row.evaluate((el) => ({
+    identityLeft: el.querySelector('.agents-row-identity').getBoundingClientRect().left,
+    detailsLeft: el.querySelector('.agents-row-meta').getBoundingClientRect().left,
+    scrollLeft: el.closest('#agentsList').scrollLeft
+  }));
+  expect(after.scrollLeft).toBeGreaterThan(80);
+  expect(Math.abs(after.identityLeft - before.identityLeft)).toBeLessThan(2);
+  expect(after.detailsLeft).toBeLessThan(before.detailsLeft - 80);
+
+  await row.click();
+  await page.keyboard.press('j');
+  await expect(page.locator('#agentsList .agents-row[data-agent-id="agent-31"]')).toHaveAttribute('aria-selected', 'true');
+});
+
 test('fleet attention mode sections healthy agents and keeps filters while expanding', async ({ page, clawnsole }) => {
   if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
 


### PR DESCRIPTION
## Summary
- add a sticky Fleet list header aligned to the row columns
- split Fleet rows into identity, health, details, and actions columns so identity/health can stay frozen during horizontal scroll
- add Playwright coverage for sticky header, frozen identity, horizontal scroll, and keyboard row navigation

## Tests
- npm run test:syntax
- npm run test:ui -- tests/ui/agents-modal.spec.js

Closes #356