### PR TITLE
Add carried draft retarget confirmation

### DIFF
--- a/app.js
+++ b/app.js
@@ -81,6 +81,7 @@ const globalElements = {
   settingsModal: document.getElementById('settingsModal'),
   settingsCloseBtn: document.getElementById('settingsCloseBtn'),
   paneSwitchHudEnabled: document.getElementById('paneSwitchHudEnabled'),
+  retargetConfirmEnabled: document.getElementById('retargetConfirmEnabled'),
   shortcutOverridesList: document.getElementById('shortcutOverridesList'),
   shortcutOverridesSave: document.getElementById('shortcutOverridesSave'),
   shortcutOverridesResetAll: document.getElementById('shortcutOverridesResetAll'),
@@ -282,6 +283,7 @@ const ADMIN_AUTH_DESTINATION_KEY = 'clawnsole.admin.authDestination.v1';
 const ADMIN_AUTH_RESTORE_PENDING_KEY = 'clawnsole.admin.authRestorePending.v1';
 const ADMIN_AUTH_RESTORE_NOTICE_KEY = 'clawnsole.admin.authRestoreNotice.v1';
 const PANE_SWITCH_HUD_ENABLED_KEY = 'clawnsole.admin.paneSwitchHud.enabled';
+const RETARGET_CONFIRM_ENABLED_KEY = 'clawnsole.admin.retargetConfirm.enabled';
 const SHORTCUT_OVERRIDES_KEY = 'clawnsole.admin.shortcutOverrides.v1';
 const ADMIN_AUTH_DESTINATION_TTL_MS = 10 * 60 * 1000;
 const WQ_RECENT_TARGETS_KEY = 'clawnsole.wq.recentTargets';
@@ -1555,6 +1557,9 @@ function openSettings() {
   if (globalElements.paneSwitchHudEnabled) {
     globalElements.paneSwitchHudEnabled.checked = isPaneSwitchHudEnabled();
   }
+  if (globalElements.retargetConfirmEnabled) {
+    globalElements.retargetConfirmEnabled.checked = isRetargetConfirmEnabled();
+  }
   shortcutOverridesDraft = readShortcutOverrides();
   renderShortcutOverrideSettings();
   globalElements.settingsModal.classList.add('open');
@@ -2397,6 +2402,10 @@ function paneSummaryLabel(pane) {
 
 function isPaneSwitchHudEnabled() {
   return String(storage.get(PANE_SWITCH_HUD_ENABLED_KEY, '1') || '1') !== '0';
+}
+
+function isRetargetConfirmEnabled() {
+  return String(storage.get(RETARGET_CONFIRM_ENABLED_KEY, '1') || '1') !== '0';
 }
 
 let paneSwitchHudHideTimer = null;
@@ -6787,6 +6796,7 @@ function paneRenderAttachments(pane) {
     remove.addEventListener('click', () => {
       pane.attachments.files.splice(index, 1);
       paneRenderAttachments(pane);
+      paneUpdateDraftOrigin(pane);
     });
     pill.append(name, remove);
     list.appendChild(pill);
@@ -6835,6 +6845,7 @@ async function paneHandleFileSelection(pane, event) {
   }
   event.target.value = '';
   paneRenderAttachments(pane);
+  paneUpdateDraftOrigin(pane);
 }
 
 async function paneUploadAttachments(pane) {
@@ -7157,6 +7168,7 @@ async function paneSendChat(pane) {
   if (command === '/clear') {
     paneClearChatHistory(pane, { wipeStorage: true });
     pane.elements.input.value = '';
+    pane.draftOrigin = null;
     paneUpdateCommandHints(pane);
     addFeed('event', 'chat', `cleared local history (${pane.sessionKey()})`);
     return;
@@ -7165,11 +7177,14 @@ async function paneSendChat(pane) {
     const key = pane.sessionKey();
     paneClearChatHistory(pane, { wipeStorage: true });
     pane.elements.input.value = '';
+    pane.draftOrigin = null;
     paneUpdateCommandHints(pane);
     pane.client.request('sessions.reset', { key });
     addFeed('event', 'chat', `reset session (${key})`);
     return;
   }
+
+  if (!(await paneShouldSendRetargetedDraft(pane))) return;
 
   const sessionKey = pane.sessionKey();
   const idempotencyKey = randomId();
@@ -7246,6 +7261,7 @@ async function paneSendChat(pane) {
   panePumpOutbox(pane);
 
   pane.elements.input.value = '';
+  pane.draftOrigin = null;
   paneUpdateCommandHints(pane);
 }
 
@@ -7667,6 +7683,143 @@ function paneHasDraftChanges(pane) {
   const draftText = String(pane.elements.input?.value || '').trim();
   const hasAttachments = Array.isArray(pane.attachments?.files) && pane.attachments.files.length > 0;
   return Boolean(draftText || hasAttachments);
+}
+
+function paneDraftTargetIdentity(pane) {
+  if (!pane) return null;
+  const kind = String(pane.kind || 'chat');
+  let targetKey = '';
+  let targetLabel = '';
+  if (kind === 'chat') {
+    targetKey = pane.role === 'admin' ? normalizeAgentId(pane.agentId || 'main') : pane.sessionKey?.() || 'chat';
+    const agent = pane.role === 'admin' ? getAgentRecord(targetKey) : null;
+    targetLabel = pane.role === 'admin' ? formatAgentLabel(agent, { includeId: false }) || targetKey : paneDisplayTargetLabel(pane);
+  } else if (kind === 'workqueue') {
+    targetKey = String(pane.workqueue?.queue || '').trim() || 'dev-team';
+    targetLabel = targetKey;
+  } else {
+    targetKey = paneDisplayTargetLabel(pane);
+    targetLabel = targetKey;
+  }
+  return {
+    paneKey: pane.key,
+    kind,
+    targetKey,
+    targetLabel,
+    label: `${paneLabel(pane)} · ${targetLabel}`
+  };
+}
+
+function paneDraftTargetsEquivalent(a, b) {
+  if (!a || !b) return true;
+  return String(a.kind || '') === String(b.kind || '') && String(a.targetKey || '') === String(b.targetKey || '');
+}
+
+function paneUpdateDraftOrigin(pane) {
+  if (!pane || pane.kind !== 'chat') return;
+  if (!paneHasDraftChanges(pane)) {
+    pane.draftOrigin = null;
+    return;
+  }
+  if (!pane.draftOrigin) pane.draftOrigin = paneDraftTargetIdentity(pane);
+}
+
+function paneFindByKey(key) {
+  return paneManager.panes.find((p) => p && p.key === key) || null;
+}
+
+function paneReturnToDraftOrigin(origin) {
+  const pane = paneFindByKey(origin?.paneKey);
+  if (!pane) return false;
+  if (pane.kind === 'chat' && origin.kind === 'chat' && origin.targetKey) {
+    paneSetAgent(pane, origin.targetKey, { requireDraftConfirm: false });
+  }
+  paneManager.focusPanePrimary(pane);
+  return true;
+}
+
+function paneConfirmRetargetSend(pane, origin, current) {
+  return new Promise((resolve) => {
+    const backdrop = document.createElement('div');
+    backdrop.className = 'modal open retarget-confirm-modal';
+    backdrop.setAttribute('aria-hidden', 'false');
+
+    const card = document.createElement('div');
+    card.className = 'modal-card retarget-confirm-card';
+    card.setAttribute('role', 'dialog');
+    card.setAttribute('aria-modal', 'true');
+    card.setAttribute('aria-labelledby', 'retargetConfirmTitle');
+
+    const title = document.createElement('h2');
+    title.id = 'retargetConfirmTitle';
+    title.textContent = 'Send carried draft?';
+
+    const body = document.createElement('p');
+    body.className = 'retarget-confirm-copy';
+    body.textContent = `This draft started in ${origin?.label || 'another target'} and is now pointed at ${current?.label || 'the current target'}.`;
+
+    const actions = document.createElement('div');
+    actions.className = 'button-row retarget-confirm-actions';
+
+    const sendBtn = document.createElement('button');
+    sendBtn.type = 'button';
+    sendBtn.className = 'primary';
+    sendBtn.textContent = 'Send to current target';
+
+    const returnBtn = document.createElement('button');
+    returnBtn.type = 'button';
+    returnBtn.className = 'secondary';
+    returnBtn.textContent = 'Return to origin pane';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.className = 'secondary';
+    cancelBtn.textContent = 'Cancel';
+
+    const cleanup = (value) => {
+      document.removeEventListener('keydown', onKeydown, true);
+      try {
+        backdrop.remove();
+      } catch {}
+      resolve(value);
+    };
+
+    const onKeydown = (event) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        cleanup('cancel');
+      }
+    };
+
+    sendBtn.addEventListener('click', () => cleanup('current'));
+    returnBtn.addEventListener('click', () => cleanup('origin'));
+    cancelBtn.addEventListener('click', () => cleanup('cancel'));
+    backdrop.addEventListener('click', (event) => {
+      if (event.target === backdrop) cleanup('cancel');
+    });
+    document.addEventListener('keydown', onKeydown, true);
+
+    actions.append(sendBtn, returnBtn, cancelBtn);
+    card.append(title, body, actions);
+    backdrop.appendChild(card);
+    document.body.appendChild(backdrop);
+    sendBtn.focus();
+  });
+}
+
+async function paneShouldSendRetargetedDraft(pane) {
+  if (!isRetargetConfirmEnabled()) return true;
+  if (!pane?.draftOrigin) return true;
+  const current = paneDraftTargetIdentity(pane);
+  if (paneDraftTargetsEquivalent(pane.draftOrigin, current)) return true;
+
+  const choice = await paneConfirmRetargetSend(pane, pane.draftOrigin, current);
+  if (choice === 'current') {
+    pane.draftOrigin = current;
+    return true;
+  }
+  if (choice === 'origin') paneReturnToDraftOrigin(pane.draftOrigin);
+  return false;
 }
 
 function anyPaneHasDraftChanges(panes) {
@@ -9330,6 +9483,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
   });
 
   elements.input.addEventListener('input', () => {
+    paneUpdateDraftOrigin(pane);
     paneUpdateCommandHints(pane);
   });
 
@@ -10106,6 +10260,9 @@ globalElements.settingsModal?.addEventListener('click', (event) => {
 });
 globalElements.paneSwitchHudEnabled?.addEventListener('change', () => {
   storage.set(PANE_SWITCH_HUD_ENABLED_KEY, globalElements.paneSwitchHudEnabled.checked ? '1' : '0');
+});
+globalElements.retargetConfirmEnabled?.addEventListener('change', () => {
+  storage.set(RETARGET_CONFIRM_ENABLED_KEY, globalElements.retargetConfirmEnabled.checked ? '1' : '0');
 });
 function handleShortcutOverrideInputKeydown(event) {
   const input = event.target?.closest?.('[data-shortcut-action]');

--- a/index.html
+++ b/index.html
@@ -533,6 +533,10 @@
               <input id="paneSwitchHudEnabled" type="checkbox" checked />
               Show pane-switch HUD
             </label>
+            <label class="inline-checkbox">
+              <input id="retargetConfirmEnabled" type="checkbox" checked />
+              Confirm carried drafts before sending to a new target
+            </label>
           </section>
 
           <section class="settings-section" aria-label="Shortcut overrides">

--- a/styles.css
+++ b/styles.css
@@ -1212,6 +1212,25 @@ button.send-btn .btn-icon {
   width: min(1060px, 96vw);
 }
 
+.retarget-confirm-modal {
+  z-index: 30;
+}
+
+.retarget-confirm-card h2 {
+  margin: 0 0 8px;
+}
+
+.retarget-confirm-copy {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.retarget-confirm-actions {
+  margin-top: 16px;
+  justify-content: flex-end;
+}
+
 /* Command palette */
 
 .command-palette-input {

--- a/tests/agent-picker.e2e.spec.js
+++ b/tests/agent-picker.e2e.spec.js
@@ -65,6 +65,27 @@ test('agent chooser: opens, shows agents, Esc closes', async ({ page }) => {
   await expect.poll(() => seenConfirm).toBe(true);
   await expect(btn).toContainText(/dev/i);
 
+  await btn.click();
+  await expect(chooser).toBeVisible();
+  page.once('dialog', async (dialog) => {
+    expect(dialog.message()).toMatch(/unsent draft\/attachment/i);
+    await dialog.accept();
+  });
+  await chooser.getByRole('button', { name: /main/i }).click();
+  await expect(btn).toContainText(/main/i);
+  await expect(pane.getByTestId('pane-input')).toHaveValue('draft that should block accidental switch');
+
+  await expect(pane.getByTestId('pane-send')).toBeEnabled({ timeout: 20000 });
+  await pane.getByTestId('pane-send').click();
+  const retargetDialog = page.getByRole('dialog', { name: 'Send carried draft?' });
+  await expect(retargetDialog).toBeVisible();
+  await expect(retargetDialog).toContainText(/Chat .* dev/i);
+  await expect(retargetDialog).toContainText(/Chat .* main/i);
+  await retargetDialog.getByRole('button', { name: 'Return to origin pane' }).click();
+  await expect(retargetDialog).toHaveCount(0);
+  await expect(btn).toContainText(/dev/i);
+  await expect(pane.getByTestId('pane-input')).toHaveValue('draft that should block accidental switch');
+
   // Re-open and Esc closes.
   await btn.click();
   await expect(chooser).toBeVisible();


### PR DESCRIPTION
## Summary\n- track chat composer draft origin by pane type and target\n- prompt before sending a carried draft to a different current target\n- add a settings opt-out and Playwright coverage\n\nFixes #390\n\n## Verification\n- npm test\n- npx playwright test tests/agent-picker.e2e.spec.js --reporter=line