### PR TITLE
Fix #206: auto-group repetitive workqueue rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ If omitted, the admin password defaults to `admin`.
   - Overview + assignments contract: [`docs/WORKQUEUE.md`](./docs/WORKQUEUE.md)
   - Recurring enqueue patterns: [`docs/WORKQUEUE_SCHEDULING.md`](./docs/WORKQUEUE_SCHEDULING.md)
 
+The Workqueue pane defaults to Auto view mode: when more than 20 rows are
+visible, related issue/routine rows are grouped behind expandable summary rows.
+Rows and Grouped are available as explicit overrides.
+
 ## Workqueue: agent→queue assignments + claim-next defaults
 
 See also:

--- a/app.js
+++ b/app.js
@@ -4800,6 +4800,7 @@ function runFleetSelectedAgent(mode = 'chat') {
 const WORKQUEUE_STATUSES = ['ready', 'pending', 'blocked', 'claimed', 'in_progress', 'done', 'failed'];
 const WORKQUEUE_PANE_INITIAL_RENDER_LIMIT = 100;
 const WORKQUEUE_PANE_RENDER_CHUNK_SIZE = 100;
+const WORKQUEUE_GROUPED_AUTO_THRESHOLD = 20;
 const WORKQUEUE_ALL_SCOPE_GUARD_THRESHOLD_KEY = 'clawnsole.admin.workqueue.allScopeGuardThreshold';
 const WORKQUEUE_ALL_SCOPE_GUARD_DEFAULT_THRESHOLD = 200;
 const WORKQUEUE_HEADER_META = {
@@ -5537,6 +5538,32 @@ function getWorkqueueIssueKey(item) {
   return parsed ? `${parsed.repo}#${parsed.issueNumber}` : '';
 }
 
+function normalizeWorkqueueGroupText(value) {
+  return String(value || '').trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+function getWorkqueueDedupeIdentity(item) {
+  const meta = item?.meta && typeof item.meta === 'object' ? item.meta : {};
+  return normalizeWorkqueueGroupText(meta.dedupeKey || item?.dedupeKey);
+}
+
+function getWorkqueueTitleGroupPrefix(item) {
+  const title = normalizeWorkqueueGroupText(formatWorkqueueIssueTitle(item) || item?.title);
+  if (!title) return '';
+  return title.slice(0, 80);
+}
+
+function getWorkqueueGroupIdentity(item) {
+  const source = getWorkqueueItemSource(item);
+  const issueKey = getWorkqueueIssueKey(item);
+  const dedupeKey = getWorkqueueDedupeIdentity(item);
+  if ((source === 'routine' || source === 'coordination') && dedupeKey) return `dedupe:${dedupeKey}`;
+  if (issueKey) return `issue:${issueKey}`;
+  if (dedupeKey) return `dedupe:${dedupeKey}`;
+  const titlePrefix = getWorkqueueTitleGroupPrefix(item);
+  return titlePrefix ? `title:${titlePrefix}` : '';
+}
+
 function chooseWorkqueueDuplicateKeepItem(items) {
   const statusRank = { in_progress: 6, claimed: 5, ready: 4, pending: 3, blocked: 2, done: 1, failed: 0 };
   return (Array.isArray(items) ? items : [])
@@ -5844,10 +5871,15 @@ function sortWorkqueueRowEntries(entries, { sortKey, sortDir } = {}) {
     .filter(Boolean);
 }
 
-function summarizeWorkqueueIssueGroups(items) {
+function formatWorkqueueGroupDisplayKey(key) {
+  const text = String(key || '');
+  return text.replace(/^(?:issue|dedupe|title):/, '');
+}
+
+function summarizeWorkqueueGroups(items) {
   const map = new Map();
   for (const item of Array.isArray(items) ? items : []) {
-    const key = getWorkqueueIssueKey(item);
+    const key = getWorkqueueGroupIdentity(item);
     if (!key) continue;
     if (!map.has(key)) map.set(key, []);
     map.get(key).push(item);
@@ -5863,6 +5895,7 @@ function summarizeWorkqueueIssueGroups(items) {
     groups.push({
       kind: 'group',
       key,
+      displayKey: formatWorkqueueGroupDisplayKey(key),
       items: groupItems,
       representative,
       title: formatWorkqueueIssueTitle(representative),
@@ -5875,7 +5908,7 @@ function summarizeWorkqueueIssueGroups(items) {
   const out = [];
   const emittedGroups = new Set();
   for (const item of Array.isArray(items) ? items : []) {
-    const key = getWorkqueueIssueKey(item);
+    const key = getWorkqueueGroupIdentity(item);
     if (key && groupedKeys.has(key)) {
       if (emittedGroups.has(key)) continue;
       const group = groups.find((entry) => entry.key === key);
@@ -5886,6 +5919,18 @@ function summarizeWorkqueueIssueGroups(items) {
     out.push({ kind: 'item', item });
   }
   return out;
+}
+
+function normalizeWorkqueueGroupMode(value) {
+  const s = String(value || '').trim().toLowerCase();
+  if (s === 'rows' || s === 'grouped') return s;
+  return 'auto';
+}
+
+function resolveWorkqueueGroupMode(value, itemCount) {
+  const mode = normalizeWorkqueueGroupMode(value);
+  if (mode === 'rows' || mode === 'grouped') return mode;
+  return Number(itemCount || 0) > WORKQUEUE_GROUPED_AUTO_THRESHOLD ? 'grouped' : 'rows';
 }
 
 function appendWorkqueuePaneItemRow(pane, body, item, { child = false } = {}) {
@@ -6078,9 +6123,9 @@ function renderWorkqueuePaneItems(pane) {
   const statusLine = pane.elements?.thread?.querySelector('[data-wq-statusline]');
   if (statusLine) statusLine.textContent = formatWorkqueueVisibleSummary(items.length, totalCount, hiddenCounts);
   renderWorkqueueFilterSummaryForPane(pane, { shownCount: items.length, totalCount, hiddenCounts });
-  const groupMode = normalizeWorkqueueGroupMode(pane.workqueue?.groupMode);
+  const groupMode = resolveWorkqueueGroupMode(pane.workqueue?.groupMode, items.length);
   const rows = groupMode === 'grouped'
-    ? summarizeWorkqueueIssueGroups(items)
+    ? summarizeWorkqueueGroups(items)
     : sortWorkqueueRowEntries(summarizeWorkqueueExactDuplicateRows(items), { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
   const renderLimit = Math.max(
     WORKQUEUE_PANE_INITIAL_RENDER_LIMIT,
@@ -6147,7 +6192,7 @@ function renderWorkqueuePaneItems(pane) {
     const row = document.createElement('button');
     row.type = 'button';
     row.className = isExactDuplicate ? 'wq-row wq-group-row wq-exact-duplicate-row' : 'wq-row wq-group-row';
-    row.setAttribute(isExactDuplicate ? 'data-wq-duplicate-row' : 'data-wq-group-row', entry.key);
+    row.setAttribute(isExactDuplicate ? 'data-wq-duplicate-row' : 'data-wq-group-row', entry.displayKey || entry.key);
     if (isExactDuplicate && representative?.id) {
       row.setAttribute('data-wq-item', representative.id);
       if (representative.id === pane.workqueue.selectedItemId) row.classList.add('selected');
@@ -8261,10 +8306,6 @@ function renderAgentOptions(selectEl, agentId) {
   selectEl.value = normalizeAgentId(agentId || 'main');
 }
 
-function normalizeWorkqueueGroupMode(value) {
-  return String(value || '').trim().toLowerCase() === 'grouped' ? 'grouped' : 'rows';
-}
-
 function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, scopeFilter, quickFilters, groupMode, sortKey, sortDir, cronAgentId, nickname, pairedTargetLock = false, closable = true } = {}) {
   const template = globalElements.paneTemplate;
   const root = template.content.firstElementChild.cloneNode(true);
@@ -8592,6 +8633,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
 
           <div class="wq-sort" role="group" aria-label="Workqueue row grouping">
             <span class="wq-sort-label">View</span>
+            <button type="button" class="wq-sort-btn" data-wq-group-mode="auto">Auto</button>
             <button type="button" class="wq-sort-btn" data-wq-group-mode="rows">Rows</button>
             <button type="button" class="wq-sort-btn" data-wq-group-mode="grouped">Grouped</button>
           </div>
@@ -9159,6 +9201,9 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         const active = key === current;
         btn.classList.toggle('active', active);
         btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+        if (key === 'auto') btn.title = `Auto groups related rows when more than ${WORKQUEUE_GROUPED_AUTO_THRESHOLD} items are visible.`;
+        else if (key === 'rows') btn.title = 'Show individual workqueue rows; exact duplicate rows still collapse.';
+        else btn.title = 'Group related issue, routine, or coordination rows.';
       });
     };
 

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -195,6 +195,37 @@ function seedExactDuplicateWorkqueueItems(queue) {
   fs.writeFileSync(path.join(dir, 'work-queues.json'), JSON.stringify(data, null, 2));
 }
 
+function seedLargeRoutineWorkqueueItems(queue) {
+  const dir = path.join(env.tempHome, '.openclaw', 'clawnsole');
+  fs.mkdirSync(dir, { recursive: true });
+  const now = new Date();
+  const iso = (offsetMs) => new Date(now.getTime() + offsetMs).toISOString();
+  const items = Array.from({ length: 22 }, (_, ix) => ({
+    id: `routine-sweep-${ix}`,
+    queue,
+    title: `[routine] PR review sweep ${ix + 1}`,
+    instructions: 'Recurring dev-team PR review sweep',
+    priority: ix === 7 ? 99 : 10 + ix,
+    status: ix % 3 === 0 ? 'pending' : 'ready',
+    claimedBy: ix === 5 ? 'dev-2' : '',
+    claimedAt: '',
+    leaseUntil: 0,
+    attempts: ix,
+    lastError: '',
+    createdAt: iso(-120000 + ix * 1000),
+    updatedAt: iso(-90000 + ix * 1000),
+    dedupeKey: 'pr-review:sweep'
+  }));
+
+  const data = {
+    version: 1,
+    queues: { [queue]: { name: queue, createdAt: iso(-180000) } },
+    assignments: {},
+    items
+  };
+  fs.writeFileSync(path.join(dir, 'work-queues.json'), JSON.stringify(data, null, 2));
+}
+
 test('workqueue pane: queue switch updates pane identity everywhere', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);
@@ -473,7 +504,7 @@ test('workqueue pane: default rows collapse exact duplicates with expandable mem
   const rows = wqPane.locator('[data-wq-list-body] .wq-row');
   const duplicateRow = wqPane.locator('[data-wq-duplicate-row]').first();
 
-  await expect(wqPane.locator('[data-wq-group-mode="rows"]')).toHaveAttribute('aria-pressed', 'true');
+  await expect(wqPane.locator('[data-wq-group-mode="auto"]')).toHaveAttribute('aria-pressed', 'true');
   await expect(wqPane.locator('[data-wq-statusline]')).toContainText('Showing 4 items');
   await expect(rows).toHaveCount(3);
   await expect(duplicateRow).toContainText('x2');
@@ -484,6 +515,38 @@ test('workqueue pane: default rows collapse exact duplicates with expandable mem
   await duplicateRow.press('Enter');
   await expect(duplicateRow).toHaveAttribute('aria-expanded', 'true');
   await expect(wqPane.locator('[data-wq-list-body] .wq-row-child')).toHaveCount(2);
+});
+
+test('workqueue pane: auto view groups large repetitive routine queues', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  const queue = `large-routine-${Date.now()}`;
+  seedLargeRoutineWorkqueueItems(queue);
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  const pane = page.locator('[data-pane]').last();
+  await pane.locator('[data-wq-queue-select]').selectOption('__custom__');
+  await pane.locator('[data-wq-queue-custom]').fill(queue);
+  await pane.locator('[data-wq-queue-custom]').press('Enter');
+  await pane.locator('[data-wq-scope="all"]').click();
+
+  const groupRow = pane.locator('[data-wq-group-row="pr-review:sweep"]');
+  await expect(pane.locator('[data-wq-group-mode="auto"]')).toHaveAttribute('aria-pressed', 'true');
+  await expect(groupRow).toBeVisible();
+  await expect(groupRow).toContainText('22 rows');
+  await expect(groupRow.locator('.wq-col.status')).toContainText('Ready');
+  await expect(groupRow.locator('.wq-col.status')).toContainText('Pending');
+  await expect(groupRow.locator('.wq-col.prio')).toHaveText('99');
+  await expect(pane.locator('.wq-row')).toHaveCount(1);
+
+  await groupRow.focus();
+  await page.keyboard.press('Enter');
+  await expect(groupRow).toHaveAttribute('aria-expanded', 'true');
+  await expect(pane.locator('.wq-row-child')).toHaveCount(22);
 });
 
 test('workqueue pane: queue target supports search + recent persistence', async ({ page }) => {
@@ -776,7 +839,7 @@ test('workqueue pane: default rows auto-collapse exact duplicates with count and
   await pane.locator('[data-wq-queue-custom]').press('Enter');
 
   const duplicateRow = pane.locator('[data-wq-duplicate-row]').first();
-  await expect(pane.locator('[data-wq-group-mode="rows"]')).toHaveClass(/active/);
+  await expect(pane.locator('[data-wq-group-mode="auto"]')).toHaveClass(/active/);
   await expect(duplicateRow).toBeVisible();
   await expect(duplicateRow).toContainText('x2');
   await expect(duplicateRow).toHaveAttribute('data-wq-item', 'exact-dup-latest');


### PR DESCRIPTION
## Summary
- add Auto / Rows / Grouped workqueue pane view modes
- make Auto resolve to grouped mode when more than 20 rows are visible
- group routine/coordination rows by dedupe key, issue rows by issue key, and fall back to normalized title prefixes
- document the Auto threshold

Fixes #206

## Tests
- npm test
- npx playwright test tests/ui/workqueue-pane.spec.js --grep "auto view groups large repetitive routine queues|grouped mode collapses duplicate issue rows|default rows collapse exact duplicates|default rows auto-collapse exact duplicates" --workers=1
