### PR TITLE
Add Fleet period timeline shortcut

### DIFF
--- a/app.js
+++ b/app.js
@@ -477,7 +477,9 @@ const KEYBIND_CATALOG = [
   { id: 'fleet.sortHeartbeatGlobal', group: 'Fleet actions', label: 'Open Fleet sorted by heartbeat age', binding: { accel: true, shift: true, key: 'h', display: 'Cmd/Ctrl+Shift+H' } },
   { id: 'fleet.next', group: 'Fleet actions', label: 'Move Fleet selection down', binding: { key: 'j', display: 'J / Down' } },
   { id: 'fleet.prev', group: 'Fleet actions', label: 'Move Fleet selection up', binding: { key: 'k', display: 'K / Up' } },
-  { id: 'fleet.runSelected', group: 'Fleet actions', label: 'Run selected Fleet agent', binding: { key: 'Enter', display: 'Enter' } },
+  { id: 'fleet.openChatSelected', group: 'Fleet actions', label: 'Open Chat for selected Fleet agent', binding: { key: 'Enter', display: 'Enter' } },
+  { id: 'fleet.openWorkqueueSelected', group: 'Fleet actions', label: 'Open Workqueue for selected Fleet agent', binding: { key: 'Enter', shift: true, display: 'Shift+Enter' } },
+  { id: 'fleet.openTimelineSelected', group: 'Fleet actions', label: 'Open Timeline for selected Fleet agent', binding: { key: '.', display: '.' } },
   { id: 'fleet.toggleHeartbeatSort', group: 'Fleet actions', label: 'Toggle Fleet heartbeat age sort', binding: { key: 'h', display: 'H / Shift+H' } }
 ];
 
@@ -5511,6 +5513,7 @@ function runFleetSelectedAgent(mode = 'chat') {
   const id = String(fleetSelectionState.selectedAgentId || '').trim();
   if (!id) return false;
   if (mode === 'workqueue') openAgentWorkqueueFromFleet(id);
+  else if (mode === 'timeline') openAgentTimelineFromFleet(id);
   else openAgentChatFromFleet(id);
   return true;
 }
@@ -11805,6 +11808,11 @@ globalElements.agentsModal?.addEventListener('keydown', (event) => {
     if (key === 'Enter') {
       event.preventDefault();
       runFleetSelectedAgent(event.shiftKey ? 'workqueue' : 'chat');
+      return;
+    }
+    if (key === '.') {
+      event.preventDefault();
+      runFleetSelectedAgent('timeline');
       return;
     }
   }

--- a/tests/pane.shortcuts.e2e.spec.js
+++ b/tests/pane.shortcuts.e2e.spec.js
@@ -136,6 +136,9 @@ test('shortcuts overlay stays in sync with registered shortcut catalog', async (
   await expect(modal).toContainText('Fleet actions');
   await expect(modal).toContainText('Open/focus Fleet pane');
   await expect(modal).toContainText('Open Fleet sorted by heartbeat age');
+  await expect(modal).toContainText('Open Chat for selected Fleet agent');
+  await expect(modal).toContainText('Open Workqueue for selected Fleet agent');
+  await expect(modal).toContainText('Open Timeline for selected Fleet agent');
 });
 
 test('pane-add shortcuts are scoped to workspace and blocked by overlays', async ({ page }) => {

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -358,7 +358,9 @@ test('fleet refresh keeps scroll anchor and keyboard triage selection', async ({
       .evaluateAll((els) => els.map((el) => el.value))
   )).toContain('agent-20');
 
-  await reopenedRow20.focus();
+  await page.waitForTimeout(350);
+  await reopenedRow20.click();
+  await expect(reopenedRow20).toBeFocused();
   const timelineCountBeforePeriod = await page.locator('[data-pane][data-pane-kind="timeline"]').count();
   await page.keyboard.press('.');
   await expect(page.locator('[data-pane][data-pane-kind="timeline"]')).toHaveCount(timelineCountBeforePeriod + 1);

--- a/tests/ui/agents-modal.spec.js
+++ b/tests/ui/agents-modal.spec.js
@@ -358,6 +358,15 @@ test('fleet refresh keeps scroll anchor and keyboard triage selection', async ({
       .evaluateAll((els) => els.map((el) => el.value))
   )).toContain('agent-20');
 
+  await reopenedRow20.focus();
+  const timelineCountBeforePeriod = await page.locator('[data-pane][data-pane-kind="timeline"]').count();
+  await page.keyboard.press('.');
+  await expect(page.locator('[data-pane][data-pane-kind="timeline"]')).toHaveCount(timelineCountBeforePeriod + 1);
+  await expect.poll(async () => (
+    page.locator('[data-pane][data-pane-kind="timeline"] [data-cron-agent]')
+      .evaluateAll((els) => els.map((el) => el.value))
+  )).toContain('agent-20');
+
   const search = page.locator('#agentsSearch');
   await search.fill('agent');
   const selectedAfterFilter = page.locator('#agentsList .agents-row[aria-selected="true"]').first();


### PR DESCRIPTION
## Summary\n- split Fleet shortcut catalog entries for selected Chat, Workqueue, and Timeline actions\n- add the '.' Fleet keyboard action to open Timeline for the selected agent\n- cover Shift+Enter and period scoped pane behavior in Fleet UI tests\n\n## Tests\n- npx playwright test tests/ui/agents-modal.spec.js --grep "fleet refresh keeps scroll anchor"\n- npx playwright test tests/pane.shortcuts.e2e.spec.js --grep "shortcuts overlay stays in sync"\n\nFixes #259