### PR TITLE
Keep Workqueue header sticky

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2910,12 +2910,15 @@ kbd {
   display: flex;
   flex-direction: column;
   min-height: 0;
+  overflow: auto;
+  scrollbar-gutter: stable both-edges;
 }
 
 .wq-pane .wq-list-body,
 .cron-pane .wq-list-body {
-  flex: 1;
+  flex: 0 0 auto;
   max-height: none;
+  overflow: visible;
 }
 
 .wq-pane .wq-inspect,
@@ -2963,12 +2966,15 @@ kbd {
 }
 
 .wq-list-header {
+  position: sticky;
+  top: 0;
+  z-index: 3;
   padding: 10px 12px;
   font-size: 11px;
   letter-spacing: 0.04em;
   text-transform: uppercase;
   color: var(--muted);
-  background: rgba(0, 0, 0, 0.2);
+  background: rgba(12, 15, 20, 0.98);
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 

--- a/tests/pane.timeline.e2e.spec.js
+++ b/tests/pane.timeline.e2e.spec.js
@@ -58,9 +58,11 @@ test('pane: timeline renders + shows recent cron run events', async ({ page }) =
   expect(Math.abs(toolbarTop - threadTop)).toBeLessThan(20);
   expect(Math.abs(layoutBottom - threadBottom)).toBeLessThan(20);
 
+  const list = cronPane.locator('.wq-list').first();
   const listBody = cronPane.locator('.wq-list-body').first();
+  await expect(list).toBeVisible();
   await expect(listBody).toBeVisible();
-  const listOverflowY = await listBody.evaluate((el) => getComputedStyle(el).overflowY);
+  const listOverflowY = await list.evaluate((el) => getComputedStyle(el).overflowY);
   expect(listOverflowY).toBe('auto');
 
   // Timeline fetches cron.list then cron.runs; assert at least one event rendered.

--- a/tests/pane.workqueue.e2e.spec.js
+++ b/tests/pane.workqueue.e2e.spec.js
@@ -86,15 +86,17 @@ test('pane: workqueue renders + core controls visible', async ({ page }) => {
   expect(Math.abs(toolbarTop - threadTop)).toBeLessThan(20);
   expect(Math.abs(layoutBottom - threadBottom)).toBeLessThan(20);
 
+  const list = wqPane.locator('.wq-pane .wq-list').first();
   const listBody = wqPane.locator('.wq-pane [data-wq-list-body]').first();
   // List body exists even when empty; after refresh it should be scrollable.
+  await expect(list).toBeVisible();
   await expect(listBody).toHaveCount(1);
 
   const itemsResP = page.waitForResponse((res) => res.url().includes('/api/workqueue/items') && res.ok(), { timeout: 15000 });
   await wqPane.locator('[data-wq-refresh]').click();
   await itemsResP;
 
-  const listOverflowY = await listBody.evaluate((el) => getComputedStyle(el).overflowY);
+  const listOverflowY = await list.evaluate((el) => getComputedStyle(el).overflowY);
   expect(listOverflowY).toBe('auto');
 
   // Workqueue pane should not show chat composer controls.

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -892,19 +892,49 @@ test('workqueue pane: controls toolbar is sticky and list scrolls independently'
 
   page.__consoleAsserts = attachConsoleErrorAsserts(page);
 
+  const queue = `sticky-scroll-${Date.now()}`;
+  const stateDir = path.join(env.tempHome, '.openclaw', 'clawnsole');
+  fs.mkdirSync(stateDir, { recursive: true });
+  const now = new Date().toISOString();
+  const items = Array.from({ length: 40 }, (_, ix) => ({
+    id: `sticky-${ix}`,
+    queue,
+    title: `sticky header item ${String(ix).padStart(2, '0')}`,
+    instructions: 'fixture item',
+    priority: ix,
+    status: 'ready',
+    claimedBy: '',
+    claimedAt: '',
+    leaseUntil: 0,
+    attempts: 0,
+    lastError: '',
+    createdAt: now,
+    updatedAt: now
+  }));
+  fs.writeFileSync(
+    path.join(stateDir, 'work-queues.json'),
+    JSON.stringify({ version: 1, queues: { [queue]: { name: queue, createdAt: now } }, items, assignments: {} }, null, 2)
+  );
+
   await loginAdmin(page, env.serverPort);
   await addPane(page, 'Workqueue pane');
 
   const wqPane = page.locator('[data-pane]').last();
   const toolbar = wqPane.locator('.wq-pane .wq-toolbar');
+  const list = wqPane.locator('.wq-pane .wq-list').first();
+  const listHeader = wqPane.locator('.wq-pane .wq-list-header').first();
   const listBody = wqPane.locator('.wq-pane [data-wq-list-body]').first();
 
   await expect(toolbar).toBeVisible();
+  await expect(list).toBeVisible();
+  await expect(listHeader).toBeVisible();
   await expect(listBody).toHaveCount(1);
 
+  await wqPane.locator('[data-wq-queue-select]').selectOption(queue);
   const itemsResP = page.waitForResponse((res) => res.url().includes('/api/workqueue/items') && res.ok(), { timeout: 15000 });
   await wqPane.locator('[data-wq-refresh]').click();
   await itemsResP;
+  await expect(wqPane.locator('.wq-row')).toHaveCount(40);
 
   const styles = await toolbar.evaluate((el) => {
     const cs = window.getComputedStyle(el);
@@ -921,11 +951,34 @@ test('workqueue pane: controls toolbar is sticky and list scrolls independently'
   expect(Number(styles.zIndex)).toBeGreaterThanOrEqual(5);
   expect(styles.backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
 
-  const listStyles = await listBody.evaluate((el) => {
+  const listStyles = await list.evaluate((el) => {
     const cs = window.getComputedStyle(el);
     return { overflowY: cs.overflowY };
   });
   expect(['auto', 'scroll']).toContain(listStyles.overflowY);
+
+  const headerStyles = await listHeader.evaluate((el) => {
+    const cs = window.getComputedStyle(el);
+    return {
+      position: cs.position,
+      top: cs.top,
+      zIndex: cs.zIndex,
+      backgroundColor: cs.backgroundColor
+    };
+  });
+  expect(headerStyles.position).toBe('sticky');
+  expect(headerStyles.top).toBe('0px');
+  expect(Number(headerStyles.zIndex)).toBeGreaterThanOrEqual(3);
+  expect(headerStyles.backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
+
+  const before = await listHeader.boundingBox();
+  await list.evaluate((el) => { el.scrollTop = 260; });
+  await expect.poll(async () => list.evaluate((el) => el.scrollTop)).toBeGreaterThan(0);
+  const after = await listHeader.boundingBox();
+  expect(Math.abs((after?.y || 0) - (before?.y || 0))).toBeLessThanOrEqual(1);
+
+  await listHeader.locator('[data-wq-sort="title"]').click();
+  await expect(listHeader.locator('[data-wq-sort="title"]')).toHaveAttribute('aria-pressed', 'true');
 });
 
 test('workqueue pane: large queues render an initial capped slice and load more incrementally', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Make the Workqueue list itself the pane scroll region so the column header can stick while items scroll.
- Give the Workqueue header sticky positioning, z-index, and an opaque pane background so rows do not overlap it.
- Extend the Workqueue pane UI spec to seed a long queue, scroll the list, verify the header stays fixed, and click a sticky sort control.

## Tests
- npm run test:syntax
- npx playwright test tests/ui/workqueue-pane.spec.js -g "controls toolbar is sticky" --workers=1

Addresses #382. Supersedes stale PR #434 with a focused current-main diff.