### PR TITLE
test(workqueue): add modal golden-path coverage

### DIFF
--- a/app.js
+++ b/app.js
@@ -5196,6 +5196,7 @@ function renderWorkqueueStatusFilters() {
     const id = `wq-status-${s}`;
     const label = document.createElement('label');
     label.className = 'wq-status-chip';
+    label.setAttribute('data-testid', `wq-modal-status-filter-${s}`);
     const count = Number(workqueueState.statusCounts?.[s] || 0);
     const display = `${formatWorkqueueStatusLabel(s)} (${count})`;
     label.innerHTML = `<input type="checkbox" id="${id}" ${workqueueState.statusFilter.has(s) ? 'checked' : ''} /> <span>${escapeHtml(display)}</span>`;
@@ -5431,6 +5432,7 @@ function renderWorkqueueItems() {
     const col = document.createElement('section');
     col.className = 'wq-board-col';
     col.setAttribute('data-wq-col', colDef.status);
+    col.setAttribute('data-testid', `wq-modal-lane-${colDef.status}`);
 
     const colItems = Array.isArray(itemsByStatus[colDef.status]) ? itemsByStatus[colDef.status] : [];
 
@@ -5467,6 +5469,7 @@ function renderWorkqueueItems() {
       const card = document.createElement('button');
       card.type = 'button';
       card.className = 'wq-card';
+      card.setAttribute('data-testid', 'wq-modal-card');
       if (it.id && it.id === workqueueState.selectedItemId) card.classList.add('selected');
       if (it.id) card.setAttribute('data-wq-item', it.id);
 
@@ -5547,8 +5550,8 @@ function renderWorkqueueInspect(item) {
   const actions = document.createElement('div');
   actions.className = 'wq-inspect-actions';
   actions.innerHTML = `
-    <button type="button" class="btn" data-wq-action="edit">Edit</button>
-    <button type="button" class="btn danger" data-wq-action="delete">Delete</button>
+    <button type="button" class="btn" data-wq-action="edit" data-testid="wq-modal-edit">Edit</button>
+    <button type="button" class="btn danger" data-wq-action="delete" data-testid="wq-modal-delete">Delete</button>
   `;
 
   const meta = root.querySelector('.wq-inspect-meta');

--- a/index.html
+++ b/index.html
@@ -291,7 +291,7 @@
       </div>
     </div>
 
-    <div id="workqueueModal" class="modal" aria-hidden="true">
+    <div id="workqueueModal" class="modal" aria-hidden="true" data-testid="wq-modal">
       <div class="modal-card wide" role="dialog" aria-modal="true" aria-labelledby="workqueueTitle">
         <div class="modal-header">
           <h2 id="workqueueTitle">Workqueue</h2>
@@ -303,11 +303,11 @@
           <div class="wq-toolbar">
             <label class="wq-field">
               Queue
-              <select id="wqQueueSelect" aria-label="Select workqueue"></select>
+              <select id="wqQueueSelect" aria-label="Select workqueue" data-testid="wq-modal-queue-select"></select>
             </label>
             <div class="wq-field">
               Status
-              <div id="wqStatusFilters" class="wq-status-filters" aria-label="Status filters"></div>
+              <div id="wqStatusFilters" class="wq-status-filters" aria-label="Status filters" data-testid="wq-modal-status-filters"></div>
             </div>
             <label class="wq-field">
               Auto-refresh
@@ -381,13 +381,13 @@
                 <button type="button" class="wq-list-sort" data-wq-modal-sort="claimedBy">Claimed by</button>
                 <button type="button" class="wq-list-sort" data-wq-modal-sort="leaseUntil">Lease expires</button>
               </div>
-              <div id="wqListBody" class="wq-list-body"></div>
+              <div id="wqListBody" class="wq-list-body" data-testid="wq-modal-list"></div>
               <div id="wqListEmpty" class="hint" hidden>No items match.</div>
             </div>
 
             <div class="wq-inspect" aria-label="Inspect workqueue item">
               <div class="wq-inspect-header">Item</div>
-              <div id="wqInspectBody" class="wq-inspect-body">
+              <div id="wqInspectBody" class="wq-inspect-body" data-testid="wq-modal-inspect">
                 <div class="hint">Select an item to inspect.</div>
               </div>
             </div>

--- a/tests/ui/workqueue-modal.spec.js
+++ b/tests/ui/workqueue-modal.spec.js
@@ -71,3 +71,95 @@ test('workqueue modal: status filters use human labels and queue-scoped counts',
   await queueSelect.selectOption('qa-team');
   await expect(page.locator('#wqStatusFilters .wq-status-chip', { hasText: 'Ready (2)' })).toHaveCount(1);
 });
+
+test('workqueue modal: golden path covers filters, kanban transition, edit, and delete', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+
+  const baseUrl = `http://127.0.0.1:${env.serverPort}`;
+  const queue = `golden-path-${Date.now()}`;
+  const createRes = await page.request.post(`${baseUrl}/api/workqueue/enqueue`, {
+    data: {
+      queue,
+      title: 'Golden path item',
+      instructions: 'Exercise workqueue UI',
+      priority: 42,
+      dedupeKey: `ui-golden-path-${Date.now()}`
+    }
+  });
+  expect(createRes.ok()).toBeTruthy();
+
+  await page.evaluate(() => window.openWorkqueue?.());
+
+  const modal = page.getByTestId('wq-modal');
+  await expect(modal).toHaveClass(/open/);
+  await expect(modal.getByTestId('wq-modal-queue-select')).toBeVisible();
+  await expect(modal.getByTestId('wq-modal-status-filters')).toBeVisible();
+  await expect(modal.getByTestId('wq-modal-status-filter-ready')).toBeVisible();
+
+  const itemsResponse = page.waitForResponse(
+    (res) => res.url().includes('/api/workqueue/items') && res.url().includes(encodeURIComponent(queue)) && res.ok(),
+    { timeout: 15000 }
+  );
+  await modal.getByTestId('wq-modal-queue-select').selectOption(queue);
+  await itemsResponse;
+
+  const readyLane = modal.getByTestId('wq-modal-lane-ready');
+  const inProgressLane = modal.getByTestId('wq-modal-lane-in_progress');
+  const itemCard = readyLane.getByTestId('wq-modal-card').filter({ hasText: 'Golden path item' }).first();
+  await expect(itemCard).toBeVisible();
+
+  const updateResponse = page.waitForResponse(
+    (res) => res.url().endsWith('/api/workqueue/update') && res.request().method() === 'POST' && res.ok(),
+    { timeout: 15000 }
+  );
+  await page.evaluate(() => {
+    const card = document.querySelector('[data-testid="wq-modal-lane-ready"] [data-testid="wq-modal-card"]');
+    const lane = document.querySelector('[data-testid="wq-modal-lane-in_progress"] .wq-board-lane');
+    if (!card || !lane) throw new Error('missing workqueue drag/drop targets');
+    const dataTransfer = new DataTransfer();
+    card.dispatchEvent(new DragEvent('dragstart', { bubbles: true, cancelable: true, dataTransfer }));
+    lane.dispatchEvent(new DragEvent('dragover', { bubbles: true, cancelable: true, dataTransfer }));
+    lane.dispatchEvent(new DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer }));
+  });
+  await updateResponse;
+
+  const movedCard = inProgressLane.getByTestId('wq-modal-card').filter({ hasText: 'Golden path item' }).first();
+  await expect(movedCard).toBeVisible();
+  await movedCard.click();
+  await expect(modal.getByTestId('wq-modal-inspect')).toContainText('Golden path item');
+
+  const editAnswers = ['Golden path item edited', 'Updated instructions', '77', 'in_progress'];
+  const editDialogHandler = async (dialog) => {
+    await dialog.accept(editAnswers.shift());
+  };
+  page.on('dialog', editDialogHandler);
+  const editResponse = page.waitForResponse(
+    (res) => res.url().endsWith('/api/workqueue/update') && res.request().method() === 'POST' && res.ok(),
+    { timeout: 15000 }
+  );
+  await modal.getByTestId('wq-modal-edit').click();
+  await editResponse;
+  page.off('dialog', editDialogHandler);
+  expect(editAnswers).toHaveLength(0);
+  await expect(inProgressLane).toContainText('Golden path item edited');
+  await expect(modal.getByTestId('wq-modal-inspect')).toContainText('Updated instructions');
+
+  page.once('dialog', async (dialog) => {
+    expect(dialog.message()).toContain('Delete workqueue item?');
+    await dialog.accept();
+  });
+  const deleteResponse = page.waitForResponse(
+    (res) => res.url().endsWith('/api/workqueue/delete') && res.request().method() === 'POST' && res.ok(),
+    { timeout: 15000 }
+  );
+  await modal.getByTestId('wq-modal-delete').click();
+  await deleteResponse;
+
+  await expect(modal.getByTestId('wq-modal-list')).not.toContainText('Golden path item edited');
+  await expect(modal.getByTestId('wq-modal-inspect')).toContainText('Select an item to inspect.');
+});


### PR DESCRIPTION
## Summary
- add stable test ids for the Workqueue modal controls, status lanes, cards, and inspect actions
- add a deterministic Playwright golden-path covering queue/status filters, kanban drag/drop transition, inspect, edit/save, and delete
- supersedes the stale older coverage attempt in #246 with a fresh branch on current main

## Validation
- npm test
- npx playwright test tests/ui/workqueue-modal.spec.js --workers=1

Closes #123