### PR TITLE
UX/Auth: add actionable admin session chip

### DIFF
--- a/app.js
+++ b/app.js
@@ -86,6 +86,12 @@ const globalElements = {
   shortcutOverridesResetAll: document.getElementById('shortcutOverridesResetAll'),
   shortcutOverridesError: document.getElementById('shortcutOverridesError'),
   rolePill: document.getElementById('rolePill'),
+  authSessionPopover: document.getElementById('authSessionPopover'),
+  authSessionStatus: document.getElementById('authSessionStatus'),
+  authSessionPrincipal: document.getElementById('authSessionPrincipal'),
+  authSessionEnvironment: document.getElementById('authSessionEnvironment'),
+  authSessionSettingsBtn: document.getElementById('authSessionSettingsBtn'),
+  authSessionLogoutBtn: document.getElementById('authSessionLogoutBtn'),
   loginOverlay: document.getElementById('loginOverlay'),
   loginPassword: document.getElementById('loginPassword'),
   loginBtn: document.getElementById('loginBtn'),
@@ -180,10 +186,18 @@ const normalizeAdminDestination = __appCore.normalizeAdminDestination || ((candi
 });
 const deriveAuthOverlayState = __appCore.deriveAuthOverlayState || ((state) => ({
   isAdmin: String(state?.role || '') === 'admin',
+  authState: state?.authed ? 'signed_in' : (String(state?.role || '') === 'admin' ? 'locked' : 'signed_out'),
+  authStateLabel: state?.authed ? 'Signed in' : (String(state?.role || '') === 'admin' ? 'Locked' : 'Signed out'),
+  principalLabel: String(state?.role || '') === 'admin' ? 'admin' : (String(state?.role || '') || 'unknown'),
+  environmentLabel: String(state?.environment || ''),
   startAgentAutoRefresh: String(state?.role || '') === 'admin' && !!state?.authed,
   stopAgentAutoRefresh: String(state?.role || '') !== 'admin' || !state?.authed,
-  rolePillText: String(state?.role || '') === 'admin' ? 'signed in' : (state?.role || 'signed out'),
-  rolePillAdmin: String(state?.role || '') === 'admin',
+  rolePillText: state?.authed
+    ? `Signed in · ${String(state?.role || 'unknown')}${state?.environment ? ` · ${state.environment}` : ''}`
+    : (String(state?.role || '') === 'admin' ? `Locked · admin${state?.environment ? ` · ${state.environment}` : ''}` : `Signed out${state?.environment ? ` · ${state.environment}` : ''}`),
+  rolePillAdmin: String(state?.role || '') === 'admin' && !!state?.authed,
+  rolePillStateClass: state?.authed ? 'signed_in' : (String(state?.role || '') === 'admin' ? 'locked' : 'signed_out'),
+  rolePillTooltip: 'Click for session details.',
   showAdminControls: String(state?.role || '') === 'admin',
   logoutEnabled: !!state?.authed,
   logoutOpacity: !!state?.authed ? '1' : '0.5'
@@ -1405,9 +1419,57 @@ function updateConnectionControls() {
   globalElements.disconnectBtn.textContent = control.text;
 }
 
+function getAuthEnvironmentLabel() {
+  const host = String(window.location.hostname || '').toLowerCase();
+  if (host === 'localhost' || host === '127.0.0.1' || host === '::1') return 'local';
+  if (host.endsWith('.local')) return 'local';
+  return host || '';
+}
+
+function currentAuthUi(role = roleState.role) {
+  return deriveAuthOverlayState({
+    authed: uiState.authed,
+    role,
+    environment: getAuthEnvironmentLabel()
+  });
+}
+
+function renderAuthSessionChip(authUi = currentAuthUi()) {
+  if (globalElements.rolePill) {
+    globalElements.rolePill.textContent = authUi.rolePillText;
+    globalElements.rolePill.classList.toggle('admin', authUi.rolePillAdmin);
+    globalElements.rolePill.dataset.authState = authUi.rolePillStateClass;
+    globalElements.rolePill.title = authUi.rolePillTooltip;
+    globalElements.rolePill.setAttribute('aria-label', authUi.rolePillTooltip);
+  }
+  if (globalElements.authSessionPopover) {
+    globalElements.authSessionPopover.dataset.authState = authUi.rolePillStateClass;
+  }
+  if (globalElements.authSessionStatus) globalElements.authSessionStatus.textContent = authUi.authStateLabel;
+  if (globalElements.authSessionPrincipal) globalElements.authSessionPrincipal.textContent = authUi.principalLabel;
+  if (globalElements.authSessionEnvironment) {
+    globalElements.authSessionEnvironment.textContent = authUi.environmentLabel || 'unknown';
+  }
+  if (globalElements.authSessionLogoutBtn) {
+    globalElements.authSessionLogoutBtn.disabled = !authUi.logoutEnabled;
+  }
+}
+
+function setAuthSessionPopoverOpen(open) {
+  if (!globalElements.authSessionPopover || !globalElements.rolePill) return;
+  globalElements.authSessionPopover.hidden = !open;
+  globalElements.rolePill.setAttribute('aria-expanded', open ? 'true' : 'false');
+}
+
+function toggleAuthSessionPopover() {
+  renderAuthSessionChip();
+  setAuthSessionPopoverOpen(!!globalElements.authSessionPopover?.hidden);
+}
+
 function setAuthState(authed) {
   uiState.authed = authed;
-  const authUi = deriveAuthOverlayState({ authed, role: roleState.role });
+  const authUi = currentAuthUi();
+  renderAuthSessionChip(authUi);
   updateGlobalStatus();
   updateConnectionControls();
   paneManager.refreshChatEnabled();
@@ -1426,11 +1488,8 @@ function setAuthState(authed) {
 
 function setRole(role) {
   roleState.role = role;
-  const authUi = deriveAuthOverlayState({ authed: uiState.authed, role });
-  if (globalElements.rolePill) {
-    globalElements.rolePill.textContent = authUi.rolePillText;
-    globalElements.rolePill.classList.toggle('admin', authUi.rolePillAdmin);
-  }
+  const authUi = currentAuthUi(role);
+  renderAuthSessionChip(authUi);
 
   const isAdmin = authUi.isAdmin;
   const visibleOpacity = isAdmin ? '1' : '0.5';
@@ -1492,9 +1551,10 @@ function showLogin(message = '') {
 
   setAuthState(false);
   if (globalElements.rolePill) {
-    globalElements.rolePill.textContent = 'signed out';
     globalElements.rolePill.classList.remove('admin');
+    globalElements.rolePill.dataset.authState = 'signed_out';
   }
+  renderAuthSessionChip(currentAuthUi(null));
   globalElements.settingsBtn?.setAttribute('disabled', 'disabled');
   if (globalElements.settingsBtn) globalElements.settingsBtn.style.opacity = '0.5';
   globalElements.shortcutsBtn?.setAttribute('disabled', 'disabled');
@@ -10306,6 +10366,24 @@ const paneManager = {
 renderShortcutHelpLabels();
 
 globalElements.settingsBtn?.addEventListener('click', () => openSettings());
+globalElements.rolePill?.addEventListener('click', (event) => {
+  event.preventDefault();
+  toggleAuthSessionPopover();
+});
+globalElements.authSessionSettingsBtn?.addEventListener('click', () => {
+  setAuthSessionPopoverOpen(false);
+  openSettings();
+});
+globalElements.authSessionLogoutBtn?.addEventListener('click', () => {
+  setAuthSessionPopoverOpen(false);
+  globalElements.logoutBtn?.click();
+});
+document.addEventListener('click', (event) => {
+  if (globalElements.authSessionPopover?.hidden) return;
+  const target = event.target;
+  if (globalElements.rolePill?.contains(target) || globalElements.authSessionPopover?.contains(target)) return;
+  setAuthSessionPopoverOpen(false);
+});
 globalElements.settingsCloseBtn?.addEventListener('click', () => closeSettings());
 globalElements.settingsModal?.addEventListener('click', (event) => {
   if (event.target === globalElements.settingsModal) closeSettings();

--- a/index.html
+++ b/index.html
@@ -54,7 +54,44 @@
               <option value="3">3-up</option>
             </select>
           </div>
-          <div class="role-pill" id="rolePill" data-testid="role-pill">signed out</div>
+          <div class="auth-session-wrap">
+            <button
+              class="role-pill"
+              id="rolePill"
+              type="button"
+              aria-haspopup="dialog"
+              aria-expanded="false"
+              aria-controls="authSessionPopover"
+              data-auth-state="signed_out"
+              data-testid="role-pill"
+              title="Session context: signed out. Click for session details."
+            >Signed out</button>
+            <div
+              class="auth-session-popover"
+              id="authSessionPopover"
+              role="dialog"
+              aria-label="Session details"
+              data-auth-state="signed_out"
+              hidden
+            >
+              <div class="auth-session-row">
+                <span>Status</span>
+                <strong id="authSessionStatus">Signed out</strong>
+              </div>
+              <div class="auth-session-row">
+                <span>Identity</span>
+                <strong id="authSessionPrincipal">unknown</strong>
+              </div>
+              <div class="auth-session-row">
+                <span>Environment</span>
+                <strong id="authSessionEnvironment">unknown</strong>
+              </div>
+              <div class="auth-session-actions">
+                <button id="authSessionSettingsBtn" class="text-btn" type="button">Settings</button>
+                <button id="authSessionLogoutBtn" class="text-btn danger" type="button" disabled>Log out</button>
+              </div>
+            </div>
+          </div>
           <button id="refreshAgentsBtn" class="icon-btn action-btn" type="button" aria-label="Refresh agent list" title="Refresh (Ctrl/Cmd+R)" hidden>
             <span class="btn-icon" aria-hidden="true">⟳</span>
             <span class="btn-label">Refresh</span>

--- a/lib/app-core.js
+++ b/lib/app-core.js
@@ -343,14 +343,43 @@
     };
   }
 
-  function deriveAuthOverlayState({ authed, role = null } = {}) {
-    const isAdmin = role === 'admin';
+  function deriveAuthOverlayState({ authed, role = null, environment = '' } = {}) {
+    const normalizedRole = String(role || '').trim().toLowerCase();
+    const isAdmin = normalizedRole === 'admin';
+    const principalLabel = isAdmin
+      ? 'admin'
+      : normalizedRole
+        ? normalizedRole
+        : 'unknown';
+    const authState = authed ? 'signed_in' : (isAdmin ? 'locked' : 'signed_out');
+    const authStateLabel = authState === 'signed_in'
+      ? 'Signed in'
+      : authState === 'locked'
+        ? 'Locked'
+        : 'Signed out';
+    const environmentLabel = String(environment || '').trim();
+    const rolePillText = [
+      authStateLabel,
+      authState === 'signed_out' ? '' : principalLabel,
+      environmentLabel
+    ].filter(Boolean).join(' · ');
+    const rolePillTooltip = authState === 'signed_in'
+      ? `Session context: signed in as ${principalLabel}${environmentLabel ? ` in ${environmentLabel}` : ''}. Click for session details.`
+      : authState === 'locked'
+        ? `Session context: ${principalLabel} is locked${environmentLabel ? ` in ${environmentLabel}` : ''}. Click for session details.`
+        : `Session context: signed out${environmentLabel ? ` in ${environmentLabel}` : ''}. Click for session details.`;
     return {
       isAdmin,
+      authState,
+      authStateLabel,
+      principalLabel,
+      environmentLabel,
       startAgentAutoRefresh: isAdmin && !!authed,
       stopAgentAutoRefresh: !isAdmin || !authed,
-      rolePillText: isAdmin ? 'signed in' : (role || 'signed out'),
-      rolePillAdmin: isAdmin,
+      rolePillText,
+      rolePillAdmin: isAdmin && !!authed,
+      rolePillStateClass: authState,
+      rolePillTooltip,
       showAdminControls: isAdmin,
       logoutEnabled: !!authed,
       logoutOpacity: authed ? '1' : '0.5'

--- a/styles.css
+++ b/styles.css
@@ -211,6 +211,12 @@ body::before {
   padding: 0 12px;
 }
 
+.auth-session-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
 .role-pill {
   padding: 6px 12px;
   border-radius: 999px;
@@ -220,12 +226,68 @@ body::before {
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--accent);
+  cursor: pointer;
 }
 
 .role-pill.admin {
   background: rgba(127, 209, 185, 0.18);
   border-color: rgba(127, 209, 185, 0.45);
   color: var(--accent-2);
+}
+
+.role-pill[data-auth-state="locked"] {
+  background: rgba(255, 179, 71, 0.2);
+  border-color: rgba(255, 179, 71, 0.55);
+  color: var(--accent);
+}
+
+.role-pill[data-auth-state="signed_out"] {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.16);
+  color: var(--muted);
+}
+
+.role-pill:focus-visible {
+  outline: 2px solid rgba(127, 209, 185, 0.75);
+  outline-offset: 2px;
+}
+
+.auth-session-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 45;
+  width: min(260px, calc(100vw - 24px));
+  padding: 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(15, 20, 27, 0.98);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.38);
+}
+
+.auth-session-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 7px 0;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.auth-session-row strong {
+  max-width: 140px;
+  overflow: hidden;
+  color: var(--text);
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.auth-session-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding-top: 10px;
 }
 
 .channel-switch select {

--- a/tests/ui/auth-lifecycle.spec.js
+++ b/tests/ui/auth-lifecycle.spec.js
@@ -7,7 +7,33 @@ test('visiting /admin without auth shows login overlay', async ({ page, clawnsol
 
   await page.goto(clawnsole.adminUrl);
   await expect(page.getByTestId('login-overlay')).toHaveClass(/open/);
-  await expect(page.getByTestId('role-pill')).toContainText('signed out');
+  await expect(page.getByTestId('role-pill')).toContainText('Signed out');
+  await expect(page.getByTestId('role-pill')).toHaveAttribute('data-auth-state', 'signed_out');
+});
+
+test('session chip shows identity context and opens details', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  await page.goto(clawnsole.adminUrl);
+  const chip = page.getByTestId('role-pill');
+  await expect(chip).toContainText('Signed out');
+  await expect(chip).toHaveAttribute('data-auth-state', 'signed_out');
+
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await clawnsole.waitForAdminUiReady(page);
+
+  await expect(chip).toContainText('Signed in');
+  await expect(chip).toContainText('admin');
+  await expect(chip).toContainText('local');
+  await expect(chip).toHaveAttribute('data-auth-state', 'signed_in');
+  await expect(chip).toHaveAttribute('title', /signed in as admin/i);
+
+  await chip.click();
+  await expect(page.locator('#authSessionPopover')).toBeVisible();
+  await expect(page.locator('#authSessionStatus')).toContainText('Signed in');
+  await expect(page.locator('#authSessionPrincipal')).toContainText('admin');
+  await expect(page.locator('#authSessionEnvironment')).toContainText('local');
 });
 
 test('admin login restores the intended in-app destination', async ({ page, clawnsole }) => {
@@ -113,6 +139,7 @@ test('gateway unauthorized triggers auth-expired UX and blocks sending until re-
 
   await expect(page.getByTestId('login-overlay')).toHaveClass(/open/, { timeout: 10000 });
   await expect(page.getByTestId('login-error')).toContainText(/session expired|sign in/i);
+  await expect(page.getByTestId('role-pill')).toHaveAttribute('data-auth-state', 'signed_out');
 
   // The current pane should be disabled while signed out.
   await expect(page.getByTestId('pane-input').first()).toBeDisabled();

--- a/tests/unit/app-core.test.js
+++ b/tests/unit/app-core.test.js
@@ -245,17 +245,24 @@ test('normalizePaneKind handles aliases safely', () => {
 test('deriveAuthOverlayState captures auth/role transition flags', () => {
   assert.deepEqual(deriveAuthOverlayState({ authed: true, role: 'admin' }), {
     isAdmin: true,
+    authState: 'signed_in',
+    authStateLabel: 'Signed in',
+    principalLabel: 'admin',
+    environmentLabel: '',
     startAgentAutoRefresh: true,
     stopAgentAutoRefresh: false,
-    rolePillText: 'signed in',
+    rolePillText: 'Signed in · admin',
     rolePillAdmin: true,
+    rolePillStateClass: 'signed_in',
+    rolePillTooltip: 'Session context: signed in as admin. Click for session details.',
     showAdminControls: true,
     logoutEnabled: true,
     logoutOpacity: '1'
   });
 
   assert.equal(deriveAuthOverlayState({ authed: false, role: 'admin' }).startAgentAutoRefresh, false);
-  assert.equal(deriveAuthOverlayState({ authed: true, role: 'guest' }).rolePillText, 'guest');
+  assert.equal(deriveAuthOverlayState({ authed: false, role: 'admin' }).rolePillText, 'Locked · admin');
+  assert.equal(deriveAuthOverlayState({ authed: true, role: 'guest', environment: 'local' }).rolePillText, 'Signed in · guest · local');
   assert.equal(deriveAuthOverlayState({ authed: false, role: 'guest' }).logoutOpacity, '0.5');
 });
 


### PR DESCRIPTION
## Summary
- replace the passive admin auth label with a clickable session chip showing state, principal, and local environment
- add a compact session details popover with settings/logout actions
- extend auth view-model and UI coverage for signed-out/signed-in/locked chip states

Fixes #402

## Tests
- npm run test:syntax
- node --test tests/unit/app-core.test.js
- npx playwright test tests/ui/auth-lifecycle.spec.js --workers=1