### PR TITLE
Add actionable auth session chip

### DIFF
--- a/app.js
+++ b/app.js
@@ -86,6 +86,7 @@ const globalElements = {
   shortcutOverridesResetAll: document.getElementById('shortcutOverridesResetAll'),
   shortcutOverridesError: document.getElementById('shortcutOverridesError'),
   rolePill: document.getElementById('rolePill'),
+  authSessionPopover: document.getElementById('authSessionPopover'),
   loginOverlay: document.getElementById('loginOverlay'),
   loginPassword: document.getElementById('loginPassword'),
   loginBtn: document.getElementById('loginBtn'),
@@ -180,10 +181,20 @@ const normalizeAdminDestination = __appCore.normalizeAdminDestination || ((candi
 });
 const deriveAuthOverlayState = __appCore.deriveAuthOverlayState || ((state) => ({
   isAdmin: String(state?.role || '') === 'admin',
+  authState: !!state?.authed ? 'signed_in' : (String(state?.role || '') === 'admin' ? 'locked' : 'signed_out'),
   startAgentAutoRefresh: String(state?.role || '') === 'admin' && !!state?.authed,
   stopAgentAutoRefresh: String(state?.role || '') !== 'admin' || !state?.authed,
-  rolePillText: String(state?.role || '') === 'admin' ? 'signed in' : (state?.role || 'signed out'),
-  rolePillAdmin: String(state?.role || '') === 'admin',
+  rolePillText: !!state?.authed ? `Signed in - ${String(state?.role || '') === 'admin' ? 'Admin' : (state?.role || 'Guest')} - ${state?.environment || 'local'}` : 'Signed out',
+  rolePillAdmin: String(state?.role || '') === 'admin' && !!state?.authed,
+  rolePillLocked: !state?.authed && String(state?.role || '') === 'admin',
+  rolePillSignedOut: !state?.authed && String(state?.role || '') !== 'admin',
+  rolePillActionLabel: !!state?.authed ? 'Open session details' : 'Focus password input to unlock session',
+  rolePillTooltip: !!state?.authed
+    ? `Session context: signed in as ${String(state?.role || '') === 'admin' ? 'Admin' : (state?.role || 'Guest')} in ${state?.environment || 'local'}. Click for session details.`
+    : `Session context: signed out in ${state?.environment || 'local'}. Click to unlock this session.`,
+  authLabel: !!state?.authed ? 'Signed in' : 'Signed out',
+  principalLabel: !!state?.authed ? (String(state?.role || '') === 'admin' ? 'Admin' : (state?.role || 'Guest')) : 'Not signed in',
+  environmentLabel: state?.environment || 'local',
   showAdminControls: String(state?.role || '') === 'admin',
   logoutEnabled: !!state?.authed,
   logoutOpacity: !!state?.authed ? '1' : '0.5'
@@ -1288,6 +1299,7 @@ async function fetchMeta() {
     if (data?.wsUrl) {
       globalElements.wsUrl.value = data.wsUrl;
       uiState.meta = data;
+      renderAuthSessionUi();
       return data;
     }
     return null;
@@ -1405,9 +1417,52 @@ function updateConnectionControls() {
   globalElements.disconnectBtn.textContent = control.text;
 }
 
+function currentAuthUi() {
+  return deriveAuthOverlayState({
+    authed: uiState.authed,
+    role: roleState.role,
+    environment: uiState.meta?.instance || 'local'
+  });
+}
+
+function closeAuthSessionPopover() {
+  if (!globalElements.authSessionPopover) return;
+  globalElements.authSessionPopover.hidden = true;
+  globalElements.rolePill?.setAttribute('aria-expanded', 'false');
+}
+
+function renderAuthSessionUi() {
+  const authUi = currentAuthUi();
+  const pill = globalElements.rolePill;
+  if (pill) {
+    pill.textContent = authUi.rolePillText;
+    pill.classList.toggle('admin', authUi.rolePillAdmin);
+    pill.classList.toggle('locked', authUi.rolePillLocked);
+    pill.classList.toggle('signed-out', authUi.rolePillSignedOut);
+    pill.dataset.authState = authUi.authState || 'signed_out';
+    pill.setAttribute('aria-label', authUi.rolePillActionLabel || 'Authentication status');
+    pill.title = authUi.rolePillTooltip || authUi.rolePillActionLabel || 'Authentication status';
+  }
+
+  const popover = globalElements.authSessionPopover;
+  if (popover) {
+    const statusEl = popover.querySelector('[data-auth-session-status]');
+    const principalEl = popover.querySelector('[data-auth-session-principal]');
+    const envEl = popover.querySelector('[data-auth-session-env]');
+    if (statusEl) statusEl.textContent = authUi.authLabel || 'Signed out';
+    if (principalEl) principalEl.textContent = authUi.principalLabel || 'Not signed in';
+    if (envEl) envEl.textContent = authUi.environmentLabel || 'local';
+    popover.querySelector('[data-auth-session-action="settings"]')?.toggleAttribute('hidden', !uiState.authed);
+    popover.querySelector('[data-auth-session-action="logout"]')?.toggleAttribute('hidden', !uiState.authed);
+    popover.querySelector('[data-auth-session-action="unlock"]')?.toggleAttribute('hidden', !!uiState.authed);
+  }
+
+  return authUi;
+}
+
 function setAuthState(authed) {
   uiState.authed = authed;
-  const authUi = deriveAuthOverlayState({ authed, role: roleState.role });
+  const authUi = renderAuthSessionUi();
   updateGlobalStatus();
   updateConnectionControls();
   paneManager.refreshChatEnabled();
@@ -1426,11 +1481,7 @@ function setAuthState(authed) {
 
 function setRole(role) {
   roleState.role = role;
-  const authUi = deriveAuthOverlayState({ authed: uiState.authed, role });
-  if (globalElements.rolePill) {
-    globalElements.rolePill.textContent = authUi.rolePillText;
-    globalElements.rolePill.classList.toggle('admin', authUi.rolePillAdmin);
-  }
+  const authUi = renderAuthSessionUi();
 
   const isAdmin = authUi.isAdmin;
   const visibleOpacity = isAdmin ? '1' : '0.5';
@@ -1491,10 +1542,7 @@ function showLogin(message = '') {
   // Guest role selection removed.
 
   setAuthState(false);
-  if (globalElements.rolePill) {
-    globalElements.rolePill.textContent = 'signed out';
-    globalElements.rolePill.classList.remove('admin');
-  }
+  closeAuthSessionPopover();
   globalElements.settingsBtn?.setAttribute('disabled', 'disabled');
   if (globalElements.settingsBtn) globalElements.settingsBtn.style.opacity = '0.5';
   globalElements.shortcutsBtn?.setAttribute('disabled', 'disabled');
@@ -2366,7 +2414,7 @@ function paneBrowserTitle(pane) {
     const target = paneDisplayTargetLabel(pane);
     if (target) parts.push(target);
   }
-  return parts.join(' · ');
+  return parts.join(' - ');
 }
 
 function updateBrowserTitle(pane = null) {
@@ -2385,14 +2433,14 @@ function paneIdentityLabel(pane, { includeUnread = false } = {}) {
   const target = paneDisplayTargetLabel(pane);
   const nickname = paneNickname(pane);
   const unread = paneUnreadCount(pane);
-  return `${letter} ${type} · ${target}${nickname ? ` · ${nickname}` : ''}${includeUnread && unread > 0 ? ` • ${unread} unread` : ''}`;
+  return `${letter} ${type} - ${target}${nickname ? ` - ${nickname}` : ''}${includeUnread && unread > 0 ? ` • ${unread} unread` : ''}`;
 }
 
 function paneSummaryLabel(pane) {
   const letter = paneHeaderLetter(pane);
   const type = paneLabel(pane);
   const target = paneDisplayTargetLabel(pane);
-  return `${letter} ${type} · ${target}`;
+  return `${letter} ${type} - ${target}`;
 }
 
 function isPaneSwitchHudEnabled() {
@@ -3109,8 +3157,8 @@ function buildCommandPaletteItems() {
       withShortcut(
         {
           id: `cmd:focus-pane-${pane.key}`,
-          label: `Focus ${type}: ${target}${nickname ? ` · ${nickname}` : ''}`,
-          detail: `Pane ${letter} · focus existing`,
+          label: `Focus ${type}: ${target}${nickname ? ` - ${nickname}` : ''}`,
+          detail: `Pane ${letter} - focus existing`,
           paneMeta: [
             ...commandPalettePaneMeta({ type, target, mode: 'focus existing' }),
             ...(nickname ? [{ label: nickname, tone: 'nickname' }] : [])
@@ -3558,7 +3606,7 @@ function renderCommandPalette() {
         ${paneMetaMarkup}
         <div class="command-palette-item-detail">${escapeHtml(item.detail || '')}</div>
       </div>
-      <div class="command-palette-item-meta">${escapeHtml(item.shortcut || '')}${idx === selected ? (item.shortcut ? ' · ↵' : '↵') : ''}</div>
+      <div class="command-palette-item-meta">${escapeHtml(item.shortcut || '')}${idx === selected ? (item.shortcut ? ' - ↵' : '↵') : ''}</div>
     `;
 
     btn.addEventListener('mouseenter', () => {
@@ -5122,7 +5170,7 @@ function formatWorkqueueHiddenBreakdown(hiddenCounts = {}) {
 function formatWorkqueueVisibleSummary(shown, total, hiddenCounts = {}) {
   const base = formatWorkqueueCountText(shown, total);
   const hidden = formatWorkqueueHiddenBreakdown(hiddenCounts);
-  return hidden ? `${base} · ${hidden}` : base;
+  return hidden ? `${base} - ${hidden}` : base;
 }
 
 function getWorkqueueQuickFilterBreakdown(items, quickFilters) {
@@ -5261,7 +5309,7 @@ function formatWorkqueueStatusSummary(items) {
   return WORKQUEUE_STATUSES
     .filter((status) => Number(counts[status] || 0) > 0)
     .map((status) => `${formatWorkqueueStatusLabel(status)} ${counts[status]}`)
-    .join(' · ');
+    .join(' - ');
 }
 
 function newestWorkqueueUpdatedAt(items) {
@@ -5624,8 +5672,8 @@ function renderWorkqueuePaneItems(pane) {
       empty.innerHTML = `
         <div class="empty-state">
           <div style="font-weight:700; margin-bottom:6px;">${escapeHtml(title)}</div>
-          <div class="hint">Queue: <span class="mono">${escapeHtml(queue)}</span> · Status: <span class="mono">${escapeHtml(statusLabel)}</span> · Scope: <span class="mono">${escapeHtml(scopeLabel)}</span></div>
-          ${filtersHidingAll ? `<div class="hint" style="margin-top:6px;">Showing 0 of <span class="mono">${escapeHtml(String(totalCount))}</span> items${hiddenSummary ? ` · ${escapeHtml(hiddenSummary)}` : ''}.</div>` : ''}
+          <div class="hint">Queue: <span class="mono">${escapeHtml(queue)}</span> - Status: <span class="mono">${escapeHtml(statusLabel)}</span> - Scope: <span class="mono">${escapeHtml(scopeLabel)}</span></div>
+          ${filtersHidingAll ? `<div class="hint" style="margin-top:6px;">Showing 0 of <span class="mono">${escapeHtml(String(totalCount))}</span> items${hiddenSummary ? ` - ${escapeHtml(hiddenSummary)}` : ''}.</div>` : ''}
           <div style="display:flex; gap:8px; margin-top:10px; flex-wrap:wrap;">
             <button type="button" class="secondary" data-wq-empty-enqueue>Enqueue item</button>
             <button type="button" class="secondary" data-wq-empty-refresh>Refresh</button>
@@ -6963,7 +7011,7 @@ function paneFinishCanceledRun(pane, { runId = null, resetSession = false, fallb
         text: fallbackText || '_Canceled._',
         persist: true,
         state: 'canceled',
-        metaLabel: `${paneAssistantLabel(pane)} · Canceled`
+        metaLabel: `${paneAssistantLabel(pane)} - Canceled`
       });
     }
     pane.abortState.canceledRunIds.add(String(rid));
@@ -6973,7 +7021,7 @@ function paneFinishCanceledRun(pane, { runId = null, resetSession = false, fallb
       text: fallbackText || '_Canceled._',
       persist: true,
       state: 'canceled',
-      metaLabel: `${paneAssistantLabel(pane)} · Canceled`
+      metaLabel: `${paneAssistantLabel(pane)} - Canceled`
     });
   }
 
@@ -7064,9 +7112,9 @@ function paneUpdateOutboundBubble(entry) {
 
   const meta = bubble.querySelector('.chat-meta');
   if (meta) {
-    if (entry.state === 'queued') meta.textContent = 'You · Queued (not sent)';
-    else if (entry.state === 'sending') meta.textContent = 'You · Sending…';
-    else if (entry.state === 'failed') meta.textContent = 'You · Failed to send';
+    if (entry.state === 'queued') meta.textContent = 'You - Queued (not sent)';
+    else if (entry.state === 'sending') meta.textContent = 'You - Sending…';
+    else if (entry.state === 'failed') meta.textContent = 'You - Failed to send';
     else meta.textContent = 'You';
   }
 }
@@ -7234,7 +7282,7 @@ async function paneSendChat(pane) {
     role: 'user',
     text: outbound,
     persist: false,
-    metaLabel: 'You · Queued (not sent)',
+    metaLabel: 'You - Queued (not sent)',
     state: 'queued',
     actions: makeActions()
   });
@@ -7457,12 +7505,12 @@ function renderPaneIdentity(pane) {
   const target = paneDisplayTargetLabel(pane);
   const nickname = paneNickname(pane);
   const unread = paneUnreadCount(pane);
-  const identity = `${letter} ${type} · ${target}${nickname ? ` · ${nickname}` : ''}${unread > 0 ? ` • ${unread} unread` : ''}`;
+  const identity = `${letter} ${type} - ${target}${nickname ? ` - ${nickname}` : ''}${unread > 0 ? ` • ${unread} unread` : ''}`;
   pane.elements.name.title = paneIdentityLabel(pane, { includeUnread: false });
   pane.elements.name.setAttribute('aria-label', identity);
   if (pane.elements.nameToken && pane.elements.nameTarget) {
     pane.elements.nameToken.textContent = `${letter} ${type}`;
-    pane.elements.nameTarget.textContent = ` · ${target}${nickname ? ` · ${nickname}` : ''}${unread > 0 ? ` • ${unread} unread` : ''}`;
+    pane.elements.nameTarget.textContent = ` - ${target}${nickname ? ` - ${nickname}` : ''}${unread > 0 ? ` • ${unread} unread` : ''}`;
   } else {
     pane.elements.name.textContent = identity;
   }
@@ -9038,7 +9086,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
             if (search) parts.push(`search:${search}`);
             paneSetHeaderTarget(pane, {
               label: 'Timeline',
-              value: parts.join(' · '),
+              value: parts.join(' - '),
               ariaLabel: 'Timeline filters',
               onClick: () => {
                 try {
@@ -9056,7 +9104,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
             if (search) parts.push(`search:${search}`);
             paneSetHeaderTarget(pane, {
               label: 'Jobs',
-              value: parts.join(' · '),
+              value: parts.join(' - '),
               ariaLabel: 'Cron job filters',
               onClick: () => {
                 try {
@@ -9093,7 +9141,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         });
 
         const schedulerLabel = status?.enabled === false ? 'paused' : status?.enabled === true ? 'running' : 'unknown';
-        if (statusline) statusline.textContent = `scheduler: ${schedulerLabel} · jobs: ${filtered.length}/${jobs.length} · ${took}ms`;
+        if (statusline) statusline.textContent = `scheduler: ${schedulerLabel} - jobs: ${filtered.length}/${jobs.length} - ${took}ms`;
 
         if (!body) return;
 
@@ -9112,7 +9160,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
             body.innerHTML = `
               <div class="hint" style="padding: 10px 8px;">
                 <div style="font-weight:700; margin-bottom:6px;">No scheduled jobs.</div>
-                <div class="hint">Agent: <span class="mono">${escapeHtml(agentFilterLabel)}</span>${searchLabel ? ` · Search: <span class="mono">${escapeHtml(searchLabel)}</span>` : ''}${flags.length ? ` · Filters: <span class="mono">${escapeHtml(flags.join(', '))}</span>` : ''}</div>
+                <div class="hint">Agent: <span class="mono">${escapeHtml(agentFilterLabel)}</span>${searchLabel ? ` - Search: <span class="mono">${escapeHtml(searchLabel)}</span>` : ''}${flags.length ? ` - Filters: <span class="mono">${escapeHtml(flags.join(', '))}</span>` : ''}</div>
                 <div style="display:flex; gap:8px; margin-top:10px; flex-wrap:wrap;">
                   <button type="button" class="secondary" data-cron-empty-refresh>Refresh</button>
                 </div>
@@ -9145,7 +9193,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
                     <span class="pill ${enabled ? 'pill--ok' : 'pill--warn'}">${enabled ? 'enabled' : 'disabled'}</span>
                   </div>
                 </div>
-                <div class="hint">${escapeHtml(id)} · ${schedule ? escapeHtml(schedule) + ' · ' : ''}next: ${escapeHtml(nextRun || '—')} · last run: ${escapeHtml(lastRun || '—')} · last: ${escapeHtml(lastStatus || '—')}</div>
+                <div class="hint">${escapeHtml(id)} - ${schedule ? escapeHtml(schedule) + ' - ' : ''}next: ${escapeHtml(nextRun || '—')} - last run: ${escapeHtml(lastRun || '—')} - last: ${escapeHtml(lastStatus || '—')}</div>
                 <div class="cron-actions" role="group" aria-label="Cron job actions">
                   <button type="button" class="secondary" data-testid="cron-action-view" data-cron-action="view" data-job-id="${escapeHtml(id)}">View</button>
                   <button type="button" class="secondary" data-testid="cron-action-edit" data-cron-action="edit" data-job-id="${escapeHtml(id)}">Edit</button>
@@ -9217,7 +9265,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
           body.innerHTML = `
             <div class="hint" style="padding: 10px 8px;">
               <div style="font-weight:700; margin-bottom:6px;">No activity in range.</div>
-              <div class="hint">Range: <span class="mono">${escapeHtml(rangeLabel || String(rangeMs))}</span> · Status: <span class="mono">${escapeHtml(statusLabel)}</span>${searchLabel ? ` · Search: <span class="mono">${escapeHtml(searchLabel)}</span>` : ''}</div>
+              <div class="hint">Range: <span class="mono">${escapeHtml(rangeLabel || String(rangeMs))}</span> - Status: <span class="mono">${escapeHtml(statusLabel)}</span>${searchLabel ? ` - Search: <span class="mono">${escapeHtml(searchLabel)}</span>` : ''}</div>
               <div class="hint" style="margin-top:8px;">Tip: broaden the range or clear filters to find older runs.</div>
             </div>
           `;
@@ -9249,7 +9297,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
                     <span class="pill ${enabled ? 'pill--ok' : 'pill--warn'}">${enabled ? 'enabled' : 'disabled'}</span>
                   </div>
                 </div>
-                <div class="hint">${escapeHtml(fmtTime(ev.ts))} · ${escapeHtml(id)}${nextRun ? ` · next: ${escapeHtml(nextRun)}` : ''}</div>
+                <div class="hint">${escapeHtml(fmtTime(ev.ts))} - ${escapeHtml(id)}${nextRun ? ` - next: ${escapeHtml(nextRun)}` : ''}</div>
                 ${summaryHtml}
                 <div class="cron-actions" role="group" aria-label="Cron job actions">
                   <button type="button" class="secondary" data-testid="cron-action-view" data-cron-action="view" data-job-id="${escapeHtml(id)}">View</button>
@@ -11077,6 +11125,58 @@ globalElements.status?.addEventListener('click', () => {
     if (pane?.client?.manualDisconnect) pane.client.manualDisconnect = false;
   });
   paneManager.connectIfNeeded();
+});
+
+globalElements.rolePill?.addEventListener('click', () => {
+  if (!uiState.authed) {
+    closeAuthSessionPopover();
+    showLogin('Please sign in to continue.');
+    return;
+  }
+  renderAuthSessionUi();
+  const popover = globalElements.authSessionPopover;
+  if (!popover) return;
+  const nextOpen = popover.hidden;
+  popover.hidden = !nextOpen;
+  globalElements.rolePill.setAttribute('aria-expanded', nextOpen ? 'true' : 'false');
+});
+
+globalElements.authSessionPopover?.addEventListener('click', async (event) => {
+  const btn = event.target instanceof HTMLElement ? event.target.closest('[data-auth-session-action]') : null;
+  if (!btn) return;
+  const action = btn.getAttribute('data-auth-session-action');
+  if (action === 'settings') {
+    closeAuthSessionPopover();
+    openSettings();
+    return;
+  }
+  if (action === 'unlock') {
+    closeAuthSessionPopover();
+    showLogin('Please sign in to continue.');
+    return;
+  }
+  if (action === 'logout') {
+    closeAuthSessionPopover();
+    try {
+      await fetch('/auth/logout', { method: 'POST' });
+    } catch {}
+    storage.set('clawnsole.auth.role', '');
+    paneManager.disconnectAll({ silent: true });
+    roleState.role = null;
+    window.location.replace('/');
+  }
+});
+
+document.addEventListener('click', (event) => {
+  const target = event.target instanceof Node ? event.target : null;
+  if (!target || !globalElements.authSessionPopover || globalElements.authSessionPopover.hidden) return;
+  if (globalElements.rolePill?.contains(target) || globalElements.authSessionPopover.contains(target)) return;
+  closeAuthSessionPopover();
+});
+
+document.addEventListener('keydown', (event) => {
+  if (event.key !== 'Escape') return;
+  closeAuthSessionPopover();
 });
 
 globalElements.loginBtn?.addEventListener('click', () => attemptLogin());

--- a/app.js
+++ b/app.js
@@ -2414,7 +2414,7 @@ function paneBrowserTitle(pane) {
     const target = paneDisplayTargetLabel(pane);
     if (target) parts.push(target);
   }
-  return parts.join(' - ');
+  return parts.join(' · ');
 }
 
 function updateBrowserTitle(pane = null) {
@@ -2433,14 +2433,14 @@ function paneIdentityLabel(pane, { includeUnread = false } = {}) {
   const target = paneDisplayTargetLabel(pane);
   const nickname = paneNickname(pane);
   const unread = paneUnreadCount(pane);
-  return `${letter} ${type} - ${target}${nickname ? ` - ${nickname}` : ''}${includeUnread && unread > 0 ? ` • ${unread} unread` : ''}`;
+  return `${letter} ${type} · ${target}${nickname ? ` · ${nickname}` : ''}${includeUnread && unread > 0 ? ` • ${unread} unread` : ''}`;
 }
 
 function paneSummaryLabel(pane) {
   const letter = paneHeaderLetter(pane);
   const type = paneLabel(pane);
   const target = paneDisplayTargetLabel(pane);
-  return `${letter} ${type} - ${target}`;
+  return `${letter} ${type} · ${target}`;
 }
 
 function isPaneSwitchHudEnabled() {
@@ -3157,8 +3157,8 @@ function buildCommandPaletteItems() {
       withShortcut(
         {
           id: `cmd:focus-pane-${pane.key}`,
-          label: `Focus ${type}: ${target}${nickname ? ` - ${nickname}` : ''}`,
-          detail: `Pane ${letter} - focus existing`,
+          label: `Focus ${type}: ${target}${nickname ? ` · ${nickname}` : ''}`,
+          detail: `Pane ${letter} · focus existing`,
           paneMeta: [
             ...commandPalettePaneMeta({ type, target, mode: 'focus existing' }),
             ...(nickname ? [{ label: nickname, tone: 'nickname' }] : [])
@@ -3606,7 +3606,7 @@ function renderCommandPalette() {
         ${paneMetaMarkup}
         <div class="command-palette-item-detail">${escapeHtml(item.detail || '')}</div>
       </div>
-      <div class="command-palette-item-meta">${escapeHtml(item.shortcut || '')}${idx === selected ? (item.shortcut ? ' - ↵' : '↵') : ''}</div>
+      <div class="command-palette-item-meta">${escapeHtml(item.shortcut || '')}${idx === selected ? (item.shortcut ? ' · ↵' : '↵') : ''}</div>
     `;
 
     btn.addEventListener('mouseenter', () => {
@@ -5170,7 +5170,7 @@ function formatWorkqueueHiddenBreakdown(hiddenCounts = {}) {
 function formatWorkqueueVisibleSummary(shown, total, hiddenCounts = {}) {
   const base = formatWorkqueueCountText(shown, total);
   const hidden = formatWorkqueueHiddenBreakdown(hiddenCounts);
-  return hidden ? `${base} - ${hidden}` : base;
+  return hidden ? `${base} · ${hidden}` : base;
 }
 
 function getWorkqueueQuickFilterBreakdown(items, quickFilters) {
@@ -5309,7 +5309,7 @@ function formatWorkqueueStatusSummary(items) {
   return WORKQUEUE_STATUSES
     .filter((status) => Number(counts[status] || 0) > 0)
     .map((status) => `${formatWorkqueueStatusLabel(status)} ${counts[status]}`)
-    .join(' - ');
+    .join(' · ');
 }
 
 function newestWorkqueueUpdatedAt(items) {
@@ -5672,8 +5672,8 @@ function renderWorkqueuePaneItems(pane) {
       empty.innerHTML = `
         <div class="empty-state">
           <div style="font-weight:700; margin-bottom:6px;">${escapeHtml(title)}</div>
-          <div class="hint">Queue: <span class="mono">${escapeHtml(queue)}</span> - Status: <span class="mono">${escapeHtml(statusLabel)}</span> - Scope: <span class="mono">${escapeHtml(scopeLabel)}</span></div>
-          ${filtersHidingAll ? `<div class="hint" style="margin-top:6px;">Showing 0 of <span class="mono">${escapeHtml(String(totalCount))}</span> items${hiddenSummary ? ` - ${escapeHtml(hiddenSummary)}` : ''}.</div>` : ''}
+          <div class="hint">Queue: <span class="mono">${escapeHtml(queue)}</span> · Status: <span class="mono">${escapeHtml(statusLabel)}</span> · Scope: <span class="mono">${escapeHtml(scopeLabel)}</span></div>
+          ${filtersHidingAll ? `<div class="hint" style="margin-top:6px;">Showing 0 of <span class="mono">${escapeHtml(String(totalCount))}</span> items${hiddenSummary ? ` · ${escapeHtml(hiddenSummary)}` : ''}.</div>` : ''}
           <div style="display:flex; gap:8px; margin-top:10px; flex-wrap:wrap;">
             <button type="button" class="secondary" data-wq-empty-enqueue>Enqueue item</button>
             <button type="button" class="secondary" data-wq-empty-refresh>Refresh</button>
@@ -7011,7 +7011,7 @@ function paneFinishCanceledRun(pane, { runId = null, resetSession = false, fallb
         text: fallbackText || '_Canceled._',
         persist: true,
         state: 'canceled',
-        metaLabel: `${paneAssistantLabel(pane)} - Canceled`
+        metaLabel: `${paneAssistantLabel(pane)} · Canceled`
       });
     }
     pane.abortState.canceledRunIds.add(String(rid));
@@ -7021,7 +7021,7 @@ function paneFinishCanceledRun(pane, { runId = null, resetSession = false, fallb
       text: fallbackText || '_Canceled._',
       persist: true,
       state: 'canceled',
-      metaLabel: `${paneAssistantLabel(pane)} - Canceled`
+      metaLabel: `${paneAssistantLabel(pane)} · Canceled`
     });
   }
 
@@ -7112,9 +7112,9 @@ function paneUpdateOutboundBubble(entry) {
 
   const meta = bubble.querySelector('.chat-meta');
   if (meta) {
-    if (entry.state === 'queued') meta.textContent = 'You - Queued (not sent)';
-    else if (entry.state === 'sending') meta.textContent = 'You - Sending…';
-    else if (entry.state === 'failed') meta.textContent = 'You - Failed to send';
+    if (entry.state === 'queued') meta.textContent = 'You · Queued (not sent)';
+    else if (entry.state === 'sending') meta.textContent = 'You · Sending…';
+    else if (entry.state === 'failed') meta.textContent = 'You · Failed to send';
     else meta.textContent = 'You';
   }
 }
@@ -7282,7 +7282,7 @@ async function paneSendChat(pane) {
     role: 'user',
     text: outbound,
     persist: false,
-    metaLabel: 'You - Queued (not sent)',
+    metaLabel: 'You · Queued (not sent)',
     state: 'queued',
     actions: makeActions()
   });
@@ -7505,12 +7505,12 @@ function renderPaneIdentity(pane) {
   const target = paneDisplayTargetLabel(pane);
   const nickname = paneNickname(pane);
   const unread = paneUnreadCount(pane);
-  const identity = `${letter} ${type} - ${target}${nickname ? ` - ${nickname}` : ''}${unread > 0 ? ` • ${unread} unread` : ''}`;
+  const identity = `${letter} ${type} · ${target}${nickname ? ` · ${nickname}` : ''}${unread > 0 ? ` • ${unread} unread` : ''}`;
   pane.elements.name.title = paneIdentityLabel(pane, { includeUnread: false });
   pane.elements.name.setAttribute('aria-label', identity);
   if (pane.elements.nameToken && pane.elements.nameTarget) {
     pane.elements.nameToken.textContent = `${letter} ${type}`;
-    pane.elements.nameTarget.textContent = ` - ${target}${nickname ? ` - ${nickname}` : ''}${unread > 0 ? ` • ${unread} unread` : ''}`;
+    pane.elements.nameTarget.textContent = ` · ${target}${nickname ? ` · ${nickname}` : ''}${unread > 0 ? ` • ${unread} unread` : ''}`;
   } else {
     pane.elements.name.textContent = identity;
   }
@@ -9086,7 +9086,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
             if (search) parts.push(`search:${search}`);
             paneSetHeaderTarget(pane, {
               label: 'Timeline',
-              value: parts.join(' - '),
+              value: parts.join(' · '),
               ariaLabel: 'Timeline filters',
               onClick: () => {
                 try {
@@ -9104,7 +9104,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
             if (search) parts.push(`search:${search}`);
             paneSetHeaderTarget(pane, {
               label: 'Jobs',
-              value: parts.join(' - '),
+              value: parts.join(' · '),
               ariaLabel: 'Cron job filters',
               onClick: () => {
                 try {
@@ -9141,7 +9141,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         });
 
         const schedulerLabel = status?.enabled === false ? 'paused' : status?.enabled === true ? 'running' : 'unknown';
-        if (statusline) statusline.textContent = `scheduler: ${schedulerLabel} - jobs: ${filtered.length}/${jobs.length} - ${took}ms`;
+        if (statusline) statusline.textContent = `scheduler: ${schedulerLabel} · jobs: ${filtered.length}/${jobs.length} · ${took}ms`;
 
         if (!body) return;
 
@@ -9160,7 +9160,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
             body.innerHTML = `
               <div class="hint" style="padding: 10px 8px;">
                 <div style="font-weight:700; margin-bottom:6px;">No scheduled jobs.</div>
-                <div class="hint">Agent: <span class="mono">${escapeHtml(agentFilterLabel)}</span>${searchLabel ? ` - Search: <span class="mono">${escapeHtml(searchLabel)}</span>` : ''}${flags.length ? ` - Filters: <span class="mono">${escapeHtml(flags.join(', '))}</span>` : ''}</div>
+                <div class="hint">Agent: <span class="mono">${escapeHtml(agentFilterLabel)}</span>${searchLabel ? ` · Search: <span class="mono">${escapeHtml(searchLabel)}</span>` : ''}${flags.length ? ` · Filters: <span class="mono">${escapeHtml(flags.join(', '))}</span>` : ''}</div>
                 <div style="display:flex; gap:8px; margin-top:10px; flex-wrap:wrap;">
                   <button type="button" class="secondary" data-cron-empty-refresh>Refresh</button>
                 </div>
@@ -9193,7 +9193,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
                     <span class="pill ${enabled ? 'pill--ok' : 'pill--warn'}">${enabled ? 'enabled' : 'disabled'}</span>
                   </div>
                 </div>
-                <div class="hint">${escapeHtml(id)} - ${schedule ? escapeHtml(schedule) + ' - ' : ''}next: ${escapeHtml(nextRun || '—')} - last run: ${escapeHtml(lastRun || '—')} - last: ${escapeHtml(lastStatus || '—')}</div>
+                <div class="hint">${escapeHtml(id)} · ${schedule ? escapeHtml(schedule) + ' · ' : ''}next: ${escapeHtml(nextRun || '—')} · last run: ${escapeHtml(lastRun || '—')} · last: ${escapeHtml(lastStatus || '—')}</div>
                 <div class="cron-actions" role="group" aria-label="Cron job actions">
                   <button type="button" class="secondary" data-testid="cron-action-view" data-cron-action="view" data-job-id="${escapeHtml(id)}">View</button>
                   <button type="button" class="secondary" data-testid="cron-action-edit" data-cron-action="edit" data-job-id="${escapeHtml(id)}">Edit</button>
@@ -9265,7 +9265,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
           body.innerHTML = `
             <div class="hint" style="padding: 10px 8px;">
               <div style="font-weight:700; margin-bottom:6px;">No activity in range.</div>
-              <div class="hint">Range: <span class="mono">${escapeHtml(rangeLabel || String(rangeMs))}</span> - Status: <span class="mono">${escapeHtml(statusLabel)}</span>${searchLabel ? ` - Search: <span class="mono">${escapeHtml(searchLabel)}</span>` : ''}</div>
+              <div class="hint">Range: <span class="mono">${escapeHtml(rangeLabel || String(rangeMs))}</span> · Status: <span class="mono">${escapeHtml(statusLabel)}</span>${searchLabel ? ` · Search: <span class="mono">${escapeHtml(searchLabel)}</span>` : ''}</div>
               <div class="hint" style="margin-top:8px;">Tip: broaden the range or clear filters to find older runs.</div>
             </div>
           `;
@@ -9297,7 +9297,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
                     <span class="pill ${enabled ? 'pill--ok' : 'pill--warn'}">${enabled ? 'enabled' : 'disabled'}</span>
                   </div>
                 </div>
-                <div class="hint">${escapeHtml(fmtTime(ev.ts))} - ${escapeHtml(id)}${nextRun ? ` - next: ${escapeHtml(nextRun)}` : ''}</div>
+                <div class="hint">${escapeHtml(fmtTime(ev.ts))} · ${escapeHtml(id)}${nextRun ? ` · next: ${escapeHtml(nextRun)}` : ''}</div>
                 ${summaryHtml}
                 <div class="cron-actions" role="group" aria-label="Cron job actions">
                   <button type="button" class="secondary" data-testid="cron-action-view" data-cron-action="view" data-job-id="${escapeHtml(id)}">View</button>

--- a/clawnsole-server.js
+++ b/clawnsole-server.js
@@ -468,7 +468,8 @@ function createClawnsoleServer(options = {}) {
       sendJson(res, 200, {
         wsUrl,
         adminWsUrl: '/admin-ws',
-        port: gatewayPort
+        port: gatewayPort,
+        instance: instance || 'local'
       });
       return;
     }

--- a/index.html
+++ b/index.html
@@ -54,7 +54,28 @@
               <option value="3">3-up</option>
             </select>
           </div>
-          <div class="role-pill" id="rolePill" data-testid="role-pill">signed out</div>
+          <button
+            class="role-pill signed-out"
+            id="rolePill"
+            type="button"
+            data-testid="role-pill"
+            data-auth-state="signed_out"
+            aria-haspopup="dialog"
+            aria-expanded="false"
+            aria-controls="authSessionPopover"
+            aria-label="Authentication status"
+            title="Session context: signed out. Click to unlock this session."
+          >Signed out</button>
+          <div id="authSessionPopover" class="auth-session-popover" data-testid="auth-session-popover" role="dialog" aria-label="Session details" hidden>
+            <div class="auth-session-popover__status" data-auth-session-status>Signed out</div>
+            <div class="auth-session-popover__principal" data-auth-session-principal>Not signed in</div>
+            <div class="auth-session-popover__env" data-auth-session-env>local</div>
+            <div class="auth-session-popover__actions">
+              <button type="button" class="secondary" data-auth-session-action="settings">Settings</button>
+              <button type="button" class="secondary" data-auth-session-action="unlock">Unlock</button>
+              <button type="button" class="secondary" data-auth-session-action="logout">Logout</button>
+            </div>
+          </div>
           <button id="refreshAgentsBtn" class="icon-btn action-btn" type="button" aria-label="Refresh agent list" title="Refresh (Ctrl/Cmd+R)" hidden>
             <span class="btn-icon" aria-hidden="true">⟳</span>
             <span class="btn-label">Refresh</span>

--- a/lib/app-core.js
+++ b/lib/app-core.js
@@ -343,14 +343,42 @@
     };
   }
 
-  function deriveAuthOverlayState({ authed, role = null } = {}) {
+  function formatPrincipalLabel(role) {
+    const raw = String(role || '').trim();
+    if (!raw) return 'Not signed in';
+    if (raw === 'admin') return 'Admin';
+    return raw.charAt(0).toUpperCase() + raw.slice(1);
+  }
+
+  function deriveAuthOverlayState({ authed, role = null, environment = '' } = {}) {
     const isAdmin = role === 'admin';
+    const authState = authed ? 'signed_in' : (isAdmin ? 'locked' : 'signed_out');
+    const authLabel = authState === 'signed_in' ? 'Signed in' : authState === 'locked' ? 'Locked' : 'Signed out';
+    const principalLabel = authed ? formatPrincipalLabel(role) : 'Not signed in';
+    const environmentLabel = String(environment || 'local').trim() || 'local';
+    const rolePillText = authState === 'signed_in'
+      ? `${authLabel} - ${principalLabel} - ${environmentLabel}`
+      : authLabel;
     return {
       isAdmin,
+      authState,
       startAgentAutoRefresh: isAdmin && !!authed,
       stopAgentAutoRefresh: !isAdmin || !authed,
-      rolePillText: isAdmin ? 'signed in' : (role || 'signed out'),
-      rolePillAdmin: isAdmin,
+      rolePillText,
+      rolePillAdmin: isAdmin && !!authed,
+      rolePillLocked: authState === 'locked',
+      rolePillSignedOut: authState === 'signed_out',
+      rolePillActionLabel: authed
+        ? 'Open session details'
+        : 'Focus password input to unlock session',
+      rolePillTooltip: authed
+        ? `Session context: ${authLabel.toLowerCase()} as ${principalLabel} in ${environmentLabel}. Click for session details.`
+        : authState === 'locked'
+          ? `Session context: locked as ${formatPrincipalLabel(role)} in ${environmentLabel}. Click to unlock this session.`
+          : `Session context: signed out in ${environmentLabel}. Click to unlock this session.`,
+      authLabel,
+      principalLabel,
+      environmentLabel,
       showAdminControls: isAdmin,
       logoutEnabled: !!authed,
       logoutOpacity: authed ? '1' : '0.5'

--- a/styles.css
+++ b/styles.css
@@ -150,6 +150,7 @@ body::before {
 }
 
 .topbar-actions {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 10px;
@@ -220,12 +221,61 @@ body::before {
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--accent);
+  cursor: pointer;
+  min-height: 32px;
+  white-space: nowrap;
 }
 
 .role-pill.admin {
   background: rgba(127, 209, 185, 0.18);
   border-color: rgba(127, 209, 185, 0.45);
   color: var(--accent-2);
+}
+
+.role-pill.locked,
+.role-pill.signed-out {
+  background: rgba(255, 114, 114, 0.14);
+  border-color: rgba(255, 114, 114, 0.42);
+  color: #ffb0b0;
+}
+
+.auth-session-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 80;
+  width: min(280px, calc(100vw - 24px));
+  padding: 12px;
+  border-radius: 8px;
+  background: rgba(12, 17, 24, 0.98);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.4);
+}
+
+.auth-session-popover__status {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.auth-session-popover__principal {
+  margin-top: 4px;
+  font-size: 14px;
+  color: var(--text);
+}
+
+.auth-session-popover__env {
+  margin-top: 2px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.auth-session-popover__actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+  flex-wrap: wrap;
 }
 
 .channel-switch select {

--- a/tests/ui/auth-lifecycle.spec.js
+++ b/tests/ui/auth-lifecycle.spec.js
@@ -7,7 +7,28 @@ test('visiting /admin without auth shows login overlay', async ({ page, clawnsol
 
   await page.goto(clawnsole.adminUrl);
   await expect(page.getByTestId('login-overlay')).toHaveClass(/open/);
-  await expect(page.getByTestId('role-pill')).toContainText('signed out');
+  await expect(page.getByTestId('role-pill')).toContainText('Signed out');
+  await expect(page.getByTestId('role-pill')).toHaveAttribute('data-auth-state', 'signed_out');
+});
+
+test('signed-in auth chip shows session details and actions', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  await clawnsole.gotoAndLoginAdmin(page);
+  const chip = page.getByTestId('role-pill');
+  await expect(chip).toContainText('Signed in');
+  await expect(chip).toContainText('Admin');
+  await expect(chip).toHaveAttribute('data-auth-state', 'signed_in');
+  await expect(chip).toHaveAttribute('title', /signed in as Admin in local/i);
+
+  await chip.click();
+  const popover = page.getByTestId('auth-session-popover');
+  await expect(popover).toBeVisible();
+  await expect(popover).toContainText('Signed in');
+  await expect(popover).toContainText('Admin');
+  await expect(popover).toContainText('local');
+  await expect(popover.getByRole('button', { name: 'Settings' })).toBeVisible();
+  await expect(popover.getByRole('button', { name: 'Logout' })).toBeVisible();
 });
 
 test('admin login restores the intended in-app destination', async ({ page, clawnsole }) => {

--- a/tests/unit/app-core.test.js
+++ b/tests/unit/app-core.test.js
@@ -245,17 +245,25 @@ test('normalizePaneKind handles aliases safely', () => {
 test('deriveAuthOverlayState captures auth/role transition flags', () => {
   assert.deepEqual(deriveAuthOverlayState({ authed: true, role: 'admin' }), {
     isAdmin: true,
+    authState: 'signed_in',
     startAgentAutoRefresh: true,
     stopAgentAutoRefresh: false,
-    rolePillText: 'signed in',
+    rolePillText: 'Signed in - Admin - local',
     rolePillAdmin: true,
+    rolePillLocked: false,
+    rolePillSignedOut: false,
+    rolePillActionLabel: 'Open session details',
+    rolePillTooltip: 'Session context: signed in as Admin in local. Click for session details.',
+    authLabel: 'Signed in',
+    principalLabel: 'Admin',
+    environmentLabel: 'local',
     showAdminControls: true,
     logoutEnabled: true,
     logoutOpacity: '1'
   });
 
   assert.equal(deriveAuthOverlayState({ authed: false, role: 'admin' }).startAgentAutoRefresh, false);
-  assert.equal(deriveAuthOverlayState({ authed: true, role: 'guest' }).rolePillText, 'guest');
+  assert.equal(deriveAuthOverlayState({ authed: true, role: 'guest', environment: 'qa' }).rolePillText, 'Signed in - Guest - qa');
   assert.equal(deriveAuthOverlayState({ authed: false, role: 'guest' }).logoutOpacity, '0.5');
 });
 

--- a/tests/unit/clawnsole-server.test.js
+++ b/tests/unit/clawnsole-server.test.js
@@ -96,6 +96,7 @@ test('GET /meta returns gateway urls and port', async () => {
   assert.equal(data.wsUrl, 'ws://127.0.0.1:19999');
   assert.equal(data.adminWsUrl, '/admin-ws');
   assert.equal(data.port, 19999);
+  assert.equal(data.instance, 'local');
   assert.equal(data.guestWsUrl, undefined);
 });
 


### PR DESCRIPTION
## Summary
- Replace the passive auth label with a clickable session chip showing auth state, principal, and instance context.
- Add a compact session details popover with Settings/Unlock/Logout actions.
- Expose the clawnsole instance marker through /meta and cover the chip in unit/UI tests.

Closes #402

## Tests
- npm test
- npx playwright test tests/ui/auth-lifecycle.spec.js --workers=1