### PR TITLE
feat: active pane highlight + context chip

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,6 +44,7 @@ const globalElements = {
   agentsList: document.getElementById('agentsList'),
   agentsEmpty: document.getElementById('agentsEmpty'),
   toastHost: document.getElementById('toastHost'),
+  activePaneChip: document.getElementById('activePaneChip'),
   commandPaletteModal: document.getElementById('commandPaletteModal'),
   commandPaletteCloseBtn: document.getElementById('commandPaletteCloseBtn'),
   commandPaletteInput: document.getElementById('commandPaletteInput'),
@@ -294,6 +295,7 @@ const FLEET_COLUMN_DEFS = [
 const ADMIN_AUTH_DESTINATION_KEY = 'clawnsole.admin.authDestination.v1';
 const ADMIN_AUTH_RESTORE_PENDING_KEY = 'clawnsole.admin.authRestorePending.v1';
 const ADMIN_AUTH_RESTORE_NOTICE_KEY = 'clawnsole.admin.authRestoreNotice.v1';
+const ADMIN_ACTIVE_PANE_KEY = 'clawnsole.admin.activePaneKey.v1';
 const PANE_SWITCH_HUD_ENABLED_KEY = 'clawnsole.admin.paneSwitchHud.enabled';
 const KEYBIND_OVERRIDES_KEY = 'clawnsole.admin.keybindOverrides.v1';
 const SHORTCUT_OVERRIDES_KEY = 'clawnsole.admin.shortcutOverrides.v1';
@@ -576,6 +578,14 @@ function getActiveAdminPaneKey() {
   } catch {
     return '';
   }
+}
+
+function activeAdminPaneKey() {
+  const focused = getActiveAdminPaneKey();
+  if (focused) return focused;
+  const remembered = String(storage.get(ADMIN_ACTIVE_PANE_KEY, '') || '').trim();
+  if (remembered) return remembered;
+  return String(paneFocusMruKeys?.[0] || '').trim();
 }
 
 function readStoredAdminDestination(key = ADMIN_AUTH_DESTINATION_KEY) {
@@ -2691,6 +2701,40 @@ function updateBrowserTitle(pane = null) {
   document.title = paneBrowserTitle(selectedPane);
 }
 
+function renderActivePaneChip(pane = null) {
+  const chip = globalElements.activePaneChip;
+  if (!chip) return;
+
+  if (!pane?.key) {
+    chip.textContent = 'Active: —';
+    chip.title = 'No active pane';
+    chip.dataset.activeKind = '';
+    return;
+  }
+
+  const label = paneSummaryLabel(pane);
+  chip.textContent = `Active: ${label}`;
+  chip.title = `Active pane: ${label}`;
+  chip.dataset.activeKind = String(pane.kind || 'chat');
+}
+
+function syncActivePaneUi(pane = null) {
+  const panes = Array.isArray(paneManager?.panes) ? paneManager.panes : [];
+  const selected =
+    pane ||
+    panes.find((entry) => String(entry?.key || '') === activeAdminPaneKey()) ||
+    panes[0] ||
+    null;
+  const selectedKey = String(selected?.key || '');
+
+  panes.forEach((entry) => {
+    const root = entry?.elements?.root;
+    if (!root) return;
+    root.dataset.paneActive = selectedKey && String(entry?.key || '') === selectedKey ? 'true' : 'false';
+  });
+  renderActivePaneChip(selected);
+}
+
 function paneIdentityLabel(pane, { includeUnread = false } = {}) {
   const letter = paneHeaderLetter(pane);
   const type = paneLabel(pane);
@@ -2811,6 +2855,9 @@ function notePaneFocused(pane) {
   paneMruTraversal = null;
   paneMruOrder();
   paneFocusMruKeys = [key, ...paneFocusMruKeys.filter((entry) => entry !== key)];
+  paneManager.lastFocusedPaneKey = key;
+  storage.set(ADMIN_ACTIVE_PANE_KEY, key);
+  syncActivePaneUi(pane);
   updateBrowserTitle(pane);
 }
 
@@ -2821,6 +2868,9 @@ function forgetFocusedPaneKey(paneKey) {
   if (paneMruTraversal?.order) {
     paneMruTraversal.order = paneMruTraversal.order.filter((entry) => entry !== key);
     if (paneMruTraversal.order.length < 2) paneMruTraversal = null;
+  }
+  if (String(storage.get(ADMIN_ACTIVE_PANE_KEY, '') || '') === key) {
+    storage.remove(ADMIN_ACTIVE_PANE_KEY);
   }
 }
 
@@ -9927,7 +9977,13 @@ const paneManager = {
     this.updatePaneLabels();
     this.updateCloseButtons();
     this.applyInferredLayout();
-    updateBrowserTitle(this.panes[0] || null);
+    const rememberedKey = String(storage.get(ADMIN_ACTIVE_PANE_KEY, '') || '').trim();
+    const restorePane = this.panes.find((pane) => String(pane?.key || '') === rememberedKey) || this.panes[0] || null;
+    if (restorePane) this.focusPanePrimary(restorePane);
+    else {
+      syncActivePaneUi(null);
+      updateBrowserTitle(null);
+    }
   },
   isLayoutLocked() {
     return !!this.layoutLocked;
@@ -10525,7 +10581,10 @@ const paneManager = {
     if (focusFallback) {
       const fallbackPane = this.panes[Math.min(idx, this.panes.length - 1)] || this.panes[0] || null;
       if (fallbackPane) notePaneFocused(fallbackPane);
-      else updateBrowserTitle(null);
+      else {
+        syncActivePaneUi(null);
+        updateBrowserTitle(null);
+      }
     }
     updateGlobalStatus();
     updateConnectionControls();
@@ -10553,12 +10612,14 @@ const paneManager = {
     this.updatePaneLabels();
     this.persistAdminPanes();
     updateGlobalStatus();
+    syncActivePaneUi();
     return true;
   },
   updatePaneLabels() {
     this.panes.forEach((pane) => renderPaneIdentity(pane));
     updatePaneShortcutBadges();
     this.updatePaneGridLabel();
+    syncActivePaneUi();
   },
   updatePaneGridLabel() {
     const grid = globalElements.paneGrid;

--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
               <option value="3">3-up</option>
             </select>
           </div>
+          <div id="activePaneChip" class="active-pane-chip" data-testid="active-pane-chip" role="status" aria-live="polite" aria-label="Active pane context">Active: —</div>
           <button
             class="role-pill signed-out"
             id="rolePill"

--- a/styles.css
+++ b/styles.css
@@ -156,6 +156,41 @@ body::before {
   gap: 10px;
 }
 
+.active-pane-chip {
+  display: inline-flex;
+  align-items: center;
+  max-width: min(34vw, 360px);
+  min-height: 30px;
+  padding: 5px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(var(--pane-accent-rgb, 255, 179, 71), 0.68);
+  background: linear-gradient(180deg, rgba(var(--pane-accent-rgb, 255, 179, 71), 0.2), rgba(var(--pane-accent-rgb, 255, 179, 71), 0.08));
+  color: var(--text);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  font-size: 11px;
+  font-weight: 800;
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.active-pane-chip[data-active-kind="chat"] {
+  --pane-accent-rgb: var(--pane-accent-chat-rgb);
+}
+
+.active-pane-chip[data-active-kind="workqueue"] {
+  --pane-accent-rgb: var(--pane-accent-workqueue-rgb);
+}
+
+.active-pane-chip[data-active-kind="cron"] {
+  --pane-accent-rgb: var(--pane-accent-cron-rgb);
+}
+
+.active-pane-chip[data-active-kind="timeline"] {
+  --pane-accent-rgb: var(--pane-accent-timeline-rgb);
+}
+
 .agent-switch {
   display: inline-flex;
   align-items: center;
@@ -475,6 +510,22 @@ body::before {
   padding-bottom: 6px;
   border-color: rgba(var(--pane-accent-rgb, 255, 255, 255), 0.28);
   box-shadow: inset 0 0 0 1px rgba(var(--pane-accent-rgb, 255, 255, 255), 0.14), var(--shadow);
+}
+
+.chat-panel.pane[data-pane-active="true"] {
+  border-color: rgba(var(--pane-accent-rgb, 255, 255, 255), 0.84);
+  box-shadow:
+    0 0 0 3px rgba(var(--pane-accent-rgb, 255, 255, 255), 0.44),
+    inset 0 0 0 1px rgba(var(--pane-accent-rgb, 255, 255, 255), 0.3),
+    var(--shadow);
+}
+
+.chat-panel.pane[data-pane-active="true"] .pane-header {
+  background:
+    linear-gradient(90deg, rgba(var(--pane-accent-rgb, 255, 255, 255), 0.26), rgba(var(--pane-accent-rgb, 255, 255, 255), 0.08)),
+    linear-gradient(90deg, var(--pane-header-tint, rgba(9, 12, 16, 0.18)), rgba(9, 12, 16, 0.12));
+  border-color: rgba(var(--pane-accent-rgb, 255, 255, 255), 0.54);
+  box-shadow: inset 0 0 0 1px rgba(var(--pane-accent-rgb, 255, 255, 255), 0.22);
 }
 
 /* Workqueue pane should be full-height: never show chat composer UI in this pane. */

--- a/tests/pane.manager.e2e.spec.js
+++ b/tests/pane.manager.e2e.spec.js
@@ -40,6 +40,12 @@ test('pane manager: lists panes + focuses via keyboard', async ({ page }) => {
 
   const panes = page.locator('[data-pane]');
   await expect(panes).toHaveCount(2);
+  const chip = page.getByTestId('active-pane-chip');
+  await expect(chip).toContainText('Active: B Workqueue');
+  await expect(chip).toHaveAttribute('data-active-kind', 'workqueue');
+  await expect(panes.nth(1)).toHaveAttribute('data-pane-active', 'true');
+  await expect(panes.nth(0)).toHaveAttribute('data-pane-active', 'false');
+  await expect(page.locator('[data-pane][data-pane-active="true"]')).toHaveCount(1);
 
   // Active element should be inside the 2nd pane.
   const focusedPaneIndex = await page.evaluate(() => {
@@ -48,6 +54,46 @@ test('pane manager: lists panes + focuses via keyboard', async ({ page }) => {
     return panes.findIndex((p) => p === active || (active && p.contains(active)));
   });
   expect(focusedPaneIndex).toBe(1);
+
+  await panes.first().locator('[data-pane-input]').click();
+  await expect(chip).toContainText('Active: A Chat');
+  await expect(chip).toHaveAttribute('data-active-kind', 'chat');
+  await expect(panes.nth(0)).toHaveAttribute('data-pane-active', 'true');
+  await expect(panes.nth(1)).toHaveAttribute('data-pane-active', 'false');
+  await expect(page.locator('[data-pane][data-pane-active="true"]')).toHaveCount(1);
+});
+
+test('pane active context: keyboard navigation updates chip and survives reload', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const panes = page.locator('[data-pane]');
+  const chip = page.getByTestId('active-pane-chip');
+
+  await page.evaluate(() => document.activeElement?.blur?.());
+  await page.keyboard.press('Alt+2');
+  await expect(chip).toContainText('Active: B Workqueue');
+  await expect(panes.nth(1)).toHaveAttribute('data-pane-active', 'true');
+  await expect(page.locator('[data-pane][data-pane-active="true"]')).toHaveCount(1);
+
+  await page.reload();
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+  await expect(chip).toContainText('Active: B Workqueue');
+  await expect(panes.nth(1)).toHaveAttribute('data-pane-active', 'true');
+  await expect(page.locator('[data-pane][data-pane-active="true"]')).toHaveCount(1);
+
+  await page.evaluate(() => document.activeElement?.blur?.());
+  await page.keyboard.press('Alt+1');
+  await expect(chip).toContainText('Active: A Chat');
+  await expect(panes.nth(0)).toHaveAttribute('data-pane-active', 'true');
+  await expect(page.locator('[data-pane][data-pane-active="true"]')).toHaveCount(1);
 });
 
 test('pane header: identity line uses "[Letter] [Type] · [Target]" across pane kinds', async ({ page }) => {


### PR DESCRIPTION
## Summary
- add a persistent topbar Active chip using the existing pane identity format
- mark exactly one pane with data-pane-active and apply stronger active styling
- persist/restore active pane selection across reload with fallback to the first live pane
- add pane-manager e2e coverage for click focus, keyboard focus, reload restore, and single-active assertions

Supersedes conflicted PR #410.
Closes #407.

## Testing
- node --check app.js
- npm test -- --runInBand tests/unit/app-core.test.js
- npx playwright test tests/pane.manager.e2e.spec.js