### PR TITLE
UX: guard pane navigation shortcuts while typing

### DIFF
--- a/app.js
+++ b/app.js
@@ -11288,7 +11288,17 @@ function reportBlockedShortcut(reason) {
 }
 
 function isTypingContext(target) {
-  const el = target || document.activeElement;
+  const start = target || document.activeElement;
+  if (!start) return false;
+  const path = typeof start.composedPath === 'function' ? start.composedPath() : [];
+  const candidates = (path.length ? path : [start]).filter((el) => el && el !== window && el !== document);
+  for (const el of candidates) {
+    if (isEditableShortcutSurface(el)) return true;
+  }
+  return false;
+}
+
+function isEditableShortcutSurface(el) {
   if (!el) return false;
   try {
     if (el.hidden || el.disabled) return false;
@@ -11297,6 +11307,13 @@ function isTypingContext(target) {
   const tag = String(el.tagName || '').toUpperCase();
   if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
   if (el.isContentEditable) return true;
+  if (typeof el.closest === 'function') {
+    const editable = el.closest('[contenteditable], [role="textbox"], .monaco-editor, .cm-editor, .CodeMirror, .ace_editor');
+    if (editable) {
+      const contentEditable = String(editable.getAttribute?.('contenteditable') || '').toLowerCase();
+      if (contentEditable !== 'false') return true;
+    }
+  }
   return false;
 }
 
@@ -11334,9 +11351,6 @@ function hasPaneNumberLayoutMismatch(event) {
 
 function isTypingShortcutExempt(event) {
   const key = String(event?.key || '').toLowerCase();
-  const override = matchingShortcutOverrideAction(event);
-  if (override?.typingExempt) return true;
-  if (matchesKeybind(event, 'workqueue.openForActiveChat')) return true;
   return (event?.metaKey || event?.ctrlKey) && !event.shiftKey && !event.altKey && (key === 'p' || key === 'k' || key === 'l');
 }
 

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -665,6 +665,12 @@ test('ctrl/cmd+shift+g opens or focuses workqueue for active chat agent', async 
   await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(0);
 
   await chatInput.focus();
+  await chatInput.fill('typing');
+  await page.keyboard.press('ControlOrMeta+Shift+G');
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(0);
+  await expect(page.getByTestId('shortcut-blocked-toast').last()).toContainText('Shortcut paused while typing');
+
+  await page.click('#connectionStatus');
   await page.keyboard.press('ControlOrMeta+Shift+G');
 
   const wqPane = page.locator('[data-pane][data-pane-kind="workqueue"]');
@@ -676,6 +682,54 @@ test('ctrl/cmd+shift+g opens or focuses workqueue for active chat agent', async 
   await page.keyboard.press('ControlOrMeta+Shift+G');
   await expect(wqPane).toHaveCount(1);
   await expect(wqPane.locator('[data-wq-queue-select]')).toBeFocused();
+});
+
+test('pane-navigation shortcuts are blocked in search and modal text fields', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!app?.skipReason, app?.skipReason);
+
+  installPageFailureAssertions(page, { appOrigin: `http://127.0.0.1:${app.serverPort}` });
+
+  await page.goto(`http://127.0.0.1:${app.serverPort}/`);
+  await page.fill('#loginPassword', 'admin');
+  await page.click('#loginBtn');
+  await page.waitForURL(/\/admin\/?$/, { timeout: 10000 });
+
+  const panes = page.locator('[data-pane]');
+  const activePaneIndex = async () => page.evaluate(() => {
+    const panes = Array.from(document.querySelectorAll('[data-pane]'));
+    const active = document.activeElement;
+    if (!active) return -1;
+    return panes.findIndex((p) => p === active || p.contains(active));
+  });
+
+  await expect(panes).toHaveCount(2);
+  await page.click('#connectionStatus');
+  await page.keyboard.press('ControlOrMeta+P');
+
+  const manager = page.locator('#paneManagerModal');
+  const search = page.getByTestId('pane-manager-search');
+  await expect(manager).toHaveAttribute('aria-hidden', 'false');
+  await search.fill('workqueue');
+  await expect(search).toBeFocused();
+  await page.keyboard.press('ControlOrMeta+Shift+K');
+  await expect(search).toBeFocused();
+  await expect(manager).toHaveAttribute('aria-hidden', 'false');
+  await expect(page.getByTestId('shortcut-blocked-toast').last()).toContainText('Close modal to use this shortcut');
+  await page.evaluate(() => closePaneManager());
+  await expect(manager).toHaveAttribute('aria-hidden', 'true');
+
+  await page.evaluate(() => focusPaneIndex(0));
+  await expect.poll(activePaneIndex).toBe(0);
+  await page.evaluate(() => openWorkqueue());
+  const workqueueModal = page.locator('#workqueueModal');
+  const title = page.locator('#wqEnqueueTitle');
+  await expect(workqueueModal).toHaveAttribute('aria-hidden', 'false');
+  await title.focus();
+  await title.fill('blocked modal shortcut');
+  await page.keyboard.press('ControlOrMeta+Shift+F');
+  await expect(title).toBeFocused();
+  await expect(panes).toHaveCount(2);
 });
 
 test('fleet quick action button + keyboard shortcut focus existing timeline pane without duplicates', async ({ page }) => {
@@ -700,6 +754,12 @@ test('fleet quick action button + keyboard shortcut focus existing timeline pane
   await expect(panes).toHaveCount(3);
   await expect(timelinePanes).toHaveCount(1);
 
+  await page.locator('[data-pane][data-pane-kind="chat"] [data-pane-input]').first().focus();
+  await page.keyboard.press('Control+Shift+F');
+  await expect(panes).toHaveCount(3);
+  await expect(timelinePanes).toHaveCount(1);
+
+  await page.click('#connectionStatus');
   await page.keyboard.press('Control+Shift+F');
   await expect(panes).toHaveCount(3);
   await expect(timelinePanes).toHaveCount(1);


### PR DESCRIPTION
## Summary
- broaden the global shortcut typing guard to inspect composed paths and editor-like text surfaces
- stop workqueue/fleet pane-navigation shortcuts from firing from composers and editable fields
- add regression coverage for composer, Pane Manager search, and Workqueue modal text fields

## Testing
- npm run test:syntax
- npx playwright test tests/pane.shortcuts.e2e.spec.js --workers=1

Closes #255