### PR TITLE
Add Pane Manager paired counterpart action

### DIFF
--- a/app.js
+++ b/app.js
@@ -2735,6 +2735,86 @@ function movePaneWithinVisible(paneKey, direction, visibleKeys) {
   return moved;
 }
 
+function getPairedPaneKind(pane) {
+  if (pane?.kind === 'chat') return 'workqueue';
+  if (pane?.kind === 'workqueue') return 'chat';
+  return '';
+}
+
+function getPanePairTarget(pane) {
+  if (!pane || (pane.kind !== 'chat' && pane.kind !== 'workqueue')) return '';
+  return normalizeAgentId(pane.agentId || 'main');
+}
+
+function findPairedPaneForPane(pane) {
+  const pairedKind = getPairedPaneKind(pane);
+  const target = getPanePairTarget(pane);
+  if (!pairedKind || !target) return null;
+  return (
+    (paneManager?.panes || []).find(
+      (candidate) =>
+        candidate &&
+        candidate !== pane &&
+        candidate.kind === pairedKind &&
+        getPanePairTarget(candidate) === target
+    ) || null
+  );
+}
+
+function getPanePairOpenOptions(pane) {
+  const pairedKind = getPairedPaneKind(pane);
+  const target = getPanePairTarget(pane);
+  if (!pairedKind || !target) return null;
+  if (pairedKind === 'workqueue') {
+    const preferredQueue =
+      String((paneManager?.panes || []).find((entry) => entry?.kind === 'workqueue')?.workqueue?.queue || '').trim() ||
+      'dev-team';
+    return {
+      agentId: target,
+      queue: preferredQueue,
+      scopeFilter: 'assigned'
+    };
+  }
+  return { agentId: target };
+}
+
+function getPaneManagerPairedAction(pane) {
+  const pairedKind = getPairedPaneKind(pane);
+  const target = getPanePairTarget(pane);
+  if (!pairedKind || !target) return null;
+
+  const existing = findPairedPaneForPane(pane);
+  const labelKind = pairedKind === 'workqueue' ? 'Workqueue' : 'Chat';
+  const disabled = !existing && (paneManager?.panes || []).length >= (paneManager?.maxPanes || 0);
+
+  return {
+    pairedKind,
+    labelKind,
+    target,
+    state: existing ? 'focus' : 'open',
+    text: existing ? `Paired ${labelKind}` : `Open paired ${labelKind}`,
+    title: existing
+      ? `Focus paired ${labelKind} for ${target}`
+      : disabled
+        ? `Pane limit reached; close a pane to open paired ${labelKind} for ${target}`
+        : `Open paired ${labelKind} for ${target}`,
+    disabled
+  };
+}
+
+function focusOrOpenPairedPaneForPane(pane) {
+  const existing = findPairedPaneForPane(pane);
+  if (existing) {
+    paneManager.focusPanePrimary(existing);
+    return existing;
+  }
+
+  const pairedKind = getPairedPaneKind(pane);
+  const options = getPanePairOpenOptions(pane);
+  if (!pairedKind || !options) return null;
+  return paneManager.addPane(pairedKind, options);
+}
+
 function renderPaneManager() {
   const panes = paneManager?.panes || [];
   const list = globalElements.paneManagerList;
@@ -2816,6 +2896,7 @@ function renderPaneManager() {
         const unreadCount = paneUnreadCount(pane);
         const paneIdentity = paneSummaryLabel(pane);
         const nickname = paneNickname(pane);
+        const pairedAction = getPaneManagerPairedAction(pane);
 
         const lockDisabled = paneManager.isLayoutLocked();
 
@@ -2835,6 +2916,7 @@ function renderPaneManager() {
             <button class="secondary pane-manager-up" type="button" data-action="move-up" data-testid="pane-manager-move-up" title="${lockDisabled ? 'Layout is locked' : 'Move pane up'}" aria-label="Move pane up" ${(visibleIdx === 0 || lockDisabled) ? 'disabled' : ''}>↑</button>
             <button class="secondary pane-manager-down" type="button" data-action="move-down" data-testid="pane-manager-move-down" title="${lockDisabled ? 'Layout is locked' : 'Move pane down'}" aria-label="Move pane down" ${(visibleIdx === visibleKeys.length - 1 || lockDisabled) ? 'disabled' : ''}>↓</button>
             ${isDuplicate ? '<button class="secondary pane-manager-close-others" type="button" data-action="close-others" data-testid="pane-manager-close-others">Close others</button>' : ''}
+            ${pairedAction ? `<button class="secondary pane-manager-paired" type="button" data-action="paired" data-testid="pane-manager-paired-action" data-paired-kind="${escapeHtml(pairedAction.pairedKind)}" data-paired-state="${escapeHtml(pairedAction.state)}" data-paired-target="${escapeHtml(pairedAction.target)}" title="${escapeHtml(pairedAction.title)}" aria-label="${escapeHtml(pairedAction.title)}" ${pairedAction.disabled ? 'disabled' : ''}>${escapeHtml(pairedAction.text)}</button>` : ''}
             <button class="secondary pane-manager-nickname-action" type="button" data-action="nickname" data-testid="pane-manager-nickname-action">Nickname</button>
             <button class="secondary pane-manager-focus" type="button" data-action="focus">Focus</button>
             <button class="secondary pane-manager-close" type="button" data-action="close">Close</button>
@@ -2902,6 +2984,15 @@ function renderPaneManager() {
           }
           if (action === 'nickname') {
             promptPaneNickname(pane);
+            return;
+          }
+          if (action === 'paired') {
+            const pairedPane = focusOrOpenPairedPaneForPane(pane);
+            if (pairedPane) {
+              closePaneManager();
+            } else {
+              renderPaneManager();
+            }
             return;
           }
           closePaneManager();

--- a/tests/ui/pane-manager-paired-action.spec.js
+++ b/tests/ui/pane-manager-paired-action.spec.js
@@ -1,0 +1,115 @@
+const { test, expect } = require('@playwright/test');
+
+const { startTestEnv, waitForAdminUiReady, attachConsoleErrorAsserts, addPane } = require('./_helpers');
+
+let env;
+
+test.beforeAll(async () => {
+  env = await startTestEnv();
+});
+
+test.afterAll(() => {
+  env?.stop?.();
+});
+
+test.afterEach(async ({ page }) => {
+  if (page.__consoleAsserts) {
+    page.__consoleAsserts.assertNoErrors();
+  }
+});
+
+async function loginWithPanes(page, panes) {
+  await page.addInitScript((nextPanes) => {
+    localStorage.setItem('clawnsole.admin.agentId', 'main');
+    localStorage.setItem('clawnsole.admin.panes.v1', JSON.stringify(nextPanes));
+    localStorage.removeItem('clawnsole.admin.authRestoreNotice.v1');
+  }, panes);
+  await page.goto(`http://127.0.0.1:${env.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await waitForAdminUiReady(page);
+}
+
+test('pane manager paired action focuses an existing counterpart', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginWithPanes(page, [
+    { key: 'ptestchat', kind: 'chat', agentId: 'main' },
+    {
+      key: 'ptestwq',
+      kind: 'workqueue',
+      agentId: 'main',
+      queue: 'dev-team',
+      statusFilter: ['ready', 'pending', 'blocked', 'claimed', 'in_progress'],
+      scopeFilter: 'assigned',
+      sortKey: 'priority',
+      sortDir: 'desc'
+    }
+  ]);
+
+  await page.locator('[data-pane-kind="chat"] [data-pane-input]').click();
+  await page.locator('#paneManagerBtn').click();
+
+  const manager = page.getByTestId('pane-manager-modal');
+  const chatRow = manager.locator('.pane-manager-row[data-pane-kind="chat"]').first();
+  const pairedAction = chatRow.getByTestId('pane-manager-paired-action');
+  await expect(pairedAction).toHaveText('Paired Workqueue');
+  await expect(pairedAction).toHaveAttribute('data-paired-kind', 'workqueue');
+  await expect(pairedAction).toHaveAttribute('data-paired-state', 'focus');
+  await expect(pairedAction).toHaveAttribute('data-paired-target', 'main');
+
+  await pairedAction.click();
+
+  await expect(manager).not.toHaveClass(/open/);
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"] [data-wq-queue-select]')).toBeFocused();
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
+});
+
+test('pane manager paired action opens a missing counterpart for the same target', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginWithPanes(page, [{ key: 'ptestchat', kind: 'chat', agentId: 'main' }]);
+
+  await page.locator('#paneManagerBtn').click();
+
+  const manager = page.getByTestId('pane-manager-modal');
+  const chatRow = manager.locator('.pane-manager-row[data-pane-kind="chat"]').first();
+  const pairedAction = chatRow.getByTestId('pane-manager-paired-action');
+  await expect(pairedAction).toHaveText('Open paired Workqueue');
+  await expect(pairedAction).toHaveAttribute('data-paired-kind', 'workqueue');
+  await expect(pairedAction).toHaveAttribute('data-paired-state', 'open');
+  await expect(pairedAction).toHaveAttribute('data-paired-target', 'main');
+
+  await pairedAction.click();
+
+  const wqPane = page.locator('[data-pane][data-pane-kind="workqueue"]').first();
+  await expect(wqPane).toBeVisible();
+  await expect(wqPane.locator('[data-wq-queue-select]')).toBeFocused();
+  await expect(wqPane.locator('[data-wq-scope="assigned"]')).toHaveAttribute('aria-pressed', 'true');
+
+  await page.locator('#paneManagerBtn').click();
+  await expect(chatRow.getByTestId('pane-manager-paired-action')).toHaveAttribute('data-paired-state', 'focus');
+});
+
+test('pane manager paired action is omitted for panes without counterpart behavior', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginWithPanes(page, [{ key: 'ptestchat', kind: 'chat', agentId: 'main' }]);
+  await addPane(page, 'New Cron pane');
+  await addPane(page, 'New Timeline pane');
+
+  await page.locator('#paneManagerBtn').click();
+
+  const manager = page.getByTestId('pane-manager-modal');
+  await expect(manager.locator('.pane-manager-row[data-pane-kind="cron"]').last().getByTestId('pane-manager-paired-action')).toHaveCount(0);
+  await expect(manager.locator('.pane-manager-row[data-pane-kind="timeline"]').last().getByTestId('pane-manager-paired-action')).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary
- Add a Pane Manager row action for Chat ↔ Workqueue counterparts with visible focus/open state and target metadata.
- Focus an existing counterpart when present, or open a matching Workqueue/Chat pane for the same target.
- Cover focus-existing, open-missing, and no-affordance cases in Playwright.

## Tests
- npm run test:syntax
- npx playwright test tests/ui/pane-manager-paired-action.spec.js --workers=1

Fixes #395