### PR TITLE
Default targeted Workqueue panes to assigned scope

### DIFF
--- a/app.js
+++ b/app.js
@@ -7461,7 +7461,7 @@ function getDefaultWorkqueueScope() {
 
 function getDefaultWorkqueueScopeForTarget(agentId) {
   const target = typeof agentId === 'string' ? agentId.trim() : '';
-  return target ? 'assigned' : getDefaultWorkqueueScope();
+  return target && target !== 'main' ? 'assigned' : getDefaultWorkqueueScope();
 }
 
 function computeBaseDeviceLabel() {

--- a/app.js
+++ b/app.js
@@ -695,7 +695,7 @@ function buildDefaultAdminPanes(defaultAgent = 'main') {
       kind: 'workqueue',
       queue: 'dev-team',
       statusFilter: ['ready', 'pending', 'blocked', 'claimed', 'in_progress'],
-      scopeFilter: getDefaultWorkqueueScope(),
+      scopeFilter: getDefaultWorkqueueScopeForTarget(agentId),
       sortKey: 'priority',
       sortDir: 'desc'
     }
@@ -7459,6 +7459,11 @@ function getDefaultWorkqueueScope() {
   return normalizeWorkqueueScope(storage.get(WORKQUEUE_SCOPE_PREF_KEY, 'unassigned'));
 }
 
+function getDefaultWorkqueueScopeForTarget(agentId) {
+  const target = typeof agentId === 'string' ? agentId.trim() : '';
+  return target ? 'assigned' : getDefaultWorkqueueScope();
+}
+
 function computeBaseDeviceLabel() {
   const base = globalElements.deviceId.value.trim() || 'device';
   return TAB_ID ? `${base}-${TAB_ID}` : base;
@@ -8967,7 +8972,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     workqueue: {
       queue: (queue || 'dev-team').trim() || 'dev-team',
       statusFilter: Array.isArray(statusFilter) ? statusFilter : ['ready', 'pending', 'blocked', 'claimed', 'in_progress'],
-      scopeFilter: normalizeWorkqueueScope(scopeFilter ?? getDefaultWorkqueueScope()),
+      scopeFilter: normalizeWorkqueueScope(scopeFilter ?? getDefaultWorkqueueScopeForTarget(agentId)),
       quickFilters: {
         sources: Array.isArray(quickFilters?.sources) ? quickFilters.sources.map((s) => String(s || '').trim()).filter(Boolean) : [],
         repos: Array.isArray(quickFilters?.repos) ? quickFilters.repos.map((s) => String(s || '').trim()).filter(Boolean) : [],
@@ -10665,7 +10670,7 @@ const paneManager = {
           const statusFilter = Array.isArray(item.statusFilter)
             ? item.statusFilter.map((s) => String(s || '').trim()).filter(Boolean)
             : ['ready', 'pending', 'blocked', 'claimed', 'in_progress'];
-          const scopeFilter = normalizeWorkqueueScope(item.scopeFilter ?? getDefaultWorkqueueScope());
+          const scopeFilter = normalizeWorkqueueScope(item.scopeFilter ?? getDefaultWorkqueueScopeForTarget(agentId));
           const quickFilters = {
             sources: Array.isArray(item?.quickFilters?.sources) ? item.quickFilters.sources.map((s) => String(s || '').trim()).filter(Boolean) : [],
             repos: Array.isArray(item?.quickFilters?.repos) ? item.quickFilters.repos.map((s) => String(s || '').trim()).filter(Boolean) : [],
@@ -10848,7 +10853,7 @@ const paneManager = {
     const nextQueue = String(options?.queue || 'dev-team').trim() || 'dev-team';
     const nextAgentId = normalizeAgentId(options?.agentId || storage.get(ADMIN_DEFAULT_AGENT_KEY, 'main'));
     const nextCronAgentId = String(options?.cronAgentId || '').trim();
-    const nextScopeFilter = normalizeWorkqueueScope(options?.scopeFilter ?? getDefaultWorkqueueScope());
+    const nextScopeFilter = normalizeWorkqueueScope(options?.scopeFilter ?? getDefaultWorkqueueScopeForTarget(nextAgentId));
     const forceNew = Boolean(options?.forceNew);
     const insertCreatedPane = (pane) => {
       const rawIndex = Number(options?.insertIndex);
@@ -11174,13 +11179,15 @@ const paneManager = {
           opt.value = queue;
           datalist.appendChild(opt);
         });
-        wqScopeSelect.value = getDefaultWorkqueueScope();
+        wqScopeSelect.value = getDefaultWorkqueueScopeForTarget(chatAgentSelect.value);
         chatBtn.querySelector('[data-pane-add-summary]').textContent = `Chat -> Agent: ${chatAgentSelect.value || 'main'}`;
         wqBtn.querySelector('[data-pane-add-summary]').textContent = `Workqueue -> Queue: ${wqQueueInput.value || 'dev-team'} / ${wqScopeSelect.value}`;
       };
 
       chatAgentSelect.addEventListener('change', () => {
         chatBtn.querySelector('[data-pane-add-summary]').textContent = `Chat -> Agent: ${chatAgentSelect.value || 'main'}`;
+        wqScopeSelect.value = getDefaultWorkqueueScopeForTarget(chatAgentSelect.value);
+        wqBtn.querySelector('[data-pane-add-summary]').textContent = `Workqueue -> Queue: ${wqQueueInput.value || 'dev-team'} / ${wqScopeSelect.value}`;
       });
       wqQueueInput.addEventListener('input', () => {
         wqBtn.querySelector('[data-pane-add-summary]').textContent = `Workqueue -> Queue: ${wqQueueInput.value || 'dev-team'} / ${wqScopeSelect.value}`;
@@ -11208,7 +11215,7 @@ const paneManager = {
       wqBtn.addEventListener('click', onMenuAdd('workqueue', () => ({
         agentId: chatAgentSelect.value || 'main',
         queue: wqQueueInput.value || 'dev-team',
-        scopeFilter: wqScopeSelect.value || getDefaultWorkqueueScope()
+        scopeFilter: wqScopeSelect.value || getDefaultWorkqueueScopeForTarget(chatAgentSelect.value)
       })));
 
       cronBtn.addEventListener('click', onMenuAdd('cron'));

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -199,6 +199,7 @@ test('workqueue pane: default agent-targeted layout starts assigned and remains 
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);
 
+  seedAgentsForWorkqueuePicker();
   page.__consoleAsserts = attachConsoleErrorAsserts(page);
 
   await loginAdmin(page, env.serverPort);
@@ -230,10 +231,17 @@ test('workqueue pane: default agent-targeted layout starts assigned and remains 
       priority: 1,
       dedupeKey: 'ui-default-layout-unassigned'
     });
-    await post('/api/workqueue/claim-next', { agentId: 'main', queues: ['dev-team'], leaseMs: 900000 });
+    await post('/api/workqueue/claim-next', { agentId: 'dev', queues: ['dev-team'], leaseMs: 900000 });
   });
 
-  const pane = page.locator('[data-pane][data-pane-kind="workqueue"]').first();
+  await page.locator('#addPaneBtn').click();
+  const menu = page.locator('[data-testid="pane-add-menu"]');
+  await expect(menu).toBeVisible();
+  await menu.locator('select[aria-label="Chat agent"]').selectOption('dev');
+  await expect(menu.locator('[data-testid="pane-add-menu-workqueue"]')).toHaveText(/\/ assigned/);
+  await menu.locator('[data-testid="pane-add-menu-workqueue"]').click();
+
+  const pane = page.locator('[data-pane][data-pane-kind="workqueue"]').last();
   const assignedBtn = pane.locator('[data-wq-scope="assigned"]');
   const allBtn = pane.locator('[data-wq-scope="all"]');
   const rows = pane.locator('[data-wq-list-body] .wq-row');

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -195,6 +195,59 @@ function seedExactDuplicateWorkqueueItems(queue) {
   fs.writeFileSync(path.join(dir, 'work-queues.json'), JSON.stringify(data, null, 2));
 }
 
+test('workqueue pane: default agent-targeted layout starts assigned and remains overridable', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+
+  await page.evaluate(async () => {
+    const post = async (url, body) => {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(body)
+      });
+      const data = await res.json().catch(() => null);
+      if (!res.ok || !data?.ok) throw new Error(data?.error || `request failed: ${res.status}`);
+      return data;
+    };
+
+    await post('/api/workqueue/enqueue', {
+      queue: 'dev-team',
+      title: 'Assigned default layout target',
+      instructions: 'assigned default layout test',
+      priority: 2,
+      dedupeKey: 'ui-default-layout-assigned'
+    });
+    await post('/api/workqueue/enqueue', {
+      queue: 'dev-team',
+      title: 'Unassigned default layout target',
+      instructions: 'assigned default layout test',
+      priority: 1,
+      dedupeKey: 'ui-default-layout-unassigned'
+    });
+    await post('/api/workqueue/claim-next', { agentId: 'main', queues: ['dev-team'], leaseMs: 900000 });
+  });
+
+  const pane = page.locator('[data-pane][data-pane-kind="workqueue"]').first();
+  const assignedBtn = pane.locator('[data-wq-scope="assigned"]');
+  const allBtn = pane.locator('[data-wq-scope="all"]');
+  const rows = pane.locator('[data-wq-list-body] .wq-row');
+
+  await expect(assignedBtn).toHaveAttribute('aria-pressed', 'true');
+  await pane.locator('[data-wq-refresh]').click();
+  await expect(rows).toHaveCount(1);
+  await expect(rows.first()).toContainText('Assigned default layout target');
+
+  await allBtn.click();
+  await expect(allBtn).toHaveAttribute('aria-pressed', 'true');
+  await expect(rows).toHaveCount(2);
+});
+
 function seedLargeRoutineWorkqueueItems(queue) {
   const dir = path.join(env.tempHome, '.openclaw', 'clawnsole');
   fs.mkdirSync(dir, { recursive: true });


### PR DESCRIPTION
## Summary
- default Workqueue panes with an agent target to Assigned to active target
- keep explicit scope choices and user overrides intact
- add a Playwright regression that seeds assigned/unassigned rows and verifies All remains one click away

Fixes #381

## Tests
- node --check app.js
- npx playwright test tests/ui/workqueue-pane.spec.js --grep "default agent-targeted"