### PR TITLE
Keep shortcuts help synced with catalog

### DIFF
--- a/app.js
+++ b/app.js
@@ -347,7 +347,6 @@ const KEYBIND_CATALOG = [
   { id: 'pane.addWorkqueue', group: 'Pane actions', label: 'Add Workqueue pane (workspace only)', binding: { accel: true, shift: true, key: 'w', display: 'Cmd/Ctrl+Shift+W' } },
   { id: 'pane.addCron', group: 'Pane actions', label: 'Add Cron pane (workspace only)', binding: { accel: true, shift: true, key: 'r', display: 'Cmd/Ctrl+Shift+R' } },
   { id: 'pane.addTimeline', group: 'Pane actions', label: 'Add Timeline pane (workspace only)', binding: { accel: true, shift: true, key: 't', display: 'Cmd/Ctrl+Shift+T' } },
-  { id: 'fleet.open', group: 'Pane actions', label: 'Open/focus Fleet pane', binding: { accel: true, shift: true, key: 'f', display: 'Cmd/Ctrl+Shift+F' } },
   {
     id: 'agents.refresh',
     group: 'Pane actions',
@@ -356,10 +355,18 @@ const KEYBIND_CATALOG = [
     risk: { kind: 'browser', reason: 'Reserved by browser reload', alternative: { accel: true, shift: true, key: 'y', display: 'Cmd/Ctrl+Shift+Y' } }
   },
   { id: 'workqueue.open', group: 'Workqueue actions', label: 'Open Workqueue modal', binding: { chord: ['g', 'w'], display: 'g w' } },
+  { id: 'workqueue.openForActiveChat', group: 'Workqueue actions', label: 'Open/focus Workqueue for active Chat pane', binding: { accel: true, shift: true, key: 'g', display: 'Cmd/Ctrl+Shift+G' } },
+  { id: 'workqueue.togglePair', group: 'Workqueue actions', label: 'Toggle paired Chat and Workqueue panes', binding: { accel: true, shift: true, key: 'l', display: 'Cmd/Ctrl+Shift+L' } },
   { id: 'workqueue.move', group: 'Workqueue actions', label: 'Move selected row in Workqueue keyboard mode', binding: { key: 'j/k', display: 'j/k' } },
   { id: 'workqueue.inspect', group: 'Workqueue actions', label: 'Inspect selected Workqueue row in keyboard mode', binding: { key: 'Enter', display: 'Enter' } },
   { id: 'workqueue.edit', group: 'Workqueue actions', label: 'Edit selected Workqueue row in keyboard mode', binding: { key: 'e', display: 'e' } },
-  { id: 'workqueue.status', group: 'Workqueue actions', label: 'Set ready, in progress, blocked, or done in keyboard mode', binding: { key: '1..4', display: '1..4' } }
+  { id: 'workqueue.status', group: 'Workqueue actions', label: 'Set ready, in progress, blocked, or done in keyboard mode', binding: { key: '1..4', display: '1..4' } },
+  { id: 'fleet.open', group: 'Fleet actions', label: 'Open/focus Fleet pane', binding: { accel: true, shift: true, key: 'f', display: 'Cmd/Ctrl+Shift+F' } },
+  { id: 'fleet.sortHeartbeatGlobal', group: 'Fleet actions', label: 'Open Fleet sorted by heartbeat age', binding: { accel: true, shift: true, key: 'h', display: 'Cmd/Ctrl+Shift+H' } },
+  { id: 'fleet.next', group: 'Fleet actions', label: 'Move Fleet selection down', binding: { key: 'j', display: 'J / Down' } },
+  { id: 'fleet.prev', group: 'Fleet actions', label: 'Move Fleet selection up', binding: { key: 'k', display: 'K / Up' } },
+  { id: 'fleet.runSelected', group: 'Fleet actions', label: 'Run selected Fleet agent', binding: { key: 'Enter', display: 'Enter' } },
+  { id: 'fleet.toggleHeartbeatSort', group: 'Fleet actions', label: 'Toggle Fleet heartbeat age sort', binding: { key: 'h', display: 'H / Shift+H' } }
 ];
 
 function readKeybindOverrides() {
@@ -465,6 +472,18 @@ function renderShortcutsContent() {
   `).join('');
   root.innerHTML = hint + html;
 }
+
+function shortcutCatalogSnapshot() {
+  return KEYBIND_CATALOG.map((entry) => ({
+    id: entry.id,
+    group: entry.group,
+    label: entry.label,
+    display: shortcutDisplay(entry.id),
+    global: isGlobalKeybindEntry(entry)
+  }));
+}
+
+window.__clawnsoleShortcutCatalog = shortcutCatalogSnapshot;
 
 function renderKeyboardSettings() {
   const root = globalElements.keybindConflictList;
@@ -10985,6 +11004,7 @@ function isTypingShortcutExempt(event) {
   const key = String(event?.key || '').toLowerCase();
   const override = matchingShortcutOverrideAction(event);
   if (override?.typingExempt) return true;
+  if (matchesKeybind(event, 'workqueue.openForActiveChat')) return true;
   return (event?.metaKey || event?.ctrlKey) && !event.shiftKey && !event.altKey && (key === 'p' || key === 'k' || key === 'l');
 }
 
@@ -11373,7 +11393,7 @@ window.addEventListener('keydown', (event) => {
   }
 
   // Cmd/Ctrl+Shift+G targets the focused chat pane, so allow it from the chat input.
-  if ((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey && String(event.key || '').toLowerCase() === 'g' && roleState.role === 'admin') {
+  if (matchesKeybind(event, 'workqueue.openForActiveChat') && roleState.role === 'admin') {
     event.preventDefault();
     openWorkqueueForActiveChatAgent();
     return;
@@ -11481,7 +11501,7 @@ window.addEventListener('keydown', (event) => {
   }
 
   // Cmd/Ctrl+Shift+L toggles paired target lock on focused Chat/Workqueue pane.
-  if ((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey && key.toLowerCase() === 'l') {
+  if (matchesKeybind(event, 'workqueue.togglePair')) {
     const focusedKey = focusedPaneKey();
     const pane = paneManager.panes.find((p) => p?.key === focusedKey) || paneManager.panes[0] || null;
     if (paneSupportsTargetLock(pane)) {
@@ -11492,7 +11512,7 @@ window.addEventListener('keydown', (event) => {
   }
 
   // Cmd/Ctrl+Shift+H opens Agents and sorts by heartbeat age (stale first).
-  if ((event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey && key.toLowerCase() === 'h') {
+  if (matchesKeybind(event, 'fleet.sortHeartbeatGlobal')) {
     event.preventDefault();
     if (roleState.role === 'admin') {
       openAgentsModal();

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -58,6 +58,58 @@ test('shortcuts overlay: ? opens, Esc closes, content renders', async ({ page })
   await expect(modal).toHaveAttribute('aria-hidden', 'true');
 });
 
+test('shortcuts overlay stays in sync with registered shortcut catalog', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  await page.click('#connectionStatus');
+  await page.keyboard.press('Shift+/');
+  const modal = page.locator('#shortcutsModal');
+  await expect(modal).toHaveAttribute('aria-hidden', 'false');
+
+  const result = await page.evaluate(() => {
+    const catalog = window.__clawnsoleShortcutCatalog?.() || [];
+    const rows = Array.from(document.querySelectorAll('#shortcutsModal [data-shortcut-id]'));
+    const renderedIds = rows.map((row) => row.getAttribute('data-shortcut-id')).filter(Boolean);
+    const renderedIdSet = new Set(renderedIds);
+    const renderedTextById = new Map(rows.map((row) => [
+      row.getAttribute('data-shortcut-id'),
+      String(row.textContent || '').replace(/\s+/g, ' ').trim()
+    ]));
+    const missing = catalog
+      .filter((entry) => !renderedIdSet.has(entry.id) || !renderedTextById.get(entry.id)?.includes(entry.label))
+      .map((entry) => entry.id);
+    const duplicateIds = renderedIds.filter((id, idx) => renderedIds.indexOf(id) !== idx);
+    const globalShortcuts = catalog.filter((entry) => entry.global);
+    const duplicateGlobalDisplays = globalShortcuts
+      .filter((entry, idx) => entry.display && globalShortcuts.findIndex((candidate) => candidate.display === entry.display) !== idx)
+      .map((entry) => `${entry.id}:${entry.display}`);
+    return {
+      catalogCount: catalog.length,
+      rowCount: renderedIds.length,
+      missing,
+      duplicateIds,
+      duplicateGlobalDisplays
+    };
+  });
+
+  expect(result.catalogCount).toBeGreaterThan(0);
+  expect(result.rowCount).toBe(result.catalogCount);
+  expect(result.missing).toEqual([]);
+  expect(result.duplicateIds).toEqual([]);
+  expect(result.duplicateGlobalDisplays).toEqual([]);
+  await expect(modal).toContainText('Fleet actions');
+  await expect(modal).toContainText('Open/focus Fleet pane');
+  await expect(modal).toContainText('Open Fleet sorted by heartbeat age');
+});
+
 test('pane-add shortcuts are scoped to workspace and blocked by overlays', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!app?.skipReason, app?.skipReason);

--- a/tests/ui/command-palette.spec.js
+++ b/tests/ui/command-palette.spec.js
@@ -202,5 +202,5 @@ test('command palette: opens or focuses Workqueue for active chat agent', async 
 
   await wqPane.locator('[data-wq-queue-select]').focus();
   await runCommand('workqueue for active chat agent');
-  await expect(page.getByTestId('toast').last()).toContainText('No active chat agent selected');
+  await expect(page.getByTestId('toast').filter({ hasText: 'No active chat agent selected' })).toBeVisible();
 });

--- a/tests/ui/command-palette.spec.js
+++ b/tests/ui/command-palette.spec.js
@@ -202,5 +202,5 @@ test('command palette: opens or focuses Workqueue for active chat agent', async 
 
   await wqPane.locator('[data-wq-queue-select]').focus();
   await runCommand('workqueue for active chat agent');
-  await expect(page.getByTestId('toast').filter({ hasText: 'No active chat agent selected' })).toBeVisible();
+  await expect(page.getByTestId('toast').last()).toContainText('No active chat agent selected');
 });


### PR DESCRIPTION
## Summary
- add missing Workqueue and Fleet shortcuts to the rendered shortcut catalog
- route previously hard-coded global shortcut handlers through catalog IDs
- add a regression that compares the rendered shortcuts modal against the shortcut catalog and checks duplicate global displays

## Tests
- npm run test:syntax
- npx playwright test tests/pane.shortcuts.e2e.spec.js --workers=1

Fixes #343