### PR TITLE
Add Fleet freshness stale indicators

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,6 +44,7 @@ const globalElements = {
   agentsSortIndicator: document.getElementById('agentsSortIndicator'),
   agentsActiveMinutes: document.getElementById('agentsActiveMinutes'),
   agentsLastRefreshed: document.getElementById('agentsLastRefreshed'),
+  agentsRefreshStateBtn: document.getElementById('agentsRefreshStateBtn'),
   agentsList: document.getElementById('agentsList'),
   agentsEmpty: document.getElementById('agentsEmpty'),
   agentsSelectionBar: document.getElementById('agentsSelectionBar'),
@@ -1174,6 +1175,8 @@ let agentAutoRefreshInterval = null;
 let agentsModalAutoRefreshInterval = null;
 let agentsModalFreshnessTicker = null;
 let agentsLastRefreshedAtMs = 0;
+const FLEET_DEFAULT_STALE_THRESHOLD_MINUTES = 1;
+const FLEET_DEFAULT_ACTIVE_WINDOW_MINUTES = 10;
 const fleetRefreshLock = {
   lockedAtMs: 0,
   pointerInsideRow: false,
@@ -1196,10 +1199,12 @@ function renderFleetRefreshPaused() {
   if (!fleetRefreshLock.lockedAtMs) {
     el.hidden = true;
     el.textContent = '';
+    renderAgentsLastRefreshed();
     return;
   }
   el.hidden = false;
   el.textContent = `Refresh paused \u2022 ${formatRelativeAge(Date.now() - fleetRefreshLock.lockedAtMs)}`;
+  renderAgentsLastRefreshed();
 }
 
 function hasFleetRowInteraction() {
@@ -1294,10 +1299,16 @@ function formatRelativeAge(msAgo) {
 function renderAgentsLastRefreshed() {
   if (!globalElements.agentsLastRefreshed) return;
   if (!agentsLastRefreshedAtMs) {
-    globalElements.agentsLastRefreshed.textContent = 'Last refreshed: never';
+    globalElements.agentsLastRefreshed.textContent = 'Last updated: never';
+    globalElements.agentsLastRefreshed.dataset.freshness = 'unknown';
     return;
   }
-  globalElements.agentsLastRefreshed.textContent = `Last refreshed: ${formatRelativeAge(Date.now() - agentsLastRefreshedAtMs)}`;
+  const ageMs = Date.now() - agentsLastRefreshedAtMs;
+  const staleMs = FLEET_DEFAULT_STALE_THRESHOLD_MINUTES * 60_000;
+  const age = formatRelativeAge(ageMs);
+  const stale = ageMs > staleMs || fleetRefreshLock.lockedAtMs;
+  globalElements.agentsLastRefreshed.dataset.freshness = stale ? 'stale' : 'fresh';
+  globalElements.agentsLastRefreshed.textContent = stale ? `Stale · ${age}` : `Last updated: ${age}`;
 }
 
 function startAgentsModalAutoRefresh() {
@@ -4708,7 +4719,7 @@ function openAgentsModal() {
   if (globalElements.agentsSort) globalElements.agentsSort.value = sort;
   if (globalElements.agentsHeatmapToggle) globalElements.agentsHeatmapToggle.checked = heatmapEnabled;
   if (globalElements.agentsActiveMinutes) {
-    const minutes = Number(storage.get(ADMIN_AGENT_ACTIVE_MINUTES_KEY, '10')) || 10;
+    const minutes = Number(storage.get(ADMIN_AGENT_ACTIVE_MINUTES_KEY, String(FLEET_DEFAULT_ACTIVE_WINDOW_MINUTES))) || FLEET_DEFAULT_ACTIVE_WINDOW_MINUTES;
     globalElements.agentsActiveMinutes.value = String(Math.max(1, minutes));
   }
   syncFleetDensityControl();
@@ -4980,7 +4991,7 @@ function renderFleetSelectionBar({ classify = null, lastSeenMap = null } = {}) {
   const triage = typeof classify === 'function'
     ? classify(id)
     : (() => {
-        const withinMinutes = Math.max(1, Number(globalElements.agentsActiveMinutes?.value) || 10);
+        const withinMinutes = Math.max(1, Number(globalElements.agentsActiveMinutes?.value) || FLEET_DEFAULT_ACTIVE_WINDOW_MINUTES);
         const paneState = getAgentPaneStateMap()[id] || 'unknown';
         const ageMs = heartbeatTs > 0 ? Math.max(0, Date.now() - heartbeatTs) : Number.POSITIVE_INFINITY;
         const ageBucket = heartbeatAgeBucket(ageMs, { activeWindowMs: withinMinutes * 60_000, paneState });
@@ -5089,7 +5100,7 @@ function renderAgentsModalList() {
     ? String(document.activeElement.closest?.('.agents-row')?.dataset?.agentId || '')
     : '';
   const search = String(globalElements.agentsSearch?.value || '').trim().toLowerCase();
-  const withinMinutes = Math.max(1, Number(globalElements.agentsActiveMinutes?.value) || 10);
+  const withinMinutes = Math.max(1, Number(globalElements.agentsActiveMinutes?.value) || FLEET_DEFAULT_ACTIVE_WINDOW_MINUTES);
   const activeWindowMs = withinMinutes * 60_000;
   const filterMode = getFleetFilter();
   const sortMode = getFleetSort();
@@ -5257,6 +5268,7 @@ function renderAgentsModalList() {
       const label = formatAgentLabel(agent, { includeId: true });
       const pinnedNow = pins.has(id);
       const heartbeatTs = Number(lastSeenMap[id]) || 0;
+      const heartbeatAgeMs = heartbeatTs > 0 ? Math.max(0, Date.now() - heartbeatTs) : Number.POSITIVE_INFINITY;
       const heartbeatAge = heartbeatTs > 0 ? formatRelativeAge(Date.now() - heartbeatTs) : 'unknown';
       const triage = classify(id);
       const healthLabel = triage.bucket === 'offline_error'
@@ -5298,6 +5310,7 @@ function renderAgentsModalList() {
         : '';
       row.dataset.heartbeatBucket = triage.ageBucket;
       row.dataset.healthState = triage.bucket;
+      row.classList.toggle('is-stale', triage.bucket === 'stale' || heartbeatAgeMs > FLEET_DEFAULT_STALE_THRESHOLD_MINUTES * 60_000);
       row.classList.toggle('agents-row-heatmap', heatmapEnabled);
       row.classList.toggle('agents-row-no-actions', !visibleColumns.actions);
 
@@ -6159,6 +6172,10 @@ async function renderWorkqueuePane(rootEl, { queue = '' } = {}) {
 window.__debug = window.__debug || {};
 window.__debug.renderWorkqueuePane = renderWorkqueuePane;
 window.__debug.refreshAgents = refreshAgents;
+window.__debug.setAgentsLastRefreshedAtMs = (value) => {
+  agentsLastRefreshedAtMs = Math.max(0, Number(value) || 0);
+  renderAgentsLastRefreshed();
+};
 
 function getWorkqueueItemRepo(item) {
   const repo = String(item?.meta?.repo || '').trim();
@@ -11746,6 +11763,12 @@ globalElements.agentsModalRefreshBtn?.addEventListener('click', () => {
     showToast('Agent refresh failed.', { kind: 'error', timeoutMs: 3500 });
   });
 });
+globalElements.agentsRefreshStateBtn?.addEventListener('click', () => {
+  clearFleetRefreshLock();
+  refreshAgents({ reason: 'manual', showSuccessToast: true }).catch(() => {
+    showToast('Agent refresh failed.', { kind: 'error', timeoutMs: 3500 });
+  });
+});
 
 globalElements.agentsBtn?.addEventListener('click', () => openAgentsModal());
 globalElements.agentsCloseBtn?.addEventListener('click', () => {
@@ -11836,9 +11859,10 @@ globalElements.agentsHeartbeatSortBtn?.addEventListener('click', () => setFleetH
 globalElements.agentsSortResetBtn?.addEventListener('click', () => resetFleetSort());
 
 globalElements.agentsActiveMinutes?.addEventListener('change', () => {
-  const minutes = Math.max(1, Number(globalElements.agentsActiveMinutes.value) || 10);
+  const minutes = Math.max(1, Number(globalElements.agentsActiveMinutes.value) || FLEET_DEFAULT_ACTIVE_WINDOW_MINUTES);
   globalElements.agentsActiveMinutes.value = String(minutes);
   storage.set(ADMIN_AGENT_ACTIVE_MINUTES_KEY, minutes);
+  renderAgentsLastRefreshed();
   renderAgentsModalList();
 });
 
@@ -12412,6 +12436,19 @@ window.addEventListener('keydown', (event) => {
 
   // Never steal focus / override browser shortcuts while typing.
   if (isTypingContext(event.target)) return;
+  if (
+    isAgentsModalOpen() &&
+    roleState.role === 'admin' &&
+    key.toLowerCase() === 'r' &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.shiftKey &&
+    !event.altKey
+  ) {
+    event.preventDefault();
+    globalElements.agentsRefreshStateBtn?.click?.();
+    return;
+  }
   if (isAnyOverlayOpen()) return;
 
   // Ctrl+Tab walks panes in most-recently-used order; Shift reverses the traversal.

--- a/index.html
+++ b/index.html
@@ -426,8 +426,9 @@
         <div class="modal-body">
           <div class="agents-toolbar">
             <div class="agents-refresh-state">
-              <span id="agentsLastRefreshed" class="agents-last-refreshed" aria-live="polite">Last refreshed: never</span>
+              <span id="agentsLastRefreshed" class="agents-last-refreshed" role="status" aria-live="polite" aria-atomic="true">Last updated: never</span>
               <span id="agentsRefreshPaused" class="agents-refresh-paused" aria-live="polite" hidden></span>
+              <button id="agentsRefreshStateBtn" type="button" class="secondary agents-refresh-state-btn" aria-label="Refresh Fleet">Refresh</button>
             </div>
             <label class="agents-field">
               <span class="agents-label">Search</span>

--- a/styles.css
+++ b/styles.css
@@ -1784,6 +1784,17 @@ button.send-btn .btn-icon {
   color: var(--muted);
 }
 
+.agents-last-refreshed[data-freshness="stale"] {
+  color: #ffcb6b;
+  font-weight: 700;
+}
+
+.agents-refresh-state-btn {
+  min-height: 24px;
+  padding: 3px 9px;
+  font-size: 12px;
+}
+
 .agents-refresh-paused {
   display: inline-flex;
   align-items: center;
@@ -2099,6 +2110,11 @@ button.agents-section-title:hover {
 .agents-row[aria-selected="true"] {
   border-color: rgba(77, 196, 255, 0.7);
   background: rgba(77, 196, 255, 0.11);
+}
+
+.agents-row.is-stale {
+  border-color: rgba(255, 203, 107, 0.32);
+  background: rgba(255, 203, 107, 0.05);
 }
 
 .agents-row-no-actions {

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -70,8 +70,40 @@ test('agents modal shows live refresh freshness indicators', async ({ page, claw
   await page.getByRole('button', { name: 'Open agents' }).click();
   await expect(page.locator('#agentsModal')).toHaveClass(/open/);
 
-  await expect(page.locator('#agentsLastRefreshed')).toContainText('Last refreshed:');
+  await expect(page.locator('#agentsLastRefreshed')).toContainText('Last updated:');
   await expect(page.locator('#agentsList .agents-row-meta').first()).toContainText(/\d+[smhd]/);
+});
+
+test('agents modal marks stale fleet data and supports header refresh parity', async ({ page, clawnsole }) => {
+  if (clawnsole.skipReason) test.skip(clawnsole.skipReason);
+
+  let agents = [{ id: 'alpha', name: 'Alpha', displayName: 'Alpha' }];
+  await page.route(/\/agents(?:\?|$)/, async (route) => {
+    await route.fulfill({ json: { agents } });
+  });
+
+  await clawnsole.gotoAndLoginAdmin(page);
+  await page.evaluate(() => {
+    localStorage.setItem('clawnsole.admin.agentLastSeenAtMs', JSON.stringify({ alpha: Date.now() - 11 * 60_000 }));
+  });
+  await page.getByRole('button', { name: 'Refresh agent list' }).click();
+  await page.getByRole('button', { name: 'Open agents' }).click();
+  await expect(page.locator('#agentsModal')).toHaveClass(/open/);
+
+  const row = page.locator('#agentsList .agents-row').filter({ hasText: 'Alpha (alpha)' });
+  await expect(row).toHaveClass(/is-stale/);
+  await expect(row.locator('.agents-health-state-chip')).toHaveText('Stale');
+
+  await page.evaluate(() => window.__debug.setAgentsLastRefreshedAtMs(Date.now() - 70_000));
+  await expect(page.locator('#agentsLastRefreshed')).toContainText('Stale');
+
+  agents = [{ id: 'beta', name: 'Beta', displayName: 'Beta' }];
+  await page.getByRole('button', { name: 'Refresh Fleet' }).click();
+  await expect(page.locator('#agentsList')).toContainText('Beta (beta)');
+
+  agents = [{ id: 'gamma', name: 'Gamma', displayName: 'Gamma' }];
+  await page.keyboard.press('r');
+  await expect(page.locator('#agentsList')).toContainText('Gamma (gamma)');
 });
 
 test('agents modal defers auto-refresh while a fleet row is active, then catches up once', async ({ page, clawnsole }) => {


### PR DESCRIPTION
## Summary
- show Fleet header freshness as `Last updated` and switch to `Stale · <age>` when data exceeds the 60s freshness threshold
- add Fleet header refresh button plus plain `r` refresh while the Fleet modal has focus
- add subtle stale row styling for heartbeat data older than the threshold
- cover stale header, stale row, header button refresh, and keyboard refresh in Agents modal UI tests

## Tests
- npm test
- npx playwright test tests/ui/agents-modal.spec.js --workers=1

Closes #301
