### PR TITLE
Hide archived Workqueue items by default

### DIFF
--- a/app.js
+++ b/app.js
@@ -75,6 +75,8 @@ const globalElements = {
   workqueueCloseBtn: document.getElementById('workqueueCloseBtn'),
   wqQueueSelect: document.getElementById('wqQueueSelect'),
   wqStatusFilters: document.getElementById('wqStatusFilters'),
+  wqShowArchivedBtn: document.getElementById('wqShowArchivedBtn'),
+  wqArchivedHint: document.getElementById('wqArchivedHint'),
   wqAutoRefreshEnabled: document.getElementById('wqAutoRefreshEnabled'),
   wqAutoRefreshInterval: document.getElementById('wqAutoRefreshInterval'),
   wqRefreshBtn: document.getElementById('wqRefreshBtn'),
@@ -5521,6 +5523,8 @@ function runFleetSelectedAgent(mode = 'chat') {
 // Workqueue (admin-only)
 
 const WORKQUEUE_STATUSES = ['ready', 'pending', 'blocked', 'claimed', 'in_progress', 'done', 'failed'];
+const WORKQUEUE_ACTIVE_STATUSES = ['ready', 'pending', 'blocked', 'claimed', 'in_progress'];
+const WORKQUEUE_TERMINAL_STATUSES = ['done', 'failed'];
 const WORKQUEUE_PANE_INITIAL_RENDER_LIMIT = 100;
 const WORKQUEUE_PANE_RENDER_CHUNK_SIZE = 100;
 const WORKQUEUE_CANONICAL_DENSITY_THRESHOLD = 0.2;
@@ -5583,7 +5587,7 @@ function getWorkqueueAllScopeGuardThreshold() {
 const workqueueState = {
   queues: [],
   selectedQueue: '',
-  statusFilter: new Set(['ready', 'pending', 'blocked', 'claimed', 'in_progress']),
+  statusFilter: new Set(WORKQUEUE_ACTIVE_STATUSES),
   statusCounts: Object.fromEntries(WORKQUEUE_STATUSES.map((s) => [s, 0])),
   items: [],
   selectedItemId: null,
@@ -5596,6 +5600,11 @@ const workqueueState = {
   autoRefreshTimer: null,
   sortingBootstrapped: false
 };
+
+function workqueueIncludesArchived(statuses) {
+  const set = new Set((Array.isArray(statuses) ? statuses : Array.from(statuses || [])).map((s) => String(s || '').trim()));
+  return WORKQUEUE_TERMINAL_STATUSES.every((s) => set.has(s));
+}
 
 function openWorkqueue() {
   if (roleState.role !== 'admin') return;
@@ -5614,6 +5623,15 @@ function closeWorkqueue({ restoreFocus = true } = {}) {
 function renderWorkqueueStatusFilters() {
   const root = globalElements.wqStatusFilters;
   if (!root) return;
+  const archivedShown = workqueueIncludesArchived(workqueueState.statusFilter);
+  if (globalElements.wqShowArchivedBtn) {
+    globalElements.wqShowArchivedBtn.textContent = archivedShown ? 'Hide archived' : 'Show archived';
+    globalElements.wqShowArchivedBtn.classList.toggle('active', archivedShown);
+    globalElements.wqShowArchivedBtn.setAttribute('aria-pressed', archivedShown ? 'true' : 'false');
+  }
+  if (globalElements.wqArchivedHint) {
+    globalElements.wqArchivedHint.textContent = archivedShown ? 'Archived done/failed items shown.' : 'Archived done/failed items hidden.';
+  }
   root.innerHTML = '';
   for (const s of WORKQUEUE_STATUSES) {
     const id = `wq-status-${s}`;
@@ -5630,6 +5648,18 @@ function renderWorkqueueStatusFilters() {
     });
     root.appendChild(label);
   }
+}
+
+async function toggleWorkqueueModalArchived() {
+  const archivedShown = workqueueIncludesArchived(workqueueState.statusFilter);
+  if (archivedShown) {
+    for (const s of WORKQUEUE_TERMINAL_STATUSES) workqueueState.statusFilter.delete(s);
+  } else {
+    for (const s of WORKQUEUE_ACTIVE_STATUSES) workqueueState.statusFilter.add(s);
+    for (const s of WORKQUEUE_TERMINAL_STATUSES) workqueueState.statusFilter.add(s);
+  }
+  renderWorkqueueStatusFilters();
+  await fetchAndRenderWorkqueueItems();
 }
 
 function ensureWorkqueueModalSorting() {
@@ -9135,7 +9165,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     agentId: role === 'admin' ? normalizeAgentId(agentId || 'main') : null,
     workqueue: {
       queue: (queue || 'dev-team').trim() || 'dev-team',
-      statusFilter: Array.isArray(statusFilter) ? statusFilter : ['ready', 'pending', 'blocked', 'claimed', 'in_progress'],
+      statusFilter: Array.isArray(statusFilter) ? statusFilter : Array.from(WORKQUEUE_ACTIVE_STATUSES),
       scopeFilter: normalizeWorkqueueScope(scopeFilter ?? getDefaultWorkqueueScopeForTarget(agentId)),
       quickFilters: {
         sources: Array.isArray(quickFilters?.sources) ? quickFilters.sources.map((s) => String(s || '').trim()).filter(Boolean) : [],
@@ -9364,9 +9394,10 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
                     <button type="button" class="secondary" data-wq-status-preset="default">Default</button>
                     <button type="button" class="secondary" data-wq-status-preset="open">Open</button>
                     <button type="button" class="secondary" data-wq-status-preset="active">Active</button>
-                    <button type="button" class="secondary" data-wq-status-preset="all">All</button>
+                    <button type="button" class="secondary" data-wq-status-preset="all" aria-pressed="false">Show archived</button>
                     <button type="button" class="secondary" data-wq-status-clear>Clear</button>
                   </div>
+                  <div class="hint wq-archive-hint" data-wq-archive-hint>Archived done/failed items hidden.</div>
                   <div class="wq-status-filters" data-wq-status-options></div>
                 </div>
               </details>
@@ -9523,6 +9554,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     const statusOptionsEl = elements.thread.querySelector('[data-wq-status-options]');
     const statusDetailsEl = elements.thread.querySelector('[data-wq-status-details]');
     const statusClearBtn = elements.thread.querySelector('[data-wq-status-clear]');
+    const archiveHintEl = elements.thread.querySelector('[data-wq-archive-hint]');
     const sourceBtns = Array.from(elements.thread.querySelectorAll('[data-wq-source]'));
     const repoChipsEl = elements.thread.querySelector('[data-wq-repo-chips]');
     const clawnsoleOnlyBtn = elements.thread.querySelector('[data-wq-preset-clawnsole]');
@@ -9532,7 +9564,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
     const keyboardModeBtn = elements.thread.querySelector('[data-wq-keyboard-mode]');
     const keyboardHint = elements.thread.querySelector('[data-wq-keyboard-hint]');
 
-    const DEFAULT_STATUSES = ['ready', 'pending', 'blocked', 'claimed', 'in_progress'];
+    const DEFAULT_STATUSES = WORKQUEUE_ACTIVE_STATUSES;
 
     const statusSet = new Set(
       (Array.isArray(pane.workqueue?.statusFilter) && pane.workqueue.statusFilter.length ? pane.workqueue.statusFilter : DEFAULT_STATUSES)
@@ -9696,6 +9728,7 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
 
       statusSelectedEl.innerHTML = '';
       const selected = Array.from(statusSet);
+      const archivedShown = workqueueIncludesArchived(selected);
       if (selected.length) {
         for (const s of selected) {
           const chip = document.createElement('span');
@@ -9708,6 +9741,15 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
         hint.className = 'hint';
         hint.textContent = 'none (will show default on refresh)';
         statusSelectedEl.appendChild(hint);
+      }
+      if (archiveHintEl) {
+        archiveHintEl.textContent = archivedShown ? 'Archived done/failed items shown.' : 'Archived done/failed items hidden.';
+      }
+      const archivedPreset = statusRootEl.querySelector('[data-wq-status-preset="all"]');
+      if (archivedPreset) {
+        archivedPreset.textContent = archivedShown ? 'Hide archived' : 'Show archived';
+        archivedPreset.classList.toggle('active', archivedShown);
+        archivedPreset.setAttribute('aria-pressed', archivedShown ? 'true' : 'false');
       }
 
       statusOptionsEl.innerHTML = '';
@@ -9856,7 +9898,10 @@ function createPane({ key, role, kind = 'chat', agentId, queue, statusFilter, sc
           const preset = String(btn.getAttribute('data-wq-status-preset') || 'default');
           if (preset === 'open') return applyStatuses(['ready', 'pending'], { closeMenu: true });
           if (preset === 'active') return applyStatuses(['claimed', 'in_progress'], { closeMenu: true });
-          if (preset === 'all') return applyStatuses(Array.from(WORKQUEUE_STATUSES), { closeMenu: true });
+          if (preset === 'all') {
+            const archivedShown = workqueueIncludesArchived(Array.from(statusSet));
+            return applyStatuses(archivedShown ? DEFAULT_STATUSES : Array.from(WORKQUEUE_STATUSES), { closeMenu: true });
+          }
           return applyStatuses(DEFAULT_STATUSES, { closeMenu: true });
         });
       });
@@ -10833,7 +10878,7 @@ const paneManager = {
           const agentId = normalizeAgentId(typeof item.agentId === 'string' ? item.agentId : defaultAgent);
           const statusFilter = Array.isArray(item.statusFilter)
             ? item.statusFilter.map((s) => String(s || '').trim()).filter(Boolean)
-            : ['ready', 'pending', 'blocked', 'claimed', 'in_progress'];
+            : Array.from(WORKQUEUE_ACTIVE_STATUSES);
           const scopeFilter = normalizeWorkqueueScope(item.scopeFilter ?? getDefaultWorkqueueScopeForTarget(agentId));
           const quickFilters = {
             sources: Array.isArray(item?.quickFilters?.sources) ? item.quickFilters.sources.map((s) => String(s || '').trim()).filter(Boolean) : [],
@@ -11075,7 +11120,7 @@ const paneManager = {
         queue: nextQueue,
         statusFilter: Array.isArray(options?.statusFilter) && options.statusFilter.length
           ? options.statusFilter
-          : ['ready', 'pending', 'blocked', 'claimed', 'in_progress'],
+          : Array.from(WORKQUEUE_ACTIVE_STATUSES),
         scopeFilter: nextScopeFilter,
         quickFilters: options?.quickFilters,
         groupMode: normalizeWorkqueueGroupMode(options?.groupMode),
@@ -11892,6 +11937,9 @@ globalElements.fleetBtn?.addEventListener('click', (event) => {
   openFleetPane({ forceNew });
 });
 globalElements.workqueueCloseBtn?.addEventListener('click', () => closeWorkqueue());
+globalElements.wqShowArchivedBtn?.addEventListener('click', () => {
+  void toggleWorkqueueModalArchived();
+});
 globalElements.workqueueModal?.addEventListener('click', (event) => {
   if (event.target === globalElements.workqueueModal) closeWorkqueue();
 });

--- a/index.html
+++ b/index.html
@@ -322,6 +322,10 @@
             </label>
             <div class="wq-field">
               Status
+              <div class="wq-status-actions">
+                <button id="wqShowArchivedBtn" class="secondary wq-archive-toggle" type="button" aria-pressed="false">Show archived</button>
+                <span id="wqArchivedHint" class="hint">Archived done/failed items hidden.</span>
+              </div>
               <div id="wqStatusFilters" class="wq-status-filters" aria-label="Status filters"></div>
             </div>
             <label class="wq-field">

--- a/styles.css
+++ b/styles.css
@@ -2663,6 +2663,21 @@ kbd {
   gap: 8px;
 }
 
+.wq-status-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 6px;
+}
+
+.wq-archive-toggle.active,
+.wq-status-presets .secondary.active {
+  border-color: rgba(127, 209, 185, 0.5);
+  background: rgba(127, 209, 185, 0.14);
+  color: var(--text);
+}
+
 .wq-autorefresh {
   display: flex;
   align-items: center;

--- a/tests/ui/workqueue-modal.spec.js
+++ b/tests/ui/workqueue-modal.spec.js
@@ -71,3 +71,53 @@ test('workqueue modal: status filters use human labels and queue-scoped counts',
   await queueSelect.selectOption('qa-team');
   await expect(page.locator('#wqStatusFilters .wq-status-chip', { hasText: 'Ready (2)' })).toHaveCount(1);
 });
+
+test('workqueue modal: hides archived statuses by default and toggles them explicitly', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+
+  const baseUrl = `http://127.0.0.1:${env.serverPort}`;
+  const enqueue = async (title) => {
+    const res = await page.request.post(`${baseUrl}/api/workqueue/enqueue`, {
+      data: {
+        queue: 'modal-archived',
+        title,
+        instructions: `seed ${title}`,
+        priority: 1
+      }
+    });
+    expect(res.ok()).toBeTruthy();
+    const data = await res.json();
+    return data.item.id;
+  };
+
+  const readyId = await enqueue('modal archived ready row');
+  const doneId = await enqueue('modal archived done row');
+  const failedId = await enqueue('modal archived failed row');
+  expect(readyId).toBeTruthy();
+  for (const [itemId, status] of [[doneId, 'done'], [failedId, 'failed']]) {
+    const res = await page.request.post(`${baseUrl}/api/workqueue/update`, { data: { itemId, patch: { status } } });
+    expect(res.ok()).toBeTruthy();
+  }
+
+  await page.evaluate(() => window.openWorkqueue?.());
+  await expect(page.locator('#workqueueModal')).toHaveClass(/open/);
+  await page.locator('#wqQueueSelect').selectOption('modal-archived');
+
+  await expect(page.locator('#wqListBody')).toContainText('modal archived ready row');
+  await expect(page.locator('#wqListBody')).not.toContainText('modal archived done row');
+  await expect(page.locator('#wqListBody')).not.toContainText('modal archived failed row');
+  await expect(page.locator('#wqArchivedHint')).toHaveText('Archived done/failed items hidden.');
+  await expect(page.locator('#wqShowArchivedBtn')).toHaveAttribute('aria-pressed', 'false');
+
+  await page.locator('#wqShowArchivedBtn').click();
+  await expect(page.locator('#wqListBody')).toContainText('modal archived done row');
+  await expect(page.locator('#wqListBody')).toContainText('modal archived failed row');
+  await expect(page.locator('#wqArchivedHint')).toHaveText('Archived done/failed items shown.');
+  await expect(page.locator('#wqShowArchivedBtn')).toHaveText('Hide archived');
+  await expect(page.locator('#wqShowArchivedBtn')).toHaveAttribute('aria-pressed', 'true');
+});

--- a/tests/ui/workqueue-pane.spec.js
+++ b/tests/ui/workqueue-pane.spec.js
@@ -195,6 +195,44 @@ function seedExactDuplicateWorkqueueItems(queue) {
   fs.writeFileSync(path.join(dir, 'work-queues.json'), JSON.stringify(data, null, 2));
 }
 
+function seedArchivedToggleWorkqueueItems(queue) {
+  const dir = path.join(env.tempHome, '.openclaw', 'clawnsole');
+  fs.mkdirSync(dir, { recursive: true });
+  const now = new Date();
+  const iso = (offsetMs) => new Date(now.getTime() + offsetMs).toISOString();
+  const mkItem = (id, status, title) => ({
+    id,
+    queue,
+    title,
+    instructions: 'archived toggle regression',
+    priority: 10,
+    status,
+    claimedBy: '',
+    claimedAt: '',
+    leaseUntil: 0,
+    attempts: 0,
+    lastError: '',
+    createdAt: iso(-60000),
+    updatedAt: iso(-60000),
+    dedupeKey: `archived-toggle-${id}`
+  });
+
+  const data = {
+    version: 1,
+    queues: {
+      'dev-team': { name: 'dev-team', createdAt: iso(-120000) },
+      [queue]: { name: queue, createdAt: iso(-120000) }
+    },
+    assignments: {},
+    items: [
+      mkItem('archived-ready', 'ready', 'archived toggle ready row'),
+      mkItem('archived-done', 'done', 'archived toggle done row'),
+      mkItem('archived-failed', 'failed', 'archived toggle failed row')
+    ]
+  };
+  fs.writeFileSync(path.join(dir, 'work-queues.json'), JSON.stringify(data, null, 2));
+}
+
 test('workqueue pane: default agent-targeted layout starts assigned and remains overridable', async ({ page }) => {
   test.setTimeout(180000);
   test.skip(!!env?.skipReason, env?.skipReason);
@@ -254,6 +292,45 @@ test('workqueue pane: default agent-targeted layout starts assigned and remains 
   await allBtn.click();
   await expect(allBtn).toHaveAttribute('aria-pressed', 'true');
   await expect(rows).toHaveCount(2);
+});
+
+test('workqueue pane: new panes default to non-terminal statuses with archived toggle', async ({ page }) => {
+  test.setTimeout(180000);
+  test.skip(!!env?.skipReason, env?.skipReason);
+
+  const queue = `pane-archived-${Date.now()}`;
+  seedArchivedToggleWorkqueueItems(queue);
+  page.__consoleAsserts = attachConsoleErrorAsserts(page);
+
+  await loginAdmin(page, env.serverPort);
+
+  const defaultPane = page.locator('[data-pane][data-pane-kind="workqueue"]').first();
+  await defaultPane.locator('[data-wq-queue-select]').selectOption(queue);
+  await expect(defaultPane.locator('[data-wq-statusline]')).toContainText('Showing 1 of 3 items');
+  await expect(defaultPane.locator('[data-wq-list-body]')).toContainText('archived toggle ready row');
+  await expect(defaultPane.locator('[data-wq-list-body]')).not.toContainText('archived toggle done row');
+
+  await addPane(page, 'Workqueue pane');
+  const newPane = page.locator('[data-pane][data-pane-kind="workqueue"]').last();
+  await newPane.locator('[data-wq-queue-select]').selectOption(queue);
+  await expect(newPane.locator('[data-wq-statusline]')).toContainText('Showing 1 of 3 items');
+  await expect(newPane.locator('[data-wq-list-body]')).not.toContainText('archived toggle failed row');
+
+  await newPane.locator('[data-wq-status-details] summary').click();
+  const archivedToggle = newPane.locator('[data-wq-status-preset="all"]');
+  await expect(newPane.locator('[data-wq-archive-hint]')).toHaveText('Archived done/failed items hidden.');
+  await expect(archivedToggle).toHaveText('Show archived');
+  await expect(archivedToggle).toHaveAttribute('aria-pressed', 'false');
+
+  await archivedToggle.click();
+  await expect(newPane.locator('[data-wq-statusline]')).toContainText('3 item');
+  await expect(newPane.locator('[data-wq-list-body]')).toContainText('archived toggle done row');
+  await expect(newPane.locator('[data-wq-list-body]')).toContainText('archived toggle failed row');
+
+  await newPane.locator('[data-wq-status-details] summary').click();
+  await expect(archivedToggle).toHaveText('Hide archived');
+  await expect(archivedToggle).toHaveAttribute('aria-pressed', 'true');
+  await expect(newPane.locator('[data-wq-archive-hint]')).toHaveText('Archived done/failed items shown.');
 });
 
 function seedLargeRoutineWorkqueueItems(queue) {


### PR DESCRIPTION
Closes #358.

Summary:
- Default new Workqueue panes and the modal to non-terminal triage statuses.
- Add explicit Show archived / Hide archived controls for done and failed rows.
- Surface whether archived rows are hidden or shown in the status UI.
- Add Playwright regressions for modal and pane archived-toggle behavior.

Tests:
- npm test
- npx playwright test tests/ui/workqueue-modal.spec.js tests/ui/workqueue-pane.spec.js --workers=1

Note: PR #619 uses the same issue branch name but is stale and contains unrelated drift; this is the clean replacement from current main.