### PR TITLE
Fix #309: guard Enter sends after pane switch

### DIFF
--- a/app.js
+++ b/app.js
@@ -2830,9 +2830,13 @@ function notePaneFocused(pane) {
   if (!key) return;
   const panes = paneManager?.panes || [];
   if (!panes.some((entry) => String(entry?.key || '') === key)) return;
+  const previousKey = paneFocusMruKeys[0] || '';
   paneMruTraversal = null;
   paneMruOrder();
   paneFocusMruKeys = [key, ...paneFocusMruKeys.filter((entry) => entry !== key)];
+  if (previousKey && previousKey !== key && pane.kind === 'chat') {
+    paneArmSwitchSendGuard(pane);
+  }
   updateBrowserTitle(pane);
 }
 
@@ -7786,6 +7790,47 @@ function paneRemoveOutboundById(pane, localId) {
   return null;
 }
 
+const PANE_SWITCH_SEND_GUARD_MS = 800;
+
+function paneArmSwitchSendGuard(pane) {
+  if (!pane || pane.kind !== 'chat') return;
+  pane.switchSendGuard = {
+    until: Date.now() + PANE_SWITCH_SEND_GUARD_MS,
+    blockedOnce: false
+  };
+  paneHideSwitchSendGuard(pane);
+}
+
+function paneHideSwitchSendGuard(pane) {
+  const row = pane?.elements?.switchSendGuard;
+  if (row) row.hidden = true;
+}
+
+function paneShowSwitchSendGuard(pane) {
+  const row = pane?.elements?.switchSendGuard;
+  if (!row) return;
+  const message = row.querySelector('[data-pane-switch-send-guard-msg]');
+  if (message) message.textContent = 'Pane changed: press Enter again to send.';
+  row.hidden = false;
+}
+
+function paneShouldBlockSwitchEnter(pane, event) {
+  if (!pane || pane.kind !== 'chat') return false;
+  if (event?.metaKey || event?.ctrlKey) return false;
+
+  const guard = pane.switchSendGuard;
+  if (!guard || Number(guard.until || 0) < Date.now()) {
+    pane.switchSendGuard = null;
+    paneHideSwitchSendGuard(pane);
+    return false;
+  }
+
+  if (guard.blockedOnce) return false;
+  guard.blockedOnce = true;
+  paneShowSwitchSendGuard(pane);
+  return true;
+}
+
 function panePumpOutbox(pane) {
   if (!pane.connected || !uiState.authed) return;
   if (pane.inFlight) return;
@@ -7839,6 +7884,8 @@ function panePumpOutbox(pane) {
 async function paneSendChat(pane) {
   const raw = pane.elements.input.value.trim();
   if (!raw) return;
+  pane.switchSendGuard = null;
+  paneHideSwitchSendGuard(pane);
 
   // During reconnect blips we allow drafting, but block sending.
   // (But we still allow enqueue once connected; for now keep behavior simple.)
@@ -8511,6 +8558,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     attachBtn: root.querySelector('[data-pane-attach]'),
     attachmentStatus: root.querySelector('[data-pane-attachment-status]'),
     attachmentList: root.querySelector('[data-pane-attachment-list]'),
+    switchSendGuard: root.querySelector('[data-pane-switch-send-guard]'),
     sendBtn: root.querySelector('[data-pane-send]'),
     stopBtn: root.querySelector('[data-pane-stop]')
   };
@@ -10059,11 +10107,13 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault();
       if (elements.sendBtn.disabled) return;
+      if (paneShouldBlockSwitchEnter(pane, event)) return;
       paneSendChat(pane);
     }
   });
 
   elements.input.addEventListener('input', () => {
+    paneHideSwitchSendGuard(pane);
     paneUpdateCommandHints(pane);
   });
 

--- a/index.html
+++ b/index.html
@@ -166,6 +166,9 @@
                   </button>
                 </div>
                 <textarea data-pane-input placeholder="Message..." data-testid="pane-input"></textarea>
+                <div class="pane-switch-send-guard" data-pane-switch-send-guard data-testid="pane-switch-send-guard" aria-live="polite" hidden>
+                  <span data-pane-switch-send-guard-msg>Pane changed: press Enter again to send.</span>
+                </div>
                 <div data-pane-command-hints class="command-hints" aria-live="polite"></div>
                 <div class="attachment-row">
                   <input class="file-input" data-pane-file-input type="file" multiple data-testid="pane-attachment-input" />

--- a/styles.css
+++ b/styles.css
@@ -3579,6 +3579,20 @@ kbd {
   gap: 8px;
 }
 
+.pane-switch-send-guard {
+  padding: 9px 11px;
+  border-radius: 8px;
+  border: 1px solid rgba(244, 184, 38, 0.4);
+  background: rgba(244, 184, 38, 0.1);
+  color: #f8e4a4;
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.pane-switch-send-guard[hidden] {
+  display: none !important;
+}
+
 .command-hints {
   display: none;
   flex-direction: column;

--- a/tests/ui/chat-pane.spec.js
+++ b/tests/ui/chat-pane.spec.js
@@ -116,6 +116,61 @@ test('chat pane: unread badge appears on inactive pane and clears on focus', asy
   await expect(firstBadge).toBeHidden();
 });
 
+test('chat pane: immediate Enter after pane switch is blocked once', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Chat pane');
+
+  const chatPanes = page.locator('[data-pane][data-pane-kind="chat"]');
+  const firstPane = chatPanes.first();
+  const secondPane = chatPanes.nth(1);
+  const secondInput = secondPane.locator('[data-pane-input]');
+  const guard = secondPane.getByTestId('pane-switch-send-guard');
+  const focusThirdVisiblePane = async () => {
+    await page.click('#connectionStatus');
+    await page.evaluate(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', {
+        key: '3',
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true
+      }));
+    });
+  };
+
+  await expect(secondPane.locator('[data-pane-send]')).toBeEnabled({ timeout: 90000 });
+  await secondInput.fill('guarded send');
+  await firstPane.locator('[data-pane-input]').focus();
+
+  await focusThirdVisiblePane();
+  await expect(secondInput).toBeFocused();
+  await page.keyboard.press('Enter');
+
+  await expect(secondInput).toHaveValue('guarded send');
+  await expect(guard).toBeVisible();
+  await expect(secondPane.locator('[data-chat-role="user"]')).toHaveCount(0);
+
+  await page.keyboard.press('Enter');
+  await expect(guard).toBeHidden();
+  await expect(secondInput).toHaveValue('');
+  await expect(secondPane.locator('[data-chat-role="assistant"]').last()).toContainText('mock-reply: guarded send');
+
+  await secondInput.fill('override send');
+  await firstPane.locator('[data-pane-input]').focus();
+
+  await focusThirdVisiblePane();
+  await expect(secondInput).toBeFocused();
+  await page.keyboard.press('ControlOrMeta+Enter');
+
+  await expect(guard).toBeHidden();
+  await expect(secondInput).toHaveValue('');
+  await expect(secondPane.locator('[data-chat-role="assistant"]').last()).toContainText('mock-reply: override send');
+});
+
 test('topbar workqueue action reuses paired pane for active chat target and falls back to modal', async ({ page }) => {
   test.setTimeout(120000);
   test.skip(!!env?.skipReason, env?.skipReason);

--- a/tests/ui/command-palette.spec.js
+++ b/tests/ui/command-palette.spec.js
@@ -202,5 +202,5 @@ test('command palette: opens or focuses Workqueue for active chat agent', async 
 
   await wqPane.locator('[data-wq-queue-select]').focus();
   await runCommand('workqueue for active chat agent');
-  await expect(page.getByTestId('toast').filter({ hasText: 'No active chat agent selected' })).toBeVisible();
+  await expect(page.getByTestId('toast').filter({ hasText: 'No active chat agent selected' }).last()).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- add a short chat-only guard after switching panes so immediate plain Enter is blocked once with a visible hint
- allow the next Enter or Cmd/Ctrl+Enter to send normally
- add Playwright regression coverage for the guard and modifier override

## Tests
- npm run test:syntax
- npx playwright test tests/ui/chat-pane.spec.js --workers=1 --grep "immediate Enter after pane switch"

Fixes #309