### PR TITLE
Clarify pane status and manager controls

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,6 +19,7 @@ const globalElements = {
   recurringPromptHistoryRows: document.getElementById('recurringPromptHistoryRows'),
   recurringPromptHistoryEmpty: document.getElementById('recurringPromptHistoryEmpty'),
   status: document.getElementById('connectionStatus'),
+  panesStatusMeta: document.getElementById('panesStatusMeta'),
   paneManagerBtn: document.getElementById('paneManagerBtn'),
   pulseCanvas: document.getElementById('pulseCanvas'),
   workqueueBtn: document.getElementById('workqueueBtn'),
@@ -1395,7 +1396,10 @@ function setStatusPill(el, state, meta = '') {
 function updateGlobalStatus() {
   const status = deriveGlobalConnectionState({ authed: uiState.authed, panes: paneManager.panes });
   setStatusPill(globalElements.status, status.state, status.meta);
-  if (globalElements.paneManagerBtn) globalElements.paneManagerBtn.textContent = status.meta;
+  if (globalElements.panesStatusMeta) {
+    globalElements.panesStatusMeta.textContent = status.meta;
+    globalElements.panesStatusMeta.title = status.meta ? `Pane status: ${status.meta}` : 'Pane status';
+  }
 }
 
 function updateConnectionControls() {

--- a/index.html
+++ b/index.html
@@ -32,14 +32,26 @@
         <div class="topbar-actions">
           <div class="status compact">
             <div class="status-pill" id="connectionStatus" data-testid="connection-status">disconnected</div>
-            <button
-              class="status-meta status-meta-btn"
-              id="paneManagerBtn"
-              type="button"
-              aria-label="Open pane manager"
+            <div
+              class="status-meta pane-status-chip"
+              id="panesStatusMeta"
+              role="status"
+              aria-live="polite"
+              aria-label="Pane connection status"
               data-testid="panes-indicator"
-            ></button>
+            ></div>
           </div>
+          <button
+            class="pane-manager-topbar-btn"
+            id="paneManagerBtn"
+            type="button"
+            aria-label="Manage panes"
+            title="Manage panes (Ctrl/Cmd+P)"
+            data-testid="pane-manager-button"
+          >
+            <span class="pane-manager-topbar-btn__icon" aria-hidden="true">▦</span>
+            <span class="pane-manager-topbar-btn__label">Manage panes</span>
+          </button>
           <div id="paneControls" class="pane-controls" hidden>
             <div class="pane-add-wrap">
               <button id="addPaneBtn" class="icon-btn action-btn" type="button" aria-haspopup="menu" aria-expanded="false" aria-label="Add pane" title="Add Pane (Ctrl/Cmd+Shift+N)" data-testid="add-pane-btn">

--- a/styles.css
+++ b/styles.css
@@ -261,6 +261,43 @@ body::before {
   text-overflow: ellipsis;
 }
 
+.pane-status-chip {
+  cursor: default;
+}
+
+.pane-manager-topbar-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 34px;
+  padding: 7px 11px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(9, 12, 16, 0.58);
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.pane-manager-topbar-btn:hover,
+.pane-manager-topbar-btn:focus-visible {
+  border-color: rgba(255, 179, 71, 0.42);
+  background: rgba(255, 179, 71, 0.14);
+}
+
+.pane-manager-topbar-btn:focus-visible {
+  outline: 2px solid rgba(255, 179, 71, 0.62);
+  outline-offset: 2px;
+}
+
+.pane-manager-topbar-btn__icon {
+  font-size: 13px;
+  line-height: 1;
+}
+
 .icon-btn {
   border: 1px solid rgba(255, 255, 255, 0.12);
   background: rgba(9, 12, 16, 0.6);
@@ -1325,17 +1362,6 @@ button.send-btn .btn-icon {
 }
 
 /* Pane Manager */
-
-.status-meta-btn {
-  background: transparent;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-}
-
-.status-meta-btn:hover {
-  color: var(--text);
-}
 
 .pane-manager-search-wrap {
   display: flex;

--- a/tests/pane.manager.e2e.spec.js
+++ b/tests/pane.manager.e2e.spec.js
@@ -257,7 +257,17 @@ test('pane manager: unread-only filter toggle', async ({ page }) => {
   await page.click('#loginBtn');
   await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
 
-  await page.getByTestId('panes-indicator').click();
+  const panesIndicator = page.getByTestId('panes-indicator');
+  await expect(panesIndicator).toHaveText(/panes: \d+\/\d+ connected/i);
+  await expect(panesIndicator).toHaveAttribute('role', 'status');
+  await expect(panesIndicator).toHaveAttribute('aria-label', 'Pane connection status');
+
+  const managerButton = page.getByTestId('pane-manager-button');
+  await expect(managerButton).toHaveText(/Manage panes/);
+  await expect(managerButton).toHaveAttribute('aria-label', 'Manage panes');
+  await expect(managerButton).toHaveAttribute('title', /Manage panes/);
+
+  await managerButton.click();
   await expect(page.getByTestId('pane-manager-modal')).toHaveAttribute('aria-hidden', 'false');
   await page.locator('.pane-manager-unread-only').click();
   await expect(page.locator('.pane-manager-row')).toHaveCount(0);


### PR DESCRIPTION
## Summary
- split the pane connection count into a non-action status chip
- add an explicit labeled Manage panes button with tooltip/focus styling
- update pane manager coverage to assert role clarity before opening the modal

## Tests
- npm run test:syntax
- npx playwright test tests/pane.manager.e2e.spec.js --grep "unread-only filter toggle" --workers=1

Fixes #376