### PR TITLE
Add triage layout preset

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ const globalElements = {
   deviceId: document.getElementById('deviceId'),
   disconnectBtn: document.getElementById('disconnectBtn'),
   resetLayoutBtn: document.getElementById('resetLayoutBtn'),
+  triageLayoutPresetBtn: document.getElementById('triageLayoutPresetBtn'),
   recurringPromptTarget: document.getElementById('recurringPromptTarget'),
   recurringPromptInterval: document.getElementById('recurringPromptInterval'),
   recurringPromptTimezone: document.getElementById('recurringPromptTimezone'),
@@ -2014,6 +2015,35 @@ function closeSettings() {
   globalElements.settingsModal.classList.remove('open');
   globalElements.settingsModal.setAttribute('aria-hidden', 'true');
   shortcutOverridesDraft = null;
+}
+
+function applyTriageLayoutPreset() {
+  if (roleState.role !== 'admin') return null;
+
+  const defaultAgent = normalizeAgentId(storage.get(ADMIN_DEFAULT_AGENT_KEY, 'main') || 'main');
+  const panes = () => Array.isArray(paneManager?.panes) ? paneManager.panes : [];
+
+  let chatPane = panes().find((pane) => pane?.role === 'admin' && pane.kind === 'chat') || null;
+  if (!chatPane) chatPane = paneManager.addPane('chat', { agentId: defaultAgent });
+
+  let workqueuePane = panes().find((pane) =>
+    pane?.role === 'admin' &&
+    pane.kind === 'workqueue' &&
+    String(pane.workqueue?.queue || '').trim() === 'dev-team'
+  ) || null;
+  if (!workqueuePane) workqueuePane = paneManager.addPane('workqueue', { queue: 'dev-team' });
+
+  let fleetPane = panes().find((pane) =>
+    pane?.role === 'admin' &&
+    pane.kind === 'timeline' &&
+    String(pane.cronAgentId || '').trim() === 'all'
+  ) || null;
+  if (!fleetPane) fleetPane = openFleetPane();
+
+  if (chatPane) paneManager.focusPanePrimary(chatPane);
+  paneManager.persistAdminPanes();
+  showToast('Triage preset ready: Chat + Workqueue + Fleet.', { kind: 'success', timeoutMs: 1800, testId: 'triage-preset-toast' });
+  return { chatPane, workqueuePane, fleetPane };
 }
 
 const SHORTCUT_OVERRIDE_ACTIONS = [
@@ -4181,6 +4211,22 @@ function buildCommandPaletteItems() {
     ),
     withShortcut(
       {
+        id: 'cmd:triage-layout-preset',
+        label: 'Layout: Triage focus',
+        detail: 'Apply Chat + Workqueue + Fleet panes without duplicating existing panes',
+        paneMeta: [
+          { label: 'Chat', tone: 'type' },
+          { label: 'Workqueue', tone: 'type' },
+          { label: 'Fleet', tone: 'type' },
+          { label: 'reuse existing', tone: 'reuse' }
+        ],
+        searchText: 'triage preset chat workqueue fleet layout',
+        run: () => applyTriageLayoutPreset()
+      },
+      ''
+    ),
+    withShortcut(
+      {
         id: 'cmd:toggle-layout-lock',
         label: 'Layout: Toggle lock',
         detail: paneManager.isLayoutLocked() ? 'Unlock pane reordering' : 'Lock pane reordering',
@@ -4311,9 +4357,9 @@ function buildCommandPaletteItems() {
       }
       return enriched;
     }
-    if (id === 'cmd:reset-layout') {
+    if (id === 'cmd:reset-layout' || id === 'cmd:triage-layout-preset') {
       enriched.group = 'Layout';
-      enriched.priority = 100;
+      enriched.priority = id === 'cmd:triage-layout-preset' ? 105 : 100;
       return enriched;
     }
     if (id === 'cmd:toggle-shortcuts') {
@@ -4792,6 +4838,7 @@ function openFleetPane({ forceNew = false } = {}) {
   pane.cronAgentId = target;
   paneManager.persistAdminPanes();
   paneManager.focusPanePrimary(pane);
+  return pane;
 }
 
 function openAgentWorkqueueFromFleet(agentId) {
@@ -10677,7 +10724,8 @@ const paneManager = {
           return { key, kind, agentId, queue, statusFilter, scopeFilter, quickFilters, groupMode, sortKey, sortDir, nickname, pairedTargetLock };
         }
         if (kind === 'cron' || kind === 'timeline') {
-          return { key, kind, nickname };
+          const cronAgentId = typeof item.cronAgentId === 'string' ? item.cronAgentId.trim() : '';
+          return { key, kind, cronAgentId, nickname };
         }
         const agentId = normalizeAgentId(typeof item.agentId === 'string' ? item.agentId : defaultAgent);
         return { key, kind: 'chat', agentId, nickname, pairedTargetLock: !!item.pairedTargetLock };
@@ -10729,7 +10777,7 @@ const paneManager = {
         };
       }
       if (pane.kind === 'cron' || pane.kind === 'timeline') {
-        return { key: pane.key, kind: pane.kind, nickname: paneNickname(pane) };
+        return { key: pane.key, kind: pane.kind, cronAgentId: String(pane.cronAgentId || '').trim(), nickname: paneNickname(pane) };
       }
       return { key: pane.key, kind: 'chat', agentId: pane.agentId || 'main', nickname: paneNickname(pane), pairedTargetLock: !!pane.pairedTargetLock };
     });
@@ -12572,6 +12620,11 @@ globalElements.addChatPaneBtn?.addEventListener('click', (event) => {
 globalElements.addQueuePaneBtn?.addEventListener('click', (event) => {
   event?.preventDefault?.();
   paneManager.addPane('workqueue');
+});
+
+globalElements.triageLayoutPresetBtn?.addEventListener('click', (event) => {
+  event?.preventDefault?.();
+  applyTriageLayoutPreset();
 });
 
 // layoutSelect deprecated; layout is inferred from pane count.

--- a/index.html
+++ b/index.html
@@ -512,6 +512,7 @@
           <div class="button-row">
             <button id="disconnectBtn">Disconnect</button>
             <button id="resetLayoutBtn" type="button" class="secondary">Reset to recommended layout</button>
+            <button id="triageLayoutPresetBtn" type="button" class="secondary">Triage preset</button>
           </div>
           <div class="hint">
             Auto-connecting with the gateway token from your local OpenClaw config.

--- a/tests/ui/command-palette.spec.js
+++ b/tests/ui/command-palette.spec.js
@@ -204,3 +204,45 @@ test('command palette: opens or focuses Workqueue for active chat agent', async 
   await runCommand('workqueue for active chat agent');
   await expect(page.getByTestId('toast').filter({ hasText: 'No active chat agent selected' })).toBeVisible();
 });
+
+test('layout triage preset reuses panes and preserves chat draft', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+  await loginAdminWithChatOnlyPane(page, env.serverPort);
+
+  const chatInput = page.locator('[data-pane][data-pane-kind="chat"]').first().locator('[data-pane-input]');
+  await expect(chatInput).toBeVisible();
+  await chatInput.fill('draft stays put');
+  await expect(page.locator('[data-pane]')).toHaveCount(1);
+
+  await page.getByRole('button', { name: 'Open settings' }).click();
+  await expect(page.locator('#triageLayoutPresetBtn')).toBeVisible();
+  await page.keyboard.press('Escape');
+
+  await page.keyboard.press('ControlOrMeta+K');
+  const input = page.locator('#commandPaletteInput');
+  await expect(input).toBeVisible();
+  await input.fill('triage preset');
+  const firstHit = page.locator('#commandPaletteList [role="option"]').first();
+  await expect(firstHit).toHaveAttribute('data-command-palette-id', 'cmd:triage-layout-preset');
+  await expect(firstHit.locator('.command-palette-item-label')).toHaveText('Layout: Triage focus');
+  await page.keyboard.press('Enter');
+
+  await expect(page.locator('[data-pane][data-pane-kind="chat"]')).toHaveCount(1);
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
+  await expect(page.locator('[data-pane][data-pane-kind="timeline"]')).toHaveCount(1);
+  await expect(chatInput).toHaveValue('draft stays put');
+
+  await page.keyboard.press('ControlOrMeta+K');
+  await expect(input).toBeVisible();
+  await input.fill('triage preset');
+  await page.keyboard.press('Enter');
+
+  await expect(page.locator('[data-pane]')).toHaveCount(3);
+  await expect(page.locator('[data-pane][data-pane-kind="chat"]')).toHaveCount(1);
+  await expect(page.locator('[data-pane][data-pane-kind="workqueue"]')).toHaveCount(1);
+  await expect(page.locator('[data-pane][data-pane-kind="timeline"]')).toHaveCount(1);
+  await expect(chatInput).toHaveValue('draft stays put');
+});


### PR DESCRIPTION
## Summary
- Add a Settings quick action for a triage layout preset: Chat + Workqueue + Fleet.
- Add a command palette action for the same preset, reusing existing panes instead of duplicating them.
- Preserve Timeline/Fleet target persistence and cover idempotent preset behavior with Playwright.

## Tests
- npm test
- npm run test:ui -- tests/ui/command-palette.spec.js

Fixes #340
