### PR TITLE
Add workqueue empty-state recovery actions

### DIFF
--- a/app.js
+++ b/app.js
@@ -5621,11 +5621,20 @@ function renderWorkqueuePaneItems(pane) {
       const filtersHidingAll = totalCount > 0;
       const title = filtersHidingAll ? 'No items match current filters.' : 'No items in this queue.';
       const hiddenSummary = formatWorkqueueHiddenBreakdown(hiddenCounts);
+      const hiddenReason = hiddenSummary.replace(/^hidden:\s*/, '');
+      const recoveryActions = filtersHidingAll ? `
+          <div class="hint" style="margin-top:6px;">0 visible of <span class="mono">${escapeHtml(String(totalCount))}</span> total${hiddenReason ? `; hidden by ${escapeHtml(hiddenReason)}` : ''}.</div>
+          <div style="display:flex; gap:8px; margin-top:10px; flex-wrap:wrap;" aria-label="Workqueue filter recovery actions">
+            <button type="button" class="secondary" data-wq-empty-reset-scope>Reset scope</button>
+            <button type="button" class="secondary" data-wq-empty-clear-status>Clear status filters</button>
+            <button type="button" class="secondary" data-wq-empty-show-all>Show all rows</button>
+          </div>
+        ` : '';
       empty.innerHTML = `
         <div class="empty-state">
           <div style="font-weight:700; margin-bottom:6px;">${escapeHtml(title)}</div>
           <div class="hint">Queue: <span class="mono">${escapeHtml(queue)}</span> · Status: <span class="mono">${escapeHtml(statusLabel)}</span> · Scope: <span class="mono">${escapeHtml(scopeLabel)}</span></div>
-          ${filtersHidingAll ? `<div class="hint" style="margin-top:6px;">Showing 0 of <span class="mono">${escapeHtml(String(totalCount))}</span> items${hiddenSummary ? ` · ${escapeHtml(hiddenSummary)}` : ''}.</div>` : ''}
+          ${recoveryActions}
           <div style="display:flex; gap:8px; margin-top:10px; flex-wrap:wrap;">
             <button type="button" class="secondary" data-wq-empty-enqueue>Enqueue item</button>
             <button type="button" class="secondary" data-wq-empty-refresh>Refresh</button>
@@ -5643,6 +5652,15 @@ function renderWorkqueuePaneItems(pane) {
           enqueueDetails?.scrollIntoView({ block: 'nearest' });
           pane.elements?.thread?.querySelector('[data-wq-enqueue-title]')?.focus();
         } catch {}
+      });
+      empty.querySelector('[data-wq-empty-reset-scope]')?.addEventListener('click', () => {
+        pane.workqueue?.recoverEmptyState?.('reset-scope');
+      });
+      empty.querySelector('[data-wq-empty-clear-status]')?.addEventListener('click', () => {
+        pane.workqueue?.recoverEmptyState?.('clear-status');
+      });
+      empty.querySelector('[data-wq-empty-show-all]')?.addEventListener('click', () => {
+        pane.workqueue?.recoverEmptyState?.('show-all');
       });
     }
   }
@@ -8587,6 +8605,33 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       await applyStatuses(DEFAULT_STATUSES);
     };
     pane.workqueue.clearAllFilters = clearAllFilters;
+
+    const recoverEmptyState = async (action) => {
+      addFeed('event', 'workqueue.emptyRecovery', `action=${action}`);
+      if (action === 'reset-scope') {
+        setScope('unassigned');
+      } else if (action === 'clear-status') {
+        await applyStatuses(Array.from(WORKQUEUE_STATUSES), { closeMenu: true });
+      } else if (action === 'show-all') {
+        sourceSet.clear();
+        repoSet.clear();
+        searchQuery = '';
+        if (searchEl) searchEl.value = '';
+        resetRenderLimit();
+        persistQuickFilters();
+        updateQuickFilterUi();
+        pane.workqueue.scopeFilter = 'all';
+        updateScopeUi();
+        pane.workqueue.statusFilter = Array.from(WORKQUEUE_STATUSES);
+        statusSet.clear();
+        for (const s of WORKQUEUE_STATUSES) statusSet.add(s);
+        renderStatusMultiSelect();
+        await fetchAndRenderWorkqueueItemsForPane(pane);
+      }
+      const firstRow = elements.thread.querySelector('[data-wq-list-body] [data-wq-item]');
+      firstRow?.focus?.({ preventScroll: true });
+    };
+    pane.workqueue.recoverEmptyState = recoverEmptyState;
 
     clearQuickBtn?.addEventListener('click', () => {
       sourceSet.clear();

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -154,6 +154,37 @@ function seedFilterSummaryWorkqueueItems(queue) {
   fs.writeFileSync(path.join(dir, 'work-queues.json'), JSON.stringify(data, null, 2));
 }
 
+function seedEmptyRecoveryWorkqueueItems(queue) {
+  const dir = path.join(env.tempHome, '.openclaw', 'clawnsole');
+  fs.mkdirSync(dir, { recursive: true });
+  const now = new Date();
+  const iso = (offsetMs) => new Date(now.getTime() + offsetMs).toISOString();
+  const data = {
+    version: 1,
+    queues: { [queue]: { name: queue, createdAt: iso(-120000) } },
+    assignments: {},
+    items: [
+      {
+        id: 'empty-recovery-failed',
+        queue,
+        title: '[issue] rmdmattingly/clawnsole#388 hidden failed row',
+        instructions: 'Repo: rmdmattingly/clawnsole\nIssue: https://github.com/rmdmattingly/clawnsole/issues/388',
+        priority: 10,
+        status: 'failed',
+        claimedBy: '',
+        claimedAt: '',
+        leaseUntil: 0,
+        attempts: 0,
+        lastError: '',
+        createdAt: iso(-60000),
+        updatedAt: iso(-60000),
+        dedupeKey: 'empty-recovery-hidden-failed'
+      }
+    ]
+  };
+  fs.writeFileSync(path.join(dir, 'work-queues.json'), JSON.stringify(data, null, 2));
+}
+
 function seedExactDuplicateWorkqueueItems(queue) {
   const dir = path.join(env.tempHome, '.openclaw', 'clawnsole');
   fs.mkdirSync(dir, { recursive: true });
@@ -405,6 +436,48 @@ test('workqueue pane: status filter uses human labels and queue-scoped counts', 
   await customQueue.press('Enter');
   await expect(wqPane.locator('[data-wq-statusline]')).toContainText('1 item');
   await expect(wqPane.locator('[data-wq-status-options] .wq-status-chip', { hasText: 'Ready (1)' })).toHaveCount(1);
+});
+
+test('workqueue pane: empty state offers recovery actions when filters hide rows', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  const queue = `empty-recovery-${Date.now()}`;
+  seedEmptyRecoveryWorkqueueItems(queue);
+
+  await page.addInitScript(() => {
+    window.__wqFeedEvents = [];
+    const originalLog = console.log;
+    console.log = (...args) => {
+      if (args[0] === '[clawnsole]' && args[1]?.label === 'workqueue.emptyRecovery') {
+        window.__wqFeedEvents.push(args[1]);
+      }
+      return originalLog.apply(console, args);
+    };
+  });
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  const wqPane = page.locator('[data-pane]').last();
+  await wqPane.locator('[data-wq-queue-select]').selectOption('__custom__');
+  await wqPane.locator('[data-wq-queue-custom]').fill(queue);
+  await wqPane.locator('[data-wq-queue-custom]').press('Enter');
+
+  const empty = wqPane.locator('[data-wq-empty]');
+  await expect(empty).toBeVisible();
+  await expect(empty).toContainText('0 visible of 1 total; hidden by status 1.');
+  await expect(empty.locator('[data-wq-empty-reset-scope]')).toBeVisible();
+  await expect(empty.locator('[data-wq-empty-clear-status]')).toBeVisible();
+  await expect(empty.locator('[data-wq-empty-show-all]')).toBeVisible();
+
+  await empty.locator('[data-wq-empty-show-all]').click();
+
+  await expect(wqPane.locator('[data-wq-list-body] .wq-row')).toHaveCount(1);
+  await expect(wqPane.locator('[data-wq-list-body]')).toContainText('hidden failed row');
+  const events = await page.evaluate(() => window.__wqFeedEvents.map((entry) => entry.payload));
+  expect(events).toContain('action=show-all');
 });
 
 test('workqueue pane: filter summary chips show counts and remove filters', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Add recovery actions to the Workqueue pane empty state when filters hide all rows.
- Show a count/reason string and log the selected recovery action.
- Cover the filtered-empty recovery path with a focused Playwright test.

## Tests
- npm run test:syntax
- npx playwright test tests/ui/workqueue-pane.spec.js -g "empty state offers recovery actions" --workers=1
