### PR TITLE
Fix inactive admin modal accessibility state

### DIFF
--- a/app.js
+++ b/app.js
@@ -104,6 +104,14 @@ const globalElements = {
   paneTemplate: document.getElementById('paneTemplate')
 };
 
+function setOverlayOpen(el, open) {
+  if (!el) return;
+  el.classList.toggle('open', !!open);
+  el.setAttribute('aria-hidden', open ? 'false' : 'true');
+  if (open) el.removeAttribute('inert');
+  else el.setAttribute('inert', '');
+}
+
 // Pure helpers live in lib/app-core.js so we can unit-test them under Node.
 const __appCore = (typeof window !== 'undefined' && window.AppCore) ? window.AppCore : {};
 const escapeHtml = __appCore.escapeHtml || ((value) => {
@@ -1818,8 +1826,7 @@ function setRole(role) {
 
 function showLogin(message = '') {
   captureAdminAuthDestination();
-  globalElements.loginOverlay.classList.add('open');
-  globalElements.loginOverlay.setAttribute('aria-hidden', 'false');
+  setOverlayOpen(globalElements.loginOverlay, true);
   globalElements.loginError.textContent = message;
   globalElements.loginPassword.value = '';
 
@@ -1841,8 +1848,7 @@ function showLogin(message = '') {
 }
 
 function hideLogin() {
-  globalElements.loginOverlay.classList.remove('open');
-  globalElements.loginOverlay.setAttribute('aria-hidden', 'true');
+  setOverlayOpen(globalElements.loginOverlay, false);
   globalElements.loginError.textContent = '';
   setAuthState(true);
 }
@@ -1890,8 +1896,7 @@ function openSettings() {
   renderKeyboardSettings();
   shortcutOverridesDraft = readShortcutOverrides();
   renderShortcutOverrideSettings();
-  globalElements.settingsModal.classList.add('open');
-  globalElements.settingsModal.setAttribute('aria-hidden', 'false');
+  setOverlayOpen(globalElements.settingsModal, true);
 
   // Guest mode removed.
 
@@ -1900,8 +1905,7 @@ function openSettings() {
 }
 
 function closeSettings() {
-  globalElements.settingsModal.classList.remove('open');
-  globalElements.settingsModal.setAttribute('aria-hidden', 'true');
+  setOverlayOpen(globalElements.settingsModal, false);
   shortcutOverridesDraft = null;
 }
 
@@ -2615,8 +2619,7 @@ function openShortcuts() {
   }
   renderShortcutsContent();
   shortcutsLastFocusedEl = document.activeElement instanceof HTMLElement ? document.activeElement : null;
-  modal.classList.add('open');
-  modal.setAttribute('aria-hidden', 'false');
+  setOverlayOpen(modal, true);
   updatePaneShortcutBadges();
   window.setTimeout(() => {
     (globalElements.shortcutsDialog || globalElements.shortcutsCloseBtn || modal).focus?.();
@@ -2626,8 +2629,7 @@ function openShortcuts() {
 function closeShortcuts() {
   const modal = globalElements.shortcutsModal;
   if (!modal || !modal.classList.contains('open')) return;
-  modal.classList.remove('open');
-  modal.setAttribute('aria-hidden', 'true');
+  setOverlayOpen(modal, false);
   updatePaneShortcutBadges();
   if (shortcutsLastFocusedEl && document.contains(shortcutsLastFocusedEl)) {
     shortcutsLastFocusedEl.focus?.();
@@ -3520,8 +3522,7 @@ function openPaneManager({ attentionOnly = false } = {}) {
   paneManagerUiState.query = String(globalElements.paneManagerSearch?.value || '').trim();
   paneManagerUiState.unreadOnly = !!globalElements.paneManagerUnreadOnly?.checked;
 
-  globalElements.paneManagerModal.classList.add('open');
-  globalElements.paneManagerModal.setAttribute('aria-hidden', 'false');
+  setOverlayOpen(globalElements.paneManagerModal, true);
   renderPaneManager();
 
   // Focus quick-find for immediate filtering.
@@ -3534,8 +3535,7 @@ function openPaneManager({ attentionOnly = false } = {}) {
 function closePaneManager({ restoreFocus = true } = {}) {
   if (!globalElements.paneManagerModal) return;
   paneManagerUiState.open = false;
-  globalElements.paneManagerModal.classList.remove('open');
-  globalElements.paneManagerModal.setAttribute('aria-hidden', 'true');
+  setOverlayOpen(globalElements.paneManagerModal, false);
   if (restoreFocus) {
     try {
       const pane = paneManager?.panes?.[0];
@@ -3649,8 +3649,7 @@ function closeCommandPalette({ restoreFocus = true } = {}) {
   if (!globalElements.commandPaletteModal) return;
   commandPaletteState.open = false;
   commandPaletteState.originPaneKey = '';
-  globalElements.commandPaletteModal.classList.remove('open');
-  globalElements.commandPaletteModal.setAttribute('aria-hidden', 'true');
+  setOverlayOpen(globalElements.commandPaletteModal, false);
   if (restoreFocus) {
     try {
       const pane = paneManager?.panes?.[0];
@@ -4221,8 +4220,7 @@ function openCommandPalette() {
   commandPaletteState.selectedIndex = 0;
   commandPaletteState.expandedSubgroups = new Set();
 
-  globalElements.commandPaletteModal.classList.add('open');
-  globalElements.commandPaletteModal.setAttribute('aria-hidden', 'false');
+  setOverlayOpen(globalElements.commandPaletteModal, true);
 
   if (globalElements.commandPaletteInput) {
     globalElements.commandPaletteInput.value = '';
@@ -4247,8 +4245,7 @@ function openCommandPalette() {
 
 function openAgentsModal() {
   if (roleState.role !== 'admin') return;
-  globalElements.agentsModal?.classList.add('open');
-  globalElements.agentsModal?.setAttribute('aria-hidden', 'false');
+  setOverlayOpen(globalElements.agentsModal, true);
 
   // Bootstrap persisted controls.
   const filter = getFleetFilter();
@@ -4355,8 +4352,7 @@ function resetFleetSort() {
 
 function closeAgentsModal() {
   clearFleetRefreshLock();
-  globalElements.agentsModal?.classList.remove('open');
-  globalElements.agentsModal?.setAttribute('aria-hidden', 'true');
+  setOverlayOpen(globalElements.agentsModal, false);
   stopAgentsModalAutoRefresh();
   stopAgentsModalFreshnessTicker();
 }
@@ -5055,8 +5051,7 @@ const workqueueState = {
 
 function openWorkqueue() {
   if (roleState.role !== 'admin') return;
-  globalElements.workqueueModal?.classList.add('open');
-  globalElements.workqueueModal?.setAttribute('aria-hidden', 'false');
+  setOverlayOpen(globalElements.workqueueModal, true);
   // Sorting wiring is synchronous; bootstrap it immediately so UI tests can click sort buttons deterministically.
   ensureWorkqueueModalSorting();
   ensureWorkqueueBootstrapped();
@@ -5065,8 +5060,7 @@ function openWorkqueue() {
 
 function closeWorkqueue() {
   stopWorkqueueAutoRefresh();
-  globalElements.workqueueModal?.classList.remove('open');
-  globalElements.workqueueModal?.setAttribute('aria-hidden', 'true');
+  setOverlayOpen(globalElements.workqueueModal, false);
 }
 
 function renderWorkqueueStatusFilters() {

--- a/index.html
+++ b/index.html
@@ -216,7 +216,7 @@
       </main>
     </div>
 
-    <div id="loginOverlay" class="login-overlay" aria-hidden="true" data-testid="login-overlay">
+    <div id="loginOverlay" class="login-overlay" aria-hidden="true" inert data-testid="login-overlay">
       <div class="login-card" role="dialog" aria-modal="true" aria-labelledby="loginTitle">
         <div class="login-brand">
           <div class="brand-mark"></div>
@@ -237,7 +237,7 @@
 
     <div id="toastHost" class="toast-host" aria-live="polite" aria-atomic="true" data-testid="toast-host"></div>
 
-    <div id="commandPaletteModal" class="modal" aria-hidden="true" data-testid="command-palette-modal">
+    <div id="commandPaletteModal" class="modal" aria-hidden="true" inert data-testid="command-palette-modal">
       <div class="modal-card" role="dialog" aria-modal="true" aria-labelledby="commandPaletteTitle">
         <div class="modal-header">
           <h2 id="commandPaletteTitle">Command palette</h2>
@@ -258,7 +258,7 @@
       </div>
     </div>
 
-    <div id="shortcutsModal" class="modal" aria-hidden="true" data-testid="shortcuts-modal">
+    <div id="shortcutsModal" class="modal" aria-hidden="true" inert data-testid="shortcuts-modal">
       <div id="shortcutsDialog" class="modal-card" role="dialog" aria-modal="true" aria-labelledby="shortcutsTitle" tabindex="-1">
         <div class="modal-header">
           <h2 id="shortcutsTitle">Keyboard shortcuts</h2>
@@ -270,7 +270,7 @@
       </div>
     </div>
 
-    <div id="paneManagerModal" class="modal" aria-hidden="true" data-testid="pane-manager-modal" tabindex="-1">
+    <div id="paneManagerModal" class="modal" aria-hidden="true" inert data-testid="pane-manager-modal" tabindex="-1">
       <div class="modal-card" role="dialog" aria-modal="true" aria-labelledby="paneManagerTitle">
         <div class="modal-header">
           <h2 id="paneManagerTitle">Panes</h2>
@@ -291,7 +291,7 @@
       </div>
     </div>
 
-    <div id="workqueueModal" class="modal" aria-hidden="true">
+    <div id="workqueueModal" class="modal" aria-hidden="true" inert>
       <div class="modal-card wide" role="dialog" aria-modal="true" aria-labelledby="workqueueTitle">
         <div class="modal-header">
           <h2 id="workqueueTitle">Workqueue</h2>
@@ -396,7 +396,7 @@
       </div>
     </div>
 
-    <div id="agentsModal" class="modal" aria-hidden="true">
+    <div id="agentsModal" class="modal" aria-hidden="true" inert>
       <div class="modal-card wide" role="dialog" aria-modal="true" aria-labelledby="agentsTitle">
         <div class="modal-header">
           <h2 id="agentsTitle">Agents</h2>
@@ -474,7 +474,7 @@
       </div>
     </div>
 
-    <div id="settingsModal" class="modal" aria-hidden="true">
+    <div id="settingsModal" class="modal" aria-hidden="true" inert>
       <div class="modal-card" role="dialog" aria-modal="true" aria-labelledby="settingsTitle">
         <div class="modal-header">
           <h2 id="settingsTitle">Gateway Link</h2>

--- a/tests/ui/modal-a11y.spec.js
+++ b/tests/ui/modal-a11y.spec.js
@@ -1,0 +1,88 @@
+const { test, expect } = require('@playwright/test');
+
+const { startTestEnv, loginAdmin, attachConsoleErrorAsserts } = require('./_helpers');
+
+let env;
+
+test.beforeAll(async () => {
+  env = await startTestEnv();
+});
+
+test.afterAll(() => {
+  env?.stop?.();
+});
+
+test.afterEach(async ({ page }) => {
+  if (page.__consoleAsserts) {
+    page.__consoleAsserts.assertNoErrors();
+  }
+});
+
+const MODALS = [
+  '#commandPaletteModal',
+  '#shortcutsModal',
+  '#paneManagerModal',
+  '#workqueueModal',
+  '#agentsModal',
+  '#settingsModal'
+];
+
+async function expectOnlyOpenModal(page, selector) {
+  await expect(page.locator(selector)).toHaveAttribute('aria-hidden', 'false');
+  await expect(page.locator(selector)).not.toHaveAttribute('inert', '');
+  await expect(page.getByRole('dialog')).toHaveCount(1);
+
+  for (const modalSelector of MODALS) {
+    if (modalSelector === selector) continue;
+    await expect(page.locator(modalSelector)).toHaveAttribute('aria-hidden', 'true');
+    await expect(page.locator(modalSelector)).toHaveAttribute('inert', '');
+  }
+}
+
+async function expectNoOpenModals(page) {
+  await expect(page.getByRole('dialog')).toHaveCount(0);
+  for (const selector of MODALS) {
+    await expect(page.locator(selector)).toHaveAttribute('aria-hidden', 'true');
+    await expect(page.locator(selector)).toHaveAttribute('inert', '');
+  }
+}
+
+test('admin modal dialogs expose only the active overlay and keep closed overlays inert', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+  await loginAdmin(page, env.serverPort);
+
+  await expectNoOpenModals(page);
+
+  await page.keyboard.press('ControlOrMeta+K');
+  await expectOnlyOpenModal(page, '#commandPaletteModal');
+  await page.keyboard.press('Escape');
+  await expectNoOpenModals(page);
+
+  await page.locator('#shortcutsBtn').click();
+  await expectOnlyOpenModal(page, '#shortcutsModal');
+  await page.keyboard.press('Escape');
+  await expectNoOpenModals(page);
+
+  await page.locator('#paneManagerBtn').click();
+  await expectOnlyOpenModal(page, '#paneManagerModal');
+  await page.keyboard.press('Escape');
+  await expectNoOpenModals(page);
+
+  await page.evaluate(() => openWorkqueue());
+  await expectOnlyOpenModal(page, '#workqueueModal');
+  await page.keyboard.press('Escape');
+  await expectNoOpenModals(page);
+
+  await page.locator('#agentsBtn').click();
+  await expectOnlyOpenModal(page, '#agentsModal');
+  await page.keyboard.press('Escape');
+  await expectNoOpenModals(page);
+
+  await page.locator('#settingsBtn').click();
+  await expectOnlyOpenModal(page, '#settingsModal');
+  await page.keyboard.press('Escape');
+  await expectNoOpenModals(page);
+});


### PR DESCRIPTION
## Summary
- initialize closed admin overlays with `inert`
- centralize modal open/close state so `open`, `aria-hidden`, and `inert` stay in sync
- add a Playwright regression test that only the active dialog is exposed and closed modals remain inert

Fixes #281.

## Tests
- `npm run test:syntax`
- `npx playwright test tests/ui/modal-a11y.spec.js --workers=1`