### PR TITLE
Add active pane highlight and topbar chip

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,6 +20,8 @@ const globalElements = {
   recurringPromptHistoryEmpty: document.getElementById('recurringPromptHistoryEmpty'),
   status: document.getElementById('connectionStatus'),
   paneManagerBtn: document.getElementById('paneManagerBtn'),
+  activePaneChip: document.getElementById('activePaneChip'),
+  activePaneChipValue: document.querySelector('[data-active-pane-chip-value]'),
   pulseCanvas: document.getElementById('pulseCanvas'),
   workqueueBtn: document.getElementById('workqueueBtn'),
   fleetBtn: document.getElementById('fleetBtn'),
@@ -602,6 +604,7 @@ function isGlobalKeybindEntry(entry) {
 }
 const WQ_RECENT_ENQUEUE_AGENTS_KEY = 'clawnsole.wq.recentEnqueueAgents';
 const WQ_RECENT_TARGETS_MAX = 6;
+const ADMIN_ACTIVE_PANE_KEY = 'clawnsole.admin.activePaneKey';
 
 function readJsonFromStorage(key, fallback) {
   try {
@@ -629,6 +632,16 @@ function getActiveAdminPaneKey() {
   } catch {
     return '';
   }
+}
+
+function rememberedActivePaneKey() {
+  return String(storage.get(ADMIN_ACTIVE_PANE_KEY, '') || '');
+}
+
+function rememberActivePaneKey(key) {
+  const next = String(key || '');
+  if (!next) return;
+  storage.set(ADMIN_ACTIVE_PANE_KEY, next);
 }
 
 function readStoredAdminDestination(key = ADMIN_AUTH_DESTINATION_KEY) {
@@ -1715,6 +1728,7 @@ function updateGlobalStatus() {
   const status = deriveGlobalConnectionState({ authed: uiState.authed, panes: paneManager.panes });
   setStatusPill(globalElements.status, status.state, status.meta);
   if (globalElements.status) globalElements.status.hidden = !uiState.authed;
+  renderActivePaneState();
   if (globalElements.paneManagerBtn) {
     globalElements.paneManagerBtn.hidden = !uiState.authed || !status.meta;
     globalElements.paneManagerBtn.textContent = uiState.authed ? status.meta : '';
@@ -2976,6 +2990,8 @@ function notePaneFocused(pane) {
   paneMruTraversal = null;
   paneMruOrder();
   paneFocusMruKeys = [key, ...paneFocusMruKeys.filter((entry) => entry !== key)];
+  rememberActivePaneKey(key);
+  renderActivePaneState(pane);
   updateBrowserTitle(pane);
 }
 
@@ -3007,10 +3023,57 @@ function forgetFocusedPaneKey(paneKey) {
   const key = String(paneKey || '');
   if (!key) return;
   paneFocusMruKeys = paneFocusMruKeys.filter((entry) => entry !== key);
+  if (rememberedActivePaneKey() === key) storage.remove(ADMIN_ACTIVE_PANE_KEY);
   if (paneMruTraversal?.order) {
     paneMruTraversal.order = paneMruTraversal.order.filter((entry) => entry !== key);
     if (paneMruTraversal.order.length < 2) paneMruTraversal = null;
   }
+}
+
+function activePaneFromState() {
+  const panes = paneManager?.panes || [];
+  if (!panes.length) return null;
+  const candidates = [
+    focusedPaneKey(),
+    paneFocusMruKeys[0],
+    rememberedActivePaneKey()
+  ].filter(Boolean);
+  for (const key of candidates) {
+    const pane = panes.find((entry) => String(entry?.key || '') === String(key));
+    if (pane) return pane;
+  }
+  return panes[0] || null;
+}
+
+function renderActivePaneState(activePane = activePaneFromState()) {
+  const panes = paneManager?.panes || [];
+  const activeKey = String(activePane?.key || '');
+  panes.forEach((pane) => {
+    const isActive = !!activeKey && String(pane?.key || '') === activeKey;
+    const root = pane?.elements?.root;
+    if (!root) return;
+    root.classList.toggle('is-active-pane', isActive);
+    root.dataset.activePane = isActive ? 'true' : 'false';
+    root.setAttribute('aria-current', isActive ? 'true' : 'false');
+  });
+
+  const chip = globalElements.activePaneChip;
+  const value = globalElements.activePaneChipValue;
+  if (!chip || !value) return;
+
+  if (!activePane) {
+    chip.hidden = true;
+    value.textContent = '';
+    chip.title = 'No active pane';
+    chip.setAttribute('aria-label', 'No active pane');
+    return;
+  }
+
+  const label = paneSummaryLabel(activePane);
+  chip.hidden = !uiState.authed;
+  value.textContent = label;
+  chip.title = `Focus ${label}`;
+  chip.setAttribute('aria-label', `Active pane: ${label}. Click to focus.`);
 }
 
 function paneIndexByKey(key) {
@@ -8463,6 +8526,7 @@ function renderPaneIdentity(pane) {
     pane.elements.name.textContent = identity;
   }
   renderPanePairCue(pane);
+  renderActivePaneState();
   if (pane.elements.nicknameBtn) {
     pane.elements.nicknameBtn.classList.toggle('has-nickname', !!nickname);
     pane.elements.nicknameBtn.title = nickname ? `Rename pane nickname: ${nickname}` : 'Set pane nickname';
@@ -10452,7 +10516,21 @@ const paneManager = {
     this.updatePaneLabels();
     this.updateCloseButtons();
     this.applyInferredLayout();
-    updateBrowserTitle(this.panes[0] || null);
+    const storedActivePaneKey = rememberedActivePaneKey();
+    const restoredActivePane = this.panes.find((pane) => pane.key === storedActivePaneKey) || this.panes[0] || null;
+    if (restoredActivePane) {
+      paneFocusMruKeys = [
+        restoredActivePane.key,
+        ...this.panes.map((pane) => pane.key).filter((key) => key && key !== restoredActivePane.key)
+      ];
+    }
+    renderActivePaneState(restoredActivePane);
+    updateBrowserTitle(restoredActivePane);
+    if (storedActivePaneKey && restoredActivePane?.key === storedActivePaneKey) {
+      setTimeout(() => {
+        if (this.panes.includes(restoredActivePane)) this.focusPanePrimary(restoredActivePane);
+      }, 0);
+    }
   },
   isLayoutLocked() {
     return !!this.layoutLocked;
@@ -10489,6 +10567,7 @@ const paneManager = {
     });
     this.panes = [];
     this.closedPaneStack = [];
+    renderActivePaneState(null);
   },
   loadAdminPanes() {
     const storedDefault = storage.get(ADMIN_DEFAULT_AGENT_KEY, 'main');
@@ -10715,6 +10794,7 @@ const paneManager = {
         pane.client.connect();
       }
       this.focusPanePrimary(pane);
+      renderActivePaneState(pane);
       return pane;
     };
 
@@ -11714,7 +11794,11 @@ function focusPaneIndex(idx, { trackMru = true, showHud = false } = {}) {
   const previousPaneKey = focusedPaneKey() || paneMruOrder()[0] || '';
   clearPaneUnread(pane);
   if (trackMru) notePaneFocused(pane);
-  else updateBrowserTitle(pane);
+  else {
+    rememberActivePaneKey(pane.key);
+    renderActivePaneState(pane);
+    updateBrowserTitle(pane);
+  }
   paneMarkSwitchSendGuard(pane, previousPaneKey);
   if (showHud) showPaneSwitchHud(pane);
 
@@ -12368,6 +12452,12 @@ globalElements.logoutBtn?.addEventListener('click', async () => {
 globalElements.addPaneBtn?.addEventListener('click', (event) => {
   event?.preventDefault?.();
   paneManager.openAddPaneMenu(globalElements.addPaneBtn);
+});
+
+globalElements.activePaneChip?.addEventListener('click', () => {
+  const pane = activePaneFromState();
+  const idx = paneManager?.panes?.indexOf?.(pane) ?? -1;
+  if (idx >= 0) focusPaneIndex(idx, { showHud: true });
 });
 
 globalElements.addChatPaneBtn?.addEventListener('click', (event) => {

--- a/app.js
+++ b/app.js
@@ -944,6 +944,16 @@ function showToast(
   const text = typeof message === 'string' ? message.trim() : String(message || '').trim();
   if (!text) return;
 
+  const existing = Array.from(globalElements.toastHost.querySelectorAll('[data-testid]')).find((node) => {
+    return (
+      node instanceof HTMLElement &&
+      node.classList.contains('open') &&
+      node.dataset.toastKind === kind &&
+      node.querySelector('.toast-message')?.textContent === text
+    );
+  });
+  if (existing) return existing;
+
   const el = document.createElement('div');
   el.className = `toast ${kind === 'error' ? 'toast-error' : 'toast-info'}`;
   const id = ++toastSeq;
@@ -2967,6 +2977,7 @@ function focusedPaneKey() {
 let paneFocusMruKeys = [];
 let paneMruTraversal = null;
 let paneMruSuppressFocusEvents = false;
+let paneActiveRestoreGuardUntil = 0;
 const PANE_SWITCH_SEND_GUARD_MS = 800;
 const PANE_SWITCH_SEND_GUARD_MESSAGE = 'Pane changed: press Enter again to send';
 
@@ -2987,6 +2998,8 @@ function notePaneFocused(pane) {
   if (!key) return;
   const panes = paneManager?.panes || [];
   if (!panes.some((entry) => String(entry?.key || '') === key)) return;
+  const rememberedKey = rememberedActivePaneKey();
+  if (rememberedKey && key !== rememberedKey && Date.now() < paneActiveRestoreGuardUntil) return;
   paneMruTraversal = null;
   paneMruOrder();
   paneFocusMruKeys = [key, ...paneFocusMruKeys.filter((entry) => entry !== key)];
@@ -3034,8 +3047,8 @@ function activePaneFromState() {
   const panes = paneManager?.panes || [];
   if (!panes.length) return null;
   const candidates = [
-    focusedPaneKey(),
     paneFocusMruKeys[0],
+    focusedPaneKey(),
     rememberedActivePaneKey()
   ].filter(Boolean);
   for (const key of candidates) {
@@ -10518,6 +10531,7 @@ const paneManager = {
     this.applyInferredLayout();
     const storedActivePaneKey = rememberedActivePaneKey();
     const restoredActivePane = this.panes.find((pane) => pane.key === storedActivePaneKey) || this.panes[0] || null;
+    paneActiveRestoreGuardUntil = storedActivePaneKey ? Date.now() + 1000 : 0;
     if (restoredActivePane) {
       paneFocusMruKeys = [
         restoredActivePane.key,
@@ -10526,11 +10540,6 @@ const paneManager = {
     }
     renderActivePaneState(restoredActivePane);
     updateBrowserTitle(restoredActivePane);
-    if (storedActivePaneKey && restoredActivePane?.key === storedActivePaneKey) {
-      setTimeout(() => {
-        if (this.panes.includes(restoredActivePane)) this.focusPanePrimary(restoredActivePane);
-      }, 0);
-    }
   },
   isLayoutLocked() {
     return !!this.layoutLocked;

--- a/index.html
+++ b/index.html
@@ -40,6 +40,18 @@
               data-testid="panes-indicator"
             ></button>
           </div>
+          <button
+            id="activePaneChip"
+            class="active-pane-chip"
+            type="button"
+            aria-label="Focus active pane"
+            title="Focus active pane"
+            data-testid="active-pane-chip"
+            hidden
+          >
+            <span class="active-pane-chip__label">Active</span>
+            <span class="active-pane-chip__value" data-active-pane-chip-value></span>
+          </button>
           <div id="paneControls" class="pane-controls" hidden>
             <div class="pane-add-wrap">
               <button id="addPaneBtn" class="icon-btn action-btn" type="button" aria-haspopup="menu" aria-expanded="false" aria-label="Add pane" title="Add Pane (Ctrl/Cmd+Shift+N)" data-testid="add-pane-btn">

--- a/styles.css
+++ b/styles.css
@@ -156,6 +156,41 @@ body::before {
   gap: 10px;
 }
 
+.active-pane-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  max-width: min(360px, 34vw);
+  padding: 7px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(127, 209, 185, 0.46);
+  background: rgba(127, 209, 185, 0.12);
+  color: #d7fff3;
+  box-shadow: 0 0 0 1px rgba(127, 209, 185, 0.08), 0 10px 28px rgba(0, 0, 0, 0.2);
+}
+
+.active-pane-chip[hidden] {
+  display: none !important;
+}
+
+.active-pane-chip__label {
+  flex: 0 0 auto;
+  font-size: 10px;
+  font-weight: 800;
+  text-transform: uppercase;
+  color: rgba(215, 255, 243, 0.76);
+}
+
+.active-pane-chip__value {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  font-weight: 700;
+}
+
 .agent-switch {
   display: inline-flex;
   align-items: center;
@@ -523,6 +558,21 @@ body::before {
   border-left: 4px solid var(--pane-accent, rgba(255, 179, 71, 0.55));
   position: relative;
   z-index: 2;
+}
+
+.pane.is-active-pane {
+  border-color: rgba(127, 209, 185, 0.88);
+  box-shadow:
+    0 0 0 2px rgba(127, 209, 185, 0.62),
+    0 18px 46px rgba(0, 0, 0, 0.34);
+}
+
+.pane.is-active-pane .pane-header {
+  background:
+    linear-gradient(90deg, rgba(127, 209, 185, 0.22), var(--pane-header-tint, rgba(9, 12, 16, 0.18))),
+    rgba(9, 12, 16, 0.18);
+  border-color: rgba(127, 209, 185, 0.7);
+  border-left-color: #7fd1b9;
 }
 
 .pane.is-pair-revealed {

--- a/tests/ui/pane-active-context.spec.js
+++ b/tests/ui/pane-active-context.spec.js
@@ -1,0 +1,66 @@
+const { test, expect } = require('@playwright/test');
+
+const { startTestEnv, loginAdmin, attachConsoleErrorAsserts, addPane } = require('./_helpers');
+
+let env;
+
+test.beforeAll(async () => {
+  env = await startTestEnv();
+});
+
+test.afterAll(() => {
+  env?.stop?.();
+});
+
+test.afterEach(async ({ page }) => {
+  if (page.__consoleAsserts) {
+    page.__consoleAsserts.assertNoErrors();
+  }
+});
+
+test('active pane highlight and topbar chip follow keyboard pane cycling', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+  await page.evaluate(() => localStorage.setItem('clawnsole.admin.layoutMode', 'custom'));
+  await addPane(page, 'Timeline pane');
+
+  const chip = page.getByTestId('active-pane-chip');
+  const panes = page.locator('[data-pane]');
+  const activePanes = page.locator('[data-pane][data-active-pane="true"]');
+
+  await expect(chip).toBeVisible();
+
+  const firstPane = panes.first();
+  const secondPane = panes.nth(1);
+  const thirdPane = panes.nth(2);
+
+  await firstPane.evaluate((el) => el.focus());
+  await expect(activePanes).toHaveCount(1);
+  await expect(firstPane).toHaveAttribute('data-active-pane', 'true');
+  await expect(secondPane).toHaveAttribute('data-active-pane', 'false');
+  await expect(thirdPane).toHaveAttribute('data-active-pane', 'false');
+  await expect(chip).toContainText(/Active\s*A Chat · main/);
+
+  await page.keyboard.press('Control+Shift+K');
+  await expect(activePanes).toHaveCount(1);
+  await expect(secondPane).toHaveAttribute('data-active-pane', 'true');
+  await expect(firstPane).toHaveAttribute('data-active-pane', 'false');
+  await expect(thirdPane).toHaveAttribute('data-active-pane', 'false');
+  await expect(chip).toContainText(/Active\s*B Workqueue · dev-team/);
+
+  await page.keyboard.press('Control+Shift+K');
+  await expect(activePanes).toHaveCount(1);
+  await expect(thirdPane).toHaveAttribute('data-active-pane', 'true');
+  await expect(firstPane).toHaveAttribute('data-active-pane', 'false');
+  await expect(secondPane).toHaveAttribute('data-active-pane', 'false');
+  await expect(chip).toContainText(/Active\s*C Timeline ·/);
+
+  await page.reload();
+  await expect(page.getByTestId('active-pane-chip')).toContainText(/Active\s*C Timeline ·/);
+  await expect(page.locator('[data-pane][data-active-pane="true"]')).toHaveCount(1);
+  await expect(page.locator('[data-pane]').nth(2)).toHaveAttribute('data-active-pane', 'true');
+});


### PR DESCRIPTION
## Summary\n- add a persistent topbar Active chip for the focused pane\n- mark exactly one pane with an unmistakable active visual state\n- persist and restore active pane state across reload when the pane still exists\n- add Playwright coverage for keyboard pane cycling and reload restore\n\nFixes #407\n\n## Tests\n- npm run test:syntax\n- npx playwright test tests/ui/pane-active-context.spec.js --workers=1\n\n🚢 please review for ship sign-off.