### PR TITLE
Show unsent draft badges on panes

### DIFF
--- a/app.js
+++ b/app.js
@@ -2732,7 +2732,8 @@ function paneIdentityLabel(pane, { includeUnread = false } = {}) {
   const target = paneDisplayTargetLabel(pane);
   const nickname = paneNickname(pane);
   const unread = paneUnreadCount(pane);
-  return `${letter} ${type} · ${target}${nickname ? ` · ${nickname}` : ''}${includeUnread && unread > 0 ? ` • ${unread} unread` : ''}`;
+  const hasDraft = paneHasDraftChanges(pane);
+  return `${letter} ${type} · ${target}${nickname ? ` · ${nickname}` : ''}${includeUnread && unread > 0 ? ` • ${unread} unread` : ''}${hasDraft ? ' • unsent draft' : ''}`;
 }
 
 function paneSummaryLabel(pane) {
@@ -2980,6 +2981,24 @@ function renderPaneActivityBadge(pane) {
   badge.textContent = count > 99 ? '99+' : String(count);
   badge.setAttribute('aria-label', countLabel);
   badge.title = countLabel;
+}
+
+function renderPaneDraftBadge(pane) {
+  const badge = pane?.elements?.draftBadge;
+  if (!badge) return;
+
+  const hasDraft = paneHasDraftChanges(pane);
+  badge.hidden = !hasDraft;
+  badge.textContent = 'Draft';
+  badge.setAttribute('aria-label', hasDraft ? 'Unsent draft' : 'No unsent draft');
+  badge.title = hasDraft ? 'Unsent draft' : 'No unsent draft';
+}
+
+function refreshPaneDraftState(pane) {
+  if (!pane) return;
+  renderPaneIdentity(pane);
+  renderPaneDraftBadge(pane);
+  if (isPaneManagerOpen()) renderPaneManager();
 }
 
 function markPaneUnread(pane, increment = 1, kind = 'chat') {
@@ -3417,9 +3436,11 @@ function renderPaneManager() {
         const duplicateCount = duplicateCounts.get(paneDuplicateKey(pane)) || 0;
         const isDuplicate = duplicateCount > 1;
         const unreadCount = paneUnreadCount(pane);
+        const hasDraft = paneHasDraftChanges(pane);
         const paneIdentity = paneSummaryLabel(pane);
         const nickname = paneNickname(pane);
         const pairedAction = getPaneManagerPairedAction(pane);
+        row.setAttribute('aria-label', `${paneIdentity}; ${state}${unreadCount > 0 ? `; ${unreadCount} unread` : ''}${hasDraft ? '; unsent draft' : ''}`);
 
         const lockDisabled = paneManager.isLayoutLocked();
 
@@ -3432,6 +3453,7 @@ function renderPaneManager() {
               ${nickname ? `<span class="pane-manager-nickname" data-testid="pane-manager-nickname" title="${escapeHtml(`Pane nickname: ${nickname}`)}">${paneManagerHighlightHtml(nickname, query)}</span>` : ''}
               <span class="pane-manager-pane-id" title="Internal pane id">${paneManagerHighlightHtml(String(pane?.key || ''), query)}</span>
               ${isDuplicate ? `<span class="pane-manager-duplicate-badge" data-testid="pane-manager-duplicate-badge" title="${escapeHtml(`${duplicateCount} duplicate panes`)}">duplicate</span>` : ''}
+              ${hasDraft ? '<span class="pane-manager-draft-badge" data-testid="pane-manager-draft-badge" title="Unsent draft">Draft</span>' : ''}
               ${unreadCount > 0 ? `<span class="pane-manager-unread-badge" data-testid="pane-manager-unread-badge" title="${escapeHtml(`${unreadCount} unread`)}">${escapeHtml(String(unreadCount))}</span>` : ''}
             </div>
             <div class="pane-manager-state" data-state="${escapeHtml(state)}">${escapeHtml(state)}</div>
@@ -7536,6 +7558,7 @@ function paneRenderAttachments(pane) {
     remove.addEventListener('click', () => {
       pane.attachments.files.splice(index, 1);
       paneRenderAttachments(pane);
+      refreshPaneDraftState(pane);
     });
     pill.append(name, remove);
     list.appendChild(pill);
@@ -7584,6 +7607,7 @@ async function paneHandleFileSelection(pane, event) {
   }
   event.target.value = '';
   paneRenderAttachments(pane);
+  refreshPaneDraftState(pane);
 }
 
 async function paneUploadAttachments(pane) {
@@ -7603,6 +7627,7 @@ async function paneUploadAttachments(pane) {
   const data = await res.json();
   pane.attachments.files = [];
   paneRenderAttachments(pane);
+  refreshPaneDraftState(pane);
   pane.elements.attachmentStatus.textContent = '';
   return Array.isArray(data.files) ? data.files : [];
 }
@@ -7907,6 +7932,7 @@ async function paneSendChat(pane) {
     paneClearChatHistory(pane, { wipeStorage: true });
     pane.elements.input.value = '';
     paneUpdateCommandHints(pane);
+    refreshPaneDraftState(pane);
     addFeed('event', 'chat', `cleared local history (${pane.sessionKey()})`);
     return;
   }
@@ -7915,6 +7941,7 @@ async function paneSendChat(pane) {
     paneClearChatHistory(pane, { wipeStorage: true });
     pane.elements.input.value = '';
     paneUpdateCommandHints(pane);
+    refreshPaneDraftState(pane);
     pane.client.request('sessions.reset', { key });
     addFeed('event', 'chat', `reset session (${key})`);
     return;
@@ -7996,6 +8023,7 @@ async function paneSendChat(pane) {
 
   pane.elements.input.value = '';
   paneUpdateCommandHints(pane);
+  refreshPaneDraftState(pane);
 }
 
 function handleGatewayFrame(pane, data) {
@@ -8206,7 +8234,8 @@ function renderPaneIdentity(pane) {
   const target = paneDisplayTargetLabel(pane);
   const nickname = paneNickname(pane);
   const unread = paneUnreadCount(pane);
-  const identity = `${letter} ${type} · ${target}${nickname ? ` · ${nickname}` : ''}${unread > 0 ? ` • ${unread} unread` : ''}`;
+  const hasDraft = paneHasDraftChanges(pane);
+  const identity = `${letter} ${type} · ${target}${nickname ? ` · ${nickname}` : ''}${unread > 0 ? ` • ${unread} unread` : ''}${hasDraft ? ' • unsent draft' : ''}`;
   pane.elements.name.title = paneIdentityLabel(pane, { includeUnread: false });
   pane.elements.name.setAttribute('aria-label', identity);
   if (pane.elements.nameToken && pane.elements.nameTarget) {
@@ -8465,8 +8494,11 @@ function paneSetAgent(pane, nextAgentId, { requireDraftConfirm = true, syncFromP
 
   if (pane.kind === 'chat') {
     renderPaneAgentIdentity(pane);
+    if (pane.elements?.input) pane.elements.input.value = '';
+    paneUpdateCommandHints(pane);
     pane.attachments.files = [];
     paneRenderAttachments(pane);
+    refreshPaneDraftState(pane);
     paneStopThinking(pane);
     paneClearChatHistory(pane, { wipeStorage: false });
     paneRestoreChatHistory(pane);
@@ -8547,6 +8579,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     agentWarning: root.querySelector('[data-pane-agent-warning]'),
     agentPill: root.querySelector('[data-pane-agent-pill]'),
     status: root.querySelector('[data-pane-status]'),
+    draftBadge: root.querySelector('[data-pane-draft-badge]'),
     activityBadge: root.querySelector('[data-pane-activity-badge]'),
     helpDetails: root.querySelector('[data-pane-help]'),
     helpPopover: root.querySelector('[data-pane-help-popover]'),
@@ -8770,6 +8803,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     clearPaneUnread(pane);
   });
   renderPaneActivityBadge(pane);
+  renderPaneDraftBadge(pane);
 
   // WORKQUEUE PANE
   if (pane.role === 'admin' && pane.kind === 'workqueue') {
@@ -10119,6 +10153,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
 
   elements.input.addEventListener('input', () => {
     paneUpdateCommandHints(pane);
+    refreshPaneDraftState(pane);
   });
 
   elements.attachBtn.addEventListener('click', () => {
@@ -10542,6 +10577,7 @@ const paneManager = {
     if (typeof options?.restoreDraftText === 'string' && pane.elements?.input) {
       pane.elements.input.value = options.restoreDraftText;
       paneUpdateCommandHints(pane);
+      refreshPaneDraftState(pane);
     }
     insertCreatedPane(pane);
     return finishCreatedPane(pane, { connect: true });

--- a/index.html
+++ b/index.html
@@ -144,6 +144,7 @@
                   <div class="pane-help-popover" data-pane-help-popover></div>
                 </details>
 
+                <div class="pane-draft-badge" data-pane-draft-badge data-testid="pane-draft-badge" hidden aria-live="polite" aria-label="No unsent draft">Draft</div>
                 <div class="pane-activity-badge" data-pane-activity-badge data-testid="pane-activity-badge" hidden aria-live="polite" aria-label="No unread activity">•</div>
                 <div class="status-pill pane-status" data-pane-status data-testid="pane-connection-status">disconnected</div>
                 <button class="icon-btn pane-close" data-pane-close type="button" aria-label="Close pane" data-testid="pane-close">

--- a/styles.css
+++ b/styles.css
@@ -883,7 +883,27 @@ body::before {
   line-height: 1;
 }
 
+.pane-draft-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 7px;
+  border-radius: 999px;
+  border: 1px solid rgba(245, 158, 11, 0.45);
+  background: rgba(245, 158, 11, 0.14);
+  color: #fcd34d;
+  font-size: 11px;
+  font-weight: 800;
+  line-height: 1;
+}
+
 .pane-activity-badge[hidden] {
+  display: none !important;
+}
+
+.pane-draft-badge[hidden] {
   display: none !important;
 }
 
@@ -1642,6 +1662,21 @@ button.send-btn .btn-icon {
   border: 1px solid rgba(239, 68, 68, 0.45);
   background: rgba(239, 68, 68, 0.14);
   color: #fecaca;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.pane-manager-draft-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 7px;
+  border-radius: 999px;
+  border: 1px solid rgba(245, 158, 11, 0.4);
+  background: rgba(245, 158, 11, 0.12);
+  color: #fbbf24;
   font-size: 10px;
   font-weight: 700;
 }

--- a/tests/ui/chat-pane.spec.js
+++ b/tests/ui/chat-pane.spec.js
@@ -116,6 +116,45 @@ test('chat pane: unread badge appears on inactive pane and clears on focus', asy
   await expect(firstBadge).toBeHidden();
 });
 
+test('chat pane: draft badge appears, persists across pane switches, and clears on send', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Chat pane');
+
+  const chatPanes = page.locator('[data-pane][data-pane-kind="chat"]');
+  const firstPane = chatPanes.first();
+  const secondPane = chatPanes.last();
+  const firstPaneKey = await firstPane.getAttribute('data-pane-key');
+  const draftBadge = firstPane.getByTestId('pane-draft-badge');
+  const paneLabel = firstPane.getByTestId('pane-type-label');
+
+  await expect(draftBadge).toBeHidden();
+  await firstPane.locator('[data-pane-input]').fill('draft marker');
+  await expect(draftBadge).toBeVisible();
+  await expect(draftBadge).toHaveText('Draft');
+  await expect(paneLabel).toHaveAttribute('aria-label', /unsent draft/);
+
+  await secondPane.locator('[data-pane-input]').focus();
+  await expect(draftBadge).toBeVisible();
+
+  await page.keyboard.press('Control+P');
+  const managerRow = page.locator(`.pane-manager-row[data-pane-key="${firstPaneKey}"]`);
+  await expect(managerRow.getByTestId('pane-manager-draft-badge')).toBeVisible();
+  await expect(managerRow).toHaveAttribute('aria-label', /unsent draft/);
+  await page.keyboard.press('Escape');
+
+  await firstPane.locator('[data-pane-send]').click();
+  await expect(firstPane.locator('[data-chat-role="assistant"]').last()).toContainText('mock-reply: draft marker');
+  await expect(draftBadge).toBeHidden();
+
+  await page.keyboard.press('Control+P');
+  await expect(page.locator(`.pane-manager-row[data-pane-key="${firstPaneKey}"]`).getByTestId('pane-manager-draft-badge')).toHaveCount(0);
+});
+
 test('chat pane: keyboard pane switch guards immediate Enter send once', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);


### PR DESCRIPTION
Fixes #305.\n\nSummary:\n- add an unsent Draft badge to pane headers and Pane Manager rows\n- include draft status in pane and Pane Manager ARIA labels\n- refresh badge state when draft text, attachments, sends, commands, or destination changes clear/update drafts\n\nTests:\n- npm run test:syntax\n- npx playwright test tests/ui/chat-pane.spec.js --workers=1