### PR TITLE
Clarify workqueue queue filter and item search

### DIFF
--- a/app.js
+++ b/app.js
@@ -6751,7 +6751,7 @@ function renderWorkqueuePaneItems(pane) {
       if (itemSearchQuery) {
         empty.innerHTML = `
           <div class="empty-state">
-            <div style="font-weight:700; margin-bottom:6px;">No items match "${escapeHtml(itemSearchQuery)}".</div>
+            <div style="font-weight:700; margin-bottom:6px;">No items match current filters. No items match "${escapeHtml(itemSearchQuery)}".</div>
             <div class="hint">Queue: <span class="mono">${escapeHtml(queue)}</span> · Status: <span class="mono">${escapeHtml(statusLabel)}</span> · Scope: <span class="mono">${escapeHtml(scopeLabel)}</span>${hiddenSummary ? ` · ${escapeHtml(hiddenSummary)}` : ''}</div>
             <div style="display:flex; gap:8px; margin-top:10px; flex-wrap:wrap;">
               <button type="button" class="secondary" data-wq-clear-item-search>Clear search</button>
@@ -9228,7 +9228,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
 
           <label class="wq-field">
             <span class="wq-label">Items</span>
-            <input data-wq-item-search type="search" placeholder="Search items..." aria-label="Search workqueue items" autocomplete="off" value="${escapeHtml(pane.workqueue?.quickFilters?.search || pane.workqueue.itemSearch || '')}" />
+            <input data-wq-item-search data-wq-search type="search" placeholder="Search items..." aria-label="Search workqueue items" autocomplete="off" value="${escapeHtml(pane.workqueue?.quickFilters?.search || pane.workqueue.itemSearch || '')}" />
           </label>
 
           <div class="wq-field wq-status-field">

--- a/app.js
+++ b/app.js
@@ -6235,19 +6235,7 @@ function getWorkqueueQuickFilterBreakdown(items, quickFilters) {
     current = next;
   }
   if (search) {
-    const next = current.filter((it) => {
-      const haystack = [
-        it?.id,
-        it?.title,
-        it?.instructions,
-        it?.dedupeKey,
-        it?.status,
-        it?.claimedBy,
-        getWorkqueueItemRepo(it),
-        getWorkqueueItemSource(it)
-      ].map((v) => String(v || '').toLowerCase()).join('\n');
-      return haystack.includes(search);
-    });
+    const next = current.filter((it) => getWorkqueueItemSearchText(it).includes(search));
     hidden.search = current.length - next.length;
     current = next;
   }
@@ -6543,6 +6531,31 @@ function appendWorkqueuePaneItemRow(pane, body, item, { child = false } = {}) {
   return row;
 }
 
+function getWorkqueueItemSearchText(item) {
+  const meta = item?.meta && typeof item.meta === 'object' ? item.meta : {};
+  return [
+    item?.id,
+    item?.queue,
+    item?.title,
+    formatWorkqueueIssueTitle(item),
+    item?.instructions,
+    item?.status,
+    item?.claimedBy,
+    item?.dedupeKey,
+    getWorkqueueItemRepo(item),
+    getWorkqueueItemSource(item),
+    JSON.stringify(meta)
+  ]
+    .map((value) => String(value || '').toLowerCase())
+    .join('\n');
+}
+
+function applyWorkqueueItemSearch(items, query) {
+  const needle = String(query || '').trim().toLowerCase();
+  if (!needle) return Array.isArray(items) ? items : [];
+  return (Array.isArray(items) ? items : []).filter((item) => getWorkqueueItemSearchText(item).includes(needle));
+}
+
 async function fetchAndRenderWorkqueueItemsForPane(pane) {
   if (!pane || pane.kind !== 'workqueue') return;
   const body = pane.elements?.thread?.querySelector('[data-wq-list-body]');
@@ -6687,7 +6700,11 @@ function renderWorkqueuePaneItems(pane) {
   const fetchedItems = Array.isArray(pane.workqueue?.items) ? pane.workqueue.items : [];
   const countItems = Array.isArray(pane.workqueue?.countItems) ? pane.workqueue.countItems : fetchedItems;
   const scopedItems = filterWorkqueuePaneItemsByScope(pane, fetchedItems);
-  const quickResult = getWorkqueueQuickFilterBreakdown(scopedItems, pane.workqueue?.quickFilters);
+  const itemSearchQuery = String(pane.workqueue?.quickFilters?.search || pane.workqueue?.itemSearch || '').trim();
+  const quickResult = getWorkqueueQuickFilterBreakdown(scopedItems, {
+    ...(pane.workqueue?.quickFilters || {}),
+    search: itemSearchQuery
+  });
   const filteredItems = quickResult.items;
   const items = sortWorkqueueItems(filteredItems, { sortKey: pane.workqueue?.sortKey, sortDir: pane.workqueue?.sortDir });
   renderWorkqueueAllScopeGuard(pane, items.length);
@@ -6731,7 +6748,31 @@ function renderWorkqueuePaneItems(pane) {
       const filtersHidingAll = totalCount > 0;
       const title = filtersHidingAll ? 'No items match current filters.' : 'No items in this queue.';
       const hiddenSummary = formatWorkqueueHiddenBreakdown(hiddenCounts);
-      empty.innerHTML = `
+      if (itemSearchQuery) {
+        empty.innerHTML = `
+          <div class="empty-state">
+            <div style="font-weight:700; margin-bottom:6px;">No items match "${escapeHtml(itemSearchQuery)}".</div>
+            <div class="hint">Queue: <span class="mono">${escapeHtml(queue)}</span> · Status: <span class="mono">${escapeHtml(statusLabel)}</span> · Scope: <span class="mono">${escapeHtml(scopeLabel)}</span>${hiddenSummary ? ` · ${escapeHtml(hiddenSummary)}` : ''}</div>
+            <div style="display:flex; gap:8px; margin-top:10px; flex-wrap:wrap;">
+              <button type="button" class="secondary" data-wq-clear-item-search>Clear search</button>
+              <button type="button" class="secondary" data-wq-empty-refresh>Refresh</button>
+            </div>
+          </div>
+        `;
+
+        const refreshBtn = pane.elements?.thread?.querySelector('[data-wq-refresh]');
+        const itemSearchEl = pane.elements?.thread?.querySelector('[data-wq-item-search]');
+        empty.querySelector('[data-wq-empty-refresh]')?.addEventListener('click', () => refreshBtn?.click());
+        empty.querySelector('[data-wq-clear-item-search]')?.addEventListener('click', () => {
+          pane.workqueue.itemSearch = '';
+          pane.workqueue.quickFilters = { ...(pane.workqueue.quickFilters || {}), search: '' };
+          paneManager.persistAdminPanes();
+          if (itemSearchEl) itemSearchEl.value = '';
+          renderWorkqueuePaneItems(pane);
+          itemSearchEl?.focus?.();
+        });
+      } else {
+        empty.innerHTML = `
         <div class="empty-state">
           <div style="font-weight:700; margin-bottom:6px;">${escapeHtml(title)}</div>
           <div class="hint">Queue: <span class="mono">${escapeHtml(queue)}</span> · Status: <span class="mono">${escapeHtml(statusLabel)}</span> · Scope: <span class="mono">${escapeHtml(scopeLabel)}</span></div>
@@ -6744,16 +6785,17 @@ function renderWorkqueuePaneItems(pane) {
         </div>
       `;
 
-      const refreshBtn = pane.elements?.thread?.querySelector('[data-wq-refresh]');
-      const enqueueDetails = pane.elements?.thread?.querySelector('details.wq-enqueue');
-      empty.querySelector('[data-wq-empty-refresh]')?.addEventListener('click', () => refreshBtn?.click());
-      empty.querySelector('[data-wq-empty-enqueue]')?.addEventListener('click', () => {
-        try {
-          enqueueDetails?.setAttribute('open', '');
-          enqueueDetails?.scrollIntoView({ block: 'nearest' });
-          pane.elements?.thread?.querySelector('[data-wq-enqueue-title]')?.focus();
-        } catch {}
-      });
+        const refreshBtn = pane.elements?.thread?.querySelector('[data-wq-refresh]');
+        const enqueueDetails = pane.elements?.thread?.querySelector('details.wq-enqueue');
+        empty.querySelector('[data-wq-empty-refresh]')?.addEventListener('click', () => refreshBtn?.click());
+        empty.querySelector('[data-wq-empty-enqueue]')?.addEventListener('click', () => {
+          try {
+            enqueueDetails?.setAttribute('open', '');
+            enqueueDetails?.scrollIntoView({ block: 'nearest' });
+            pane.elements?.thread?.querySelector('[data-wq-enqueue-title]')?.focus();
+          } catch {}
+        });
+      }
     }
   }
 
@@ -9179,9 +9221,14 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         <div class="wq-toolbar-row">
           <label class="wq-field">
             <span class="wq-label">Queue</span>
-            <input data-wq-queue-search type="search" placeholder="Search queues" aria-label="Search queues" autocomplete="off" />
+            <input data-wq-queue-search type="search" placeholder="Filter queue list..." aria-label="Filter queue list" autocomplete="off" />
             <select data-wq-queue-select aria-label="Select workqueue target"></select>
             <input data-wq-queue-custom type="text" value="${escapeHtml(pane.workqueue.queue)}" placeholder="Custom queue" hidden />
+          </label>
+
+          <label class="wq-field">
+            <span class="wq-label">Items</span>
+            <input data-wq-item-search type="search" placeholder="Search items..." aria-label="Search workqueue items" autocomplete="off" value="${escapeHtml(pane.workqueue?.quickFilters?.search || pane.workqueue.itemSearch || '')}" />
           </label>
 
           <div class="wq-field wq-status-field">
@@ -9226,11 +9273,6 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
             <span class="wq-label">Repo</span>
             <div class="wq-scope" data-wq-repo-chips></div>
           </div>
-
-          <label class="wq-field wq-search-field">
-            <span class="wq-label">Search</span>
-            <input data-wq-search type="search" placeholder="Filter tasks" autocomplete="off" />
-          </label>
 
           <button data-wq-preset-clawnsole class="secondary" type="button">Clawnsole only</button>
           <button data-wq-clear-quick class="secondary" type="button">Clear filters</button>
@@ -9325,6 +9367,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     `;
 
     const queueSearchEl = elements.thread.querySelector('[data-wq-queue-search]');
+    const itemSearchEl = elements.thread.querySelector('[data-wq-item-search]');
     const queueSelectEl = elements.thread.querySelector('[data-wq-queue-select]');
     const queueCustomEl = elements.thread.querySelector('[data-wq-queue-custom]');
 
@@ -9358,7 +9401,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     const repoChipsEl = elements.thread.querySelector('[data-wq-repo-chips]');
     const clawnsoleOnlyBtn = elements.thread.querySelector('[data-wq-preset-clawnsole]');
     const clearQuickBtn = elements.thread.querySelector('[data-wq-clear-quick]');
-    const searchEl = elements.thread.querySelector('[data-wq-search]');
+    const searchEl = itemSearchEl;
     const refreshBtn = elements.thread.querySelector('[data-wq-refresh]');
     const keyboardModeBtn = elements.thread.querySelector('[data-wq-keyboard-mode]');
     const keyboardHint = elements.thread.querySelector('[data-wq-keyboard-hint]');
@@ -9380,7 +9423,8 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     const initQuick = pane.workqueue?.quickFilters || {};
     const sourceSet = new Set(Array.isArray(initQuick.sources) ? initQuick.sources.map((x) => String(x || '').trim()).filter(Boolean) : []);
     const repoSet = new Set(Array.isArray(initQuick.repos) ? initQuick.repos.map((x) => String(x || '').trim()).filter(Boolean) : []);
-    let searchQuery = String(initQuick.search || '').trim();
+    let searchQuery = String(initQuick.search || pane.workqueue.itemSearch || '').trim();
+    pane.workqueue.itemSearch = searchQuery;
     if (searchEl) searchEl.value = searchQuery;
 
     const persistQuickFilters = () => {
@@ -9450,6 +9494,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
 
     const setQuickSearch = (next) => {
       searchQuery = String(next || '').trim();
+      pane.workqueue.itemSearch = searchQuery;
       if (searchEl && searchEl.value !== searchQuery) searchEl.value = searchQuery;
       resetRenderLimit();
       persistQuickFilters();
@@ -9671,7 +9716,6 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         doRefresh();
       }
     });
-
     renderStatusMultiSelect();
     populateQueueSelect().then(() => doRefresh());
 
@@ -9751,6 +9795,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       sourceSet.clear();
       repoSet.clear();
       searchQuery = '';
+      pane.workqueue.itemSearch = '';
       if (searchEl) searchEl.value = '';
       resetRenderLimit();
       persistQuickFilters();
@@ -9764,6 +9809,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
       sourceSet.clear();
       repoSet.clear();
       searchQuery = '';
+      pane.workqueue.itemSearch = '';
       if (searchEl) searchEl.value = '';
       resetRenderLimit();
       persistQuickFilters();
@@ -12029,6 +12075,20 @@ function focusChatComposer() {
   return true;
 }
 
+function focusActiveWorkqueueItemSearch() {
+  const panes = paneManager?.panes || [];
+  const activeKey = focusedPaneKey();
+  const activePane = panes.find((pane) => pane.key === activeKey && pane.kind === 'workqueue');
+  if (!activePane) return false;
+  const input = activePane.elements?.thread?.querySelector?.('[data-wq-item-search]');
+  if (!input || typeof input.focus !== 'function') return false;
+  input.focus();
+  try {
+    input.select?.();
+  } catch {}
+  return true;
+}
+
 function cyclePaneFocus() {
   const panes = paneManager.panes;
   if (!panes || panes.length === 0) return;
@@ -12265,6 +12325,13 @@ window.addEventListener('keydown', (event) => {
     event.preventDefault();
     openShortcuts();
     return;
+  }
+
+  if (key === '/' && !event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey) {
+    if (focusActiveWorkqueueItemSearch()) {
+      event.preventDefault();
+      return;
+    }
   }
 
   // Alt/Option+1..9 focuses panes by visible order.

--- a/styles.css
+++ b/styles.css
@@ -3162,6 +3162,11 @@ kbd {
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
+[data-wq-empty] {
+  position: relative;
+  z-index: 4;
+}
+
 .wq-list-body {
   min-height: 0;
   flex: 1;

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -473,7 +473,7 @@ test('workqueue pane: filter summary chips show counts and remove filters', asyn
   await expect(summary).not.toContainText('Repo rmdmattingly/clawnsole');
   await expect(wqPane.locator('.wq-row')).toHaveCount(2);
 
-  await wqPane.locator('[data-wq-search]').fill('alternate repo');
+  await wqPane.locator('[data-wq-item-search]').fill('alternate repo');
   await expect(wqPane.locator('[data-wq-statusline]')).toContainText('Showing 1 of 3 items');
   await expect(summary).toContainText('Search alternate repo');
 
@@ -575,6 +575,85 @@ test('workqueue pane: queue target supports search + recent persistence', async 
   const secondPane = page.locator('[data-pane]').last();
   const secondSelect = secondPane.locator('[data-wq-queue-select]');
   await expect(secondSelect.locator('option', { hasText: '★ qa-hotfix' })).toHaveCount(1);
+});
+
+test('workqueue pane: queue filter and item search are distinct controls', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  const queue = `item-search-${Date.now()}`;
+
+  await loginAdmin(page, env.serverPort);
+  await addPane(page, 'Workqueue pane');
+
+  await page.evaluate(async (queueName) => {
+    const post = async (url, body) => {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(body)
+      });
+      const data = await res.json().catch(() => null);
+      if (!res.ok || !data?.ok) throw new Error(data?.error || `request failed: ${res.status}`);
+      return data;
+    };
+
+    await post('/api/workqueue/enqueue', {
+      queue: queueName,
+      title: 'Alpha item search target',
+      instructions: 'needle-from-instructions',
+      priority: 1,
+      dedupeKey: `${queueName}:alpha`
+    });
+    await post('/api/workqueue/enqueue', {
+      queue: queueName,
+      title: 'Beta item',
+      instructions: 'not the target',
+      priority: 1,
+      dedupeKey: `${queueName}:beta`
+    });
+    await post('/api/workqueue/enqueue', {
+      queue: 'ops-team',
+      title: 'Ops queue item',
+      instructions: 'different queue',
+      priority: 1,
+      dedupeKey: `${queueName}:ops`
+    });
+  }, queue);
+
+  const wqPane = page.locator('[data-pane]').last();
+  await wqPane.locator('[data-wq-queue-select]').selectOption('__custom__');
+  await wqPane.locator('[data-wq-queue-custom]').fill(queue);
+  await wqPane.locator('[data-wq-queue-custom]').press('Enter');
+
+  await expect(wqPane.locator('[data-wq-queue-search]')).toHaveAttribute('placeholder', 'Filter queue list...');
+  await expect(wqPane.locator('[data-wq-item-search]')).toHaveAttribute('placeholder', 'Search items...');
+
+  const rows = wqPane.locator('[data-wq-list-body] .wq-row');
+  await expect(rows.filter({ hasText: 'Alpha item search target' })).toBeVisible();
+  await expect(rows.filter({ hasText: 'Beta item' })).toBeVisible();
+
+  await wqPane.locator('[data-wq-queue-search]').fill('ops');
+  await expect(rows.filter({ hasText: 'Alpha item search target' })).toBeVisible();
+  await expect(rows.filter({ hasText: 'Beta item' })).toBeVisible();
+
+  await wqPane.locator('[data-wq-item-search]').fill('needle-from-instructions');
+  await expect(rows).toHaveCount(1);
+  await expect(rows.first()).toContainText('Alpha item search target');
+
+  await wqPane.locator('[data-wq-item-search]').fill('missing-search-value');
+  await expect(wqPane.locator('[data-wq-empty]')).toContainText('No items match "missing-search-value".');
+  await wqPane.locator('[data-wq-clear-item-search]').click();
+  await expect(rows.filter({ hasText: 'Alpha item search target' })).toBeVisible();
+  await expect(rows.filter({ hasText: 'Beta item' })).toBeVisible();
+
+  await wqPane.locator('[data-wq-item-search]').blur();
+  await wqPane.locator('[data-wq-refresh]').focus();
+  await page.keyboard.press('/');
+  await expect(wqPane.locator('[data-wq-item-search]')).toBeFocused();
 });
 
 test('workqueue pane: enqueue assignment target supports search, keyboard select, and recents', async ({ page }) => {


### PR DESCRIPTION
## Summary\n- rename the queue search control to make clear it only filters queue names\n- add a separate item search control that filters workqueue rows by title, instructions, IDs, repo/source, and metadata\n- add an item-search empty state with clear action and / shortcut focus coverage\n\n## Tests\n- npm test -- --run tests/unit/app-core.test.js\n- npx playwright test tests/ui/workqueue-pane.spec.js -g "queue target supports search|queue filter and item search" --reporter=line\n\nFixes #332