### PR TITLE
Highlight active pane context

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,6 +20,8 @@ const globalElements = {
   recurringPromptHistoryEmpty: document.getElementById('recurringPromptHistoryEmpty'),
   status: document.getElementById('connectionStatus'),
   paneManagerBtn: document.getElementById('paneManagerBtn'),
+  activePaneChip: document.getElementById('activePaneChip'),
+  activePaneChipValue: document.querySelector('[data-active-pane-chip-value]'),
   pulseCanvas: document.getElementById('pulseCanvas'),
   workqueueBtn: document.getElementById('workqueueBtn'),
   fleetBtn: document.getElementById('fleetBtn'),
@@ -2944,7 +2946,46 @@ function notePaneFocused(pane) {
   paneMruTraversal = null;
   paneMruOrder();
   paneFocusMruKeys = [key, ...paneFocusMruKeys.filter((entry) => entry !== key)];
+  storage.set(ADMIN_ACTIVE_PANE_KEY, key);
+  updateActivePaneUi(pane);
   updateBrowserTitle(pane);
+}
+
+function activePaneFromState() {
+  const panes = paneManager?.panes || [];
+  const activeKey = focusedPaneKey() || paneMruOrder()[0] || storage.get(ADMIN_ACTIVE_PANE_KEY, '');
+  return panes.find((pane) => String(pane?.key || '') === String(activeKey || '')) || panes[0] || null;
+}
+
+function updateActivePaneUi(activePane = null) {
+  const panes = paneManager?.panes || [];
+  const selected = activePane && panes.includes(activePane) ? activePane : activePaneFromState();
+  const selectedKey = String(selected?.key || '');
+
+  panes.forEach((pane) => {
+    const isActive = !!selectedKey && String(pane?.key || '') === selectedKey;
+    const root = pane?.elements?.root;
+    if (!root) return;
+    root.classList.toggle('is-active-pane', isActive);
+    root.dataset.activePane = isActive ? 'true' : 'false';
+    root.setAttribute('aria-current', isActive ? 'true' : 'false');
+  });
+
+  const chip = globalElements.activePaneChip;
+  const value = globalElements.activePaneChipValue;
+  if (!chip || !value) return;
+
+  if (!selected) {
+    chip.hidden = true;
+    value.textContent = '';
+    chip.removeAttribute('title');
+    return;
+  }
+
+  const label = paneSummaryLabel(selected);
+  chip.hidden = false;
+  value.textContent = label;
+  chip.title = `Active pane: ${label}`;
 }
 
 function paneMarkSwitchSendGuard(pane, fromPaneKey) {
@@ -7261,6 +7302,7 @@ renderPulse();
 // Panes
 
 const ADMIN_PANES_KEY = 'clawnsole.admin.panes.v1';
+const ADMIN_ACTIVE_PANE_KEY = 'clawnsole.admin.activePaneKey.v1';
 const ADMIN_LAYOUT_LOCK_KEY = 'clawnsole.admin.layout.lock.v1';
 // Layout is inferred from pane count; no manual layout toggle.
 const ADMIN_LAYOUT_MODE_KEY = 'clawnsole.admin.layoutMode';
@@ -8811,6 +8853,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
   } catch {}
 
   elements.root.addEventListener('click', () => notePaneFocused(pane));
+  elements.root.addEventListener('focusin', () => notePaneFocused(pane));
   elements.header?.addEventListener('mouseenter', () => setPanePairReveal(pane, true));
   elements.header?.addEventListener('mouseleave', () => setPanePairReveal(pane, false));
   elements.header?.addEventListener('focusin', () => setPanePairReveal(pane, true));
@@ -10379,7 +10422,8 @@ const paneManager = {
     this.updatePaneLabels();
     this.updateCloseButtons();
     this.applyInferredLayout();
-    updateBrowserTitle(this.panes[0] || null);
+    this.restoreActivePaneState({ focus: false });
+    updateBrowserTitle(activePaneFromState());
   },
   isLayoutLocked() {
     return !!this.layoutLocked;
@@ -10616,6 +10660,22 @@ const paneManager = {
       const firstPane = this.panes[0];
       firstPane?.elements?.input?.focus?.();
     } catch {}
+  },
+  restoreActivePaneState({ focus = true } = {}) {
+    const storedKey = String(storage.get(ADMIN_ACTIVE_PANE_KEY, '') || '');
+    const pane = this.panes.find((entry) => String(entry?.key || '') === storedKey) || this.panes[0] || null;
+    if (!pane) {
+      updateActivePaneUi(null);
+      updateBrowserTitle(null);
+      return null;
+    }
+    paneMruOrder();
+    paneFocusMruKeys = [pane.key, ...paneFocusMruKeys.filter((key) => key !== pane.key)];
+    storage.set(ADMIN_ACTIVE_PANE_KEY, pane.key);
+    updateActivePaneUi(pane);
+    updateBrowserTitle(pane);
+    if (focus) this.focusPanePrimary(pane);
+    return pane;
   },
   addPane(kind = 'chat', options = {}) {
     if (roleState.role !== 'admin') return;
@@ -11110,6 +11170,7 @@ const paneManager = {
   },
   updatePaneLabels() {
     this.panes.forEach((pane) => renderPaneIdentity(pane));
+    updateActivePaneUi();
     updatePaneShortcutBadges();
     this.updatePaneGridLabel();
   },
@@ -12365,8 +12426,7 @@ window.addEventListener('load', () => {
 
       const isTouch = window.matchMedia && window.matchMedia('(hover: none) and (pointer: coarse)').matches;
       if (!isTouch) {
-        const firstPane = paneManager.panes[0];
-        firstPane?.elements.input?.focus();
+        paneManager.restoreActivePaneState({ focus: true });
       }
     })
     .catch(() => {

--- a/index.html
+++ b/index.html
@@ -40,6 +40,10 @@
               data-testid="panes-indicator"
             ></button>
           </div>
+          <div class="active-pane-chip" id="activePaneChip" data-testid="active-pane-chip" role="status" aria-live="polite" hidden>
+            <span class="active-pane-chip__label">Active</span>
+            <span class="active-pane-chip__value" data-active-pane-chip-value></span>
+          </div>
           <div id="paneControls" class="pane-controls" hidden>
             <div class="pane-add-wrap">
               <button id="addPaneBtn" class="icon-btn action-btn" type="button" aria-haspopup="menu" aria-expanded="false" aria-label="Add pane" title="Add Pane (Ctrl/Cmd+Shift+N)" data-testid="add-pane-btn">

--- a/styles.css
+++ b/styles.css
@@ -156,6 +156,42 @@ body::before {
   gap: 10px;
 }
 
+.active-pane-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  max-width: min(320px, 28vw);
+  min-height: 32px;
+  padding: 5px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(127, 209, 185, 0.46);
+  background: rgba(127, 209, 185, 0.12);
+  color: #dffbf3;
+  white-space: nowrap;
+}
+
+.active-pane-chip[hidden] {
+  display: none !important;
+}
+
+.active-pane-chip__label {
+  flex: 0 0 auto;
+  color: rgba(230, 238, 246, 0.68);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.active-pane-chip__value {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: #f8fafc;
+  font-size: 12px;
+  font-weight: 700;
+}
+
 .agent-switch {
   display: inline-flex;
   align-items: center;
@@ -523,6 +559,20 @@ body::before {
   border-left: 4px solid var(--pane-accent, rgba(255, 179, 71, 0.55));
   position: relative;
   z-index: 2;
+}
+
+.pane.is-active-pane {
+  box-shadow:
+    0 0 0 2px rgba(var(--pane-accent-rgb, 127, 209, 185), 0.68),
+    0 18px 46px rgba(var(--pane-accent-rgb, 127, 209, 185), 0.18),
+    var(--shadow);
+}
+
+.pane.is-active-pane .pane-header {
+  border-color: rgba(var(--pane-accent-rgb, 127, 209, 185), 0.78);
+  border-left-color: rgb(var(--pane-accent-rgb, 127, 209, 185));
+  background:
+    linear-gradient(90deg, rgba(var(--pane-accent-rgb, 127, 209, 185), 0.24), rgba(9, 12, 16, 0.18));
 }
 
 .pane.is-pair-revealed {

--- a/tests/pane.manager.e2e.spec.js
+++ b/tests/pane.manager.e2e.spec.js
@@ -85,6 +85,46 @@ test('pane header: identity line uses "[Letter] [Type] · [Target]" across pane 
   await expect(page.locator('.pane-manager-row .pane-manager-pane-id').first()).toHaveText(/^[a-zA-Z0-9]+$/);
 });
 
+test('pane focus: active visual state and topbar chip follow keyboard pane navigation', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const panes = page.locator('[data-pane]');
+  const chip = page.getByTestId('active-pane-chip');
+  await expect(panes).toHaveCount(2);
+  await expect(chip).toContainText(/Active\s+A Chat · /);
+  await expect(panes.first()).toHaveAttribute('data-active-pane', 'true');
+  await expect(panes.nth(1)).toHaveAttribute('data-active-pane', 'false');
+
+  await page.evaluate(() => document.activeElement?.blur?.());
+  await page.keyboard.press('Alt+2');
+  await expect(chip).toContainText(/Active\s+B Workqueue · /);
+  await expect(panes.first()).toHaveAttribute('data-active-pane', 'false');
+  await expect(panes.nth(1)).toHaveAttribute('data-active-pane', 'true');
+  await expect(page.locator('[data-pane][data-active-pane="true"]')).toHaveCount(1);
+
+  await page.reload();
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+  await expect(chip).toContainText(/Active\s+B Workqueue · /);
+  await expect(panes.first()).toHaveAttribute('data-active-pane', 'false');
+  await expect(panes.nth(1)).toHaveAttribute('data-active-pane', 'true');
+  await expect(page.locator('[data-pane][data-active-pane="true"]')).toHaveCount(1);
+
+  await page.evaluate(() => document.activeElement?.blur?.());
+  await page.keyboard.press('Alt+1');
+  await expect(chip).toContainText(/Active\s+A Chat · /);
+  await expect(panes.first()).toHaveAttribute('data-active-pane', 'true');
+  await expect(panes.nth(1)).toHaveAttribute('data-active-pane', 'false');
+  await expect(page.locator('[data-pane][data-active-pane="true"]')).toHaveCount(1);
+});
+
 test('pane manager: quick-find filters, highlights, and focuses first match', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!app?.skipReason, app?.skipReason);

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -161,6 +161,7 @@ test('pane-add shortcuts are scoped to workspace and blocked by overlays', async
     }));
   });
 
+  await expect(panes).toHaveCount(2);
   const initialCount = await paneCount();
   await page.click('#connectionStatus');
 


### PR DESCRIPTION
Fixes #407.

Summary:
- Adds a persistent topbar Active chip that shows the focused pane as [Letter] [Type] · [Target].
- Marks exactly one pane as active with data-active-pane/aria-current and a stronger accent/header treatment.
- Persists/restores the active pane key across reloads with fallback to the first live pane.

Validation:
- npm run test:syntax
- npx playwright test tests/pane.manager.e2e.spec.js --workers=1

No production deploy.
