### PR TITLE
Complete fleet triage keyboard loop

### DIFF
--- a/app.js
+++ b/app.js
@@ -385,7 +385,9 @@ const KEYBIND_CATALOG = [
   { id: 'fleet.sortHeartbeatGlobal', group: 'Fleet actions', label: 'Open Fleet sorted by heartbeat age', binding: { accel: true, shift: true, key: 'h', display: 'Cmd/Ctrl+Shift+H' } },
   { id: 'fleet.next', group: 'Fleet actions', label: 'Move Fleet selection down', binding: { key: 'j', display: 'J / Down' } },
   { id: 'fleet.prev', group: 'Fleet actions', label: 'Move Fleet selection up', binding: { key: 'k', display: 'K / Up' } },
-  { id: 'fleet.runSelected', group: 'Fleet actions', label: 'Run selected Fleet agent', binding: { key: 'Enter', display: 'Enter' } },
+  { id: 'fleet.openSelectedChat', group: 'Fleet actions', label: 'Open Chat for selected Fleet agent', binding: { key: 'Enter', display: 'Enter' } },
+  { id: 'fleet.openSelectedWorkqueue', group: 'Fleet actions', label: 'Open Workqueue for selected Fleet agent', binding: { shift: true, key: 'Enter', display: 'Shift+Enter' } },
+  { id: 'fleet.openSelectedTimeline', group: 'Fleet actions', label: 'Open Timeline for selected Fleet agent', binding: { key: '.', display: '.' } },
   { id: 'fleet.toggleHeartbeatSort', group: 'Fleet actions', label: 'Toggle Fleet heartbeat age sort', binding: { key: 'h', display: 'H / Shift+H' } }
 ];
 
@@ -5368,6 +5370,7 @@ function runFleetSelectedAgent(mode = 'chat') {
   const id = String(fleetSelectionState.selectedAgentId || '').trim();
   if (!id) return false;
   if (mode === 'workqueue') openAgentWorkqueueFromFleet(id);
+  else if (mode === 'timeline') openAgentTimelineFromFleet(id);
   else openAgentChatFromFleet(id);
   return true;
 }
@@ -11626,6 +11629,11 @@ globalElements.agentsModal?.addEventListener('keydown', (event) => {
     if (key === 'Enter') {
       event.preventDefault();
       runFleetSelectedAgent(event.shiftKey ? 'workqueue' : 'chat');
+      return;
+    }
+    if (key === '.') {
+      event.preventDefault();
+      runFleetSelectedAgent('timeline');
       return;
     }
   }

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -136,6 +136,9 @@ test('shortcuts overlay stays in sync with registered shortcut catalog', async (
   await expect(modal).toContainText('Fleet actions');
   await expect(modal).toContainText('Open/focus Fleet pane');
   await expect(modal).toContainText('Open Fleet sorted by heartbeat age');
+  await expect(modal).toContainText('Open Chat for selected Fleet agent');
+  await expect(modal).toContainText('Open Workqueue for selected Fleet agent');
+  await expect(modal).toContainText('Open Timeline for selected Fleet agent');
 });
 
 test('pane-add shortcuts are scoped to workspace and blocked by overlays', async ({ page }) => {

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -325,6 +325,12 @@ test('fleet refresh keeps scroll anchor and keyboard triage selection', async ({
     page.locator('[data-pane][data-pane-kind="workqueue"] [data-wq-claim-agent]')
       .evaluateAll((els) => els.map((el) => el.value))
   )).toContain('agent-20');
+  await reopenedRow20.click();
+  await page.keyboard.press('.');
+  await expect.poll(async () => (
+    page.locator('[data-pane][data-pane-kind="timeline"] [data-cron-agent]')
+      .evaluateAll((els) => els.map((el) => el.value))
+  )).toContain('agent-20');
 
   const search = page.locator('#agentsSearch');
   await search.fill('agent');


### PR DESCRIPTION
## Summary\n- expose distinct Fleet shortcut catalog entries for Enter, Shift+Enter, and period actions\n- add period handling to open the selected Fleet agent timeline\n- extend UI coverage for selected-agent Timeline and shortcut modal discoverability\n\nFixes #259\n\n## Tests\n- npm run test:syntax\n- npx playwright test tests/ui/agents-modal.spec.js --grep "fleet refresh keeps scroll anchor"\n- npx playwright test tests/pane.shortcuts.e2e.spec.js --grep "shortcuts overlay"