### PR TITLE
Add Agents modal keyboard triage shortcuts

### DIFF
--- a/app.js
+++ b/app.js
@@ -4787,10 +4787,11 @@ function moveFleetSelection(delta) {
   return true;
 }
 
-function runFleetSelectedAgent() {
+function runFleetSelectedAgent(mode = 'chat') {
   const id = String(fleetSelectionState.selectedAgentId || '').trim();
   if (!id) return false;
-  openAgentTriageFromFleet(id);
+  if (mode === 'workqueue') openAgentWorkqueueFromFleet(id);
+  else openAgentChatFromFleet(id);
   return true;
 }
 
@@ -10808,7 +10809,7 @@ globalElements.agentsModal?.addEventListener('keydown', (event) => {
     }
     if (key === 'Enter') {
       event.preventDefault();
-      runFleetSelectedAgent();
+      runFleetSelectedAgent(event.shiftKey ? 'workqueue' : 'chat');
       return;
     }
   }

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -304,15 +304,37 @@ test('fleet refresh keeps scroll anchor and keyboard triage selection', async ({
   await expect(page.locator('#agentsList .agents-row[data-agent-id="agent-21"]')).toHaveAttribute('aria-selected', 'true');
   await page.keyboard.press('k');
   await expect(row20).toHaveAttribute('aria-selected', 'true');
+  const workqueueCountBeforeEnter = await page.locator('[data-pane][data-pane-kind="workqueue"]').count();
   await page.keyboard.press('Enter');
   await expect.poll(async () => (
     page.locator('[data-pane][data-pane-kind="chat"] [data-pane-agent-select]')
       .evaluateAll((els) => els.map((el) => el.value))
   )).toContain('agent-20');
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(workqueueCountBeforeEnter);
+
+  await page.locator('#agentsCloseBtn').click();
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await page.locator('#agentsSearch').fill('agent-20');
+  const healthyShow = page.getByRole('button', { name: /Healthy \(\d+\) Show/ });
+  if (await healthyShow.count()) await healthyShow.click();
+  const reopenedRow20 = page.locator('#agentsList .agents-row[data-agent-id="agent-20"]');
+  await expect(reopenedRow20).toBeVisible();
+  await reopenedRow20.click();
+  await page.keyboard.press('Shift+Enter');
   await expect.poll(async () => (
     page.locator('[data-pane][data-pane-kind="workqueue"] [data-wq-claim-agent]')
       .evaluateAll((els) => els.map((el) => el.value))
   )).toContain('agent-20');
+
+  const search = page.locator('#agentsSearch');
+  await search.fill('agent');
+  const selectedAfterFilter = page.locator('#agentsList .agents-row[aria-selected="true"]').first();
+  const selectedIdAfterFilter = await selectedAfterFilter.getAttribute('data-agent-id');
+  expect(selectedIdAfterFilter).toBeTruthy();
+  await search.focus();
+  await search.press('ArrowDown');
+  await expect(search).toHaveValue('agent');
+  await expect(page.locator(`#agentsList .agents-row[data-agent-id="${selectedIdAfterFilter}"]`)).toHaveAttribute('aria-selected', 'true');
 });
 
 test('fleet list keeps header and identity columns visible while scrolling', async ({ page, clawnsole }) => {


### PR DESCRIPTION
Fixes #383.

## Summary
- Change Agents modal Enter to open/focus Chat for the selected agent.
- Add Shift+Enter to open/focus Workqueue for the selected agent.
- Extend the Agents modal UI test for j/k navigation, Enter, Shift+Enter, and input shortcut suppression.

## Verification
- npm run test:syntax
- npx playwright test tests/ui/agents-modal.spec.js --grep "fleet refresh keeps scroll anchor and keyboard triage selection" --workers=1

No production deploy.