### PR TITLE
Default targeted workqueue panes to assigned scope

### DIFF
--- a/app.js
+++ b/app.js
@@ -647,9 +647,10 @@ function buildDefaultAdminPanes(defaultAgent = 'main') {
     {
       key: `p${randomId().slice(0, 8)}`,
       kind: 'workqueue',
+      agentId,
       queue: 'dev-team',
       statusFilter: ['ready', 'pending', 'blocked', 'claimed', 'in_progress'],
-      scopeFilter: getDefaultWorkqueueScope(),
+      scopeFilter: getDefaultWorkqueueScopeForTarget(agentId),
       sortKey: 'priority',
       sortDir: 'desc'
     }
@@ -7046,6 +7047,10 @@ function getDefaultWorkqueueScope() {
   return normalizeWorkqueueScope(storage.get(WORKQUEUE_SCOPE_PREF_KEY, 'unassigned'));
 }
 
+function getDefaultWorkqueueScopeForTarget(agentId) {
+  return normalizeAgentId(agentId || '') ? 'assigned' : getDefaultWorkqueueScope();
+}
+
 function computeBaseDeviceLabel() {
   const base = globalElements.deviceId.value.trim() || 'device';
   return TAB_ID ? `${base}-${TAB_ID}` : base;
@@ -8515,6 +8520,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     stopBtn: root.querySelector('[data-pane-stop]')
   };
 
+  const normalizedPaneAgentId = role === 'admin' ? normalizeAgentId(agentId || 'main') : null;
   const pane = {
     key,
     role,
@@ -8523,11 +8529,11 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       const k = String(kind || 'chat').trim().toLowerCase();
       return allowed.has(k) ? k : k.startsWith('w') ? 'workqueue' : 'chat';
     })(),
-    agentId: role === 'admin' ? normalizeAgentId(agentId || 'main') : null,
+    agentId: normalizedPaneAgentId,
     workqueue: {
       queue: (queue || 'dev-team').trim() || 'dev-team',
       statusFilter: Array.isArray(statusFilter) ? statusFilter : ['ready', 'pending', 'blocked', 'claimed', 'in_progress'],
-      scopeFilter: normalizeWorkqueueScope(scopeFilter ?? getDefaultWorkqueueScope()),
+      scopeFilter: normalizeWorkqueueScope(scopeFilter ?? getDefaultWorkqueueScopeForTarget(normalizedPaneAgentId)),
       quickFilters: {
         sources: Array.isArray(quickFilters?.sources) ? quickFilters.sources.map((s) => String(s || '').trim()).filter(Boolean) : [],
         repos: Array.isArray(quickFilters?.repos) ? quickFilters.repos.map((s) => String(s || '').trim()).filter(Boolean) : [],
@@ -10307,7 +10313,7 @@ const paneManager = {
     const nextQueue = String(options?.queue || 'dev-team').trim() || 'dev-team';
     const nextAgentId = normalizeAgentId(options?.agentId || storage.get(ADMIN_DEFAULT_AGENT_KEY, 'main'));
     const nextCronAgentId = String(options?.cronAgentId || '').trim();
-    const nextScopeFilter = normalizeWorkqueueScope(options?.scopeFilter ?? getDefaultWorkqueueScope());
+    const nextScopeFilter = normalizeWorkqueueScope(options?.scopeFilter ?? getDefaultWorkqueueScopeForTarget(nextAgentId));
     const forceNew = Boolean(options?.forceNew);
 
     const findMatchingPane = () => {
@@ -10595,7 +10601,7 @@ const paneManager = {
           opt.value = queue;
           datalist.appendChild(opt);
         });
-        wqScopeSelect.value = getDefaultWorkqueueScope();
+        wqScopeSelect.value = getDefaultWorkqueueScopeForTarget(chatAgentSelect.value || 'main');
         chatBtn.querySelector('[data-pane-add-summary]').textContent = `Chat -> Agent: ${chatAgentSelect.value || 'main'}`;
         wqBtn.querySelector('[data-pane-add-summary]').textContent = `Workqueue -> Queue: ${wqQueueInput.value || 'dev-team'} / ${wqScopeSelect.value}`;
       };
@@ -10629,7 +10635,7 @@ const paneManager = {
       wqBtn.addEventListener('click', onMenuAdd('workqueue', () => ({
         agentId: chatAgentSelect.value || 'main',
         queue: wqQueueInput.value || 'dev-team',
-        scopeFilter: wqScopeSelect.value || getDefaultWorkqueueScope()
+        scopeFilter: wqScopeSelect.value || getDefaultWorkqueueScopeForTarget(chatAgentSelect.value || 'main')
       })));
 
       cronBtn.addEventListener('click', onMenuAdd('cron'));

--- a/tests/pane.workqueue.e2e.spec.js
+++ b/tests/pane.workqueue.e2e.spec.js
@@ -35,6 +35,7 @@ test('pane: workqueue renders + core controls visible', async ({ page }) => {
   await expect(paneGrid).toHaveAttribute('aria-label', 'Chat panes');
 
   await page.getByTestId('add-pane-btn').click();
+  await page.getByTestId('pane-add-menu-workqueue-scope').selectOption('all');
   await page.getByTestId('pane-add-menu-workqueue').click();
   await expect(paneGrid).toHaveAttribute('aria-label', 'Panes');
 
@@ -113,6 +114,7 @@ test('pane: workqueue golden path (list + inspect)', async ({ page }) => {
   await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
 
   await page.getByTestId('add-pane-btn').click();
+  await page.getByTestId('pane-add-menu-workqueue-scope').selectOption('all');
   await page.getByTestId('pane-add-menu-workqueue').click();
 
   const wqPane = page.locator('[data-pane]').last();

--- a/tests/ui/_helpers.js
+++ b/tests/ui/_helpers.js
@@ -225,8 +225,14 @@ async function openAddPaneMenu(page) {
   await page.getByRole('menu', { name: 'Add pane' }).waitFor({ state: 'visible' });
 }
 
-async function addPane(page, name) {
+async function addPane(page, name, options = {}) {
   await openAddPaneMenu(page);
+  if (options.workqueueScope) {
+    await page.getByTestId('pane-add-menu-workqueue-scope').selectOption(options.workqueueScope);
+  } else if (/workqueue/i.test(name)) {
+    // Most Workqueue pane specs seed broad queue fixtures and assert legacy all-scope row counts.
+    await page.getByTestId('pane-add-menu-workqueue-scope').selectOption('all');
+  }
   await page.getByRole('button', { name }).click();
 }
 

--- a/tests/ui/pane-add-menu.spec.js
+++ b/tests/ui/pane-add-menu.spec.js
@@ -38,7 +38,7 @@ test('pane add menu: opens + adds explicit pane kinds + focuses sane defaults', 
   await expect(menu.locator('[data-testid="pane-add-menu-cron"]')).toHaveText(/New Cron pane/);
   await expect(menu.locator('[data-testid="pane-add-menu-timeline"]')).toHaveText(/New Timeline pane/);
   await expect(menu.locator('[data-testid="pane-add-menu-chat"]')).toHaveText(/Chat -> Agent: main/);
-  await expect(menu.locator('[data-testid="pane-add-menu-workqueue"]')).toHaveText(/Workqueue -> Queue: dev-team \/ unassigned/);
+  await expect(menu.locator('[data-testid="pane-add-menu-workqueue"]')).toHaveText(/Workqueue -> Queue: dev-team \/ assigned/);
 
   // Add a workqueue pane and ensure it exists + focus lands on primary control.
   await menu.locator('[data-testid="pane-add-menu-workqueue"]').click();
@@ -49,6 +49,28 @@ test('pane add menu: opens + adds explicit pane kinds + focuses sane defaults', 
   const queueSelect = wqPane.locator('[data-wq-queue-select]');
   await expect(queueSelect).toBeVisible();
   await expect(queueSelect).toBeFocused();
+  await expect(wqPane.locator('[data-wq-scope="assigned"]')).toHaveAttribute('aria-pressed', 'true');
+});
+
+test('pane add menu: agent-targeted workqueue defaults to assigned despite saved global scope', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+  await page.addInitScript(() => {
+    localStorage.setItem('clawnsole.admin.workqueue.scope.v1', 'all');
+  });
+
+  await loginAdmin(page, env.serverPort);
+
+  const wqPane = page.locator('[data-pane][data-pane-kind="workqueue"]').first();
+  await expect(wqPane).toBeVisible();
+  await expect(wqPane.locator('[data-wq-scope="assigned"]')).toHaveAttribute('aria-pressed', 'true');
+
+  await page.locator('#addPaneBtn').click();
+  const menu = page.locator('[data-testid="pane-add-menu"]');
+  await expect(menu).toBeVisible();
+  await expect(menu.locator('[data-testid="pane-add-menu-workqueue"]')).toHaveText(/Workqueue -> Queue: dev-team \/ assigned/);
 });
 
 test('pane add menu: workqueue override is applied before pane opens', async ({ page }) => {

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -448,7 +448,7 @@ test('workqueue pane: filter summary chips show counts and remove filters', asyn
   seedFilterSummaryWorkqueueItems(queue);
 
   await loginAdmin(page, env.serverPort);
-  await addPane(page, 'Workqueue pane');
+  await addPane(page, 'Workqueue pane', { workqueueScope: 'unassigned' });
 
   const wqPane = page.locator('[data-pane]').last();
   await wqPane.locator('[data-wq-queue-select]').selectOption('__custom__');


### PR DESCRIPTION
## Summary
- Default agent-targeted Workqueue panes to the `assigned` scope instead of the saved global scope.
- Store the default reset Workqueue pane with the active agent target and assigned scope.
- Keep explicit scope choices, including `All`, user-overridable in the add-pane menu.

Fixes #381

## Tests
- npm run test:syntax
- npx playwright test tests/ui/pane-add-menu.spec.js --workers=1