### PR TITLE
feat(fleet): show freshness state and refresh shortcut

### DIFF
--- a/app.js
+++ b/app.js
@@ -286,7 +286,9 @@ const ADMIN_AGENT_ACTIVE_MINUTES_KEY = 'clawnsole.admin.agents.activeMinutes';
 const ADMIN_AGENT_DENSITY_KEY = 'clawnsole.admin.agents.density';
 const ADMIN_AGENT_COLUMNS_KEY = 'clawnsole.admin.agents.columns';
 const ADMIN_AGENT_HEALTHY_COLLAPSED_KEY = 'clawnsole.admin.agents.healthyCollapsed';
+const ADMIN_AGENT_STALE_THRESHOLD_MS_KEY = 'clawnsole.admin.agents.staleThresholdMs';
 const ADMIN_AGENT_HEALTHY_COLLAPSE_THRESHOLD = 10;
+const FLEET_DEFAULT_STALE_THRESHOLD_MS = 60_000;
 const FLEET_COLUMN_DEFS = [
   { key: 'id', label: 'Agent id', defaultVisible: true },
   { key: 'health', label: 'Health', defaultVisible: true },
@@ -988,6 +990,7 @@ let agentAutoRefreshInterval = null;
 let agentsModalAutoRefreshInterval = null;
 let agentsModalFreshnessTicker = null;
 let agentsLastRefreshedAtMs = 0;
+let agentsLastRefreshFailedAtMs = 0;
 const fleetRefreshLock = {
   lockedAtMs: 0,
   pointerInsideRow: false,
@@ -1072,6 +1075,13 @@ function clearFleetRefreshLock() {
   renderFleetRefreshPaused();
 }
 
+function refreshFleetManually() {
+  clearFleetRefreshLock();
+  refreshAgents({ reason: 'manual', showSuccessToast: true }).catch(() => {
+    showToast('Agent refresh failed.', { kind: 'error', timeoutMs: 3500 });
+  });
+}
+
 const fleetSelectionState = {
   selectedAgentId: '',
   selectedIndex: 0,
@@ -1105,13 +1115,24 @@ function formatRelativeAge(msAgo) {
   return `${Math.floor(ms / 3_600_000)}h ago`;
 }
 
+function getFleetStaleThresholdMs() {
+  const fromStorage = Number(storage.get(ADMIN_AGENT_STALE_THRESHOLD_MS_KEY, String(FLEET_DEFAULT_STALE_THRESHOLD_MS)));
+  return Number.isFinite(fromStorage) && fromStorage > 0 ? fromStorage : FLEET_DEFAULT_STALE_THRESHOLD_MS;
+}
+
 function renderAgentsLastRefreshed() {
   if (!globalElements.agentsLastRefreshed) return;
   if (!agentsLastRefreshedAtMs) {
-    globalElements.agentsLastRefreshed.textContent = 'Last refreshed: never';
+    globalElements.agentsLastRefreshed.textContent = 'Last updated: never';
+    globalElements.agentsLastRefreshed.dataset.freshnessState = 'stale';
     return;
   }
-  globalElements.agentsLastRefreshed.textContent = `Last refreshed: ${formatRelativeAge(Date.now() - agentsLastRefreshedAtMs)}`;
+  const ageMs = Date.now() - agentsLastRefreshedAtMs;
+  const isPaused = !!fleetRefreshLock.lockedAtMs;
+  const isStale = isPaused || agentsLastRefreshFailedAtMs > agentsLastRefreshedAtMs || ageMs > getFleetStaleThresholdMs();
+  const age = formatRelativeAge(ageMs);
+  globalElements.agentsLastRefreshed.dataset.freshnessState = isStale ? 'stale' : 'fresh';
+  globalElements.agentsLastRefreshed.textContent = isStale ? `Stale \u00b7 ${age}` : `Last updated: ${age}`;
 }
 
 function startAgentsModalAutoRefresh() {
@@ -1169,6 +1190,8 @@ async function refreshAgents({ reason = 'manual', showSuccessToast = false } = {
     }
 
     if (!Array.isArray(next) || next.length === 0) {
+      agentsLastRefreshFailedAtMs = Date.now();
+      renderAgentsLastRefreshed();
       if (prev.length > 0) {
         showToast('Agent refresh failed; showing last-known list.', { kind: 'error', timeoutMs: 3500 });
         return prev;
@@ -1179,6 +1202,7 @@ async function refreshAgents({ reason = 'manual', showSuccessToast = false } = {
 
     uiState.agents = next;
     agentsLastRefreshedAtMs = Date.now();
+    agentsLastRefreshFailedAtMs = 0;
     renderAgentsLastRefreshed();
 
     // Preserve UI state (selected agent per pane).
@@ -4567,6 +4591,7 @@ function renderAgentsModalList() {
   const search = String(globalElements.agentsSearch?.value || '').trim().toLowerCase();
   const withinMinutes = Math.max(1, Number(globalElements.agentsActiveMinutes?.value) || 10);
   const activeWindowMs = withinMinutes * 60_000;
+  const staleThresholdMs = getFleetStaleThresholdMs();
   const filterMode = getFleetFilter();
   const sortMode = getFleetSort();
   const heatmapEnabled = getFleetHeatmapEnabled();
@@ -4587,7 +4612,7 @@ function renderAgentsModalList() {
     const ageBucket = heartbeatAgeBucket(ageMs, { activeWindowMs, paneState });
     if (paneState === 'error' || paneState === 'offline') return { bucket: 'offline_error', ageBucket, ts, ageMs };
     if (!Number.isFinite(ageMs)) return { bucket: 'offline_error', ageBucket, ts, ageMs };
-    if (ageMs <= activeWindowMs) return { bucket: 'active', ageBucket, ts, ageMs };
+    if (ageMs <= staleThresholdMs) return { bucket: 'active', ageBucket, ts, ageMs };
     return { bucket: 'stale', ageBucket, ts, ageMs };
   };
 
@@ -5633,6 +5658,17 @@ async function renderWorkqueuePane(rootEl, { queue = '' } = {}) {
 window.__debug = window.__debug || {};
 window.__debug.renderWorkqueuePane = renderWorkqueuePane;
 window.__debug.refreshAgents = refreshAgents;
+Object.defineProperty(window.__debug, 'agentsLastRefreshedAtMs', {
+  configurable: true,
+  get() {
+    return agentsLastRefreshedAtMs;
+  },
+  set(value) {
+    agentsLastRefreshedAtMs = Number(value) || 0;
+    renderAgentsLastRefreshed();
+    if (isAgentsModalOpen()) renderAgentsModalList();
+  }
+});
 
 function getWorkqueueItemRepo(item) {
   const repo = String(item?.meta?.repo || '').trim();
@@ -11009,15 +11045,10 @@ globalElements.recurringPromptRows?.addEventListener('click', (event) => {
 });
 
 globalElements.refreshAgentsBtn?.addEventListener('click', () => {
-  clearFleetRefreshLock();
-  refreshAgents({ reason: 'manual', showSuccessToast: true }).catch(() => {
-    showToast('Agent refresh failed.', { kind: 'error', timeoutMs: 3500 });
-  });
+  refreshFleetManually();
 });
 globalElements.agentsModalRefreshBtn?.addEventListener('click', () => {
-  refreshAgents({ reason: 'manual', showSuccessToast: true }).catch(() => {
-    showToast('Agent refresh failed.', { kind: 'error', timeoutMs: 3500 });
-  });
+  refreshFleetManually();
 });
 
 globalElements.agentsBtn?.addEventListener('click', () => openAgentsModal());
@@ -11041,6 +11072,11 @@ globalElements.agentsModal?.addEventListener('keydown', (event) => {
     return;
   }
   if (!event.metaKey && !event.ctrlKey && !event.altKey) {
+    if (lower === 'r') {
+      event.preventDefault();
+      refreshFleetManually();
+      return;
+    }
     if (key === 'ArrowDown' || lower === 'j') {
       event.preventDefault();
       moveFleetSelection(1);

--- a/index.html
+++ b/index.html
@@ -412,7 +412,7 @@
         <div class="modal-body">
           <div class="agents-toolbar">
             <div class="agents-refresh-state">
-              <span id="agentsLastRefreshed" class="agents-last-refreshed" aria-live="polite">Last refreshed: never</span>
+              <span id="agentsLastRefreshed" class="agents-last-refreshed" role="status" aria-live="polite">Last updated: never</span>
               <span id="agentsRefreshPaused" class="agents-refresh-paused" aria-live="polite" hidden></span>
             </div>
             <label class="agents-field">

--- a/styles.css
+++ b/styles.css
@@ -1679,8 +1679,26 @@ button.send-btn .btn-icon {
 }
 
 .agents-last-refreshed {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  padding: 2px 8px;
   font-size: 12px;
   color: var(--muted);
+}
+
+.agents-last-refreshed[data-freshness-state="fresh"] {
+  border-color: rgba(86, 211, 100, 0.38);
+  background: rgba(86, 211, 100, 0.09);
+  color: var(--text);
+}
+
+.agents-last-refreshed[data-freshness-state="stale"] {
+  border-color: rgba(255, 138, 76, 0.55);
+  background: rgba(255, 138, 76, 0.13);
+  color: var(--text);
 }
 
 .agents-refresh-paused {

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -70,7 +70,13 @@ test('agents modal shows live refresh freshness indicators', async ({ page, claw
   await page.getByRole('button', { name: 'Open agents' }).click();
   await expect(page.locator('#agentsModal')).toHaveClass(/open/);
 
-  await expect(page.locator('#agentsLastRefreshed')).toContainText('Last refreshed:');
+  await expect(page.locator('#agentsLastRefreshed')).toContainText('Last updated:');
+  await expect(page.locator('#agentsLastRefreshed')).toHaveAttribute('data-freshness-state', 'fresh');
+  await page.evaluate(() => {
+    window.__debug.agentsLastRefreshedAtMs = Date.now() - 70_000;
+  });
+  await expect(page.locator('#agentsLastRefreshed')).toContainText('Stale');
+  await expect(page.locator('#agentsLastRefreshed')).toHaveAttribute('data-freshness-state', 'stale');
   await expect(page.locator('#agentsList .agents-row-meta').first()).toContainText(/\d+[smhd]/);
 });
 
@@ -268,6 +274,27 @@ test('fleet refresh preserves selected row and falls back when it disappears', a
   await page.locator('#agentsModalRefreshBtn').click();
   await expect(page.locator('#agentsList .agents-row').filter({ hasText: 'Gamma (gamma)' })).toHaveAttribute('aria-selected', 'true');
   await expect(page.locator('#agentsSortIndicator')).toContainText('Selected agent no longer in current filter');
+});
+
+test('fleet focused r key refreshes agents like the header button', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  let agents = [{ id: 'alpha', name: 'Alpha', displayName: 'Alpha' }];
+  await page.route(/\/agents(?:\?|$)/, async (route) => {
+    await route.fulfill({ json: { agents } });
+  });
+
+  await clawnsole.gotoAndLoginAdmin(page);
+  await page.getByRole('button', { name: 'Refresh agent list' }).click();
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsList')).toContainText('Alpha (alpha)');
+
+  agents = [{ id: 'beta', name: 'Beta', displayName: 'Beta' }];
+  await page.locator('#agentsList .agents-row').first().focus();
+  await page.keyboard.press('r');
+
+  await expect(page.locator('#agentsList')).toContainText('Beta (beta)');
+  await expect(page.locator('#agentsList')).not.toContainText('Alpha (alpha)');
 });
 
 test('fleet refresh keeps scroll anchor and keyboard triage selection', async ({ page, clawnsole }) => {


### PR DESCRIPTION
Fixes #301

## Summary
- show Fleet header freshness as Last updated or explicit Stale state
- mark stale refresh failures/paused refresh in the live status text
- add Fleet-focused `r` manual refresh parity with the header refresh button
- add focused Playwright coverage for freshness and `r` refresh

## Tests
- npm run test:syntax
- npm run test:unit
- npx playwright test tests/ui/agents-modal.spec.js --workers=1

No production deployment.