### PR TITLE
Add labeled header controls setting

### DIFF
--- a/app.js
+++ b/app.js
@@ -82,6 +82,7 @@ const globalElements = {
   settingsModal: document.getElementById('settingsModal'),
   settingsCloseBtn: document.getElementById('settingsCloseBtn'),
   paneSwitchHudEnabled: document.getElementById('paneSwitchHudEnabled'),
+  labeledHeaderControlsEnabled: document.getElementById('labeledHeaderControlsEnabled'),
   keybindConflictList: document.getElementById('keybindConflictList'),
   shortcutOverridesList: document.getElementById('shortcutOverridesList'),
   shortcutOverridesSave: document.getElementById('shortcutOverridesSave'),
@@ -301,6 +302,7 @@ const ADMIN_AUTH_DESTINATION_KEY = 'clawnsole.admin.authDestination.v1';
 const ADMIN_AUTH_RESTORE_PENDING_KEY = 'clawnsole.admin.authRestorePending.v1';
 const ADMIN_AUTH_RESTORE_NOTICE_KEY = 'clawnsole.admin.authRestoreNotice.v1';
 const PANE_SWITCH_HUD_ENABLED_KEY = 'clawnsole.admin.paneSwitchHud.enabled';
+const LABELED_HEADER_CONTROLS_KEY = 'clawnsole.admin.labeledHeaderControls.enabled';
 const KEYBIND_OVERRIDES_KEY = 'clawnsole.admin.keybindOverrides.v1';
 const SHORTCUT_OVERRIDES_KEY = 'clawnsole.admin.shortcutOverrides.v1';
 const ADMIN_AUTH_DESTINATION_TTL_MS = 10 * 60 * 1000;
@@ -1887,6 +1889,9 @@ function openSettings() {
   if (globalElements.paneSwitchHudEnabled) {
     globalElements.paneSwitchHudEnabled.checked = isPaneSwitchHudEnabled();
   }
+  if (globalElements.labeledHeaderControlsEnabled) {
+    globalElements.labeledHeaderControlsEnabled.checked = isLabeledHeaderControlsEnabled();
+  }
   renderKeyboardSettings();
   shortcutOverridesDraft = readShortcutOverrides();
   renderShortcutOverrideSettings();
@@ -2743,6 +2748,14 @@ function paneSummaryLabel(pane) {
 
 function isPaneSwitchHudEnabled() {
   return String(storage.get(PANE_SWITCH_HUD_ENABLED_KEY, '1') || '1') !== '0';
+}
+
+function isLabeledHeaderControlsEnabled() {
+  return String(storage.get(LABELED_HEADER_CONTROLS_KEY, '0') || '0') === '1';
+}
+
+function applyLabeledHeaderControlsPreference() {
+  document.body.classList.toggle('labeled-header-controls', isLabeledHeaderControlsEnabled());
 }
 
 let paneSwitchHudHideTimer = null;
@@ -10855,6 +10868,7 @@ const paneManager = {
 };
 
 // Global event wiring
+applyLabeledHeaderControlsPreference();
 renderShortcutHelpLabels();
 
 globalElements.settingsBtn?.addEventListener('click', () => openSettings());
@@ -10864,6 +10878,10 @@ globalElements.settingsModal?.addEventListener('click', (event) => {
 });
 globalElements.paneSwitchHudEnabled?.addEventListener('change', () => {
   storage.set(PANE_SWITCH_HUD_ENABLED_KEY, globalElements.paneSwitchHudEnabled.checked ? '1' : '0');
+});
+globalElements.labeledHeaderControlsEnabled?.addEventListener('change', () => {
+  storage.set(LABELED_HEADER_CONTROLS_KEY, globalElements.labeledHeaderControlsEnabled.checked ? '1' : '0');
+  applyLabeledHeaderControlsPreference();
 });
 function handleShortcutOverrideInputKeydown(event) {
   const input = event.target?.closest?.('[data-shortcut-action]');

--- a/index.html
+++ b/index.html
@@ -84,15 +84,17 @@
             <span class="btn-icon" aria-hidden="true">★</span>
             <span class="btn-label">Agents</span>
           </button>
-          <button id="fleetBtn" class="icon-btn" type="button" aria-label="Open fleet pane" title="Open Fleet pane (Cmd/Ctrl+Shift+F)" hidden>
-            FL
+          <button id="fleetBtn" class="icon-btn action-btn" type="button" aria-label="Open fleet pane" title="Open Fleet pane (Cmd/Ctrl+Shift+F)" hidden>
+            <span class="btn-icon" aria-hidden="true">FL</span>
+            <span class="btn-label">Fleet</span>
           </button>
           <button id="workqueueBtn" class="icon-btn action-btn" type="button" aria-label="Open workqueue" title="Workqueue (g w)" hidden>
             <span class="btn-icon" aria-hidden="true">WQ</span>
             <span class="btn-label">Workqueue</span>
           </button>
-          <button id="shortcutsBtn" class="icon-btn" type="button" aria-label="Open keyboard shortcuts" title="Keyboard shortcuts (?)" hidden data-testid="shortcuts-btn">
-            ?
+          <button id="shortcutsBtn" class="icon-btn action-btn" type="button" aria-label="Open keyboard shortcuts" title="Keyboard shortcuts (?)" hidden data-testid="shortcuts-btn">
+            <span class="btn-icon" aria-hidden="true">?</span>
+            <span class="btn-label">Shortcuts</span>
           </button>
           <button id="settingsBtn" class="icon-btn action-btn" type="button" aria-label="Open settings" title="Settings">
             <span class="btn-icon" aria-hidden="true">⚙︎</span>
@@ -508,6 +510,10 @@
             <label class="inline-checkbox">
               <input id="paneSwitchHudEnabled" type="checkbox" checked />
               Show pane-switch HUD
+            </label>
+            <label class="inline-checkbox">
+              <input id="labeledHeaderControlsEnabled" type="checkbox" />
+              Labeled header controls
             </label>
           </section>
 

--- a/styles.css
+++ b/styles.css
@@ -207,8 +207,12 @@ body::before {
 }
 
 .pane-controls .action-btn {
-  width: auto;
   min-width: 36px;
+  padding: 0;
+}
+
+body.labeled-header-controls .pane-controls .action-btn {
+  width: auto;
   padding: 0 12px;
 }
 
@@ -332,13 +336,18 @@ body::before {
 }
 
 .action-btn {
-  width: auto;
   min-width: 40px;
   height: 40px;
-  gap: 8px;
-  padding: 0 12px;
+  gap: 0;
+  padding: 0;
   font-size: 13px;
   font-weight: 600;
+}
+
+body.labeled-header-controls .topbar .action-btn {
+  width: auto;
+  gap: 8px;
+  padding: 0 12px;
 }
 
 .action-btn .btn-icon {
@@ -347,10 +356,20 @@ body::before {
 }
 
 .action-btn .btn-label {
+  display: none;
+  min-width: 0;
+  max-width: 84px;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
+body.labeled-header-controls .topbar .action-btn .btn-label {
+  display: inline;
+}
+
 @media (max-width: 920px) {
+  body.labeled-header-controls .topbar .action-btn,
   .action-btn {
     width: 36px;
     min-width: 36px;
@@ -358,6 +377,7 @@ body::before {
     gap: 0;
   }
 
+  body.labeled-header-controls .topbar .action-btn .btn-label,
   .action-btn .btn-label {
     display: none;
   }

--- a/tests/ui/settings-recurring-prompts.spec.js
+++ b/tests/ui/settings-recurring-prompts.spec.js
@@ -1,5 +1,34 @@
 const { test, expect } = require('./fixtures');
 
+test('settings: labeled header controls toggle persists and collapses on narrow screens', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await clawnsole.gotoAndLoginAdmin(page);
+
+  const settingsLabel = page.locator('#settingsBtn .btn-label');
+  await expect(page.locator('body')).not.toHaveClass(/labeled-header-controls/);
+  await expect(settingsLabel).toBeHidden();
+
+  await page.getByRole('button', { name: 'Open settings' }).click();
+  const toggle = page.locator('#labeledHeaderControlsEnabled');
+  await expect(toggle).not.toBeChecked();
+  await toggle.check();
+  await expect(page.locator('body')).toHaveClass(/labeled-header-controls/);
+  await expect(settingsLabel).toBeVisible();
+  await expect(settingsLabel).toHaveText('Settings');
+
+  await page.reload();
+  await clawnsole.waitForAdminUiReady(page);
+  await expect(page.locator('body')).toHaveClass(/labeled-header-controls/);
+  await expect(page.locator('#settingsBtn .btn-label')).toBeVisible();
+
+  await page.setViewportSize({ width: 700, height: 800 });
+  await expect(page.locator('#settingsBtn .btn-label')).toBeHidden();
+  await expect(page.locator('#settingsBtn')).toHaveAttribute('aria-label', 'Open settings');
+  await expect(page.locator('#settingsBtn')).toHaveAttribute('title', 'Settings');
+});
+
 test('settings: shortcut overrides validate, persist, and update help', async ({ page, clawnsole }) => {
   if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
 


### PR DESCRIPTION
## Summary
- add a persisted Settings toggle for labeled header controls
- keep topbar actions icon-only by default and switch to icon+text when enabled
- collapse labels back to icon-only on constrained widths while preserving aria labels and titles

## Tests
- npm run test:syntax
- npx playwright test tests/ui/settings-recurring-prompts.spec.js --workers=1

Closes #321