### PR TITLE
Guard Enter sends after pane switches

### DIFF
--- a/app.js
+++ b/app.js
@@ -2824,6 +2824,8 @@ function focusedPaneKey() {
 let paneFocusMruKeys = [];
 let paneMruTraversal = null;
 let paneMruSuppressFocusEvents = false;
+const PANE_SWITCH_SEND_GUARD_MS = 800;
+const PANE_SWITCH_SEND_GUARD_MESSAGE = 'Pane changed: press Enter again to send';
 
 function paneMruOrder() {
   const panes = paneManager?.panes || [];
@@ -2846,6 +2848,30 @@ function notePaneFocused(pane) {
   paneMruOrder();
   paneFocusMruKeys = [key, ...paneFocusMruKeys.filter((entry) => entry !== key)];
   updateBrowserTitle(pane);
+}
+
+function paneMarkSwitchSendGuard(pane, fromPaneKey) {
+  const fromKey = String(fromPaneKey || '');
+  if (!pane || pane.kind !== 'chat' || !fromKey || fromKey === pane.key) return;
+  pane.sendGuard = {
+    paneSwitchAt: Date.now(),
+    consumed: false,
+    fromPaneKey: fromKey
+  };
+}
+
+function paneConsumeSwitchSendGuard(pane) {
+  const guard = pane?.sendGuard;
+  if (!guard || guard.consumed) return false;
+  const elapsed = Date.now() - Number(guard.paneSwitchAt || 0);
+  if (elapsed < 0 || elapsed > PANE_SWITCH_SEND_GUARD_MS) return false;
+  guard.consumed = true;
+  showToast(PANE_SWITCH_SEND_GUARD_MESSAGE, {
+    kind: 'info',
+    timeoutMs: 1800,
+    testId: 'pane-switch-send-guard-toast'
+  });
+  return true;
 }
 
 function forgetFocusedPaneKey(paneKey) {
@@ -8580,6 +8606,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     catchUp: { active: false, attemptsLeft: 0, timer: null },
     outbox: [],
     inFlight: null,
+    sendGuard: null,
     chatKey: () => computeChatKey({ role: pane.role, agentId: pane.agentId }),
     legacySessionKey: () => computeLegacySessionKey({ role: pane.role, agentId: pane.agentId }),
     sessionKey: () => computeSessionKey({ role: pane.role, agentId: pane.agentId, paneKey: pane.key }),
@@ -10075,6 +10102,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault();
       if (elements.sendBtn.disabled) return;
+      if (!event.metaKey && !event.ctrlKey && paneConsumeSwitchSendGuard(pane)) return;
       paneSendChat(pane);
     }
   });
@@ -10415,7 +10443,9 @@ const paneManager = {
   },
   focusPanePrimary(pane) {
     if (!pane?.elements?.root) return;
+    const previousPaneKey = focusedPaneKey() || paneMruOrder()[0] || '';
     notePaneFocused(pane);
+    paneMarkSwitchSendGuard(pane, previousPaneKey);
 
     try {
       pane.elements.root.focus?.({ preventScroll: true });
@@ -11320,9 +11350,11 @@ function closeTopmostOverlay() {
 function focusPaneIndex(idx, { trackMru = true, showHud = false } = {}) {
   const pane = paneManager.panes[idx];
   if (!pane) return;
+  const previousPaneKey = focusedPaneKey() || paneMruOrder()[0] || '';
   clearPaneUnread(pane);
   if (trackMru) notePaneFocused(pane);
   else updateBrowserTitle(pane);
+  paneMarkSwitchSendGuard(pane, previousPaneKey);
   if (showHud) showPaneSwitchHud(pane);
 
   try {

--- a/tests/ui/chat-pane.spec.js
+++ b/tests/ui/chat-pane.spec.js
@@ -116,6 +116,52 @@ test('chat pane: unread badge appears on inactive pane and clears on focus', asy
   await expect(firstBadge).toBeHidden();
 });
 
+test('chat pane: keyboard pane switch guards immediate Enter send once', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Chat pane');
+
+  const chatPanes = page.locator('[data-pane][data-pane-kind="chat"]');
+  const firstPane = chatPanes.first();
+  const secondPane = chatPanes.last();
+  const secondInput = secondPane.locator('[data-pane-input]');
+
+  await expect(secondPane.locator('[data-pane-send]')).toBeEnabled({ timeout: 90000 });
+  await firstPane.locator('[data-pane-input]').focus();
+  await secondInput.evaluate((el) => {
+    el.value = 'guarded send';
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+
+  await page.locator('#addPaneBtn').focus();
+  await page.keyboard.press('Alt+3');
+  await expect(secondInput).toBeFocused();
+
+  await page.keyboard.press('Enter');
+  await expect(page.getByTestId('pane-switch-send-guard-toast')).toContainText('Pane changed: press Enter again to send');
+  await expect(secondPane.locator('[data-chat-role="user"]')).toHaveCount(0);
+
+  await page.keyboard.press('Enter');
+  await expect(secondPane.locator('[data-chat-role="user"]').last()).toContainText('guarded send');
+  await expect(secondPane.locator('[data-chat-role="assistant"]').last()).toContainText('mock-reply: guarded send');
+
+  await firstPane.locator('[data-pane-input]').focus();
+  await secondInput.evaluate((el) => {
+    el.value = 'override send';
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+  await page.locator('#addPaneBtn').focus();
+  await page.keyboard.press('Alt+3');
+  await expect(secondInput).toBeFocused();
+
+  await page.keyboard.press('Control+Enter');
+  await expect(secondPane.locator('[data-chat-role="user"]').last()).toContainText('override send');
+});
+
 test('topbar workqueue action reuses paired pane for active chat target and falls back to modal', async ({ page }) => {
   test.setTimeout(120000);
   test.skip(!!env?.skipReason, env?.skipReason);


### PR DESCRIPTION
## Summary\n- Add a one-shot Enter send guard for chat panes during the short window after switching from another pane.\n- Show a lightweight toast explaining that Enter was blocked and allowing the next Enter to send.\n- Preserve Ctrl/Cmd+Enter as an immediate intentional-send override.\n\nFixes #309\n\n## Tests\n- npm test\n- npx playwright test tests/ui/chat-pane.spec.js --grep "keyboard pane switch guards" --workers=1