### PR TITLE
Add Pane Manager paired counterpart action

### DIFF
--- a/app.js
+++ b/app.js
@@ -4173,7 +4173,7 @@ function openCommandPalette() {
   if (!globalElements.commandPaletteModal) return;
 
   commandPaletteState.open = true;
-  commandPaletteState.originPaneKey = focusedPaneKey() || paneMruOrder()[0] || '';
+  commandPaletteState.originPaneKey = focusedPaneKey() || '';
   commandPaletteState.items = buildCommandPaletteItems();
   commandPaletteState.filtered = commandPaletteState.items.slice();
   commandPaletteState.selectedIndex = 0;
@@ -4274,10 +4274,13 @@ function findExistingPane(kind, predicate = null) {
 }
 
 function getActiveChatAgentPane() {
-  const focusedKey = focusedPaneKey();
-  const fallbackKey = paneMruOrder()[0] || '';
   const originKey = commandPaletteState.open ? String(commandPaletteState.originPaneKey || '') : '';
-  const activeKey = originKey || focusedKey || fallbackKey;
+  if (commandPaletteState.open) {
+    return (paneManager?.panes || []).find((pane) => String(pane?.key || '') === originKey && pane.kind === 'chat') || null;
+  }
+
+  const focusedKey = focusedPaneKey();
+  const activeKey = focusedKey || paneMruOrder()[0] || '';
   return (paneManager?.panes || []).find((pane) => String(pane?.key || '') === activeKey && pane.kind === 'chat') || null;
 }
 

--- a/app.js
+++ b/app.js
@@ -3449,7 +3449,8 @@ function renderPaneManager() {
           if (action === 'paired') {
             const pairedPane = focusOrOpenPairedPaneForPane(pane);
             if (pairedPane) {
-              closePaneManager();
+              closePaneManager({ restoreFocus: false });
+              paneManager.focusPanePrimary(pairedPane);
             } else {
               renderPaneManager();
             }
@@ -8386,6 +8387,7 @@ function renderAgentOptions(selectEl, agentId) {
 function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, scopeFilter, quickFilters, groupMode, sortKey, sortDir, cronAgentId, nickname, pairedTargetLock = false, closable = true } = {}) {
   const template = globalElements.paneTemplate;
   const root = template.content.firstElementChild.cloneNode(true);
+  root.tabIndex = -1;
   const elements = {
     root,
     header: root.querySelector('.pane-header'),
@@ -10312,8 +10314,13 @@ const paneManager = {
     if (!pane?.elements?.root) return;
     notePaneFocused(pane);
 
+    try {
+      pane.elements.root.focus?.({ preventScroll: true });
+    } catch {}
+
     // Defer until DOM has painted.
     setTimeout(() => {
+      if (paneFocusMruKeys[0] !== pane.key) return;
       try {
         if (pane.kind === 'chat') {
           pane.elements.input?.focus?.();

--- a/tests/pane.manager.e2e.spec.js
+++ b/tests/pane.manager.e2e.spec.js
@@ -299,6 +299,59 @@ test('pane manager: status stays in sync with pane header while modal is open', 
   await expect(chatManagerState).toHaveText('disconnected');
 });
 
+test('pane manager: paired action focuses existing counterpart and opens missing counterpart', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  await page.keyboard.press('Control+P');
+  const modal = page.locator('#paneManagerModal');
+  await expect(modal).toHaveAttribute('aria-hidden', 'false');
+
+  const chatRow = page.locator('.pane-manager-row', { hasText: 'Chat · main' }).first();
+  await chatRow.evaluate((row) => {
+    const paired = row.querySelector('[data-action="paired"]');
+    paired?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+
+  await expect(modal).toHaveAttribute('aria-hidden', 'true');
+  const focusedKindAfterFocus = await page.evaluate(() => {
+    const panes = Array.from(document.querySelectorAll('[data-pane]'));
+    const active = document.activeElement;
+    const pane = panes.find((p) => p === active || (active && p.contains(active)));
+    return pane?.getAttribute('data-pane-kind') || null;
+  });
+  expect(focusedKindAfterFocus).toBe('workqueue');
+
+  // Remove the chat pane so Workqueue has no open counterpart.
+  await page.keyboard.press('Control+P');
+  await expect(modal).toHaveAttribute('aria-hidden', 'false');
+  await page.locator('.pane-manager-row', { hasText: 'Chat · main' }).first().locator('[data-action="close"]').click();
+
+  // Trigger Paired from Workqueue row; should open Chat and focus it.
+  const workqueueRow = page.locator('.pane-manager-row', { hasText: 'Workqueue' }).first();
+  await workqueueRow.evaluate((row) => {
+    const paired = row.querySelector('[data-action="paired"]');
+    paired?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+  await expect(modal).toHaveAttribute('aria-hidden', 'true');
+
+  await expect(page.locator('[data-pane][data-pane-kind="chat"]')).toHaveCount(1);
+  const focusedKindAfterOpen = await page.evaluate(() => {
+    const panes = Array.from(document.querySelectorAll('[data-pane]'));
+    const active = document.activeElement;
+    const pane = panes.find((p) => p === active || (active && p.contains(active)));
+    return pane?.getAttribute('data-pane-kind') || null;
+  });
+  expect(focusedKindAfterOpen).toBe('chat');
+});
+
 test('pane manager: supports reordering panes', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!app?.skipReason, app?.skipReason);

--- a/tests/pane.manager.e2e.spec.js
+++ b/tests/pane.manager.e2e.spec.js
@@ -329,10 +329,28 @@ test('pane manager: paired action focuses existing counterpart and opens missing
   });
   expect(focusedKindAfterFocus).toBe('workqueue');
 
-  // Remove the chat pane so Workqueue has no open counterpart.
+  // Start the missing-counterpart path from a Workqueue-only stored layout.
+  await page.evaluate(() => {
+    localStorage.setItem(
+      'clawnsole.admin.panes.v1',
+      JSON.stringify([
+        {
+          key: 'ptestwqonly',
+          kind: 'workqueue',
+          agentId: 'main',
+          queue: 'dev-team',
+          statusFilter: ['ready', 'pending', 'blocked', 'claimed', 'in_progress'],
+          scopeFilter: 'assigned',
+          sortKey: 'priority',
+          sortDir: 'desc'
+        }
+      ])
+    );
+  });
+  await page.reload();
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
   await page.keyboard.press('Control+P');
   await expect(modal).toHaveAttribute('aria-hidden', 'false');
-  await page.locator('.pane-manager-row', { hasText: 'Chat · main' }).first().locator('[data-action="close"]').click();
 
   // Trigger Paired from Workqueue row; should open Chat and focus it.
   const workqueueRow = page.locator('.pane-manager-row', { hasText: 'Workqueue' }).first();


### PR DESCRIPTION
## Summary
- add Pane Manager paired Chat/Workqueue action per eligible row
- focus an existing counterpart when present, or open the missing counterpart and focus it
- cover both paths in Pane Manager Playwright tests

## Tests
- npm run test:syntax
- npx playwright test tests/pane.manager.e2e.spec.js --workers=1

Closes #395