### PR TITLE
Clarify Workqueue queue and item search

### DIFF
--- a/app.js
+++ b/app.js
@@ -6159,24 +6159,30 @@ function getWorkqueueQuickFilterBreakdown(items, quickFilters) {
     current = next;
   }
   if (search) {
-    const next = current.filter((it) => {
-      const haystack = [
-        it?.id,
-        it?.title,
-        it?.instructions,
-        it?.dedupeKey,
-        it?.status,
-        it?.claimedBy,
-        getWorkqueueItemRepo(it),
-        getWorkqueueItemSource(it)
-      ].map((v) => String(v || '').toLowerCase()).join('\n');
-      return haystack.includes(search);
-    });
+    const next = current.filter((it) => workqueueItemMatchesSearch(it, search));
     hidden.search = current.length - next.length;
     current = next;
   }
 
   return { items: current, hidden };
+}
+
+function workqueueItemMatchesSearch(item, search) {
+  const query = String(search || '').trim().toLowerCase();
+  if (!query) return true;
+  const meta = item?.meta && typeof item.meta === 'object' ? item.meta : {};
+  const haystack = [
+    item?.id,
+    item?.title,
+    item?.instructions,
+    item?.dedupeKey,
+    item?.status,
+    item?.claimedBy,
+    getWorkqueueItemRepo(item),
+    getWorkqueueItemSource(item),
+    JSON.stringify(meta)
+  ].map((v) => String(v || '').toLowerCase()).join('\n');
+  return haystack.includes(query);
 }
 
 function renderWorkqueueFilterSummaryForPane(pane, { shownCount, totalCount, hiddenCounts } = {}) {
@@ -6652,8 +6658,9 @@ function renderWorkqueuePaneItems(pane) {
       const statuses = Array.isArray(pane.workqueue?.statusFilter) ? pane.workqueue.statusFilter : [];
       const statusLabel = statuses.length ? statuses.join(', ') : 'default';
       const scopeLabel = pane.workqueue?.scopeFilter || 'all';
+      const itemSearch = String(pane.workqueue?.quickFilters?.search || '').trim();
       const filtersHidingAll = totalCount > 0;
-      const title = filtersHidingAll ? 'No items match current filters.' : 'No items in this queue.';
+      const title = itemSearch ? `No items match "${itemSearch}".` : (filtersHidingAll ? 'No items match current filters.' : 'No items in this queue.');
       const hiddenSummary = formatWorkqueueHiddenBreakdown(hiddenCounts);
       empty.innerHTML = `
         <div class="empty-state">
@@ -6661,6 +6668,7 @@ function renderWorkqueuePaneItems(pane) {
           <div class="hint">Queue: <span class="mono">${escapeHtml(queue)}</span> · Status: <span class="mono">${escapeHtml(statusLabel)}</span> · Scope: <span class="mono">${escapeHtml(scopeLabel)}</span></div>
           ${filtersHidingAll ? `<div class="hint" style="margin-top:6px;">Showing 0 of <span class="mono">${escapeHtml(String(totalCount))}</span> items${hiddenSummary ? ` · ${escapeHtml(hiddenSummary)}` : ''}.</div>` : ''}
           <div style="display:flex; gap:8px; margin-top:10px; flex-wrap:wrap;">
+            ${itemSearch ? '<button type="button" class="secondary" data-wq-empty-clear-search>Clear item search</button>' : ''}
             <button type="button" class="secondary" data-wq-empty-enqueue>Enqueue item</button>
             <button type="button" class="secondary" data-wq-empty-refresh>Refresh</button>
           </div>
@@ -6671,6 +6679,7 @@ function renderWorkqueuePaneItems(pane) {
       const refreshBtn = pane.elements?.thread?.querySelector('[data-wq-refresh]');
       const enqueueDetails = pane.elements?.thread?.querySelector('details.wq-enqueue');
       empty.querySelector('[data-wq-empty-refresh]')?.addEventListener('click', () => refreshBtn?.click());
+      empty.querySelector('[data-wq-empty-clear-search]')?.addEventListener('click', () => pane.workqueue?.setQuickSearch?.(''));
       empty.querySelector('[data-wq-empty-enqueue]')?.addEventListener('click', () => {
         try {
           enqueueDetails?.setAttribute('open', '');
@@ -9101,8 +9110,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       <div class="wq-toolbar">
         <div class="wq-toolbar-row">
           <label class="wq-field">
-            <span class="wq-label">Queue</span>
-            <input data-wq-queue-search type="search" placeholder="Search queues" aria-label="Search queues" autocomplete="off" />
+            <span class="wq-label">Queue target</span>
+            <input data-wq-queue-search type="search" placeholder="Filter queue list..." aria-label="Filter queue list" autocomplete="off" />
             <select data-wq-queue-select aria-label="Select workqueue target"></select>
             <input data-wq-queue-custom type="text" value="${escapeHtml(pane.workqueue.queue)}" placeholder="Custom queue" hidden />
           </label>
@@ -9151,8 +9160,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
           </div>
 
           <label class="wq-field wq-search-field">
-            <span class="wq-label">Search</span>
-            <input data-wq-search type="search" placeholder="Filter tasks" autocomplete="off" />
+            <span class="wq-label">Search items</span>
+            <input data-wq-search data-wq-item-search type="search" placeholder="Search items..." aria-label="Search items" autocomplete="off" />
           </label>
 
           <button data-wq-preset-clawnsole class="secondary" type="button">Clawnsole only</button>
@@ -12142,6 +12151,24 @@ window.addEventListener('keydown', (event) => {
   if (!event.defaultPrevented && roleState.role === 'admin') {
     const activeKey = focusedPaneKey() || paneMruOrder()[0] || '';
     const activePane = (paneManager?.panes || []).find((pane) => String(pane?.key || '') === activeKey);
+    if (
+      activePane?.kind === 'workqueue' &&
+      String(event.key || '') === '/' &&
+      !event.shiftKey &&
+      !event.metaKey &&
+      !event.ctrlKey &&
+      !event.altKey &&
+      !isTypingContext(event.target) &&
+      !isAnyOverlayOpen()
+    ) {
+      const itemSearch = activePane.elements?.thread?.querySelector?.('[data-wq-item-search]');
+      if (itemSearch) {
+        event.preventDefault();
+        itemSearch.focus();
+        itemSearch.select?.();
+        return;
+      }
+    }
     if (activePane?.kind === 'workqueue' && activePane?.workqueue?.keyboardMode) {
       if (handleWorkqueuePaneKeyboard(event, activePane)) return;
     }

--- a/styles.css
+++ b/styles.css
@@ -3119,6 +3119,15 @@ kbd {
   scrollbar-gutter: stable both-edges;
 }
 
+.wq-list:has([data-wq-empty]:not([hidden])) .wq-list-body {
+  flex: 0 0 auto;
+}
+
+.wq-list [data-wq-empty] {
+  position: relative;
+  z-index: 4;
+}
+
 /* Kanban-style board for Workqueue (Issue #89) */
 .wq-list-kanban {
   overflow: hidden;

--- a/tests/pane.workqueue.e2e.spec.js
+++ b/tests/pane.workqueue.e2e.spec.js
@@ -227,5 +227,5 @@ test('pane: workqueue scope filter toggles deterministic row counts', async ({ p
   await wqPane.locator('[data-wq-search]').fill(`missing-${runId}`);
   await expect(rowsWithPrefix()).toHaveCount(0);
   await expect(statusLine).toContainText(/Showing 0 of \d+ items .*hidden:.*search \d+/);
-  await expect(wqPane.locator('[data-wq-empty]')).toContainText('No items match current filters.');
+  await expect(wqPane.locator('[data-wq-empty]')).toContainText(`No items match "missing-${runId}".`);
 });

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -154,6 +154,47 @@ function seedFilterSummaryWorkqueueItems(queue) {
   fs.writeFileSync(path.join(dir, 'work-queues.json'), JSON.stringify(data, null, 2));
 }
 
+function seedQueueAndItemSearchWorkqueueItems({ queue, otherQueue }) {
+  const dir = path.join(env.tempHome, '.openclaw', 'clawnsole');
+  fs.mkdirSync(dir, { recursive: true });
+  const now = new Date();
+  const iso = (offsetMs) => new Date(now.getTime() + offsetMs).toISOString();
+  const mkItem = (id, title, instructions, patch = {}) => ({
+    id,
+    queue,
+    title,
+    instructions,
+    priority: 10,
+    status: 'ready',
+    claimedBy: '',
+    claimedAt: '',
+    leaseUntil: 0,
+    attempts: 0,
+    lastError: '',
+    createdAt: iso(-60000),
+    updatedAt: iso(-60000),
+    dedupeKey: `search-split-${id}`,
+    meta: { repo: 'rmdmattingly/clawnsole', source: 'playwright-search-split' },
+    ...patch
+  });
+
+  const data = {
+    version: 1,
+    queues: {
+      [queue]: { name: queue, createdAt: iso(-120000) },
+      [otherQueue]: { name: otherQueue, createdAt: iso(-120000) }
+    },
+    assignments: {},
+    items: [
+      mkItem('search-alpha', 'alpha release checklist', 'Title hit row'),
+      mkItem('search-beta', 'beta diagnostics', 'Contains instructions needle'),
+      mkItem('search-meta', 'metadata-only row', 'No visible query text', { meta: { repo: 'rmdmattingly/clawnsole', ticket: 'meta-only-needle' } }),
+      mkItem('other-queue-row', 'other queue item', 'Should not render in selected queue', { queue: otherQueue })
+    ]
+  };
+  fs.writeFileSync(path.join(dir, 'work-queues.json'), JSON.stringify(data, null, 2));
+}
+
 function seedExactDuplicateWorkqueueItems(queue) {
   const dir = path.join(env.tempHome, '.openclaw', 'clawnsole');
   fs.mkdirSync(dir, { recursive: true });
@@ -481,6 +522,55 @@ test('workqueue pane: filter summary chips show counts and remove filters', asyn
   await expect(wqPane.locator('[data-wq-statusline]')).toContainText('Showing 2 of 3 items');
   await expect(summary).not.toContainText('Search alternate repo');
   await expect(wqPane.locator('[data-wq-queue-custom]')).toHaveValue(queue);
+});
+
+test('workqueue pane: separates queue filtering from item search', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  const stamp = Date.now();
+  const queue = `queue-item-search-${stamp}`;
+  const otherQueue = `queue-picker-target-${stamp}`;
+  seedQueueAndItemSearchWorkqueueItems({ queue, otherQueue });
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  const wqPane = page.locator('[data-pane]').last();
+  const queueSearch = wqPane.locator('[data-wq-queue-search]');
+  const itemSearch = wqPane.locator('[data-wq-item-search]');
+
+  await expect(queueSearch).toHaveAttribute('placeholder', 'Filter queue list...');
+  await expect(itemSearch).toHaveAttribute('placeholder', 'Search items...');
+
+  await wqPane.locator('[data-wq-queue-select]').selectOption('__custom__');
+  await wqPane.locator('[data-wq-queue-custom]').fill(queue);
+  await wqPane.locator('[data-wq-queue-custom]').press('Enter');
+  await expect(wqPane.locator('.wq-row')).toHaveCount(3);
+
+  await queueSearch.fill('picker-target');
+  await expect(wqPane.locator('[data-wq-queue-select] option:not([hidden])', { hasText: otherQueue })).toHaveCount(1);
+  await expect(wqPane.locator('.wq-row')).toHaveCount(3);
+
+  await itemSearch.fill('instructions needle');
+  await expect(wqPane.locator('.wq-row')).toHaveCount(1);
+  await expect(wqPane.locator('.wq-row')).toContainText('beta diagnostics');
+
+  await itemSearch.fill('meta-only-needle');
+  await expect(wqPane.locator('.wq-row')).toHaveCount(1);
+  await expect(wqPane.locator('.wq-row')).toContainText('metadata-only row');
+
+  await itemSearch.fill('missing-query');
+  await expect(wqPane.locator('[data-wq-empty]')).toContainText('No items match "missing-query".');
+  await wqPane.locator('[data-wq-empty-clear-search]').click();
+  await expect(itemSearch).toHaveValue('');
+  await expect(wqPane.locator('.wq-row')).toHaveCount(3);
+
+  await wqPane.click();
+  await page.keyboard.press('/');
+  await expect(itemSearch).toBeFocused();
 });
 
 test('workqueue pane: default rows collapse exact duplicates with expandable members', async ({ page }) => {


### PR DESCRIPTION
## Summary
- relabel the queue picker search as queue-list filtering only
- make item search explicit, searchable by title/instructions/repo/source/meta, with / focus when a Workqueue pane is active
- add empty-state clear affordance and Playwright coverage for queue-filter vs item-search behavior

## Tests
- npm run test:syntax
- npx playwright test tests/ui/workqueue-pane.spec.js --grep "separates queue filtering from item search|filter summary chips" --workers=1 --timeout=60000

Fixes #332