### PR TITLE
feat: add paired target lock for Chat and Workqueue panes

### DIFF
--- a/app.js
+++ b/app.js
@@ -2686,6 +2686,78 @@ function paneManagerHighlightHtml(value, query) {
   ].join('');
 }
 
+function panePairContextKey(pane) {
+  if (!pane) return '';
+  const kind = String(pane.kind || 'chat');
+  if (kind !== 'chat' && kind !== 'workqueue') return '';
+  return normalizeAgentId(pane.agentId || 'main');
+}
+
+function paneCounterpartKind(kind) {
+  if (kind === 'chat') return 'workqueue';
+  if (kind === 'workqueue') return 'chat';
+  return '';
+}
+
+function findPairedPane(sourcePane, panes = [], { contextKey } = {}) {
+  if (!sourcePane) return null;
+  const counterpartKind = paneCounterpartKind(String(sourcePane.kind || ''));
+  if (!counterpartKind) return null;
+  const pairContextKey = contextKey || panePairContextKey(sourcePane);
+  return panes.find((entry) =>
+    entry &&
+    entry !== sourcePane &&
+    String(entry.kind || '') === counterpartKind &&
+    panePairContextKey(entry) === pairContextKey
+  ) || null;
+}
+
+function paneSupportsTargetLock(pane) {
+  if (!pane || pane.role !== 'admin') return false;
+  return pane.kind === 'chat' || pane.kind === 'workqueue';
+}
+
+function renderPaneTargetLockChip(pane) {
+  const chip = pane?.elements?.agentPill;
+  if (!chip) return;
+  if (!paneSupportsTargetLock(pane)) {
+    chip.hidden = true;
+    return;
+  }
+  const locked = !!pane.pairedTargetLock;
+  chip.hidden = false;
+  chip.textContent = locked ? '🔒 Linked' : 'Unlocked';
+  chip.setAttribute('aria-pressed', locked ? 'true' : 'false');
+  chip.setAttribute('aria-label', locked ? 'Target lock enabled; click to unlock' : 'Target lock disabled; click to link paired panes');
+  chip.title = locked
+    ? 'Linked: changing this pane target also retargets its paired pane'
+    : 'Unlocked: this pane target changes independently';
+}
+
+function paneToggleTargetLock(pane) {
+  if (!paneSupportsTargetLock(pane)) return;
+  pane.pairedTargetLock = !pane.pairedTargetLock;
+  renderPaneTargetLockChip(pane);
+  paneManager.persistAdminPanes();
+  toast(pane.pairedTargetLock ? 'Target lock enabled.' : 'Target lock disabled.', 'info');
+}
+
+function syncPairedPaneTarget(sourcePane, nextAgentId, { previousAgentId } = {}) {
+  if (!paneSupportsTargetLock(sourcePane) || !sourcePane.pairedTargetLock) return;
+  const previousContextKey = previousAgentId ? normalizeAgentId(previousAgentId) : '';
+  const paired = findPairedPane(sourcePane, paneManager?.panes || [], {
+    contextKey: previousContextKey || panePairContextKey(sourcePane)
+  });
+  if (!paired || !paneSupportsTargetLock(paired)) {
+    toast('No compatible paired pane to sync.', 'info');
+    return;
+  }
+  paneSetAgent(paired, nextAgentId, {
+    requireDraftConfirm: false,
+    syncFromPaneKey: sourcePane.key
+  });
+}
+
 function paneGroupOrder(kind) {
   const order = { chat: 0, workqueue: 1, cron: 2, timeline: 3 };
   return Number.isInteger(order[kind]) ? order[kind] : 99;
@@ -3122,6 +3194,18 @@ function buildCommandPaletteItems() {
       )
     );
   });
+
+  const focusedKey = focusedPaneKey();
+  const focusedPane = paneManager.panes.find((p) => p?.key === focusedKey) || paneManager.panes[0] || null;
+  if (paneSupportsTargetLock(focusedPane)) {
+    const nextLabel = focusedPane.pairedTargetLock ? 'Disable' : 'Enable';
+    items.push(withShortcut({
+      id: 'cmd:toggle-target-lock',
+      label: `Pane: ${nextLabel} target lock`,
+      detail: `${paneLabel(focusedPane)} · ${paneTargetLabel(focusedPane)}`,
+      run: () => paneToggleTargetLock(focusedPane)
+    }, '⌘/Ctrl+Shift+L'));
+  }
 
   // Core open actions for all enabled pane types.
   items.push(
@@ -7690,10 +7774,11 @@ function paneSetDestinationStrip(pane) {
   valueEl.textContent = displayText;
 }
 
-function paneSetAgent(pane, nextAgentId, { requireDraftConfirm = true } = {}) {
+function paneSetAgent(pane, nextAgentId, { requireDraftConfirm = true, syncFromPaneKey = '' } = {}) {
   if (pane.role !== 'admin') return;
   const next = normalizeAgentId(nextAgentId);
   if (next === pane.agentId) return;
+  const previous = pane.agentId;
 
   if (requireDraftConfirm && pane.kind === 'chat' && paneHasDraftChanges(pane)) {
     const nextAgent = getAgentRecord(next);
@@ -7704,21 +7789,35 @@ function paneSetAgent(pane, nextAgentId, { requireDraftConfirm = true } = {}) {
 
   pane.agentId = next;
   markAgentSeen(next);
-  storage.set(ADMIN_DEFAULT_AGENT_KEY, next);
+  if (pane.kind === 'chat') {
+    storage.set(ADMIN_DEFAULT_AGENT_KEY, next);
+  }
   try {
+    renderAgentOptions(pane.elements.agentSelect, next);
     if (pane.elements.agentSelect) pane.elements.agentSelect.value = next;
   } catch {}
-  renderPaneAgentIdentity(pane);
 
-  pane.attachments.files = [];
-  paneRenderAttachments(pane);
-  paneStopThinking(pane);
-  paneClearChatHistory(pane, { wipeStorage: false });
-  paneRestoreChatHistory(pane);
-  paneSetChatEnabled(pane);
+  if (pane.kind === 'chat') {
+    renderPaneAgentIdentity(pane);
+    pane.attachments.files = [];
+    paneRenderAttachments(pane);
+    paneStopThinking(pane);
+    paneClearChatHistory(pane, { wipeStorage: false });
+    paneRestoreChatHistory(pane);
+    paneSetChatEnabled(pane);
+  } else {
+    renderPaneIdentity(pane);
+    renderPaneTargetLockChip(pane);
+    if (pane.kind === 'workqueue') {
+      renderWorkqueuePaneItems(pane);
+    }
+  }
 
   paneManager.persistAdminPanes();
-  if (pane.connected) {
+  if (!syncFromPaneKey || syncFromPaneKey !== pane.key) {
+    syncPairedPaneTarget(pane, next, { previousAgentId: previous });
+  }
+  if (pane.kind === 'chat' && pane.connected) {
     pane.client.request('sessions.resolve', { key: pane.sessionKey() });
   }
 }
@@ -7762,7 +7861,7 @@ function normalizeWorkqueueGroupMode(value) {
   return String(value || '').trim().toLowerCase() === 'grouped' ? 'grouped' : 'rows';
 }
 
-function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, scopeFilter, quickFilters, groupMode, sortKey, sortDir, cronAgentId, nickname, closable = true } = {}) {
+function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, scopeFilter, quickFilters, groupMode, sortKey, sortDir, cronAgentId, nickname, pairedTargetLock = false, closable = true } = {}) {
   const template = globalElements.paneTemplate;
   const root = template.content.firstElementChild.cloneNode(true);
   const elements = {
@@ -7781,6 +7880,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     agentButton: root.querySelector('[data-pane-agent-button]'),
     agentLabel: root.querySelector('[data-pane-agent-label]'),
     agentWarning: root.querySelector('[data-pane-agent-warning]'),
+    agentPill: root.querySelector('[data-pane-agent-pill]'),
     status: root.querySelector('[data-pane-status]'),
     activityBadge: root.querySelector('[data-pane-activity-badge]'),
     helpDetails: root.querySelector('[data-pane-help]'),
@@ -7841,6 +7941,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     chat: { runs: new Map(), history: [] },
     unreadCount: 0,
     unreadKind: '',
+    pairedTargetLock: !!pairedTargetLock,
     scroll: { pinned: true },
     thinking: { active: false, timer: null, dotsTimer: null, bubble: null },
     activeRunId: null,
@@ -7870,6 +7971,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     event.stopPropagation();
     promptPaneNickname(pane);
   });
+  elements.agentPill?.addEventListener('click', () => paneToggleTargetLock(pane));
+  renderPaneTargetLockChip(pane);
 
   // Pane header: kind label + type pill (icon + text)
   try {
@@ -8177,6 +8280,15 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         } catch {}
       }
     });
+    renderAgentOptions(elements.agentSelect, pane.agentId);
+    if (elements.agentSelect) {
+      try {
+        elements.agentSelect.value = pane.agentId;
+      } catch {}
+      elements.agentSelect.addEventListener('change', (event) => {
+        paneSetAgent(pane, String(event.target.value || '').trim());
+      });
+    }
     const statusRootEl = elements.thread.querySelector('[data-wq-status]');
     const statusSelectedEl = elements.thread.querySelector('[data-wq-status-selected]');
     const statusOptionsEl = elements.thread.querySelector('[data-wq-status-options]');
@@ -9403,6 +9515,7 @@ const paneManager = {
         sortKey: cfg.sortKey,
         sortDir: cfg.sortDir,
         nickname: cfg.nickname,
+        pairedTargetLock: cfg.pairedTargetLock,
         closable: true
       })
     );
@@ -9465,6 +9578,7 @@ const paneManager = {
         if (!key) return null;
         const nickname = normalizePaneNickname(item.nickname);
         if (kind === 'workqueue') {
+          const pairedTargetLock = !!item.pairedTargetLock;
           const queue = typeof item.queue === 'string' && item.queue.trim() ? item.queue.trim() : 'dev-team';
           const agentId = normalizeAgentId(typeof item.agentId === 'string' ? item.agentId : defaultAgent);
           const statusFilter = Array.isArray(item.statusFilter)
@@ -9479,17 +9593,17 @@ const paneManager = {
           const sortKey = typeof item.sortKey === 'string' ? item.sortKey : 'priority';
           const sortDir = item.sortDir === 'asc' ? 'asc' : 'desc';
           const groupMode = normalizeWorkqueueGroupMode(item.groupMode);
-          return { key, kind, agentId, queue, statusFilter, scopeFilter, quickFilters, groupMode, sortKey, sortDir, nickname };
+          return { key, kind, agentId, queue, statusFilter, scopeFilter, quickFilters, groupMode, sortKey, sortDir, nickname, pairedTargetLock };
         }
         if (kind === 'cron' || kind === 'timeline') {
           return { key, kind, nickname };
         }
         const agentId = normalizeAgentId(typeof item.agentId === 'string' ? item.agentId : defaultAgent);
-        return { key, kind: 'chat', agentId, nickname };
+        return { key, kind: 'chat', agentId, nickname, pairedTargetLock: !!item.pairedTargetLock };
       }
       // Super-legacy format: ['pabc','pdef'] (treat as chat panes)
       if (typeof item === 'string' && item) {
-        return { key: item, kind: 'chat', agentId: defaultAgent };
+        return { key: item, kind: 'chat', agentId: defaultAgent, pairedTargetLock: false };
       }
       return null;
     };
@@ -9518,6 +9632,7 @@ const paneManager = {
           key: pane.key,
           kind: 'workqueue',
           agentId: pane.agentId || 'main',
+          pairedTargetLock: !!pane.pairedTargetLock,
           queue: pane.workqueue?.queue || 'dev-team',
           statusFilter: Array.isArray(pane.workqueue?.statusFilter) ? pane.workqueue.statusFilter : [],
           scopeFilter: pane.workqueue?.scopeFilter || 'all',
@@ -9535,7 +9650,7 @@ const paneManager = {
       if (pane.kind === 'cron' || pane.kind === 'timeline') {
         return { key: pane.key, kind: pane.kind, nickname: paneNickname(pane) };
       }
-      return { key: pane.key, kind: 'chat', agentId: pane.agentId || 'main', nickname: paneNickname(pane) };
+      return { key: pane.key, kind: 'chat', agentId: pane.agentId || 'main', nickname: paneNickname(pane), pairedTargetLock: !!pane.pairedTargetLock };
     });
     storage.set(ADMIN_PANES_KEY, JSON.stringify(payload));
   },
@@ -10954,6 +11069,17 @@ window.addEventListener('keydown', (event) => {
     event.preventDefault();
     openFleetPane();
     return;
+  }
+
+  // Cmd/Ctrl+Shift+L toggles paired target lock on focused Chat/Workqueue pane.
+  if ((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey && key.toLowerCase() === 'l') {
+    const focusedKey = focusedPaneKey();
+    const pane = paneManager.panes.find((p) => p?.key === focusedKey) || paneManager.panes[0] || null;
+    if (paneSupportsTargetLock(pane)) {
+      event.preventDefault();
+      paneToggleTargetLock(pane);
+      return;
+    }
   }
 
   // Cmd/Ctrl+Shift+H opens Agents and sorts by heartbeat age (stale first).

--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
                 </div>
               </div>
               <div class="pane-header-right">
-                <div class="pane-agent-pill" data-pane-agent-pill data-testid="pane-agent-pill" hidden></div>
+                <button class="pane-agent-pill" data-pane-agent-pill data-pane-target-lock type="button" data-testid="pane-target-lock" hidden></button>
                 <div class="pane-agent-warning" data-pane-agent-warning hidden></div>
 
                 <details class="pane-help" data-pane-help>

--- a/tests/agent-picker.e2e.spec.js
+++ b/tests/agent-picker.e2e.spec.js
@@ -71,3 +71,49 @@ test('agent chooser: opens, shows agents, Esc closes', async ({ page }) => {
   await page.keyboard.press('Escape');
   await expect(chooser).toHaveCount(0);
 });
+
+test('paired target lock: ON syncs chat target to paired workqueue; OFF does not', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.evaluate(() => {
+    localStorage.removeItem('clawnsole.admin.panes.v1');
+    localStorage.removeItem('clawnsole.admin.agentId');
+  });
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const chatPane = page.locator('[data-pane-kind="chat"]').first();
+  const wqPane = page.locator('[data-pane-kind="workqueue"]').first();
+  const lockBtn = chatPane.getByTestId('pane-target-lock');
+  const chatTargetBtn = chatPane.getByTestId('pane-agent-button');
+
+  await expect(lockBtn).toContainText(/unlocked/i);
+  await lockBtn.click();
+  await expect(lockBtn).toContainText(/linked/i);
+
+  await chatTargetBtn.click();
+  const chooser = page.getByRole('dialog', { name: 'Choose agent' });
+  await chooser.getByRole('button', { name: /dev/i }).click();
+  await expect(chooser).toHaveCount(0);
+
+  await expect
+    .poll(async () => wqPane.getByTestId('pane-agent-select').inputValue())
+    .toBe('dev');
+
+  await lockBtn.click();
+  await expect(lockBtn).toContainText(/unlocked/i);
+
+  await chatTargetBtn.click();
+  const secondChooser = page.getByRole('dialog', { name: 'Choose agent' });
+  await secondChooser.getByRole('button', { name: /main/i }).click();
+  await expect(secondChooser).toHaveCount(0);
+
+  await expect
+    .poll(async () => wqPane.getByTestId('pane-agent-select').inputValue())
+    .toBe('dev');
+});


### PR DESCRIPTION
## Summary
- add an optional Linked/Unlocked target-lock chip for admin Chat and Workqueue panes
- sync the paired pane target when the lock is enabled, with a non-blocking hint when no compatible pair exists
- persist lock state and expose it through the command palette / Cmd+Shift+L

Supersedes the older conflicting implementation in #403.

## Tests
- npm test
- npx playwright test tests/agent-picker.e2e.spec.js --workers=1

Fixes #393