### PR TITLE
Guard pane shortcuts while typing

### DIFF
--- a/app.js
+++ b/app.js
@@ -11166,15 +11166,25 @@ function reportBlockedShortcut(reason) {
 }
 
 function isTypingContext(target) {
-  const el = target || document.activeElement;
+  const el = target instanceof Element ? target : document.activeElement;
   if (!el) return false;
   try {
     if (el.hidden || el.disabled) return false;
     if (el.getClientRects && el.getClientRects().length === 0) return false;
   } catch {}
-  const tag = String(el.tagName || '').toUpperCase();
-  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
-  if (el.isContentEditable) return true;
+  const editable = el.closest?.('input, textarea, select, [contenteditable=""], [contenteditable="true"], [role="textbox"]');
+  if (editable) return true;
+  if (el.isContentEditable || el.closest?.('[contenteditable="true"], [contenteditable=""]')) return true;
+  const editorSurface = el.closest?.([
+    '.monaco-editor',
+    '.cm-editor',
+    '.CodeMirror',
+    '.ace_editor',
+    '[data-gramm]',
+    '[data-slate-editor="true"]',
+    '[data-lexical-editor="true"]'
+  ].join(', '));
+  if (editorSurface) return true;
   return false;
 }
 
@@ -11522,13 +11532,7 @@ window.addEventListener('keydown', (event) => {
     updatePaneShortcutBadges();
   }
 
-  const isEditableTarget = (() => {
-    const el = event.target;
-    if (!el) return false;
-    if (el.isContentEditable) return true;
-    const tag = String(el.tagName || '').toUpperCase();
-    return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
-  })();
+  const isEditableTarget = isTypingContext(event.target);
 
   if (event.key === 'Escape') {
     const closedOverlay = closeTopmostOverlay();

--- a/app.js
+++ b/app.js
@@ -11855,7 +11855,8 @@ function reportBlockedShortcut(reason) {
 }
 
 function isTypingContext(target) {
-  const el = target instanceof Element ? target : document.activeElement;
+  const el = target === undefined ? document.activeElement : target;
+  if (!(el instanceof Element)) return false;
   if (!el) return false;
   try {
     if (el.hidden || el.disabled) return false;

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -465,6 +465,74 @@ test('g then pane letter is suppressed while typing and while modals are active'
   await expect.poll(activePaneIndex).not.toBe(1);
 });
 
+test('global pane shortcuts are blocked from editable and modal text surfaces', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  await page.getByTestId('add-pane-btn').click();
+  await page.getByTestId('pane-add-menu-cron').click();
+  await expect(page.locator('[data-pane]')).toHaveCount(3);
+
+  const activePaneIndex = async () => page.evaluate(() => {
+    const panes = Array.from(document.querySelectorAll('[data-pane]')).filter((pane) => pane.getClientRects().length > 0);
+    const active = document.activeElement;
+    if (!active) return -1;
+    return panes.findIndex((p) => p === active || p.contains(active));
+  });
+
+  await page.evaluate(() => focusPaneIndex(0));
+  const composer = page.locator('[data-pane][data-pane-kind="chat"] [data-pane-input]').first();
+  await composer.focus();
+  await page.keyboard.press('Control+Shift+K');
+  await expect.poll(activePaneIndex).toBe(0);
+  await expect(page.getByTestId('shortcut-blocked-toast').last()).toContainText('Shortcut paused while typing');
+
+  const workqueueSearch = page.locator('[data-pane][data-pane-kind="workqueue"] [data-wq-search]').first();
+  await workqueueSearch.focus();
+  await page.keyboard.press('Control+Shift+K');
+  await expect.poll(activePaneIndex).toBe(1);
+
+  await page.evaluate(() => {
+    const host = document.querySelector('[data-pane][data-pane-kind="chat"]');
+    const editor = document.createElement('div');
+    editor.className = 'monaco-editor';
+    editor.tabIndex = 0;
+    editor.textContent = 'editor';
+    host.appendChild(editor);
+    editor.focus();
+  });
+  await expect.poll(activePaneIndex).toBe(0);
+  await page.keyboard.press('Control+Shift+K');
+  await expect.poll(activePaneIndex).toBe(0);
+
+  await page.evaluate(() => {
+    const host = document.querySelector('[data-pane][data-pane-kind="chat"]');
+    const editable = document.createElement('div');
+    editable.contentEditable = 'true';
+    editable.tabIndex = 0;
+    editable.textContent = 'draft';
+    host.appendChild(editable);
+    editable.focus();
+  });
+  await page.keyboard.press('Control+Shift+K');
+  await expect.poll(activePaneIndex).toBe(0);
+
+  await page.click('#connectionStatus');
+  await page.keyboard.press('Control+P');
+  await expect(page.getByTestId('pane-manager-modal')).toHaveAttribute('aria-hidden', 'false');
+  await page.locator('#paneManagerSearch').focus();
+  await page.keyboard.press('Control+Shift+K');
+  await expect(page.getByTestId('pane-manager-modal')).toHaveAttribute('aria-hidden', 'false');
+  await expect.poll(activePaneIndex).not.toBe(1);
+});
+
 test('pane-switch HUD appears for keyboard pane navigation and respects settings', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!app?.skipReason, app?.skipReason);


### PR DESCRIPTION
## Summary
- Expand the shared typing-context guard to cover editable ancestors, contenteditable regions, and common code-editor surfaces.
- Reuse that guard for Escape/editable handling in the global shortcut listener.
- Add Playwright regression coverage for composer focus, Workqueue search focus, editor/contenteditable surfaces, and modal search focus.

Fixes #255.

## Tests
- npm run test:syntax
- npx playwright test tests/pane.shortcuts.e2e.spec.js --grep "global pane shortcuts are blocked" --workers=1

Note: full tests/pane.shortcuts.e2e.spec.js also ran; the new regression passed, but two existing tests failed unrelated to this change: toast expectation in cmd/ctrl+alt+j/k and MRU ctrl+tab reverse.